### PR TITLE
Clean up Realms of Power: Faerie

### DIFF
--- a/Ars Magica 5e - Realms of Power - Faerie.md
+++ b/Ars Magica 5e - Realms of Power - Faerie.md
@@ -1,0 +1,7947 @@
+# Credits
+
+**Authors:** Erik Dahl (Faerie Wizardry, Touches of Faerie), Timothy Ferguson (Nature of Faerie, Faerie Characters, Bestiary), Mark Shirley (The Faerie Realm, Touches of Faerie, Faerie Stories)
+
+**Development, Editing, & Project Management:** David Chart **Layout, Art Direction, & Proofreading:** Michelle Nephew **Publisher:** John Nephew
+
+**Cover Illustration:** Grey Thornberry
+
+**Interior Art:** Keith DeCesare, Kelly Hensing, Bradley McDevitt, Jeff Menges, Robert Scott, Grey Thornberry
+
+**Ars Magica Fifth Edition Trade Dress:** J. Scott Reeves
+
+**Publisher's Special Thanks**: Jerry Corrick & the gang at the Source. **First Round Playtesters**: Mark Barltrop, Mark Lawford, David Staveley, Simon Turner; Chris "CJ" Jensen-Romer, Kevin Sides, Luke Price, Lloyd Graney, Peter Hiley, Ben Hayes; Jason Fryer, Matt Dyson, Emily Dyson; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Angus MacDonald, Sarah MacDonald, Brian Watson, Quetta Watson, Wendell BSP Joyner, Steve Woyach, Aja Hodge; Eric Menge, Ann Sasahara, Scott Benfield, Lynn Reed-Kendall, Christopher Day; Nicholas Peterson, Jennafyr Peterson, Michael Pisarsky, Kristi Pisarsky; Matthew L. Seidl; Christoph Safferling, Andrew Smith; Carlo Veltri, Chad Vincent, Greg Palechek, Greg Rothwell
+
+**Second Round Playtesters:** Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Angus MacDonald, Brian Watson, Quetta Watson, Sarah MacDonald; Matt Ryan, Alexis K. Heinz, Tobias Wheeler, Mario Cerame, Rob Llwyd; Ulrich Willmünder; Neil Taylor; Sean Winslow; Erik Tyrrell
+
+# Author Bios
+
+**Erik Dahl** lives in Davis, California, and would like to dedicate his work on this book to his enchanting wife (who must not be named directly), to thank her for all of her support and encouragement over the past few years. In her honor, he'd like to get a few lame jokes out of his system: this book required some faerie hard work, and for faerie low pay, but writing for it was ultimately faerie rewarding, and it will likely be a faerie good read. Whew, thank goodness that's out of the way!
+
+**Timothy Ferguson** lives on the Golden Coast of the Unknown Land in the South. He curates collections of stories, rationing where, and when, and to whom they go. He dedicates this work to his wife, who is even now preparing a garden for their new familiars. He never loses a book, not even this one, and he is awake while you are sleeping.
+
+**Mark Shirley** haunts the woods near Newcastle upon Tyne. He can be distinguished from other varieties of troll by his bright clothing and four-dimensional hat. His Sympathy Traits include Zoology, Epidemiological Modelling, Ferrets, and Woodcarving. His Traditional Wards are Beetroot, and the Incorrect Use of Apostrophes. Mark dedicates this book to Richard, whose unmitigated and terrifying whimsy has helped defined Faerie for him.
+
+**Ars Magica** players participate in a thriving fan community by subscribing to email discussion lists (like the Berkeley list), compiling archives of game material (such as Project Redcap), maintaining fan-created web sites, and running demos through Atlas Games' Special Ops program. To learn more, visit www.atlas-games.com/ArM5. You can also participate in discussions of **Ars Magica** at the official Atlas Games forums located at forum.atlas-games.com.
+
+Copyright 2011 Trident, Inc. d/b/a Atlas Games. All rights reserved. Reproduction of this work by any means without written permission from the publisher, except short excerpts for the purpose of reviews, is expressly prohibited.
+
+**Ars Magica**, Mythic Europe, The Lion and the Lily, and Charting New Realms of Imagination are trademarks of Trident, Inc. Order of Hermes, Termere, and Doissetep are trademarks of White Wolf, Inc. and are used with permission.
+
+DIGITAL VERSION 1.0
+
+# Table of Contents
+
+**Introduction: Dreams & Nightmares**<br>
+&emsp;What is Faerie?<br>
+&emsp;Faerie & Other Realms<br>
+&emsp;&emsp;Faerie and the Divine<br>
+&emsp;&emsp;Faerie and the Infernal<br>
+&emsp;&emsp;Faerie and Magic<br>
+<br>
+**Chapter 1: Nature of Faerie**<br>
+&emsp;Cognizance: Understanding the Need for Humans<br>
+&emsp;&emsp;Incognizant Faeries<br>
+&emsp;&emsp;Narrowly Cognizant Faeries<br>
+&emsp;&emsp;Highly Cognizant Faeries<br>
+&emsp;Glamour: Rules Instead of a Soul<br>
+&emsp;&emsp;Bodies: Incidental Matter<br>
+&emsp;&emsp;Ownership<br>
+&emsp;&emsp;Stock Characters<br>
+&emsp;&emsp;Taboos<br>
+&emsp;&emsp;Pretenses<br>
+&emsp;&emsp;The Open Body is Vulnerable to Glamour<br>
+&emsp;Vitality: Energy to Act and Change<br>
+&emsp;&emsp;Stories Guide Humans and Faeries<br>
+&emsp;&emsp;Expressed Emotion Feeds Faeries<br>
+&emsp;&emsp;Artistic Expression Feeds Faeries<br>
+&emsp;&emsp;Traditional Offerings Feed Faeries<br>
+&emsp;&emsp;Certain Types of Theft Feed Faeries<br>
+&emsp;&emsp;Spirits of the Borders<br>
+&emsp;&emsp;Murder & Eating People<br>
+&emsp;&emsp;Violence<br>
+&emsp;What Are Faeries Like When Not Seeking Vitality?<br>
+&emsp;Faerie Auras<br>
+&emsp;&emsp;Faerie Presence<br>
+&emsp;&emsp;Epic Events<br>
+&emsp;&emsp;Local Folklore<br>
+&emsp;&emsp;Legacies and Monuments<br>
+&emsp;&emsp;Auras Rise and Fall<br>
+&emsp;&emsp;Traveling Auras<br>
+&emsp;&emsp;Aura Conflicts<br>
+&emsp;&emsp;Gaining Admittance<br>
+&emsp;&emsp;Keeping Home Wonderful<br>
+&emsp;Regiones<br>
+&emsp;&emsp;Finding A Regio Entrance<br>
+&emsp;&emsp;Ephemeral Exile<br>
+&emsp;&emsp;Faerie Roads<br>
+&emsp;&emsp;Regio Levels as Acts<br>
+&emsp;&emsp;Some Regiones Are the Past Made Present<br>
+&emsp;&emsp;Time in Faerie Regiones<br>
+&emsp;&emsp;Withering Away To Dust<br>
+&emsp;Vis<br>
+&emsp;&emsp;Encased Vis<br>
+&emsp;&emsp;Anchors<br>
+&emsp;&emsp;Accrued Vis<br>
+&emsp;&emsp;Sleeping Vis<br>
+&emsp;&emsp;Abstract Vis<br>
+<br>
+**Chapter 2: The Faerie Realm**<br>
+&emsp;The Three Worlds<br>
+&emsp;Getting to Faerie<br>
+&emsp;&emsp;Sources of Threshold Points<br>
+&emsp;&emsp;Geographical Thresholds<br>
+&emsp;&emsp;Temporal Thresholds<br>
+&emsp;&emsp;Personal Thresholds<br>
+&emsp;&emsp;Artistic Endeavor<br>
+&emsp;&emsp;Assistance of Threshold Faeries<br>
+&emsp;&emsp;Assistance of Faerie Magic<br>
+&emsp;&emsp;Arcadian Mysteries<br>
+&emsp;&emsp;The Guardian of the Threshold<br>
+&emsp;Adventures in Faerie<br>
+&emsp;&emsp;Environment and the Faerie Aura<br>
+&emsp;&emsp;The Mother Road<br>
+&emsp;&emsp;Glamour<br>
+&emsp;&emsp;Lands of Story and Fable<br>
+&emsp;&emsp;Vitality and Fable in Faerie<br>
+&emsp;&emsp;Gaining Fable Points<br>
+&emsp;&emsp;Becoming Faerie Through Fable<br>
+&emsp;Creativity in the Faerie Realm<br>
+&emsp;&emsp;Crafting an Offer<br>
+&emsp;&emsp;Offer Modifiers<br>
+&emsp;&emsp;The Promise of Service<br>
+&emsp;&emsp;Changes in Environment<br>
+&emsp;&emsp;Changes in Attitude<br>
+&emsp;&emsp;Changes in Symbolism<br>
+&emsp;&emsp;An Example of Using Creativity<br>
+&emsp;Leaving Faerie<br>
+&emsp;Warping and the Passage of Time<br>
+&emsp;Living in the Story<br>
+&emsp;Spinning Tales in the Faerie Realm<br>
+&emsp;&emsp;Audience Participation<br>
+&emsp;&emsp;Player-Driven Stories<br>
+&emsp;&emsp;Player-Influenced Stories<br>
+&emsp;&emsp;Pitfalls in Player-Run Stories<br>
+&emsp;Arcadia<br>
+&emsp;&emsp;The Inhabitants of Arcadia<br>
+&emsp;&emsp;The Path of Chance<br>
+&emsp;&emsp;Typical Arcadian Guardians of the Threshold<br>
+&emsp;&emsp;Arcadian Stories<br>
+&emsp;&emsp;Planning Arcadian Stories<br>
+&emsp;Elysium<br>
+&emsp;&emsp;The Bible<br>
+&emsp;&emsp;Legends of Ancient Greece and Dead Rome<br>
+&emsp;&emsp;Pagan Legends<br>
+&emsp;&emsp;Romances and Märchen<br>
+&emsp;&emsp;A Thousand and One Nights<br>
+&emsp;&emsp;The Road of Destiny<br>
+&emsp;&emsp;Typical Elysian Guardians of the Threshold<br>
+&emsp;&emsp;Identification as the Hero<br>
+&emsp;&emsp;Elysian Stories<br>
+&emsp;&emsp;Planning Elysian Stories<br>
+&emsp;&emsp;Adding New Scenes<br>
+&emsp;&emsp;Running Elysian Stories<br>
+&emsp;&emsp;The Measure of Success<br>
+&emsp;Eudokia<br>
+&emsp;&emsp;The Forking Path<br>
+&emsp;&emsp;Typical Eudokian Guardians of the Threshold<br>
+&emsp;&emsp;Eudokian Stories<br>
+&emsp;&emsp;Planning Eudokian Stories<br>
+&emsp;&emsp;Leaving Eudokia<br>
+&emsp;Faerie Boons<br>
+&emsp;Story Elements<br>
+&emsp;&emsp;Title<br>
+&emsp;&emsp;Actors<br>
+&emsp;&emsp;The Pied Stranger<br>
+&emsp;&emsp;Grateful Lions<br>
+&emsp;&emsp;The Captive Princess<br>
+&emsp;&emsp;The Task-Setting Ogre<br>
+&emsp;&emsp;The Mouse-Groom<br>
+&emsp;&emsp;The Ferryman<br>
+&emsp;&emsp;The Pale Man<br>
+&emsp;&emsp;Props<br>
+&emsp;&emsp;The Poisoned Apple<br>
+&emsp;&emsp;Mjollnir<br>
+&emsp;&emsp;The Dragon’s Tongue<br>
+&emsp;&emsp;The Swan Cloak<br>
+&emsp;&emsp;The Dull Knife<br>
+&emsp;&emsp;Snake Soup<br>
+&emsp;&emsp;Scenery<br>
+&emsp;&emsp;The Market at the Crossroads<br>
+&emsp;&emsp;Winter<br>
+&emsp;&emsp;The Forbidden Chamber<br>
+&emsp;&emsp;Summer<br>
+&emsp;&emsp;The Glass Mountain<br>
+&emsp;&emsp;The Perilous Forest<br>
+&emsp;&emsp;The Abandoned Shrine<br>
+<br>
+**Chapter 3: Faerie Characters**<br>
+&emsp;Faerie Character Creation<br>
+&emsp;&emsp;Role and Personality<br>
+&emsp;&emsp;Might and Powers<br>
+&emsp;&emsp;Characteristics and Qualities<br>
+&emsp;&emsp;Personality Traits<br>
+&emsp;&emsp;Abilities and Virtues<br>
+&emsp;&emsp;Equipment and Appearance<br>
+&emsp;Faerie Might<br>
+&emsp;Faerie Powers<br>
+&emsp;&emsp;Types of Faerie Powers<br>
+&emsp;&emsp;Power Levels<br>
+&emsp;&emsp;Learning Powers<br>
+&emsp;Faerie Qualities and Inferiorities<br>
+&emsp;&emsp;Improved Characteristics<br>
+&emsp;&emsp;Increased Faerie Might<br>
+&emsp;&emsp;Personal Powers<br>
+&emsp;&emsp;Lesser Powers<br>
+&emsp;&emsp;Greater Powers<br>
+&emsp;&emsp;Skilled Parens<br>
+&emsp;&emsp;Wealth<br>
+&emsp;&emsp;Reduction<br>
+&emsp;&emsp;Susceptible to Deprivation<br>
+&emsp;&emsp;Poor Characteristics<br>
+&emsp;&emsp;Decreased Faerie Might<br>
+&emsp;&emsp;No Fatigue<br>
+&emsp;&emsp;Incognizant<br>
+&emsp;&emsp;Narrowly Cognizant<br>
+&emsp;&emsp;Reduced Might<br>
+&emsp;&emsp;Traditional Ward<br>
+&emsp;&emsp;Vulnerability<br>
+&emsp;Pretenses<br>
+&emsp;&emsp;Long-Winded<br>
+&emsp;&emsp;Poor Liar<br>
+&emsp;&emsp;Poor Memory<br>
+&emsp;&emsp;Poor Sense of Direction<br>
+&emsp;&emsp;Compassionate<br>
+&emsp;&emsp;Fearful<br>
+&emsp;&emsp;Proud<br>
+&emsp;&emsp;Wrathful<br>
+&emsp;&emsp;Envious<br>
+&emsp;&emsp;Greedy<br>
+&emsp;&emsp;Gluttonous<br>
+&emsp;&emsp;Lustful<br>
+&emsp;Designing Faerie Characters<br>
+&emsp;&emsp;The Black Dog<br>
+&emsp;&emsp;The White Lady<br>
+&emsp;&emsp;The Green Man<br>
+<br>
+**Chapter 4: Faerie Bestiary**<br>
+&emsp;Animals<br>
+&emsp;&emsp;Black Dogs<br>
+&emsp;&emsp;Cats<br>
+&emsp;&emsp;Hounds and Huntsmen<br>
+&emsp;&emsp;Horses<br>
+&emsp;&emsp;Owls<br>
+&emsp;&emsp;Ravens<br>
+&emsp;&emsp;Stags<br>
+&emsp;&emsp;Swan Maidens<br>
+&emsp;&emsp;Wolves<br>
+&emsp;Humanoids<br>
+&emsp;&emsp;Bacchae and Maenads<br>
+&emsp;&emsp;Dwarfs<br>
+&emsp;&emsp;Elves<br>
+&emsp;&emsp;Giants<br>
+&emsp;&emsp;Hags<br>
+&emsp;&emsp;Nymphs<br>
+&emsp;&emsp;Old Men of the Sea<br>
+&emsp;&emsp;Satyrs and Fauns<br>
+&emsp;&emsp;Trolls<br>
+&emsp;&emsp;Women in White<br>
+&emsp;Monsters<br>
+&emsp;&emsp;Basilisks<br>
+&emsp;&emsp;Dragons<br>
+&emsp;&emsp;Ettins<br>
+&emsp;&emsp;Gorgons<br>
+&emsp;&emsp;Grendels<br>
+&emsp;&emsp;Harpies<br>
+&emsp;&emsp;Hydras<br>
+&emsp;&emsp;Kelpies<br>
+&emsp;&emsp;Manticores<br>
+&emsp;&emsp;Unicorns<br>
+&emsp;Spirits<br>
+&emsp;&emsp;Fetches<br>
+&emsp;&emsp;Genii Loci<br>
+&emsp;&emsp;Ghosts<br>
+&emsp;&emsp;Nightmares<br>
+&emsp;&emsp;Will-o’-the-Wisps<br>
+<br>
+**Chapter 5: Touches of Faerie**<br>
+&emsp;Humans and Faerie<br>
+&emsp;&emsp;The Legacy of Faerie<br>
+&emsp;&emsp;Vitality and Humans<br>
+&emsp;&emsp;Faerie Warping<br>
+&emsp;Faerie Blood<br>
+&emsp;&emsp;Faerie Upbringing<br>
+&emsp;&emsp;Faerie Friend<br>
+&emsp;&emsp;Faerie Speech<br>
+&emsp;&emsp;Second Sight<br>
+&emsp;&emsp;Ways of the Land<br>
+&emsp;Faerie Sympathy<br>
+&emsp;&emsp;Gaining Faerie Sympathy Traits<br>
+&emsp;&emsp;Using Faerie Sympathy Traits<br>
+&emsp;&emsp;Losing Faerie Sympathy Traits<br>
+&emsp;Faerie Warping<br>
+&emsp;&emsp;Sources of Faerie Warping<br>
+&emsp;&emsp;The Faerie Realm<br>
+&emsp;&emsp;Faerie Auras<br>
+&emsp;&emsp;Faerie Powers<br>
+&emsp;&emsp;Botches<br>
+&emsp;Faerie Calling<br>
+<br>
+**Chapter 6: Faerie Wizardry**<br>
+&emsp;Rites of Faerie<br>
+&emsp;&emsp;Performing Faerie Rites<br>
+&emsp;&emsp;Hermetic Rites<br>
+&emsp;Faerie Methods<br>
+&emsp;&emsp;Evocation<br>
+&emsp;&emsp;Enchantment<br>
+&emsp;&emsp;Empathy<br>
+&emsp;Faerie Powers<br>
+&emsp;&emsp;Beguile<br>
+&emsp;&emsp;Conjure<br>
+&emsp;&emsp;Dream<br>
+&emsp;&emsp;Grant<br>
+&emsp;&emsp;Portage<br>
+&emsp;&emsp;Ware<br>
+&emsp;&emsp;Weal<br>
+&emsp;&emsp;Woe<br>
+&emsp;Faerie Bargaining<br>
+&emsp;&emsp;Ars Fabulosa<br>
+&emsp;&emsp;Summoning<br>
+&emsp;&emsp;Bonding<br>
+&emsp;&emsp;Captivating<br>
+&emsp;&emsp;Dismissing<br>
+&emsp;Pagan Traditions<br>
+&emsp;&emsp;Borrowers<br>
+&emsp;&emsp;Ollamhain<br>
+&emsp;&emsp;Volkhvy<br>
+&emsp;&emsp;Wise Folk<br>
+<br>
+**Chapter 7: Telling Faerie Stories**<br>
+&emsp;Revel in Anachronism & Appropriation<br>
+&emsp;&emsp;Anachronism<br>
+&emsp;&emsp;Appropriation<br>
+&emsp;Be Topical<br>
+&emsp;Use Other Stories<br>
+&emsp;Dissecting Stories<br>
+&emsp;&emsp;Story Flow<br>
+&emsp;&emsp;The Hook<br>
+&emsp;&emsp;The Trigger<br>
+&emsp;&emsp;The Setting<br>
+&emsp;&emsp;The Twist<br>
+&emsp;&emsp;The Resolution<br>
+&emsp;&emsp;The Consequences<br>
+&emsp;&emsp;Dramatic Elements<br>
+&emsp;&emsp;Dramatis Personae<br>
+&emsp;&emsp;The Hero<br>
+&emsp;&emsp;The Villain<br>
+&emsp;&emsp;The Donor<br>
+&emsp;&emsp;The Helper<br>
+&emsp;&emsp;The Princess<br>
+&emsp;&emsp;The Task-Setter<br>
+&emsp;&emsp;The False Hero<br>
+&emsp;&emsp;Acts<br>
+&emsp;&emsp;Interdiction<br>
+&emsp;&emsp;Reconnaissance<br>
+&emsp;&emsp;Trickery<br>
+&emsp;&emsp;Villainy<br>
+&emsp;&emsp;Receipt<br>
+&emsp;&emsp;Transference<br>
+&emsp;&emsp;Struggle<br>
+&emsp;&emsp;Pursuit<br>
+&emsp;&emsp;Ordeal<br>
+&emsp;&emsp;Imposture<br>
+&emsp;&emsp;Reconciliation<br>
+<br>
+**Appendix: Bibliography**<br>
+<br>
+>## List of Inserts
+>
+>### I. Nature of Faerie
+>
+> Where Did Faeries Come From?
+>
+> Story Seed: Base Slander
+>
+> Where Are the Rules for Faeries Feeding on Vitality?
+>
+> Faeries and Truth
+>
+> Does My Character Know This?
+>
+>
+>### II. The Faerie Realm
+>
+> Example Threshold
+>
+> Trods
+>
+> New Power: Spirit Away
+>
+> Faerie Adventurers
+>
+> The Power of God in the Faerie Realm
+>
+> Consequences of Creativity
+>
+> Leaving by Using Merinita Mysteries
+>
+> The Subjective Nature of Time
+>
+> Example Plot Devices
+>
+> Example of Arcadian Story Creation
+>
+> Hermetic Legends
+>
+> Example of Elysian Story Creation
+>
+> A Twist to the Tale
+>
+> Example Story Themes, and Virtues & Flaws
+>
+> Example of Eudokian Story Creation
+>
+> Further Ideas for Actor Story Elements
+>
+> Further Ideas for Prop Story Elements
+>
+> Further Ideas for Scenery Story Elements
+>
+> Ten Thousand More Story Elements
+>
+>
+>### III. Faerie Characters
+>
+> Quick Start Guideline
+>
+> Scale of Typical Might Scores
+>
+> What Do Size Scores Represent?
+>
+> Unspecialized Role
+>
+> An Exemplary Catalog of Faerie Powers
+>
+> Faerie Power Virtue Comparison Table
+>
+> Constant Powers
+>
+> Conversion
+>
+> Powers of Transformation
+>
+> Power Design: An Example
+>
+> Player-Defined Pretense Example Chivalrous Combat
+>
+> Story Seed: Advancement
+>
+> Using Abilities On Faeries
+>
+> Why Isn’t My Faerie a Genius At Every Ability?
+>
+> Two Borders
+>
+>
+>### IV. Faerie Bestiary
+>
+> Story Seed: The Battle of Child Eaters
+>
+> Story Seed: The Tortoise Game
+>
+> Happily Ever After is Just a Pleasant Sort of Death
+>
+> Story Seed: The Deluded Hero
+>
+> Story Seed: Południca
+>
+> Saga Seed: Escape, Then Fortify
+>
+> Story Seed: Searching For Sanctuary
+>
+> Story Seed: A Monstrous Protector
+>
+> Story Seed: The Covenant’s Reputation
+>
+> Story Seed: The Mother of Vis Sources
+>
+>
+>### V. Touches of Faerie
+>
+> Sympathetic Influence
+>
+> Tinting an Aura
+>
+> Examples of Charmed Virtues
+>
+> Faerie Blood and the Soul
+>
+> Faerie Powers for the Faerie Blooded
+>
+> Story Seeds: Faerie Blood
+>
+> New and Modified Virtues
+>
+> Example Greater Benedictions
+>
+> Example Lesser Benedictions
+>
+> New and Modified Flaws
+>
+> Example of Curse-Throwing
+>
+> Sin-Eating
+>
+> Story Seed: The Sorcerous Scapegoat
+>
+>
+>### VI. Faerie Wizardry
+>
+> Faerie Ranges, Durations, and Targets
+>
+> Beguile Guidelines
+>
+> Conjure Guidelines
+>
+> Dream Guidelines
+>
+> Grant Guidelines
+>
+> Portage Guidelines
+>
+> Ware Guidelines
+<
+> Weal Guidelines
+>
+> Woe Guidelines
+>
+> Summoning Faeries
+>
+> Faerie Bargains
+>
+>
+>### VII. Telling Faerie Stories
+>
+> Mistakes To Avoid
+>
+> The Thirty Six Dramatic Situations
+
+# Introduction: Dreams & Nightmares
+
+*Realms of Power: Faerie* is an overview of the Faerie realm of Mythic Europe, written for **Ars Magica Fifth Edition**. It addresses everything from the otherworldly place where faeries apparently originate to the people who use fae influence to fulfill their own desires, and includes all manner of faerie beings that live on the border between these two extremes. These are the things that characters with knowledge of Faerie Lore are likely to know, and depend upon to get along with faeries and those who associate with them.
+
+There are seven chapters to this book, loosely organized into four parts. The first part, **Faerie Visions**, describes the many roles that faeries play on the world's stage, and the places and things over which faeries have the greatest influence (Chapter 1: Nature of Faerie and Chapter 2: The Faerie Realm). **Faerie Envoys**, the second part, describes beings with Faerie Might and how to design and play them for a saga (Chapter 3: Faerie Characters and Chapter 4: Faerie Bestiary). The third part, **Faerie Vessels**, develops human characters who have been invested with the power of the Faerie realm and draw upon it to work different types of faerie "magic" (Chapter 5: Touches of Faerie and Chapter 6: Faerie Wizardry). Finally, **Faerie Tales**, part four, is intended to give players ideas for playing and running stories that involve faeries and the Faerie realm (Chapter 7: Telling Faerie Stories).
+
+## What is Faerie?
+
+Faerie is the realm of power in Mythic Europe most associated with human belief. Conscious and subconscious hopes and fears give the realm its strength, and many think humans actually become faeries through their exposure to the realm. If this is true, Faerie might be described as visions and nightmares made real, fantastic beings given a physical existence and purpose by those whose lives ultimately sustain them. However, while dedicated belief in supernatural beings may cause them to come about through the power of Faerie, it is clear that ceasing to believe in them does not drive them away again. Perhaps, then, Faerie is simply a supernatural repository for human myths and legends that grows stronger as they circulate, but does not weaken if they do not. More information about Faerie — specifically how the power of the realm defines and manifests in beings with Faerie Might — can be found in Chapter 1: Nature of Faerie.
+
+### Faerie & Other Realms
+
+Faerie’s most powerful influence is over the mundane realm, where it does not clash with the other supernatural powers. Generally, Faerie is weaker than the others; it is easily dominated by the Divine and often subverted by the Infernal. The penalties that faeries and those who practice faerie wizardry suffer in these auras are worse than those suffered by Magic creatures and practitioners of magic like Hermetic magi. In places that have no other supernatural presence, however, it is common for faeries to move in and thrive, especially if there are human beings living nearby — human settlements in Mythic Europe rarely go without an aura for very long, and if they do not have a Divine aura, they usually develop a Faerie one.
+
+#### Faerie and the Divine
+
+While the Divine realm tends to treat other powers as either good or evil depending on how they are used, Faerie has an additional disadvantage when compared to Magic in that the Faerie realm is generally perceived as more alien and unnatural, especially by followers of the Divine. Many of them believe that faeries only serve to lead mortals into sin and temptation, and see little difference between them and demons. Of course, the Divine actively discourages the pagan worship that tends to go with Faerie powers. However, since the Dominion protects many places where people experience intense emotion and concentrated belief, there are many faeries that live within it, despite the penalties they endure there, and some faeries even participate in Divine worship. It would seem that the Divine realm encourages this, in some circumstances allowing such faeries to set up small Faerie auras within the Dominion (see Chapter 1: Nature of Faerie, Traveling Auras).
+
+#### Faerie and the Infernal
+
+Faeries are terribly vulnerable to the power of the Infernal realm — not as much as they are weakened by the Divine, but the Infernal actively seeks to undermine and corrupt the power of Faerie, and once a faerie has been subverted by demonic influences, the Divine will cease to distinguish between the faerie and the devils that have marked it. The Infernal realm also takes grim delight in destroying anything and everything, and faeries are often caught in the path of marauding demons. Some faeries oppose the Infernal, and a few unite with it (many people fear demons, and faeries can prey upon that fear), but most faeries are simply unable to understand it. Faeries are amoral by definition; they simply play a role as it is envisioned for them, and rarely choose a side in the struggle between Heaven and Hell. More interesting to faeries is what human beings want, and also what they believe. The Infernal only regards these concerns as means to turn humanity against the Divine, and thus it tends to treat faeries the same way.
+
+#### Faerie and Magic
+
+The Faerie realm has more in common with Magic than with either of the other realms. Like Magic, Faerie rarely concerns itself with morality and immorality. Faerie powers are more compatible with Magic, in that faeries are not penalized by Magic auras, and in fact derive a small benefit from them.
+
+However, Magic tends to favor subjects that are old and rooted to the natural order of things, while Faerie often prefers those that display the vitality of youth and fanciful notions born from imagination. Magic beings strive to improve themselves over time, growing more powerful as they enhance their defining characteristics, and losing their power if they stray too far into the mundane; faeries must adhere to the rules that surround their identities, and have little incentive to change at all, advancing themselves only by encouraging others to advance, and gaining more power only when their defining role changes in an artistically satisfying way.
+
+Many believe that beings of Faerie and Magic opposed each other in the past, fighting great wars between gods and monsters such as the Olympians versus the Titans, the Tuatha De Danann against the Fomorii, or the Æsir and the Vanir versus the Jotnar. Some think that the two realms were once a single realm, and that perhaps it was this struggle or some other cataclysmic event that separated them. As those well-versed in the lore of Faerie know, however, this theory is very difficult to prove — or rather opposing theories are impossible to disprove. Faeries draw upon human stories to form themselves, so it is not uncommon to find faeries playing the parts of beings that seem magical, because those beings appear in the stories that produce faeries. Just as there are thought to be faeries that resemble the ancient gods Zeus, Lugh, and Odin, faerie versions of their fabled opponents Cronos, Balor, and Ymir almost certainly exist somewhere in the Faerie realm as well.
+
+# Chapter One: Nature of Faerie
+
+Faeries are spirits with bodies made of incidental matter, held together with a type of spiritual energy called glamour, and moved with stolen vitality. The bodies of faeries are constructed as temporary vessels for interacting with humans, out of symbolically significant matter. Each interacts with humans through a role, which is a series of symbols that the faerie cannot change, and rules that the faerie cannot break. The intricate mystical rules a faerie must follow are called its glamour, and define its nature and its supernatural powers. The faerie's glamour also defines how the faerie must appear to humans, and how it seeks vitality.
+
+Faeries are drawn, instinctively, to the mutable lives and passionate emotions of humans. Faeries can borrow these capacities from people. This human energy, called vitality by magi who study these things, allows faeries to feel, grow, learn, and age. Many faeries do not know why they are drawn to humans: they lack a quality that Hermetic magi call cognizance.
+
+## Cognizance: Understanding the Need for Humans
+
+All faeries require human vitality, and seek it instinctively. This instinct to seek humans, and catch their attention — to bask in their aliveness — is what separates faeries from creatures aligned to the other Realms. Different types of faerie are aware of this need to varying degrees. And faeries can be divided into broad classes based on their understanding of the relationship between their glamour, role, and need for human vitality. Examples of the following strata are found in Chapter 4: Faerie Bestiary, and each has its own Virtue, described in Chapter 3: Faerie Characters.
+
+### Incognizant Faeries
+
+Those faeries with the least cognizance are often the focus of very simple stories, usually warnings and advice for methods of avoidance or propitiation. Some animals and werewolves, as examples, demonstrate this level of cognizance. They are completely unaware that they derive nourishment from the fear of and precautions taken by humans, rather than from the sheep they worry to death. They usually do not know that their bodies are held together by glamour, and may imagine themselves to be as organic as humans. If their bodies are destroyed, incognizant faeries may create new ones, but have no memory of their previous incarnation. This is the most common sort of faerie encountered by humans.
+
+Not all incognizant faeries are simple creatures. Many powerful faeries act upon complex plans, unaware that by fulfilling any of the overt goals of their plan, they also gain human vitality. When the Queen of Winter kidnaps a baby, and then forces its parents to play a sinister game with the life of the child as the prize, she is acting with this level of cognizance. She desires the child. She enjoys playing ruthless games with terrified adults. She is unaware that this behavior is typical of her type of faerie creature, and that she is harvesting vitality either by gaining a child or by terrifying its parents.
+
+### Narrowly Cognizant Faeries
+
+Some faeries are aware that they feed on human vitality, but understand only a single, narrow mechanism for harvesting it. Take, for example, a faerie wife who deliberately drains the life of her husband away so that she is able to bear a child. She is far more cognizant of her nature than the faerie queen above. Other faeries instinctively reenact variations on a single story. They are unable to consider why this particular series of events provides them the greatest sense of well-being, though.
+
+Narrowly cognizant faeries are aware that they need something from humans, and are usually aware that their bodies are made of enchanted matter. They are able to use their powers strategically, and their memories persist if they create a replacement body. They cannot, however, seek to improve themselves in the way that highly cognizant fairies do. Narrowly cognizant faeries are less common than incognizant faeries.
+
+> # Where Did Faeries Come From?
+> 
+> Members of the Order do not have a definitive answer concerning the origin of faeries, but many speculate. Popular conjectures include:
+> 
+> - Faeries are angels that did not aid God during the Satanic Rebellion, but did not actively rebel. They fell from Heaven, but did not fall all the way to Hell.
+> - Faeries are the descendants of Cain. When Cain was banished to the Land of Nod, he went to Arcadia.
+> - Faeries are the dead of the pagans.
+> - Faeries are the spirits of unbaptized
+> 
+> - children.
+> - Faeries are the spirits of those who died, incomplete, as they crossed a border.
+> - Faeries are the power of human dreams, art, and vision made manifest.
+> - Faeries are spirits that treat humans as prey, feeding on spiritual essences.
+> 
+> It is possible that different varieties of faerie derive from dissimilar sources, or even that different examples of the same variety of faerie do.
+> 
+> This book is about what faeries do – not what faeries are.
+
+### Highly Cognizant Faeries
+
+Highly cognizant faeries are those that may seek out creative humans, because they are aware that these humans provide opportunities for self-redefinition. If they wish to, these faeries can develop new powers by tricking or bargaining with humans. With sufficient human vitality they can change roles, allowing them to become a completely different sort of faerie. Highly cognizant faeries are little concerned by the loss of their bodies, creating and dissipating them as required. Highly cognizant faeries are rare.
+
+## Glamour: Rules Instead of a Soul
+
+Glamour, the term that players are most likely to have heard in relation to faerie magic, is not used outside of a small piece of Scotland in Mythic Europe. It's a mispronunciation of the word "grammar." Faeries emerge from, and change the world through, a set of rules concerning the appropriate placement of symbolic things in relation to each other. Each role has a particular set of rules: its own grammar.
+
+Faeries cannot break their glamour. A faerie who ceases to fulfill its role simply fades away, or perhaps retreats into Arcadia until it re-emerges, in some other form, to participate again in the game of grammar. Etiquette and symbolism are vital to faeries because doing things in the correct way, fulfilling a role in a story, holds the faerie's body and psyche together.
+
+Faeries become more powerful when they participate in stories. A story, to a human, is series of events that will entertain others when recounted after they are complete. To a faerie, a story occurs when symbolic objects and events are placed in sequences that shake vitality free from humans. A faerie need only be an incidental character in a story to harvest some vitality from the human participant. Faeries are fascinated by stories because faeries are living story elements.
+
+#### Bodies: Incidental Matter
+
+When a faerie manifests in an area, it creates its body by seizing nearby objects that are symbolically related to its role, and writing its glamour into them. This spiritual anchor then draws to itself dust, water, and other incidental matter to create a substantial form that is granted cohesion and superficial appearance by the faerie's glamour. Incognizant faeries feel pain when their bodies are damaged, narrowly cognizant faeries must appear to, and highly cognizant faeries suffer pain only if they wish to.
+
+The role a faerie plays determines how the matter of its body is arrayed. When a faerie has the role of a fox, it must look and act like a fox. The ugliness of spirit in a malicious faerie is expressed through its appearance. Beautiful faeries can generally be trusted to be kind and good.
+
+Some stories, however, allow faeries to have predatory roles. Bluebeard, for example, who is handsome, passionate, and solicitous of his wife, changes physically when the heroine breaks a taboo and sees something he tells her she must not see — the corpses of his previous victims. He is required to be as physically as hideous as the actions that his glamour requires. In each half of the role, a character reading the mind of the faerie would find appropriately benign or murderous thoughts.
+
+It is a source of endless frustration and fascination to the fae that humans have an inner life. Humans can talk to themselves inside their heads, and interpret events, and console themselves with explanations. Humans interpret themselves through a continuous process of internal autobiography. Faeries are either incapable of that level of self-reflection, or are unable to act on it while in material forms. Faeries have a rulebook instead of a soul.
+
+If its body is catastrophically disrupted, the faerie may not have sufficient time to draw its glamour from its spiritual anchor. The spiritual anchor, filled with glamour, is the vis that magi hunt so earnestly. Most of the faeries described in Chapter 4: Faerie Bestiary have mundane objects in which they have stored their vis; these are examples of spiritual anchors.
+
+Some faeries have unusual anchors, which are purchased with Virtues described in the Chapter 3: Faerie Characters. Some faeries place their spiritual anchor at a distance from the rest of their material form, snapping the Arcane Connection as the body becomes useless. Others keep their spiritual anchor at hand, but place sufficient of their power in it that it offers a minor supernatural ability to a human that possesses it. These well-maintained anchors allow the faerie to build a new body far more swiftly.
+
+#### Ownership
+
+The clothes and tools of faeries are usually parts of their bodies, created by their glamour. The things that a faerie owns usually cannot pass from its possession except with its permission, or by completing a story in such a way as to change the ownership of the item. Items taken from faeries that they do not wish to relinquish turn into incidental matter, like leaves or coal, when the faerie withdraws its glamour. This usually happens when the thief leaves the Faerie aura. Any vis in these items vanishes, as well. All of a faerie's possessions, if generated from glamour, are Arcane Connections to the faerie until it changes its role.
+
+Faeries acknowledge that those things that form Arcane Connections to a human are an extension of the life of that human, and that to steal them is to steal part of the human's life. Mortal goods that lack Arcane Connections are considered not owned, and faeries feel no compunction against taking them. Those things that are not part of a particular mortal's life, because they contain a vitality of their own — like milk, beer, risen bread, and gemstones — are particularly valued, and therefore frequent targets of what mortals call theft.
+
+Some powerful faeries spread their glamour over a large area surrounding their spiritual anchor. They embody many, or even every, object in their surroundings. These faeries usually also generate a human body in order to direct the attention of guests to a certain focus. They then appear to be human-like and have mystical control over their surroundings, but are actually only controlling distant parts of their bodies. Incognizant faeries may be unaware of this.
+
+#### Stock Characters
+
+Faeries take roles in stories so that they can interact with humans, but often do not take on personas, which is one of the ways they can be detected. In **Ars Magica**, unlike many other role-playing games, troupes are encouraged to design specific monsters and specific people for the player characters to encounter. Many faeries, however, lack the subtlety required to impersonate humans successfully. The characters these faeries assume are, to a greater or lesser degree, caricatures. Faeries pretending to be humans often seem like representations of the stock characters that appear in folk tales.
+
+Faeries tend to gloss over details. A faerie pretending to be a healer may carry a bag of medicines, but a real healer looking in it would know that the collection of colored liquids, herbs, and seashells is just a prop. Some faeries pretending to be healers just carry a single, sovereign remedy, and a large silver spoon. The remedy works because of the faerie's magic, not because the horrible concoction has medicinal value. Similarly, when asked for names and biographical details, faeries passing for human often lack the creativity to convincingly lie, so they give vague, general answers.
+
+#### Taboos
+
+The glamour of each faerie contains rules that the faerie must obey. Some actions are mandatory, but others are forbidden. The taboos kept by individual faeries vary, and are detailed as Flaws in Chapter 3: Faerie Characters. A human breaking the taboos of a faerie offends it, and owes it redress.
+
+Humans dealing with faeries should avoid breaking any of their taboos. These usually revolve around hospitality, carrying iron, using names, ownership of objects, payment for favors, religion, and opening the body to influence. Human characters, at creation, may take a broken faerie taboo as a the cause of a Story Flaw like Plagued by Supernatural Entity or Enemy.
+
+#### Pretenses
+
+Faeries pretend to have human Abilities, but instead simulate them with minor magical powers called Pretenses. Pretenses do not cost Might, and faeries use them without Concentration — they are an expression of glamour. Players use the mechanics for Abilities when using Pretenses, but faeries cannot learn Abilities through experience as humans do. They instead develop the power to mimic superior human models, causing their Pretense scores to rise through the methods described in Chapter 3: Faerie Characters.
+
+> # Story Seed: Base Slander
+> 
+> A bard in the employ of an enemy of the covenant is spreading lies about its prominent servants, slandering their moral character. Unknown to the bard, one of these servants is a faerie. When the faerie next visits the area where he has developed a negative reputation, how he responds is affected by his level of cognizance.
+> 
+> An incognizant faerie may continue to behave normally, because he subconsciously calculates that the vitality he gains from retaining his current role is superior to that he would gain from the new interpretation. Or he may develop new personality traits based on the bard's stories. As a third option, he might instead switch back and forth, unaware of the changes that take place depending on his audience, garnering the maximum vitality from each person. The other player characters eventually notice this, and must rehabilitate the reputation of their colleague, so that, subconsciously, he decides to return to his previous role.
+> 
+> A highly cognizant faerie is able to feel the potential vitality in the new story, and consciously act to harvest it. His strategies might mirror those of less-cognizant faeries, or he might take more-subtle action. For example, he faerie may recruit a second cognizant faerie, and reveal him to the populace in the role of his evil twin brother, allowing the two to develop a lucrative public feud. Or the faerie may attack the veracity of the bard, arranging humiliating experiences that erode his believability. The faerie might also kill the bard. Cognizant faeries know they need humans, but they also know that they rarely need specific humans.
+
+If the faerie is deliberately using a Pretense to accomplish things no human could, then any character who is a master of the simulated Ability notices this immediately. Other characters may notice, or not, depending on their level of credulity. A character who has mastered an Ability, which is represented by a score of 6 or more, may notice that the faerie is using subtle magic instead of that Ability, even if it stays within human possibility. This requires a Perception + Awareness check of 12 – the Ability score the faerie is pretending to have.
+
+The fata, for example, are faeries who inconspicuously join the sessions of weaving and gossip among elderly ladies in some villages. These women, who are mistresses of the craft of weaving, might notice that the fata's fingers are not making all of the movements required to weave cloth, and are not moving fast enough to create it in such volume. It's rude to point this out, because it tells the fata she is playing her role badly and scares her away, but they watch what they say in her presence.
+
+#### The Open Body is Vulnerable to Glamour
+
+Any opening of the body allows faeries to attempt to influence the character of a human. Parts of the person can spill out and be taken by the faeries, but also, faeries can slide their glamour into the person and enthrall him. These links can be purged by contact with Traditional or Sovereign Wards, which are described in greater depth in Chapter 3: Faerie Characters.
+
+By speaking, the character lays himself open to fairy dominance, because the faerie has the right to reply. And when the faerie's words enter the character's head, they can carry a piece of glamour. Humans can also change the faerie with their eloquence, and Free Expression Virtue. This is why faeries so often paralyze the tongue of their victims, or forbid them to speak. Speaking to a faerie creates an Arcane Connection to that faerie with a Penetration multiplier of 2 that endures until the conversation ends.
+
+If a character eats the food of a faerie, the character becomes the guest of the faerie, and, like medieval guests, cannot leave the court without permission. By eating the host's glamorous food, the guest takes a fragment of the host's power into his body. This makes him part of faerie society — a servant of the one whose food he ate. This also creates an Arcane Connection to the glamour the character carries, with a Penetration multiplier of 2 that continues until the character is permitted to leave.
+
+> # Where Are the Rules for Faeries Feeding on Vitality?
+> 
+> There is no numerical system for vitality. Faeries do not gain a number of vitality points when watching a story conclude, and then spend a number of vitality points per year to survive, or to gain new powers. Faeries can survive indefinitely without vitality; they just never want to.
+> 
+> Faeries always want more vitality, regardless of how much they already have. They are chronically addicted to people, as part of their Essential Nature. This is what differentiates faeries from magical spirits, who care about humans if it suits their nature or purposes, but do not incessantly desire human attention.
+
+Wounds bring the character closer to the faeries that guard the border of mortality, or who are themselves the dead. When a character is wounded, he is effectively leaking the vitality that fairies crave, and this may make them act in ways uncharacteristic of their roles. A character whose blood is taken or tasted by a faerie has an Arcane Connection to that Faerie with a Penetration multiplier of 3 until the wound heals.
+
+Sex with a faerie can create Arcane Connections, and allow the body of the victim to be controlled by the faerie. While carrying a faerie's child, a human mother sometimes develops supernatural powers; but the faerie father can usually find her, and often wishes to steal the baby away. Intercourse with a faerie creates an Arcane Connection to that faerie with a Penetration multiplier of 4 during the intercourse. Pregnancy creates an Arcane Connection between the parents with a Penetration multiplier of 5 until it ends.
+
+## Vitality: Energy to Act and Change
+
+Some humans have more vitality than others do. Faeries subconsciously sense this greater supply of nourishment, and seek it out. Humans are more vital when their emotions are roused. Some humans have the ability to find new ways to feed vitality directly to faeries, and other humans can follow the feeding methods that creative individuals establish. Humans are more vital when they are about to enter or leave a stage of life. Humans also carry vitality in the physical structures of their bodies, so some faeries eat people, or suck their vitality away with their blood.
+
+### Stories Guide Humans and Faeries
+
+Faeries both mold, and are molded by, the stories told in the communities that adjoin their homes. A story is an etiquette — a way for humans and faeries to promise each other rewards. The faerie knows it will get vitality from the human's roused emotions and, perhaps, change of life stage. The human gets rewards similar to those claimed by past heroes. The actions of faeries change the stories that humans tell, but faeries also change their actions and appearance to suit the stories that humans remember.
+
+#### Expressed Emotion Feeds Faeries
+
+Some faeries, through repeated, similar interactions with humans, develop a preference for a particular expression of vitality. This faerie's presence and behavior then enter local folklore. Stories about the faerie are told to younger members of the community, so they know how to interact with their strange neighbor. If the story spreads to other places, new faeries are drawn to the story and the human vitality it promises. In this way, new species of faeries, demonstrating minor regional variations, can spring up in the wake of a quick-moving story that captures the imagination of those who hear it.
+
+Other faeries sense the expectations of humans they encounter, and adapt to suit them. The faerie master of a small wood might take many shapes, from terrifying ogre to tempting woodwife, depending on which will draw the most vitality from the human currently in the wood. Some faeries are aware that they change shape to provoke humans. Others forget they had previous shapes, and recall only interactions had in their present form.
+
+Many faeries seem superficially similar to creatures from other Realms. It is easy for an untutored person to mistake the Magical spirit of a woodland glade, or an Infernal poltergeist, for a faerie. This is because faeries often borrow the shapes of these creatures, to complete stories.
+
+Faeries often ally with covenants because magi seem to be regularly beset by trouble, which lead to stories and heightened emotions. Adventuring parties are, on one level, a source of flavorsome food for faeries.
+
+#### Artistic Expression Feeds Faeries
+
+Artistic works that cause a lift in the spirit of humans can feed faeries. The producers of such works usually have the Free Expression Virtue. Noble faeries often seek out bards, storytellers, and other artists for this reason. Lesser faeries often lack sufficient cognizance to seek out artists, but are still able to feed on the vitality of art. Some magi think that the unfettered imaginations of children allow them to feed faeries in a similar way to artists, partially explaining the common desire among faeries to steal children, but this is disputed.
+
+#### Traditional Offerings Feed Faeries
+
+Traditional offerings are the pivotal elements in simple tales. Each bowl of porridge left on the doorstep, tiny suit of clothes on the mantel, or pot of cream in the dairy also expresses a little hope or fear, which faeries can feed upon. Pagan gods were, some magi conjecture, fed with a similar mechanism, although on a far larger scale.
+
+Violent faeries are fed by the traditional wards that protect against them. There is little difference, metaphysically, between a brownie given milk on the doorstep and a vampire given a tribute of garlic over every windowsill, although the vampire and brownie lack the cognizance to realize this.
+
+#### Certain Types of Theft Feed Faeries
+
+Some faeries can consume the vitality out of particular objects, even if they are not offered as part of a traditional transaction. These faeries are likely to be thieves, because they do not see ownership in human terms. Individual faeries may draw strength from various objects, but the things they steal all seem to possess a natural vitality. Faeries have been found that are able to feed on milk, ale, wine, leavened bread, moldy cheeses, and gemstones. (Most gemstones, in Mythic Europe, reproduce sexually deep beneath the surface of the Earth, after all.) It may be that some faeries can naturally feed on the vitality of these items, or that these are the offerings of forgotten traditions. Faeries lack human concepts of ownership, and may see a human going to the effort of baking bread, milking a cow, or mining a stone, and then leaving it unowned, as a form of offering.
+
+### Spirits of the Borders
+
+Faeries reside in liminal states — that is, they are the spirits of borders. Human vitality surges when a person crosses from one stage of life to another, so people about to make these transitions are the most likely to encounter faeries. Human emotions are roused when they venture beyond their homes and into dangerous places, so many faeries live at the edges of communities. Some faeries are guides between states of consciousness, as well, while others patrol the borders between social classes, ethnic groups, and periods of time. Many faeries embody two liminal states simultaneously. Chapter 4: Bestiary gives examples of faeries that dwell in each liminal space.
+
+### Murder & Eating People
+
+Some faeries feed on humans by consuming their vitality directly. People assailed by these faeries feel lethargic, and if they continue to be harvested, they become weak and then die. Other faeries consume vitality by drinking blood, eating flesh, or sucking the breath from humans. Some magi believe these faerie can ingest vitality directly. Others suggest that these faeries feed on terror, or feed on the offerings of traditional wards. Occasional murders become necessary so that the terror and warding continues. The faerie, they hypothesize, eats victims simply to be shocking.
+
+### Violence
+
+One way of rousing emotions is by threatening people. The threats from faeries take several forms. Some threaten to kill, unless kept away by folk rituals. Some merely threaten harm to people or property, again harvesting the vitality they gain from traditional wards. Others attack humans, so that the humans will kill them. A few do kill, but only so that their reputation spreads. A few faeries encourage violence on a larger scale — family feuds and village warfare are sometimes stoked by faeries pretending to be ancestors, or taken as spouses.
+
+Many faeries engage in violence with the expectation that they will suffer, and perhaps even seem to die, at the hands of the human foe they face. Many of the more violent forms of faerie have ways of mitigating the effects of violence. Others simply lack sufficient cognizance to understand that defeat by this particular hero will lead to interaction with generations of future heroes. Each will defeat the faerie, and in so doing, feed it attention and violent passion.
+
+> # Faeries and Truth
+> 
+> One of the most important borders that faeries straddle is that of belief. People in Mythic Europe do not believe every faerie story they tell. Nor do they dismiss them all as a false. Each faerie story might be true or not, and different versions of a story might be true, or false, or a mixture. Stories are told because they are amusing, and might be valuable. Similarly, faeries don't care whether stories are told accurately or not, provided the stories still engender heightened emotions and traditional gifts. The only faeries that require humans to fervently believe in them are those that feed primarily from the gifts of worshipers. This method of feeding has been rare since the Church rose to dominance.
+> 
+> *Desire* that the story be true matters more than that it *actually* be true. That a story be told is more important than that it be told accurately.
+
+## What Are Faeries Like When Not Seeking Vitality?
+
+Magi don't agree on what faeries are like when they are not interacting with humans. The key problem for researchers is that faeries will provide confirmatory evidence for any theory, if it will lead to further research. Faeries treat attempts to understand their nature as a form of traditional offering, and try to complete stories around the researcher's dream of enlightenment or glory. Many theories about faeries are popular, though, and different theories may be true for different faeries, or even for the same faerie depending on whether it's in Arcadia and the mundane world. These possibilities include:
+
+- Faeries have permanent identities and a complex society in Arcadia, hidden behind a defensive façade of stories.
+
+- Faeries act freely when humans are not watching, but select a role suited to their audience when a human is encountered.
+
+- Faeries act freely when unobserved, but are forced into a role that suits an observer.
+
+- Faeries continue to play their role in whatever story they were last involved with, until they find a new audience. If the story concludes, it begins again, repeating endlessly until a human intervenes.
+
+- Faeries don't do anything when people aren't watching. They just wait for human observers. Humans that repeatedly visit a group of faeries may not realize that the faeries lose motivation in their absence. When the faeries restart the story, they may skip events so that, to the human, the narrative seems to have progressed.
+
+- Faeries don't even remain physically incarnate when people aren't watching. It is impossible to find the same faeries repeatedly. When humans appear, a faerie present will adopt whichever available role is most prominent and likely to allow a harvest of vitality, and so often switches characters.
+
+- Faeries cease to hold their roles when people cease to observe them, even for an instant, and new faeries seize each role as human attention returns.
+
+> # Does My Character Know This?
+> 
+> The Faerie Lore Ability quantifies the character's capacity to understand the motives of, bargain with, and predict the actions of faeries. Some characters with high Faerie Lore do this through an encyclopedic knowledge of the roles faeries have played in recorded events. Some do this through an intuitive sense of what is correct in faerie-related situations. Some calculate the faerie's reaction through the framework given in this chapter. Your character may use this framework if that suits your personal preference, but there is no in-play disadvantage to characters who have other perspectives. For example, a character who worship faeries as gods, and learns Faerie Lore from the sacred texts of his religion, is just as capable of predicting what faeries will do, and negotiating with them, as a character who views them in a more secular way. In part, this is because faeries deliberately modify how they respond to humans to suit the human's attitude toward the fae.
+
+### Faerie Auras
+
+Auras arise in those places where the fae are strong. Events that promote the well being of the fae make auras more powerful, and auras decline if the faeries leave them. Faeries often change their roles to continue to reside in an area once humans have altered it, but faeries that wish to continue in their old roles are forced to continually recede, as the wilderness does. If humans drift away from an area, faeries may desert it as well, to flock closer to the vitality they crave. In some distant parts of the wilderness, however, some incognizant faeries continue to play roles defined in pagan times, at sites where they were worshiped.
+
+Potent faerie auras are found at the edge of civilization's influence. The courts of faeries are usually in the ring of semi-settled land that that separates the true wilderness from the Dominion. Other auras emerge in places within human cities that have been abandoned. Some also haunt the dangerous places where humans regularly go, like mines, the sea and mountain passes.
+
+#### Faerie Presence
+
+The presence of any faerie with the Extend Glamour Power creates an aura. Any place that such a faerie claims with its glamour has an aura of (Faerie Might / 5). If such a being moves away or is destroyed, the aura immediately vanishes unless another faerie steps into the role. If many faeries live in an area, it is usual for only one to claim the territory with its glamour, and only this faerie's Might generates the aura.
+
+At times, two powerful faeries may clash over an area. While both pour their glamour over the area, it has an aura of 2+(highest Might/5) to a maximum of 9. Each of these faeries may be supported by others in the roles of its retainers, but they do not add to this total. This is most often observed when seasonal courts battle for the control of an area, at the equinoxes or solstices. Magi have also reported times when co-rulers of a court, or challengers for the role of ruler, have fallen into dispute, causing the aura to surge and each side to seek mortal supporters. Areas filled with minor, territorial faeries may have high auras because of this friction between their glamours.
+
+#### Epic Events
+
+The sites where epic events are believed to have taken place, which are recorded in popular tales, often have faerie auras. This is not, magi have discovered, because events imprint themselves in the landscape — though that sometimes creates Magic auras. It is because faeries flock to legendary sites to feed on the vitality of the humans near them by assuming the resonant roles that the humans expect. A Merinita magus of the Stonehenge Tribunal first explained this to his sodales, after the many duplications of Arthurian sites in the area enabled him to visit several places that seemed to be Camelot — near Edinburgh in Scotland, within Winchester in England, and near Caerleon in Wales — and meet at least three Arthurs.
+
+#### Local Folklore
+
+Every villager knows there are some places where it is dangerous to go, because the faeries dance, or feast, or live there. It's not clear if the story that a particular faerie lives in an area always precedes the formation of an aura in a place, or if a faerie new to an area deliberately confronts humans to spread its fame. It is obvious to magi that once there is either a chicken or an egg, each possible cause contributes to the other: the story makes more people aware of the faerie, while encounters with the faerie encourage people to tell its story. If a local faerie is destroyed, another rapidly seeks its role.
+
+Some faerie auras lack obvious principal faeries because the site itself draws sentimental power from folklore. Humans come to these sites and repeatedly fulfill simple stories without prompting, so the resident faerie need never bother with a material shape. These sites include lanes and glades frequented by courting lovers, and diving pools and caves where young men challenge each other's bravery.
+
+#### Legacies and Monuments
+
+Ancient sites of pagan worship often have faerie auras, because the faeries that dwell in them refuse to leave, even when humans ignore them. These faeries may be incognizant, and therefore unable to understand that they can leave. Some trapped faeries are narrowly cognizant, and are only waiting for a human to come and conclude their story. A few are highly cognizant, but enjoy their current role so much that rather than relinquish it, they are willing to wait for a human to arrive so that they can attempt to modify it.
+
+#### Auras Rise and Fall
+
+When a foreign aura impinges on a faerie area, it increases or reduces the Might of the faerie generating the aura. This causes the aura to rise or fall. Other activities can cause the aura to change in local areas, by making the area more or less suited, symbolically, to the glamour of the presiding faerie. If part of a forest lord's territory is felled and tilled for crops, for example, it loses its connection to his glamour, and its aura. If another faerie takes control of the area, or the forest lord redefines its role as a fertility faerie, then an aura returns.
+
+When a magus begins to take vis from a Faerie aura, the presiding faerie must decide on a response. If the faerie prevents its removal, the vis remains the faerie's and the aura does not fall. If the faerie is unable to prevent the extraction, the magus has effectively challenged the faerie's ownership of the area and the aura falls by 1. Each extraction further distances the area from the glamour of the faerie, causing the aura to fall until the faerie relinquishes the area entirely. This hole in the aura is usually only 300 paces across, but may be larger or smaller if the magus performing the extraction operated in a space that could be easily labeled, like a glade, an island, or a barn.
+
+The faerie may regain control of the area, and renew its aura, by seeking redress. The faerie must take something from the magus that symbolically balances the vis he has stolen. Faeries and magi may make deals that allow the removal of vis, in exchange for something of equal value from the magi. Note that this means equal value to the faerie, not the magus; simple rituals performed when gathering the vis may suffice in some cases, while other faeries might demand a season of service. This does not challenge the glamour of the faerie, provided the magi do not breach the conditions laid upon them by the faerie. To prevent damage to the aura, the faerie usually takes vis from elsewhere in its demesne and releases it into the harvested area.
+
+#### Traveling Auras
+
+The role of some powerful faeries permits them to travel. When they do, their glamour encircles them, sweeping over the countryside, then retreating as they pass. When a faerie travels with glamour extended, the land around them seems to twist into new shapes that suit the faerie's motif.
+
+The basic geography of the region does not change when the faerie spreads its glamour. Local people do not believe they have been swept away to another country: even if the change happens while they sleep, they will know that their own land has been changed around them.
+
+The changes made when the glamour of the faerie lays over an area are not permanent, unless the faerie wills them to be and uses an appropriate power, but the effects of human action are. If, as an example, a Queen of Winter freezes a village, then the crops that have shriveled beneath her glamourous snow will return to health as she departs, unless she makes an effort to destroy the crops by feasting on their vitality. Cattle, or people, that freeze to death will revive as if they have slept, unless the Queen makes a special effort to murder them under the cover of glamour. If a human chops up a table for firewood and burns it to keep warm, then the table will still be destroyed.
+
+#### Aura Conflicts
+
+A faerie that enters an area dominated by another Realm, if it has not followed a traditional method of gaining admittance, must withdraw its glamour into its own body. This barring occurs regardless of the strength of the other aura. This inability to pour glamour over objects means that faerie characters cannot use powers with Ranges greater than Touch until they have been given leave to do so, unless they have Arcane Connections to the targets.
+
+If the faerie has gained admittance to an area, then it is able to pour its glamour over its surroundings. This creates a tiny pocket of Faerie within the larger aura. The area may transform to suit the motif of the faerie, but generally does not. The hospitality that faeries invoke varies by place and method, and has limitations that may prevent such overt changes.
+
+#### Gaining Admittance
+
+Each area has different methods of gaining admittance, and faeries can read these with their Sight. Typical methods include:
+
+Many Magical and some Infernal areas are not home to any conscious thing. Faeries can sense that this is not a "home" automatically — that it is **terra nullius**. Note that all Divine areas are attended, as are all Faerie places.
+
+**Having the right**, recognized in local folklore, to enter at certain times or when certain events occur. Some urban faeries, for example, simply have the right to exist in their city. When a hero kills a giant, and the same faerie returns in the guise of its brother seeking revenge, it has tricked the hero into giving it the right to seek the hero out, even if he is within the Dominion.
+
+**Being invited in** by a human aligned with the spiritual force that holds the faerie at bay. In the Dominion this is relatively simple. A human that invites a faerie into a home as a guest gives the faerie leave to use its powers in that house. A human responding to the faerie with fear gives it permission to do the things that are feared. Many medieval people reflexively face their fear by calling on the power of the Divine to save them, which withdraws this permission.
+
+Likewise, in a covenant an invitation into a house may grant the faerie leave to use its powers in that house. But only participation in the Aegis of the Hearth ritual, and possession of one of the tokens this creates, allows a faerie to use its powers without facing the formidable magical resistance common to covenants.
+
+**Agreeing to a code of behavior** that severely limits the faerie, like forsaking actions that would be sinful for a human while within a town, or performing a profane actions for the amusement of demons.
+
+**Paying a price**, like offering a service or a small faerie as a servant, in exchange for entrance. Some courts of faeries pay Hell a human soul every seven years, in exchange for access to the seedy parts of cities.
+
+**Contesting for ownership** of a place with a local faerie. This boosts the aura of the place while the contest occurs, but each faerie might become a supporting character to the other's role.
+
+#### Keeping Home Wonderful
+
+When a faerie leaves its traditional demesne, it may mark the place so that it retains its wonder if a human visits while the faerie is absent. Few faeries wish for humans to believe that a place sanctified by folklore has been abandoned. The faerie may mark its demesne in one of three ways. It may leave a steward, it may leave its essence, or it may block access to its site.
+
+Principal faeries peruse different strategies when they travel from their usual haunts. Some powerful faeries **leave a lesser steward** in their place, to tend the site until they return. Their return is usually rapid, because a faerie's steward is a servant, and contains a little of the faerie's glamour. This glamour provides an Arcane Connection used for rapid travel.
+
+A faerie with the External Vis Virtue may **leave its spiritual anchor** in its site, allowing its body to roam. If the court is visited, the faerie simply sheds its distant body and appears around its anchor.
+
+Some faeries ensure that local folklore suggests their sites are **accessible only at certain times**. The lord of a barrow said to open to Faerie every Midsummer's Eve can simply leave, knowing that humans who seek him will wait for a time that he finds convenient.
+
+Regardless of the method used to slow or dissuade human visitors, the lesser faeries of the court may be left behind with instructions on how to deal with unexpected audiences.
+
+ Humans surprising the faeries may discern that the aura of the site is lower than expected, though. If they enter an area kept by a steward, then its aura will be (steward's Might/5). If they enter a site lacking a steward, that is meant to be accessed only at set times, they may find it abandoned. A character breaking into a faerie barrow on an unseasonal day may simply find the dusty remains of a Saxon king.
+
+## Regiones
+
+Regiones (see **ArM5**, page 189) are very common in Faerie areas. They are caused by an affront or injury to the glamour of the presiding faerie in a regio.
+
+#### Finding A Regio Entrance
+
+Faerie regiones are often far easier to enter than the regiones of the other Realms. Magi who study Faerie suggest that this is because the faeries desire humans to seek them. A character almost always enters the regio by performing an action, and a character who has successfully perceived the correct action can explain it to others, but cannot perform the action on their behalf. For many regiones, the action is simply walking through a symbolic doorway, but it may include defeating a particular menace or solving a riddle.
+
+Characters may find the entrance to a faerie regio in several ways.
+
+A character with **Faerie Sight, Second Sight, or Magic Sensitivity** can, at an appropriate place, read how to enter the next level of a faerie regio with a Perception + Awareness roll against an Ease Factor of (5 + twice the difference between the current aura and the next level). Characters seeking regiones sometimes gain one of these Virtues temporarily by using folk charms.
+
+If the faerie that claims the region **wants the characters to enter**, they can. The faerie may send a minion to make the entrance obvious, by guarding it for example, or may make it seem that the character can find his own way in. For example, a mother who can hear the cry of her stolen child, guiding her into the regio, may well be listening to a faerie imitating her baby.
+
+A person who has learned the **symbolic action** required to enter, either from a human who has perceived it or from a faerie guide, may perform it.
+
+A person with an **Arcane Connection** to something in the regio, and the ability to sense Arcane Connections, can automatically find the entrance by following the connection, but will not necessarily know the required action.
+
+Regio entrances can be seen with **Intellego Vim spells**, like *Piercing the Faerie Veil* (ArM 5, page 158).
+
+A character whose **True Love** is within the regio can always find the entrance, and although he will not necessarily know the method of entry, faeries, either serving the regio's principal or stealing some of the vitality from the story, will give it to the character, although this may involve some other trial.
+
+A character who has found an entrance, but does not know the action required to open it, may use **Faerie Lore** to guess it, based on the motif of the local faeries. This requires an Intelligence + Faerie Lore roll against an Ease Factor of 15.
+
+This target is reduced if the story the faeries are telling reduces the range of likely actions, so that the magus is simply weighing their suitability. For example, if the magus is told that before a particular door will open he must either blow a horn or draw a sword, and if he chooses incorrectly he will be cast out, then the Faerie Lore roll has a target of only 3. This choice is common in folklore, and the magus understands clearly what each tool symbolizes, so he knows he needs to blow the horn to open the door.
+
+Also note that if a regio leads to Faerieland, then the principal faerie of the regio is often the threshold faerie. Entrances to Faerieland from a faerie regio are treated as regio levels with an aura of 10, unless a trod runs through the regio. Then the rules for trods, given in Chapter 2: The Realm of Faerie, apply.
+
+#### Ephemeral Exile
+
+Faeries may not steal those areas marked by God, the Infernal Realm, or magical spirits as theirs, but the converse is not true. When another Realm attempts to steal the home of a faerie, the faerie may flee to a new place, or may instead choose to duplicate its part of the the mortal world. This duplicate, which is made of the glamour of the faerie, touches the real world only where the invading power is comparatively weak. The faerie may often touch the world in points of traditional strength, where humans, seeking the faerie, tacitly invite it to reach out to them and draw them in.
+
+Faeries may bargain with the power that dominates the material world, seeking lenient terms allowing access to humans, however. Much as faeries offer gifts and services for the hospitality of alien powers, so they offer similar things for the right to influence the real world at certain specific times and places. But some faeries do not bargain: they choose to wait out their exile, or to only have access to humans lucky or misfortunate enough to stray into the power of the faerie.
+
+#### Faerie Roads
+
+Faeries do not need permission to enter an area when they have the "right of way" — the ancient right to travel through a locale. In many parts of Europe there are certain paths known to be used by the fairies as they travel. These roads are also, commonly, the paths used to carry corpses from isolated villages to a central church for burial. In many areas it is considered unlucky to use a different road than the traditional one when carting a corpse.
+
+How the faeries and the corpse roads are linked varies from place to place. In some areas the faeries made the roads in ancient times, and thus own them. In others, the carrying of a corpse creates a liminal space — a space where the living and the dead travel together. The road is not entirely of the mortal world anymore, and the faeries can claim it. Characters traveling a faerie road are usually left unmolested, although they may be aware that invisible spirits are traveling around and through them.
+
+Faeries are particularly careful not to molest funerals on the road because these processions have a greater right of way, and they may actively assist pall bearers. For instance, along most corpse roads are places to rest coffins. The faeries who dwell near the road keep these places clear, and protect the springs that are sometimes found at stops. Other travelers, unaware that they are on a faerie road, are punished if they desecrate such places.
+
+As an example, pall bearers are allowed to camp at certain sites on the faerie road, but others may not be. If camping is allowed, humans will still be punished if they camp in the wrong place, or break a taboo. In many places a camper would be punished for chopping down trees, going to the toilet inside the cleared area, or failing to leave beer or bread as a token of thanks. Characters with Supernatural Abilities who camp on corpse roads often see dead travelers, but these encounters should not lead to combat. Fighting on the road is generally taboo.
+
+Also, characters with mystical abilities traveling a faerie road may slip onto an aspect of the Mother Road, described in Chapter 2: The Faerie Realm. Characters traveling on a faerie road do not feel that they are traveling faster than normal, because they are required to make every step along the road. The unpredictable flow of time in faerie is what differs from that of the normal world, so that they arrive at a distant place more quickly or slowly than usual. Characters bearing a corpse never miss the funeral, because of the strange flow of time on a Faerie road.
+
+Each faerie road has an owner or caretaker. If a human slips into the regio along the road, he must meet this threshold faerie. It is usual to pay a traditional toll for use of the road. Some people fight the faerie instead, and use the road by force. But if the faerie is merely the caretaker for a greater power, this may rouse all of the faeries of a region against the transgressors.
+
+Corpse roads are the most common form of faerie road, and faerie roads are the most common type of trod (see Chapter 2: The Faerie Realm). Not every road a corpse is carried along remains a faerie road, although many become one, briefly, while the corpse passes.
+
+#### Regio Levels As Acts
+
+When two powerful faeries clash over a site, they play a game of symbols that may result in the glamour of one infecting the other. This makes the victorious faerie the principal faerie of a site, dominant over the other, but not to such a degree that the lesser faerie is drawn into the immediate orbit of its superior. This, too, creates regiones: the humans see their real world as interpreted by the increasingly powerful faeries that they encounter, which are progressively more-potent lieutenants of the principal faerie. Each level of the regio corresponds to a discrete series of tests that the human must face. If the experience were written as memoir, each chapter in the book would represent one regio level in the magus' quest.
+
+Jerbiton magi often report that a principal faerie prefers to have two lieutenants, with each of the three supervising one level of a regio. Merinita magi dispute this. They suggest that complex regiones are rare, and that the faeries are just responding to the observing magi, giving them encounters that have the five-act structure of a play by Seneca because Jerbitons enjoy that structure. Regardless of whether this structure is indigenous to the faeries for mystical reasons, used by the fairies because humans respond emotionally to trinities, or provoked by humans, it is common.
+
+In the five-act structure, humans are motivated to visit the faeries by something outside the regio. Though those who criticize this structure note that the provocation of human action is often a servant of the principal faerie. In the next two encounters, the human quester draws closer to the final confrontation, gathering information and equipment while being exposed to the motif of the regio, and two variations on a moral or theme. In the highest level of the regio, the human has a final confrontation after which his success or failure is obvious, and he leaves the regio. The human then returns to real life, either stronger or weaker for the story's outcome.
+
+#### Some Regiones Are The Past Made Present
+
+Many humans see faeries as linked to the past. This is particularly apparent in areas where the dominant group displaced another tribe to gain its land. In part, this is because when one nation invades another, they often bring alien supernatural forces that subdue the indigenous faeries. In areas where invasion occurred, some faeries, rather than flee or accept secondary status, instead enter exile and recreate the lands and customs of the displaced tribe, so that their stories can continue undisturbed.
+
+#### Time in Faerie Regiones
+
+Characters who willingly enter a faerie regio, and successfully complete the story they find there, use the same rules to determine the length of their stay that characters who enter Faerieland do (see Chapter 2: The Faerie Realm). Characters who enter mortal places with faerie auras do not experience time flowing at unusual rates.
+
+Characters who are led into a faerie regio, or who find their own way into a regio and affront the glamour of the principal faerie, leave when their departure is appropriate to the glamour of the principal faerie. Affronting the glamour of the principal faerie is not the same as harming, or even killing, the principal faerie. It is harming the principal faerie's role — refusing to grapple with the principal faerie and feed the local spirits with stories and vitality.
+
+Characters who destroy the principal faerie, by harvesting the vis in its anchor, do not regain control of the rate time passes for them in the Faerie aura. A new faerie takes the principal role, and it gains control of the rate of time for the characters. Characters who repeatedly slay the principal faerie eventually encounter a highly cognizant claimant for the role of principal. This faerie may bargain with or fight the player characters through servants, and may refuse to take anchored form.
+
+The appropriate time to return a human is not a choice freely made by the principal faerie — it is always a time that symbolically connects with the faerie's glamour. A character who has climbed a faerie hill on Saint John's Eve is usually returned a dawn. A character who loses track of time dancing with the maids of the harvest is usually returned at planting. Humans who travel to faerie auras usually age as suits their subjective experience of time.
+
+#### Withering Away To Dust
+
+Mythic Europeans often fear that if they enter faerie places, when they leave hundreds of years may have passed and they will crumble to dust. This is uncommon — it happens to humans who live in faerie regiones for so long that they die of old age, not noticing their frail state under the glamour of health that has been laid over them. After this, the human's spirit continues to reside in the regio with a material form held together by the glamour of the host. When this faerie, thinking itself human, leaves faerie, its glamourous body falls apart.
+
+It is not the passage of Earthly years that destroys those who dwell in Faerie auras then return. Instead, it is the fact that they have lived so many subjective years that their bodies have been worn away to dust. Characters determined to flee a Faerie court do not find that they fall away to dust when they leave, unless their escape attempts feel like they take many decades to accomplish.
+
+## Vis
+
+The vis collected from the fae comes in many types, but these are not usually distinguished by magi. A character can immediately tell that his vis is of a faerie type with any simple Intellego Vim spell, like *Sense the Nature of Vis.*
+
+#### Encased Vis
+
+Encased vis is the most common form discovered by magi in faerie areas. Encased vis is simply Magic vis that a faerie has laid glamour over, to claim possession of it. Faeries have many uses for vis. They primarily desire it for the same reason they seek out milk, bread, and beer, because they can consume its vitality. Vis also allows them to make glamourous objects real, by giving them independent vitality, which allows faeries to reward mortals for participating in stories. And faeries may use vis to make it easier for them to change roles, as described in the Chapter 3: Faerie Characters. Many of the faerie courts that surround human areas are placed as they are because a vis source lies nearby.
+
+Faeries do not impinge upon the Magic auras that support these vis sources, though, because it would damage them. Instead, they use glamour to play tricks, befuddling humans so that they never see the vis source, or fail to understand its nature. These tricks may include games with distance so that a court seems to take up the space in which the source is found, or faeries may create beautiful facades that the vis sources are hidden behind. In some courts, there are fascinating things hidden around a drab vis source, so that humans are distracted from it. Finally, leaving faerie areas can play tricks on the memory, so that the vis source is forgotten, or made to seem inconsequential.
+
+#### Anchors
+
+Anchors are mundane objects into which faeries have settled their glamour — the cores around which faeries agglomerate bodies. When a faerie's body is destroyed unexpectedly, it is this anchor that magi prize for its vis. Some anchors are distant from the body they motivate, while other types allow the bearer to access one of a faerie's powers. Each of these unusual anchor types is found as a Virtue in Chapter 3: Faerie Characters. Highly cognizant faeries understand what anchors are, and may bargain for them with magi.
+
+A faerie remains conscious, and in its current role, while trapped in its anchor. But it is unable to use its powers, other than the ability to draw matter to produce a new body. Characters may communicate with a faerie trapped in its anchor using Intellego Vim spells.
+
+The connection between the faerie and its anchor is enforced by glamour, and can be broken if the faerie's glamour is damaged. For example, if the faerie's anchor breaks a taboo — represented by a Ward Flaw — the faerie's role breaks and it fades from the mortal world. This is particularly fortunate for some faeries, who are forbidden from straying from their lands or are unable to enter the Dominion, because it allows them to escape to Faerieland before magi destroy them permanently. Anchors whose faeries break taboo become accrued vis.
+
+#### Accrued Vis
+
+Accrued vis forms when faeries end their roles. As an obvious example, it accrues in places where those faeries that age go to die. Fragments of their glamour are left behind in the matter that formed their bodies, and over time this accrues into useful quantities of vis. These tangles of glamour might, some thinkers suggest, become the simplest of faeries, and so this form of accrued vis might actually be an obscure form of anchored vis.
+
+Accrued vis is also found in the bodies and accouterments shed by narrowly cognizant faeries when they complete their roles. These items contain a great deal of coherent glamour, and may be used in several ways by humans. Many of these items retain Pretenses, which a human bearer may use. A faerie offered a tool that contains accrued vis may, if the creature accepts it, immediately take up the role that the previous faerie has laid aside. All faeries can read the glamour within accrued vis, and decide if they want to incorporate it into themselves. Highly cognizant faeries are willing to bargain for desirable roles.
+
+#### Sleeping Vis
+
+Sleeping vis is like accrued or anchored vis, in that it is a material object with a simple glamour in it. But it lacks any vitality, and so makes no attempt to form a body and participate in its role. If provided with vitality, some sleeping vis ceases to be dormant and becomes a faerie. Magi conjecture that this may be true of all sleeping vis, and that they have only awakened faeries that are lightly dormant by singing to them, soaking them in milk, or seeping them in blood, rather than those that require more expensive forms of vitality — like vis or murdered babies — to awaken. Some sleeping vis spontaneously awakens. This odd form of vis has been discovered occasionally, but it is difficult to differentiate from accrued vis, so it might be more common than the few confirmed examples indicate
+
+Magi are divided on the cause of this vis, as even highly cognizant faeries that are awakened are unable to account for their state. Popular theories include that these faeries are new, and have not been embodied before; that these are faeries that have been struck down by the Divine through the miracles of saints, the spread of the Dominion, or the silencing of the oracles; and that faeries are able to drive each other to sleep as part of their games of status.
+
+Some powerful faeries choose, for their amusement, to shed their more-complex roles for a time, and live as a narrowly cognizant faerie. They leave the surplus parts of their glamour in a guarded object, and pick up their more powerful role as they require it. It is conjectured that some powerful faeries have many such roles, kept in Faerieland that they wear as humans wear clothes. These shed roles might creating sleeping vis that, when given a spark of vitality, becomes a faerie independent of its previous spirit.
+
+Magi of House Merinita are willing to pay handsomely for sleeping vis. Many believe that the vitality offered to the vis will influence the role and attitude of the embodied faerie. They hope to create a class of tractable faerie assistants, to aid them in their research.
+
+#### Abstract Vis
+
+Abstract vis is a lie, or perhaps a promise made solid. It is a tiny piece of glamour pressed on matter that can be detected as enchanted, but does not truly have vis within it. The faerie that creates the abstract vis treats the items as if it were as valuable as real vis, and uses its glamour to create effects that mimic those expected when the abstract vis is used in its demesnes. This includes the effects that mundane people enjoy when they use vis, like warriors who know that if they eat apples from a certain tree their wounds will be healed, or witches who know they can predict famine by sucking the icicles from a particular overhang.
+
+The servants of a powerful faerie immediately recognize and must always honor the abstract vis of their master. If other faeries honor the abstract vis, then the faerie who originally created it owes them a favor, which they usually collect through human intermediaries. Magi cannot employ abstract vis for concrete uses like crafting magic items.
+
+# Chapter Two: The Faerie Realm
+
+Faerie is the place where stories are born, live, and die. It is a realm of possibility rather than actuality, where one's perceptions are as important as the scenery. There is no moral dimension to the Faerie Realm, nothing is either right or wrong, good or bad. What is paramount is the story: those things that capture the imagination are powerful in faerie, whereas the banal and mundane is impotent.
+
+This chapter describes the Faerie Realm — how to get there, what to do while there, and how to get back. Stories that take place in Arcadia are unusual in that the characters can often determine the shape of the story affecting them, and so while a storyguide might plan the story, the player can adapt the outline to give the most enjoyable experience for all. Adventures that take place in the Faerie Realm can therefore be challenging, but also rewarding.
+
+## The Three Worlds
+
+The Faerie Realm is an equivalent place to Heaven, Hell, or the mysterious Magic Realm, if these realms can really be referred to as "places." Unlike a faerie regio, it is evermutable, and perhaps infinite in variety. However, the types of stories experienced there fall into one of three sorts, just as the purpose of all stories ultimately falls into one of three categories. These three paradigms of the Faerie Realm are sufficiently different from one another that they are referred to as "worlds" or realms in their own right, although they all partake in Faerie's nature. Some stories are designed to entertain, and **Arcadia** is the name given to that part of Faerie in which these new stories are made. It is the one with which players of Ars Magica may be most familiar. Other stories recount tales of great deeds, and while these can be entertaining, their prime function is to remember and record a culture's history. **Elysium** is the land of these myths, where characters can interact with the heroes and villains of familiar stories, and perhaps even meet with the faerie gods. Finally, stories can be teaching tales, exploring wisdom and stupidity in equal measure to provide guidance, both in ethical decisions and life stages. **Eudokia** is a realm where one's personal story is told, where an insight into a dilemma can be achieved, or a difficult life transition resolved. The circumstances of one's journey to the Faerie Realm dictate which of the three worlds is experienced.
+
+Some magi of House Merinita refer to the three worlds as paths or roads, as if one's visit to the Faerie Realm was a journey rather than a destination. They acknowledge that just as roads in the mundane world cross, so do the roads through Faerie. One might find oneself changing paths without realizing it, and stepping into a different world. Some who have studied the byways of the Faerie Realm claim to have found further, unfamiliar paths, and say that there are more than three worlds. Others argue that all roads are actually one, and that the so-called "paths" of the Faerie Realm are matters of perception only, and that all travelers in Faerie tread the same path, but experience it differently. Another point for debate is the existence of these roads — or even the worlds themselves — when there is no-one to observe them. All these ideas are hot topics in House Merinita. But regardless of the hypotheses, the three most commonly recognized routes through the Faerie Realm are the Path of Chance, the Path of Destiny, and the Path of Choice.
+
+The **Path of Chance** wends its way through Arcadia, a realm populated by the fragments of stories yet to be told. This is the land of pure adventure, where characters may be simply in search of excitement and wonder, or may be questing for a specific reason — embassy, retrieval, revenge, investigation, and so forth.
+
+The **Path of Destiny** leads through Elysium. It is a straighter road than the rambling path through Arcadia, and here characters seek answers to their problems in the mundane world by reliving allegorical stories that have already been told. Such stories are driven by necessity, since their outcomes have already been established by human consensus. Nevertheless, by reenacting these stories, mortals can earn insights, discover knowledge, or win faerie gifts.
+
+The **Path of Choice**, or the Forked Path, twists its way through Eudokia. This is a place where the character's morals and emotions play an important role, and the inhabitants ape the attitudes and fashions of the mundane world. Here, the plot of the story is not as important as the development of the characters caught up within it. Many adventurers in Eudokia arrive here by accident, and seek only to escape. By doing so, they can affect the direction of their own personal change.
+
+## Getting to Faerie
+
+The Faerie Realm is ever-present in the sub-lunar world, and yet just out of reach. It is described in folk tales as being "just over the next hill," or "beyond the ninth wave," or "between the beating of the heart and the breath," and so forth; all are metaphors for its simultaneous closeness and distance. The mundanity of the world repels Faerie just as humanity attracts it. As a result, humans can only reach the Faerie Realm if they can reject (albeit temporarily) the routine of their banal life and accept the fantastic and fabulous as the rules through which the world works. Every time a mortal becomes lost in a story, entranced by a sunset, or is overcome by celebration, he can be touched by the Faerie Realm; and sometimes it only takes a small nudge to push him the rest of the way into the Realm of Enchantment.
+
+Scholars of Faerie refer to the simultaneous attraction and repulsion of Faerie for the mundane world as the Threshold. In certain places, at certain times, the attraction is greater than the repulsion, and Threshold comes closer. For example, the unfettering of the human mind through artwork designed to invoke wonder can attract the Threshold closer, as can an individual who is on the verge of a personal life change. Finally, the Threshold can be crossed with supernatural assistance; some faeries can assist the passage into Faerie, as can practitioners of Faerie Magic. Those learned in the ways of the faeries (i.e. who have Faerie Lore) can deliberately attract a Threshold by manufacturing the right set of conditions, but some visitors to the Faerie Realm get there entirely by chance.
+
+The Faerie Realm can be entered anywhere, even in regions under the Dominion, if the conditions are right. Practically, however, unless one is in a powerful Faerie aura it is exceptionally difficult to access the Faerie Realm unless many factors align perfectly to attract a Threshold. To enter the Faerie Realm, the characters — through circumstance or action — must accumulate a number of Threshold points equal to the Threshold strength:
+
+**Threshold Strength: (13 – aura modifier) x 3**
+
+The aura modifier is the strength of the local aura, multiplied according to the Realm Interaction Table (**ArM5**, page 183) as if this was a Faerie Power in action. For example, in a Faerie aura of 3 the Threshold strength is 30 (13 – Faerie 3) x 3, whereas in a Dominion aura of 3 the Threshold strength is 75 (13 – (–4 x Dominion 3)) x 3. Thresholds are closest to the world in Faerie regiones: add the aura modifier for any base Faerie aura to the aura modifier of the regio before determining the Threshold strength, but ignore the existence of any aura other than a Faerie one. Thus, a Faerie regio of aura 5 that overlays a Faerie aura of 2 has an aura modifier of 7 (for a Threshold strength of 15), but if the regio instead exists over a Dominion of 3, the aura modifier is still 5 (for a Threshold strength of 24). Note that the mechanics for entering the Faerie Realm are wholly different from those for entering a regio — Abilities such as Second Sight or Intellego Vim spells do not help at all.
+
+### Sources of Threshold Points
+
+Threshold points can be accumulated from a number of different sources: geography, time, changes in personal circumstances, artistic endeavor, assistance of Threshold faeries, faerie magic, and so forth; each of which is detailed in the following section. Only one attempt can be made to enter Faerie for any given set of circumstances, and if the Threshold fails to arrive, then this set of circumstances cannot create a portal into the Faerie Realm. If the characters are knowingly trying to enter Faerie, they must change the composition of one of the elements before trying again, and their attempt cannot be made sooner than the next moonrise. If the character is ignorant that circumstances nearly spirited him away, he will simply feel brush of the Threshold passing as a feeling of strong emotion appropriate to the circumstance — awe, joy, or even terror.
+
+A character or group of characters who successfully enter the Faerie Realm immediately find themselves on one of the Three Paths, and will soon be confronted by a Guardian of the Threshold. Which Path they find themselves on depends very much on the manner in which they attracted the Threshold; see later for details on the Three Paths.
+
+>## Example Threshold
+> 
+> Branoic is a young man on the night before his marriage to his love. His friends ply him with alcohol and then dare him to climb Goat Hill; a traditional challenge for local men on their stag night. The hill has a Faerie Aura of 5, so the Threshold strength is 24. He is on the verge of a major life change to be reinforced by a church ceremony, so he's very susceptible to stumbling into the Faerie Realm (18 Threshold points). On his journey up the hill he fords a stream where it is joined by two others (6 Threshold points), and he emerges from the other side of the stream into the Faerie Realm.
+
+#### Geographical Thresholds
+
+As described in Chapter 1: The Nature of Faerie, faeries are the spirits of the borders, and in places that are traditional haunts of the fae, humans can sometimes slip through the cracks and end up in Faerie. This is especially true if the characters are lost — add 3 Threshold points for a border crossed when the travelers truly have no idea where they are. Even without a Faerie aura, a geographical boundary is a potent attractor of the Threshold, and the sharper and more distinct the border crossed, the larger effect it has on the Threshold points of the travelers.
+
+**Border Crossed:** Insignificant
+
+**Threshold Points:** 3
+
+**Examples:** A road, stream, or fence.
+
+**Border Crossed:** Minor
+
+**Threshold Points:** 6
+
+**Examples:** A crossroads, confluence of rivers, edge of a wood, or city wall.
+
+**Border Crossed:** Significant **Threshold Points:** 9
+
+**Examples:** An oasis in a desert, beyond the treeline of a mountain, or a trod.
+
+**Border Crossed:** Major **Threshold Points:** 12
+
+**Examples:** A significant border that is also a boundary into a Faerie regio.
+
+**Border is Crossed While Lost:** +3
+
+>## Trods
+> 
+> A trod is a geographic boundary — a river, shoreline, edge of a forest, and so forth — that has a Faerie Aura. In a trod, just the liminal space of the border itself has an aura, not the surrounding landscape, so the edge of a faerie forest is not a trod. A Faerie Road (see Chapter 1: The Nature of Faerie) is a particularly effective trod, since regiones in general are highly amenable to passage into Faerie.
+> 
+> Trods are potent paths into Faerie; as well as their inherent Faerie aura, they are also always accounted to be at least a Significant Threshold. Those entering the Faerie Realm on a trod often find themselves on the Mother Road (see later), and the locations of trods are highly sought by those who use the Mother Road.
+> 
+> Trods also connect the different levels of a Faerie regio with one another, and characters with Second Sight, Magic Sensitivity, or suitable Intellego Vim spells can see them as winding paths, and follow them between the levels of reality (see **ArM5**, page 189). No trod has verifiably connected a layer of one regio to a layer of a different regio; those who claim to have made such a journey are believed to have briefly used the Mother Road.
+
+#### Temporal Thresholds
+
+Certain times of year mark Thresholds in time, such as the turning of the seasons. At these times, the border between the mundane world and Faerie becomes thinner and more easily traversed. Such times are worth a number of Threshold points determined by the table. Note that if the characters are potentially crossing into Faerie from a Faerie Aura, they may benefit twice from the time of year, since the Faerie aura may be increased, thus decreasing the Threshold strength as well as adding Threshold points.
+
+| Time            | Points Threshold |
+|-----------------|------------------|
+| New Moon        | 1                |
+| Full Moon       | 3                |
+| Pagan Holiday\* | 3                |
+| Solstice        | 6                |
+| Equinox         | 9                |
+
+\* If observed locally
+
+#### Personal Thresholds
+
+Characters who are in a state of personal change are more prone to entering Faerie than others. Such people can act as conduits, allowing others to pass into Faerie with them. Such portals invariably lead to Eudokia, and Threshold points from personal circumstances usually apply where a single person enters the Faerie Realm. However, a group of characters who are all experiencing the same personal circumstances might attract a Threshold as a group. Alternatively, one character might attract such a Threshold, but his friends also travel with him into the Faerie Realm. In the latter case use only the focal character's personal Threshold points, but remember that this character will also be the focus of any stories played out in Faerie. If a religious ceremony — such as one of the sacraments — accompanies or marks a particular life change, then it is a source of more Threshold points than one without such significance.
+
+Characters who already straddle the boundary between the mundane realm and Faerie are more prone to cross the Threshold. Characters who only have Minor faerie-derived Virtues or any faerie-derived Flaws have only a small connection to Faerie, whereas those with Major faerie Virtues must be more careful in strong Faerie Auras if they want to avoid accidental trips to the Faerie Realm. Threshold points from Virtues and/or Flaws are not cumulative: choose only the highest.
+
+Characters experiencing extreme emotions such as overwhelming rage, fear, or grief are also more likely to slip into the Faerie Realm. They need not have a Personality Trait for such emotions — just the current expression of that emotion in an intense fashion — but an appropriate Personality Trait brings the Threshold closer still. If the character has an appropriate Personality Flaw, consider him to have a Personality Trait of +3 (if it is a Minor Flaw) or +6 (if it is a Major Flaw).
+
+The magnitude of the change that is occurring within the individual determines how many Threshold points he contributes:
+
+**Circumstance:** One or more Minor
+
+faerie Virtues **Threshold Points: 3 Examples:** Faerie Blood
+
+**Circumstance:** One or more Major
+
+faerie Virtues **Threshold Points:** 9
+
+**Examples:** Strong Faerie Blood
+
+**Circumstance:** One or more faerie Flaws
+
+**Threshold Points:** 3 **Examples:** Faerie Heritage
+
+**Circumstance:** Extreme emotion **Threshold Points:** 3 + Personality Trait **Examples:** Lust, anger, anxiety, or fear
+
+**Circumstance:** Minor life change
+
+**Threshold Points:** 9
+
+**Examples:** Menopause or puberty
+
+**Circumstance:** Minor life change marked by a celebration **Threshold Points:** 12 **Examples:** Betrothal
+
+**Circumstance:** Major life change
+
+**Threshold Points:** 15
+
+**Examples:** Common law marriage or birth
+
+**Circumstance:** Major life change commemorated with religious ceremony
+
+**Threshold Points:** 18
+
+**Examples:** Wedding or baptism
+
+#### Artistic Endeavor
+
+The products of human industry — specifically human creative thought — can assist in the transition to Faerie. The work of art must specifically commemorate Faerie, and enhance the sense of wonder of those on the Threshold . However, the work of art need not have been created for the purpose of reaching Faerie; it just allows the audience of the art to temporarily be lifted from their mundane existences and be transported into the fantasy created by the artist. Examples of works of art that promote the transit to Faerie include: songs, poems, and dramas about a fantastic adventure; music that invokes unfamiliar emotions; and sculptures, paintings, and engravings detailing scenes of fantasy.
+
+Add the Aesthetic Quality (either Dexterity + Craft Ability or Communication + Profession Ability of the Artist; for more details, see *Art and Academe*, Chapter 8: Artists) to the Threshold points for a transit into Faerie. The artwork must be viewed or performed by the prospective travelers for it to assist transport. The subject of the artwork can affect the path embarked upon by the travelers; a hymn praising marriage is likely to lead to Eudokia, whereas a woodcarving of a pagan deity doubtless leads to Elysium.
+
+#### Assistance of Threshold Faeries
+
+Some types of faerie achieve Vitality through assisting humans to cross a Threshold of some description. They might seek to trick characters into attracting the Threshold, or assist those who are intending to do so. These faeries all possess a Power called Spirit Away (see insert) that allows it to assist an individual or group in crossing the Threshold. Note that not all faeries can assist the transit to Faerie; see Chapter 4: Faerie Bestiary for examples of Threshold faeries. A Threshold faerie cannot attract the Threshold to the mundane realm on its own even if its Might exceeds the Threshold strength.
+
+Many Threshold faeries also serve as the Guardian of the Threshold (see later).
+
+#### Assistance of Faerie Magic
+
+The Faerie Power of Portage allows a faerie magician entrance into the Faerie Realm. See Chapter 6: Faerie Wizardry for more details.
+
+#### Arcadian Mysteries
+
+There are members of House Merinita who possess the Mystery Virtue of Arcadian Travel (see *Houses of Hermes: Mystery Cults*, page 92). They must construct an appropriate charm (a physical object or a performance) to enact this ability, requiring either a Dexterity + Ability roll (for an object) or a Communication + Ability roll (for a performance) against an Ease Factor of 18. Making the charm takes at least 10 minutes. If the charm is successful, the magus gains his Arcadian Travel Total in Threshold points:
+
+**Arcadian Travel Total: stress die + Perception + (Ability used to make the charm) + aura**
+
+The magus can take a number of people with him by using this charm that is equal to his Faerie Magic score, so long as they all participate in the activation of the charm. This variety of charm is only available to those with the Mystery Virtue of Arcadian Travel.
+
+>## New Power: Spirit Away
+> 
+> Greater Faerie Power, variable points, Init 0, Vim
+> 
+> The faerie can add Threshold points to the total accumulated by a mortal individual or group, at a cost of 1 Might Point per Threshold point. The characters affected by this power must already have a Threshold total; the faerie cannot be the only source of Threshold points. The characters must still face the Guardian of the Threshold (see later) — who may indeed by the faerie with this power — but if the faerie wants them to enter the Faerie Realm, then it may well indicate the right path. This power can also be used to send characters away from the Faerie Realm as well; this costs 3 Might Points per character.
+
+### The Guardian of the Threshold
+
+The Guardian of the Threshold is always the first entity encountered when a character (or group of characters) gains access to the Faerie Realm. Until the Guardian has been passed, the crossing to Faerie has not actually occurred. The purpose of the Guardian is to test the resolve of the characters. Faerie protects its own borders, and the Guardian is there to ensure that people do not slip through its bounds whenever they cross into a Faerie aura. The Guardian presents a choice (in reality or metaphorically) — carry on or go back. It should usually be obvious to the characters which choice indicates passage into the Faerie Realm. If they are struggling, a successful Intelligence + Faerie Lore roll against an Ease Factor of 6 will provide additional hints. In general, choices that lead to adventure, danger, or wonder take the characters into the Faerie Realm; whereas those that suggest safety, routine, or mundanity take the characters home.
+
+>## Faerie Adventurers
+> 
+> A faerie must go through exactly the same procedure as a mortal character to enter Faerie. Cognizant faerie characters can often pinpoint specific conditions that grant the best chance of attracting a Threshold, and consequently are more adept at entering the Faerie Realm. Highly cognizant faeries automatically have a number of Threshold points equal to the magnitude of their Might. Narrowly cognizant faeries can add the magnitude of their Might to Threshold totals that evoke liminal conditions related to their understanding of their role. Thus a narrowly cognizant night terror can assist in Threshold totals that occur at night or rely on strong emotions of fear. Incognizant faeries get no bonuses to Threshold totals. Note that these extra Threshold points are different than the Spirited Away power; in this case, the faerie itself must be crossing the Threshold, rather than assisting others to do so.
+> 
+> All faeries intuitively know which of the choices provided by the Guardian of the Threshold leads to the Faerie Realm, and which one goes to the mundane world.
+> 
+> When in the Faerie Realm, faerie characters retain the same role that they possessed in the mundane world, but often find it easier to gain fable points (see later) since they understand the rules of the game better than humans. Assume that all faerie characters have the Common Sense Virtue while in the Faerie Realm. Since they have a Might Score, they are also immune to any Warping acquired when leaving the Faerie Realm (see Leaving Faerie, later).
+
+The form of the Guardian of the Threshold varies wildly between trips, and is also dependent on the circumstances of the journey. It is not always even a faerie being. For example, the Guardian could take the form of a physical barrier (such as a bramble thicket) or a monument. As a barrier, the traveler must make a choice to cross; the monument might have a foreboding aspect or bear dire words to repel the unready. **Passive Guardians** of this type may be incorporated into the Threshold itself, particularly if it's a geographic boundary. Characters can therefore slip inadvertently into Faerie by trying to overcome the obstacle presented by a passive Guardian.
+
+More commonly, the Guardian takes the form of a human or animal who attempts to halt the journey, through threats or friendly counsel. Such characters are never purely mundane, and there is always something unusual about them. Most obvious, for **animal Guardians**, is the ability to speak; more rarely the animal takes on human mannerisms or even clothes. Guardians who take the form of animals are usually creatures who straddle a border — often waterfowl such as geese, storks, herons, or ibis — which all partake in both water and air. Amphibious creatures such as frogs and otters are also common Guardians. Another type of animal guardian is those that have undergone a role reversal, such as a domestic animal that has clearly gone feral, or a wild animal that has adopted the trappings of domesticity. Fierce animals such as wolves and bears usually come under the category of the kerberoi (see later).
+
+**Human Guardians** often have a deformity, such as giant size, excessive amounts of hair, or the feet of a duck. The color of the skin may be particularly vivid, with green being the most common. Human Guardians are more often women than men, and more often old women than maidens. The shape that they take is again is that of a person who traverses multiple human realms, such as a wanderer or outcast, a prophetess or madman.
+
+The last type of Guardian is a **fearsome monster** that blocks the way. This sort of Guardian is referred to as *kerberoi* by the followers of Merinita, and many travelers make the mistake of trying to fight the monster, assuming that the only progress can be over its corpse. This is certainly one way; however, a kerberos is always restrained in some fashion, and can always be bypassed through trickery or courage. The fearsomeness of the monster is usually sufficient to repel the casual traveler.
+
+>## The Power of God in the Faerie Realm
+> 
+> As the home (and perhaps source) of all things fay, the beings found in the Faerie Realm are subject to the same restrictions as those found in the mundane realm. Faeries with traditional or sovereign wards (see Chapter 3: Faerie Characters) involving religious symbols are affected by them just as strongly on their home turf. The power of God permeates the Faerie Realm just as it does all creation, so characters with True Faith, miraculous powers, or relics find these things just as potent as they are elsewhere.
+> 
+
+All Guardians of the Threshold have a Faerie Might at least equal to the Threshold total of the group, although Guardians at famed entrances to Faerie (such as a powerful aura or regio) may have much higher Might. The other details must be determined according to the situation, but some of the statistics of faeries in Chapter 4's Faerie Bestiary can be used for inspiration. However, the Guardian is supposed to be a roleplaying challenge rather than a battle, and a fight should never be inevitable. The sections below about the different aspects of Faerie give typical Guardians.
+
+## Adventures in Faerie
+
+Having negotiated with the Guardian of the Threshold, the characters enter the Faerie Realm proper. The sections later in this chapter detail which of the Three Worlds the characters find themselves in, and what they encounter there. This section discusses more general aspects of a visit to the Faerie Realm.
+
+### Environment and the Faerie Aura
+
+The environment of the Faerie Realm is superficially the same as in the mundane world, but there are a few important differences. The rules of nature, which characters normally take for granted, cannot necessarily be relied upon in the Faerie Realm, since they follow the dictates of the story. For example, if the lake is home to an underwater castle, then its water can be breathed as easy as can air, and it does not impede movement. The water is still water, though — characters can swim through it, and float on top of it. Similarly, a fire might be solid, and yet still burn those who touch it. It could be possible to walk on clouds, or ascend a stairway of smoke, if the story demands it. However, this is not to say that these things are always true in Faerie. If the purpose of a lake is to act as a barrier, it will drown those who try to breathe it just like a lake in the mundane world would do.
+
+The Faerie Realm has a pervasive Faerie aura of 10, meaning that most magi receive a +5 bonus but roll an additional ten botch dice in any magical actions. The extra botch dice for the Faerie aura should be rolled separately from any other botch dice, because any botches that result from these dice tend to be strange or bizarre rather than dangerous. A typical effect is for the spell to become a sentient faerie. The rules for Animae Magic (*Houses of Hermes: Mystery Cults*, pages 92–96) give guidelines for creating faeries with magic, and a Momentary Duration is sufficient to permanently create a faerie in the Faerie Realm. For example, a magus botches a *Ball of Abysmal Flame* in the Faerie Realm. This is a 35th-level spell, which is sufficient to create an Ignem Anima of Might 15 (base 15, +1 Touch, +15 levels for a Might of 15). It takes the form of a standard *Ball of Abysmal Flame*, but one that follows the magus around offering unwanted criticism. If a standard botch occurs as well as a botch from the Realm dice, then the effects can be truly spectacular.
+
+#### The Mother Road
+
+The imagery of the Faerie Realm as a road, and adventures therein as journeys, is a pervasive metaphor. After all, stories themselves are journeys that bring the hero from boring mundanity, through a place of fantasy and adventure, to attain some wondrous prize at his destination. Furthermore, a road — like a story — is a method of communication. Some storytellers tell of a Mother Road, the source of all roads, whose highways and byways may be traveled by those who know its secrets. This Mother Road is the Faerie Realm, and it can be used to swiftly traverse vast distances in a short space of time.
+
+Practitioners of the Faerie Power of Portage have learned to exploit the Mother Road as if they were a native. Hermetic magic is more limited in this regard, and expertise with the Mother Road is largely the expertise of those members of House Merinita who belong to the group known as the Wayfarers (*Houses of Hermes: Mystery Cults*, page 80). By stepping onto a trod, a maga deliberately invokes the Threshold and enters the Faerie Realm. She must then strike a bargain with the Guardian of the Threshold to allow her to immediately leave Faerie, but at a point of her choosing (although the exit must also be onto a trod). The stay in the Faerie Realm is often so brief that she see little more of it than a road, which supports the hypothesis that all paths in Faerie are really one. Since the traveler spends no time interacting with story elements, she accumulates no fable points (see later) and the whole journey might take a fraction of the time that it appears to (typically one minute passes for every 24 minutes spent in the Faerie Realm; see Leaving Faerie, later). This method of travel is not without peril, since the Guardian of the Threshold may be her only way out of the Faerie Realm. Since her purpose is the journey itself, she cannot complete her story, which is the usual method for leaving the Faerie Realm. Without possessing another exit (such as the Arcadian Travel Mystery Virtue), she is dependent on pleading, bargaining with, or forcing the Guardian to let her return to the mundane world. Nevertheless, the advantages of being able to travel to a place to which one has never been, nor owns an Arcane Connection, is worth the risk in the opinion of some magi.
+
+### Glamour
+
+Some believe that the Faerie Realm is mere dream — clever illusions that beguile the senses of the unwary. However, most who have direct experience of the Faerie Realm deny this vehemently. They know that what they have seen, heard, touched has as much reality and solidity as anything they have experienced among mortals. Yet it cannot be denied that the stuff of Faerie — whatever that is — is more transient and malleable than normal stuff. The very fact that the environment cannot be relied upon as it can in the mundane world (see earlier) lends credence to this. It is usually assumed that the Faerie Realm is made of glamour (see Chapter 1: Nature of Faerie, Glamour). And indeed, that it is perhaps the source of all glamour.
+
+#### Lands of Story and Fable
+
+The landscape of a region of Faerie is written by its glamour. Every story should be considered to be a kingdom within the greater Realm, and these kingdoms are bordered by high mountains, fierce seas, and swift-flowing rivers. Suffice it to say that one cannot travel between kingdoms; there is nothing beyond the landscape dictated by a story. These kingdoms are not to be taken literally — there are no lands such as Avalon, Olympos, or Vanaheim that have an existence independent from the stories in which they dwell. It is impossible to travel between stories, for the kingdom is as big as the story needs it to be. One cannot begin in a story about swan-maidens and then take a side trip to the vineyards of Dionysios, since the latter place does not exist in the stories of swan-maidens. A legendary location is merely a collection of story elements that makes it fit the character's perceptions of what that location is like, and the location does not go outside the parameters of the story. For example, if a group of characters visits the Giant's Dance (Stonehenge) in the Faerie Realm, they cannot cross the Salisbury Plain and visit Glastonbury Tor while they are there, if the latter has no place in the story they are visiting.
+
+Travel within a story can vary according to its own dictates. Many stories involve heroes who strike out from home in search of adventure, and like them, visitors to Faerie might simply walk from scene to scene. Characters can decide the direction of travel and the means as they see fit, but it is rarely geography that determines where they end up. Their hopes, fears, the choices they make, and their treatment of the other participants in the story — all these things dictate the flow of the story, along with, more prosaically, the dramatic requirements of the storyguide. It matters not whether they set off on the rose-strewn path rather than the cobbled road — the Summer Kingdom that they seek will come to them no sooner.
+
+This is not to say that a story in the Faerie Realm is a linear path. The decision to set out on the rose-strewn path has a symbolic meaning to the story that influences future events. It might affect the order in which they encounter the obstacles set in their way, and thus the ease with which they are dealt. However, the Summer Kingdom comes no quicker merely because they have chosen a road that corresponds to summer. A good story in the Faerie Realm has many options for the characters to affect the outcome, based on choices they make earlier on.
+
+Any story, or element of a story, told in the mundane world has a reflection in Faerie, although the relative contributions to cause and effect is a matter of disagreement among scholars versed in fay matters. Merinita magi who have told wholly new stories have found their version in the Faerie Realm almost immediately. Faeries themselves are incapable of creating new stories, suggesting that they are the product rather than the authors. Although stories in Faerie are not immutable, changing a story in Faerie does not effect changes in the mundane world; the story does not change because the characters have changed it in Faerie. This is perhaps because the modified story exists in the minds of the authors of those changes, so in effect the "real" story *has* been changed. Of course, all stories are re-invented by the teller, and regional variations exist in all tales, so who is to say that the "real" story is anyway. Finally, the Faerie Realm has a long memory: even stories that have been forgotten in the mundane world are remembered here.
+
+### Vitality and Fable in Faerie
+
+Characters are not bound to obey the laws of the Faerie Realm in the same way that its inhabitants are, but if they deny the fantasy of what they are experiencing in favor of a mundane solution, they exert less control over the outcome than those who revel in the experience. Vitality is the power of stories that nourishes faeries (See Chapter 1: Nature of Faerie). While they are in the Faerie Realm, humans can spend some of their vitality by partaking in stories, and receive in fair exchange a measure of control over those stories. Characters adventuring in the Faerie Realm accumulate fable points when they accept the glamour of the realm as reality and play along in the story they are experiencing (and writing!) — that is, whenever they spend vitality. These fable points contribute to a fable score that represents the control that the character has over the Faerie Realm itself through the vitality he has spent. The first fable point gained by a character is immediately converted into a fable score of 1. Further points can be used to increase one's fable score further, or to exert influence over Faerie. To increase one's fable score requires the expenditure of a number of fable points equal to the current score plus one. Thus, if a character's fable score is 5, it takes 6 fable points to increase the score by 1 point.
+
+To influence the glamour of the Faerie Realm, a fable point can be spent to gain a bonus to one roll equal to the character's current fable score:
+
+**Fable Point Expenditure: +(fable score) to one roll**
+
+**Increase Fable Score: fable points equal to 1 + (current fable score)**
+
+Fable points can also be spent on enacting more-substantial changes to the story; see Creativity in the Faerie Realm, later. In addition to influencing Faerie, the fable score reflects how much faerie has influenced the character. See Becoming Faerie Through Fable, later.
+
+A human character cannot have a fable score unless he is in the Faerie Realm — all fable points and fable score disappears upon leaving Faerie. And if a character returns to Faerie he begins with no fable points or fable score, regardless of whatever total he achieved on a previous visit.
+
+#### Gaining Fable Points
+
+Broadly speaking, every time the character is presented with a choice as to whether to act with or against a faerie story and he chooses the former, he expends vitality and gains a fable point in return. Acquiring fable points often requires acting according to dramatic necessity rather than common sense; some examples are given below. Note that these are one-time awards; a character who has decided to eat fay food while in the Faerie Realm does not gain a fable point every time he eats a meal, just when he first makes the decision to do so.
+
+- Eat food originating in the Faerie Realm;
+- Accept fantastic or unusual means of travel;
+- Contest with an obstacle on its own terms (for example, a riddle contest with a dragon rather than a battle);
+- Identification with the Hero (see The Road to Destiny, later);
+- Show a defeated villain mercy even though you know he'll be back to cause trouble later in the story;
+- Deliberately breaking an interdiction (see Acts, later);
+- Use a plot device (see Player-Influenced Stories, later).
+
+This list is non-exhaustive; any dramatic and entertaining event should be rewarded with fable points, and players should find it easy to earn their characters 10 or more every session in Faerie, if they want to.
+
+Managing fable points is an important consideration for a player in an adventure that's set in Faerie. The character is rewarded for taking part in the story by bigger and bigger bonuses to his actions; but upon the completion of the quest, the character's final fable score determines the amount of time that has passed in the real world and the amount of warping that the character has gained from his stay in Faerie (see Leaving Faerie, later). Experienced travelers in the Faerie Realm show far less enthusiasm for a high fable score than novices.
+
+#### Becoming Faerie Through Fable
+
+Fable can also leave an imprint on the character; those who have spent a lot of vitality in the Faerie Realm often take on a faerielike nature. A character's fable score represents the magnitude of the changes that overcome him. A player can choose to exchange a number of his character's Virtues equal to the fable score with Virtues listed in Chapter 3: Faerie Characters; Major Virtues count as three Virtues for these purposes. If a player makes the decision to do this, the storyguide and/or troupe should exchange an equal number of his Flaws for those listed in Chapter 3. Whenever the character's fable score increases, the player can decide to exchange a new Virtue, or else keep it in reserve — perhaps for the exchange of a Major Virtue, or to allow the character to develop a particularly useful Virtue as needed (see later).
+
+When the character returns to the mundane world, his normal selection of Virtues is restored. But should he ever go back to the Faerie Realm, all Virtues and Flaws that were exchanged reassert themselves. Further, as he develops a new fable score on his subsequent trip, he can continue to exchange Virtues and Flaws. Consequently, the player should record all changes to the faerie version of the character on a copy of his character sheet that is only used in the Faerie Realm. Characters who make many repeated trips to the Faerie Realm gradually transform into faerie beings, and may eventually find it preferable to stay in Faerie and relish their new powers.
+
+With the agreement of his troupe, the player can also choose Virtues that are not specific to faeries but are thematically appropriate. Any Virtues gained that grant experience points (such as Warrior) grant Abilities as Pretences, not real Abilities. If the character takes a Virtue that affects his physical form (such as Humanoid Faerie), he gains the benefits of having a glamoured body — such as immunity to Fatigue and Decrepitude — and the ability to banish wounds at the end of the scene (which, for characters who are still human, is when they leave the Faerie Realm). He must take one of these Virtues before he can take the Increased Might Virtue. For a human character in Faerie, this Virtue grants a Might pool rather than a Might Score; Might points can be spent on powers acquired through further Faerie Virtues, and the maximum pool is used to calculate Penetration. However, the character does not gain any Magic Resistance or immunity to warping. The character cannot take Virtues that require Might pool (such as Faerie Powers) until he has taken the Increased Might Virtue. All characters are assumed to be Narrowly Cognizant, in that they know that they are humans who have acquired the characteristics of a faerie.
+
+When deciding upon Flaws, those that are swapped out first should be those pertaining to the mundane world, such as Feud or Outlaw Leader; other Flaws might be altered so that they pertain to Faerie. A mundane Mentor could be replaced with a faerie Mentor, and a magical Supernatural Nuisance could become a faerie one, for example. Other Flaws that are appropriate (such as Disfigured and Greater/Lesser Malediction) can also be used to replace the character's Flaws. A character who gains a faerie body (such as the Humanoid Faerie Virtue) must acquire a Traditional Ward.
+
+*Example: Coll the grog gains a fable score of 1 while visiting Arcadia. During the adventure he is nearly killed by some faerie wolves when he fails a Stealth roll. His player decides to exchange his Puissant Stealth Virtue (which is clearly not working!) for the Humanoid Faerie Virtue. The storyguide decides that he should acquire a Traditional Ward (wolves) in place of Branded Criminal (which is inappropriate among faeries). Later in the story, his fable score has increased to 2 during an encounter with a faerie lady, where he boasts about his sexual prowess. He decides to exchange his Social Contacts Virtue for a new Virtue, Reputation as Confidence. One of the other players suggests that he should also acquire the Disfigured (excessively priapic) Flaw in exchange for his Weakness for Women Flaw, and the rest of the troupe agrees.*
+
+Often the resolution of a faerie story relies on the ability to perform some magical act. For a man to scale a glass cliff, he needs to take lessons from the birds on how to fly. To escape a giant, the characters must make a comb transform into an impassable thicket. To rescue the princess, the hero must walk through flames. In the Faerie Realm one need not be a wizard to perform wonders: one can get such powers from glamour. Any character with a fable score that has not been wholly used to swap Virtues can learn from a faerie how to duplicate the effects of any power or Virtue it possesses. These powers are gained as Lesser or Greater Benedictions (see Chapter 5: Touches of Faerie) as appropriate. The Flaws acquired in exchange are often Lesser or Greater Charms (again, see Chapter 5: Touches of Faerie). The necessary instruction takes anywhere between a matter of minutes to several days, depending on the needs of the story, and often the donor has to give up the ability it is teaching: a bird who teaches someone how to fly loses the ability himself. Understandably, faeries are often loathe to teach such abilities, and may require persuasion.
+
+### Creativity in the Faerie Realm
+
+The Faerie Realm is subject to human creativity, like all things fay. Characters with the requisite creative spark can in effect make a bargain with the Faerie Realm itself; in return for a creative performance the character can alter the environment of Faerie, the symbolism of the current scene, or the attitude of the faeries taking part in the scene. To make changes in the Faerie Realm requires a trade; the character expends vitality in exchange for the ability to change the nature of Faerie. Since the character's expenditure of vitality is charted by the acquisition of a fable score, any character with unspent fable points can attempt to enact a change in the story he and his companions are currently experiencing. To initiate a change, the character must make an offer — a description of the change that he wishes to cause, either in words or through another creative outlet such as performance or craft. Included in the offer is the promise of a service that supplies the necessary vitality to make the change. If the offer is accepted then the change occurs as described.
+
+#### Crafting an Offer
+
+Offers are usually made verbally, using either the Charm or Profession: Storyteller Ability. Performance artists may use other professional Abilities, and a crafter may work her hopes into an object, and offer it instead. Crafted offers take the same amount of time to make as a mundane object, and thus this is not a favored option while in Faerie, except for simple crafts like whittling. Although some items can be prepared before entering the Faerie Realm and finished in a fraction of the usual time. An offer constructed with insufficient skill always fails, because the faerie cannot comprehend its value.
+
+**Offer Total: Communication + Charm or (Profession) Ability or (Craft) Ability + Offer Modifier + Promise Modifier + Change Modifier + stress die**
+
+Making an offer requires the expenditure of a fable point and a Long Term Fatigue Level; along with the promise (see later), these sacrifices provide the vitality needed to enact a change to the whole realm of Faerie. The cost of fable points and fatigue are incurred whether or not the offer is accepted, but the character is not bound to his promise if the offer is not comprehended.
+
+The Ease Factor required to make a change using creativity does not depend on the extent of the change. Instead, it depends on the size of the obstacle that the change allows the human protagonist to overcome. The more that a change simplifies the completion of the story, the greater the compensation the principal faerie's glamour demands for the vitality the human refuses to express when overcoming the obstacle.
+
+The table given here classifies threats by the degree of harm they are likely to cause the individual human, if not overcome by the intended change. Faeries tell stories that suit the humans available, and scale the level of challenge so that it forces the human into an optimal emotional state. The ruggedness of individual humans varies, which means that a peasant with a fine singing voice may find a sprite a deadly threat, while a minstrel supported by a cadre of Merinita magi and their grogs might find a giant trivial.
+
+**Ease Factor:** 6 **Threat Level:** Trivial **Effect:** A threat of this level causes discomfort and inconvenience, but rarely causes wounds.
+
+**Ease Factor:** 9
+
+**Threat Level:** Minor **Effect:** A threat of this level damages the equipment of the characters, or causes minor wounds, but rarely kills characters.
+
+**Ease Factor:** 12 **Threat Level:** Serious **Effect:** A threat of this level often causes damage to characters, and seriously wounds or kills them in some encounters.
+
+**Ease Factor:** 15 **Threat Level:** Major **Effect:** A threat of this level often seriously wounds characters, and kills them in about half of all encounters.
+
+**Ease Factor:** 18 **Threat Level:** Overwhelming **Effect:** A threat of this level usually kills characters.
+
+#### Offer Modifiers
+
+Certain situations offer bonuses to rolls for making offers to faeries in the Faerie Realm. A character can only gain a single bonus from a Virtue, or for an offer of goods; use the highest bonus that applies. This includes Virtues not listed here; a character with Puissant Charm and Free Expression only gets a +3 bonus. Further modifiers may apply according to the environmental, attitudinal, or symbolic change desired; see the main text for details.
+
+Stories taking place in Elysium are strongly resistant to this process due to the faithful repetition of legends by mortals in an unchanging form. Consequently, offer rolls to cause changes in Elysium have a penalty of 6. The exception to this is if the creative efforts are bent towards restoring an Elysian story back on track after it has gone astray through the actions of the characters; in this situation all Ease Factors are decreased by 3.
+
+##### Offer Modifier: +1
+
+**Situation:** Offering minor mortal goods that contain vitality, like bread, beer, milk, cheese, and wine.
+
+##### Offer Modifier: +2
+
+**Situation:** Offering mortal crafts that express creativity, like clothes, tools or ornaments.
+
+##### Offer Modifier: +3
+
+**Situation:** Free Expression Virtue, or offering highly desirable items like vis or human children.
+
+If your troupe is using the rules for artistic creation in *Art & Academe*, the following bonuses can also be gained:
+
+**Offer Modifier:** +1 per 3 points (or fraction) of Reputation **Situation:** Artistic Reputation
+
+**Offer Modifier:** +1 per 5 points (or fraction) of Might Score
+
+**Situation:** Might bequeathed by a Faerie Patron
+
+#### The Promise of Service
+
+In addition to offering mundane goods and one's personal gift of vitality, the human character must make a promise to perform some action that symbolically transfers the vitality to Faerie. This promise might be entirely symbolic and accomplished immediately, or may involve a complex scheme to grant a major boon, thereby enacting a story. It is this action — or the promise of the action — that negates the threat posed by the story. Naturally, the greater the promise, the bigger the bonus to the Offer Total, but woe betide those who renege on a promise made to Faerie!
+
+##### Promise Modifier: –6
+
+**Situation:** Mundane actions entirely overcome the threat.
+
+**Example:** *The giant blocking the pass agrees to lay down his weapons after shaking hands*.
+
+##### Promise Modifier: –3
+
+**Situation:** The threat can be evaded with a series of simple symbolic actions.
+
+**Example:** *The giant blocking the pass agrees to kneel, and if a character can remove his head with a single blow he and his companions can continue*.
+
+**Promise Modifier:** 0
+
+**Situation:** The character can follow a conventional story to overcome the threat.
+
+**Example:** *The giant blocking the pass allows passage if a character can inflict on him a wound in single combat*.
+
+##### Promise Modifier: +3
+
+**Situation:** A cunning plan with a high chance of failure is still required to overcome the threat.
+
+**Example:** *The giant blocking the pass allows passage if the character promises to retrieve his heart from the clutches of the witch who has stolen it*.
+
+#### Changes in Environment
+
+A character may use artistic Abilities to alter the environment of Faerie areas. Magi and highly cognizant faeries understand that what is really happening is that the artist is altering the glamour that the principal faerie has spread over the area. The faerie's glamour allows this to improve the story in a way requested by the human. In exchange, the faerie is able to harvest a little of the vitality of the human, when the story concludes, and may gain other benefits through negotiation.
+
+##### Change Modifier: +3
+
+**Desired Change:** Change a single object in the environment for the characters to use as a tool to overcome the threat.
+
+##### Change Modifier: 0
+
+**Desired Change:** Change the immediate environment so that the characters gain substantial advantage against the threat.
+
+# Changes in Attitude
+
+The simplest change the faerie can accept is an alteration in its role in the story. A faerie blocking the progress of the characters, that allows them to pass in exchange for a cask of beer, is accepting a change of attitude. By taking a symbolic object offered by the humans, and harvesting a little vitality as their story progresses, the faerie agrees to a minor change in the part of its glamour that affects its attitude. Powerful faeries, which present greater challenges, require greater prompting to alter their role. Changes of attitude usually only last for a single transaction, and may only be toward a single person.
+
+##### Change Modifier: –3
+
+**Desired Change:**Change the intentions of a faerie so that the characters gain a substantial advantage. This may be expressed by changing the faerie's apparent Personality Traits by up to 3 points.
+
+##### Change Modifier: –6
+
+**Desired Change:** Change the mind of a faerie comprehensively. This may be expressed by changing the faerie's apparent Personality Traits by up to 5 points.
+
+#### Changes in Symbolism
+
+A character with an understanding of symbolism may be able to alter the glamour of the faerie so that its motifs change. This has profound effects on the faerie, since the appearance, actions, and thoughts of a faerie are inextricably connected. There is no simple way for a human to know which changes are possible within the faerie's glamour before the attempt, and many faeries are angered by efforts to rewrite their nature.
+
+##### Change Modifier: –3
+
+**Desired Change:** Change the motif of a faerie so that the characters gain a substantial advantage. This may be expressed by changing the motif of the faerie to another, strongly related motif.
+
+##### Change Modifier: –6
+
+**Desired Change:** Change the motif of a faerie comprehensively. This may be expressed by changing the motif of the faerie to another, tenuously related motif.
+
+#### An Example of Using Creativity
+
+*The characters are in the woods of the Queen of Winter, and are trekking to her palace. A closing blizzard is a Serious threat (Ease Factor 12). One of the player characters is a minstrel with a Communication + Profession score of 8 and the Free Expression Virtue, which provides him with a base Offer Total of 11, before the stress die and bonuses. He knows that he can use his art to change the way the story is progressing, but pauses to consider his options, and ask his magi for advice. He can:*
+
+- *• Have one of the nearby trees change into a hut, to hide from the storm (+3 changes a single object, –6 requires only mundane actions), for –3 on his roll and few repercussions;*
+- *• Sing the ground around him into spring (0 changes environment, –6 requires only mundane actions), for a –6 on his roll, but may cause alarm to nearby faeries;*
+
+- *• Draw out a local ice maiden and offer to woo and bed her, if she will thaw the earth about his camp (–3 changes the mind of a local faerie, –3 requires simple but ritualized actions), for a –6 on his roll, and requiring a Carouse check. Allows easy passage through the area where the ice maiden's writ runs, protecting from weather while camping and from faeries weaker than she is;*
+- *• Sing of the beautiful gift he would bring to the Queen of Winter if only she were not so harsh and cruel, assuming that the blizzard represents her attitude (–6 changes a major motif of the faerie, +3 for owing the troupe a cunning and dangerous plan), for a –3 on his roll. Thaws the Queen's disposition to the party, making the entire trip easier, but the minstrel needs the perfect gift or a cunning plan to avoid death when the characters arrive at the Palace.*
+
+>## Consequences of Creativity
+> 
+> The use of creativity in the Faerie Realm allows a character to change a story, and potentially bypass a dramatic story element. However, the intention is that this process should never be resolved by a simple die roll; to make even relatively minor changes to a faerie the character must come up with a clever way to employ his creative abilities, and must often also promise a story in return for the resolution. Further, the cost in terms of fable points and Fatigue limits the use of this device in any given story. Creativity cannot entirely bypass an entire story, just a single plot element. And by encouraging creative ways to negotiate their way out of a situation they cannot solve in their usual manner, the player characters are generating stories and feeding Faerie. A storyguide should ensure that as much enjoyment can be derived from the creative changes as from the original story.
+
+>## Leaving by Using Merinita Mysteries
+> 
+> Members of House Merinita who are Initiated into the Mystery Virtue of Arcadian Travel (*Houses of Hermes: Mystery Cults*, page 92) can leave the Faerie Realm with greater ease and finesse than other characters. They can not only leave before the story has ended, but they can also choose their destination. The maga must have a charm for this process (see Arcadian Mysteries under Entering Faerie, earlier), and must generate an Arcadian Travel Total equal to (13 – destination aura modifier) x 3. If she has an Arcane Connection to her destination, she subtracts 6 from the Ease Factor. She can leave the Faerie Realm with as many additional travelers as her score in Faerie Magic; these need not be those with whom she entered the Faerie Realm. Any she leaves behind must find their own way home. The rules for determining the passage of time and warping apply to characters leaving the Faerie Realm through Arcadian Travel just like any other characters.
+
+Characters cannot prolong their stay in the Faerie Realm by refusing to partake in stories. For example, aware of the time dilation effect of Faerie (see later), a magus might decide to spend a season studying in Arcadia on the assumption that a miniscule amount of time might pass in the real world. However, this never works. The very essence of the Faerie Realm is story, and adventure will quite literally come knocking on the character's door. Furthermore, the resolution of even the tiniest of nuisances ends the story and the character finds himself back in the mundane world.
+
+>## The Subjective Nature of Time
+> 
+> What happens if a group of characters travels into the Faerie Realm and meets up with another human who has been there for a different amount of real time — and then they all return together? For example, the characters aim to release the captive of a faerie from several months of bondage. Should this situation occur, the storyguide must determine what happens when they all return together; some possibilities are given here. Note that the effects of such a situation should not be known prior to the rescue event, and may be different the next time such a situation occurs.
+> 
+> - Time passes at the rate determined by the rescuers.
+> - As above, but the rescued person ages the number of years difference.
+> - Time passes at the rate determined by the rescued character.
+> - The rescued character disappears upon reaching the mundane world, only to reappear years later after the appropriate time has passed.
+> - The rescued person is replaced by an exact faerie replica.
+> - Nothing untoward appears to happen at all.
+
+## Leaving Faerie
+
+Adventures in the Faerie Realm come to an end when the story reaches its conclusion. Due to the nature of stories in Faerie there is always a conclusive end: the hero triumphs over the villain, recovers the princess, or fails to save his kingdom from his half-brother. Once the story has run its natural course, the characters encounter the Guardian of the Threshold again, who sends them home. Under most circumstances, the Guardian appears slightly different than when the characters first met it, depending on the outcome of the story. For example, if a story revolved around fighting the force of Winter and restoring Spring, then the ancient white stag who initially barred their passage may return as a stumbling fawn. If the story ends by the hero marrying the princess, the bride may transform into the crone who acted as the Guardian. The inscription on a monolith might change, or a barrier of thorns transform into a garden of roses. Whatever the change, passing the Guardian the second time returns the characters to the mundane world. They are usually deposited in the same place they left, but characters exploiting the Mother Road (see later) intentionally or by accident find themselves elsewhere.
+
+### Warping and the Passage of Time
+
+None leave the Faerie Realm unscathed. Those characters who reveled in the stories they played out may have been assisted by the vitality they accumulated (in terms of fable points), but this vitality means that they are more likely to suffer permanent effects from the adventure in terms of Warping points. Further, these characters may discover that they have been away much longer than they believed; and that weeks, months, or even years have passed when they thought it was merely days.
+
+Conversely, characters who stubbornly resist the lure of the story have a more-difficult time resolving the issues to effect a return home (since they do not accumulate fable points to spend), but by avoiding the story they have resisted the transformative effect of the Faerie Realm's glamour, and escape with little or no Warping. Additionally, by rejecting Faerie it rejects them in return, and the whole experience in Faerie may take less time than they believed.
+
+Once the story is over and the characters
+
+are ready to return home, convert any remaining fable points into fable score, if possible. The final fable score determines the speed by which time passes in the mortal world:
+
+| Fable Score | 1 Faerie Day Lasts |
+|-------------|--------------------|
+| 0           | 1 hour             |
+| 1           | 12 hours           |
+| 2           | 1 day              |
+| 3           | 3 days             |
+| 4           | 1 week             |
+| 5           | 1 month            |
+| 6           | 1 season           |
+| 7+          | 1 year             |
+
+As the character passes out of Faerie he can feel the warring powers of mundanity and glamour beating at him, and may elect to shield himself against the excessive passage of time by taking some of the realm's glamour with him when he goes. In game terms, the player can elect to take Warping points for his character to avoid substantial dilation of time due to a stay in Faerie. Every Warping point taken reduces the effective fable score by 1. Thus, a character who spent four days in Arcadia and gained a fable score of 5 in that time can elect to take 3 Warping points and reduce the real duration of the adventure from four months to four days.
+
+It is not necessary to take Warping points to ameliorate the faster passage of time, and many characters instinctively reject the siren call of glamour as they pass into the mundane world. Any character with the Faerie Lore Ability of at least 1 is aware of the possibility and can warn others of the potential for losing time, and how to guard against it. If a group of characters leave the Faerie Realm at the same time, they all suffer the same time dilation effect, equal to that of the person who elected for the lowest effective fable score. All the other characters take sufficient Warping points to bring them to the same level. Magi do not need to check to see if they enter Twilight for receiving these Warping points. Unlike time dilation in some Faerie regiones (see Chapter 1: Nature of Faerie), characters in the Faerie Realm make aging rolls according to the time spent in Faerie, not the time that has passed in the real world. 
+
+*Example: Branoic is lost in the Faerie Realm, but he is heedful of his grandmother's tales about avoiding the generosity of faeries (he has a Faerie Lore of 1). He accepts just 3 fable points in the three days it takes him to complete the story (fable score 2), and his player chooses to take 2 Warping points upon leaving Faerie. His effective fable score is therefore 0, and each of the three days he spent on his adventure lasted just one hour. He makes it home before dawn.*
+
+*Example: Fleeing the Norman invasion of England, a Saxon nobleman called Aethelbald stumbles into the Faerie realm with the assistance of a seductive faerie queen who desires him as only faeries can. Initially he rejects her advances, and accumulates only a meager amount of vitality. However, he is eventually won over by the wiles of the queen, and luxuriates in the bounty of her kingdom. After five months of feasting, hunting, and adventuring he feels he has recuperated sufficiently and seeks a way home. Upon crossing the Threshold he resists the call of Faerie due to his desire to rejoin the fight against his Norman foes, and chooses to take no Warping points. To his dismay, Aethelbald discovers that a whole year has passed for every one of the 140 days he spent with his supernatural lover (since his final fable score was 8), and it is now the 1220th Year of Our Lord.*
+
+### Living in the Story
+
+A character can quite literally become a living story in the Faerie Realm. Rather than participating in stories, the character begins to stage them instead, and becomes more and more mired in the glamour of the realm. Eventually the desire to return home fades entirely, along with the character's humanity. The glamour of the Faerie Realm gradually replaces his flesh, and the character becomes a faerie. Since the character has retired from the game by choosing to remain in Faerie, there needs to be no specific mechanic for this process; troupes who need to simulate it are directed towards the Becoming Mystery Virtue on pages 93–96 of *Houses of Hermes: Mystery Cults*, House Merinita. Typically, this process starts to takes place after several years pass since gaining a fable score of 10.
+
+## Spinning Tales in the Faerie Realm
+
+Stories that take place in the Faerie Realm are fairy tales in a way that tales involving faeries in the mundane world are not. In worldly stories, it isn't possible for a peasant to become a prince, but in Faerie this is not only possible, but expected. Advice on running faerie stories in general can be found in Chapter 7: Telling Faerie Stories, but when using these ideas for adventures in the Faerie Realm you can be less inhibited. Here the fabulous is commonplace and marvels can be bought for two a penny. Due to this loosening of the bounds of the credible and the banal, stories spun in the Faerie Realm should be more vivid than would normally be entertained, and perhaps more bizarre. One way to make a clear separation between faerie stories in the mundane world and those in the Faerie Realm is through audience participation.
+
+### Audience Participation
+
+Fairy stories are not static things. Every storyteller worth her salt embellishes a tale as she spins it, making it truly hers. The story is thus invested with the teller's own creativity, and has appeal even to those who have heard it before. In this vein, stories that take place in the Faerie Realm need not be fixed and immutable. While the story has defined dramatis personae and acts, the playing out of those acts by player characters can often take an unexpected turn, and in the Realm of Stories itself, this should be even more true. Allowing the characters to change the stories that they are experiencing through the expenditure of fable points (see Creativity in the Faerie Realm, earlier) puts some of the power into the hands of the players. Another effective way to make the players invest in the tales of the Faerie Realm is to offer some of the control of the plot to them directly. This can be done in two principle ways. **Playerdriven stories** are those in which the players decide even the gross elements of the scenery and the characters they meet, although the storyguide still controls the underlying plot. Alternatively, **player-influenced stories** allow a player to change the events that affect his character without changing the flow of the story too dramatically.
+
+#### Player-Driven Stories
+
+An effective way to introduce the wonder and malleability of a story set in Faerie is to place the reins of the adventure initially in the hands of the players. Imagine this: a group of characters have a reason to enter the Faerie Realm. They perform a rite to attract the Threshold and step onto the Path of Chance. They encounter the Guardian, and negotiate the onwards journey. The storyguide then announces to her players: "leaving the Guardian behind, you proceed deeper into the Faerie Realm. Before you lies the landscape of Arcadia. What does it look like?"
+
+Suddenly, the control of the story is in the hands of the players. After initial confusion (mirrored by the confusion of their characters, no doubt), they begin to describe the scenery before them. The storyguide should ask more questions to clarify the scene before them, looking for ways to integrate one of her story elements, and ensuring that the scene is properly populated with potential storyguide characters, if appropriate. The scene's contents are described by the players, but their role is determined by the storyguide. The players might describe a snow scene complete with the Queen of Winter, but the storyguide determines whether the queen will be a protagonist, antagonist, or simply background color in the story.
+
+This technique may only really works the first time that a group of players experience Arcadia. After the first visit — indeed, after the first few scenes of the first visit this technique quickly loses its focus, and the storyguide will need to exert some control over the story to ensure that it includes the elements she has planned. However, some troupes may take to the freeform nature of this technique, and decide to continue with player-driven stories rather than adopting a more traditional style of gaming.
+
+> # Example Plot Devices
+> 
+> Proverbs make excellent plot devices, and storyguides are encouraged to use books or web pages of proverbs and aphorisms to invent new plot devices. Here are twenty plot devices (some proverbial, some not) to get you started:
+> 
+> Charity Begins at Home Even a Strong Man Drowns in Armor Familiarity Breeds Contempt Double Jeopardy Pride Comes Before a Fall To Err is Human A Stumble Prevents a Fall
+> 
+> Misplaced Trust is the Unkindest Cut Barking Dogs Don't Bite Give a Man a Second Chance Every "Bad" has its "Worse" Diamonds May Be Overlooked When
+> 
+> Covered in Mud Kind Words Unlock Iron Doors A Dragon's Tail Can Look Like a Snake Every Garden Has Weeds Every Cloud has a Silver Lining Many Hands Make Light Work There is Nothing to Fear but Fear Itself A Problem Shared is a Problem Halved What Doesn't Kill Me Makes Me Stronger
+
+#### Player-Influenced Stories
+
+An alternative to the player-driven stories, but still not returning wholly to the storyguide-driven stories of the mundane world, are those stories in which players influence the outcome of certain events in a way that enhances the enjoyment for all without abandoning the point of the story itself. This can be done by issuing each player with a generic plot device that he can use once during the adventure in the Faerie Realm. A plot device should be encapsulated in a succinct phrase or proverb, such as "misery loves company" or "never judge a book by its cover," and given in secret to the player. At any point in the game, the player can elect to influence the plot by employing his device, which he should do by revealing the device to the storyguide and briefly outlining how the device can be used to change the current situation. A plot device is applied to the player's own character, and can change the situation for that character only; although storyguide characters and perhaps any pooled characters may be indirectly affected. A plot device cannot directly influence another player's character. The storyguide should try find a way to integrate the suggestions of the player into the scene, but is not obliged to do so and can always veto the use of a plot device if it does not seem appropriate. If the plot device is refused by the storyguide, then the player can attempt to use it later on in the story.
+
+*Example: In the court of the King of Summer, Mark's character accidentally insults the king, and is condemned to imprisonment awaiting judgment. Richard (another player) employs his "misery loves company" plot device, and suggests to the storyguide that his magus is condemned along with the offending character, as Richard feels that the two characters together may be able to make an escape. Their storyguide agrees, and the king deems that since the magus laughed at the insult, he will suffer the same fate as the slanderer. Note that Mark couldn't have used the same plot device to drag Richard's magus into the same fate as his own character, because plot devices do not work on another player's character.*
+
+Plot devices should *not* be tailored to the specifics of the story. That is, the successful resolution of a story should not be dependent on a player employing the plot device assigned to him. Plot devices are assigned to players, not characters. If you are using the troupe-style play of **Ars Magica Fifth Edition**, then the player should use his plot device on his magus or companion character rather than any grog character he is currently running. However, this is not a hard and fast rule, and the plot device should be employed where it will improve the game the most. Successfully employing a plot device is worth the reward of a bonus Confidence point at the end of the story, and also earns the character to whom it was applied a fable point.
+
+> # Example of Arcadian Story Creation
+> 
+> Andrea is planning an adventure in Arcadia. She knows that the purpose of the journey is to free the local priest from the grip of a disgruntled faerie, so she makes the Enchanted Priest one of her story elements. She also wants to introduce her players to a particular faerie— Lofanneth Wolf-Brother — who will be important in a later story. Finally, she needs to include the priest's captor Arduinna, the villain of the piece, and a variant of the Pale Man element described later. She decides to pick two more elements at random from the tables later on in this chapter, and comes up with the Stone Drum and the Wounded River. She now has to associate these elements with each other. Arduinna is clearly the captor of the Enchanted Priest, and Andrea also decides to make Lofanneth Wolf-Brother her captive as well, but she overlays this with a link of rivalry between the two faeries. Andrea makes the Stone Drum the weakness of Arduinna; the sound it makes causes all her powers to cease. Lofanneth is the donor who is the means by which the heroes (i.e. the characters) acquire the Drum, in that he knows where it is hidden. But since he is under Arduinna's power, he can't tell anyone. Finally, the Wounded River (a strange combination, but it came up at random and Andrea liked the idea of a river of blood) is where the drum is hidden, but Andrea also decides to link it to Arduinna, in that she bathes there every day to refresh her Might.
+> 
+> From starting with a handful of elements, Andrea has invented a story in a matter of minutes that has the feel of a faerie tale. She doesn't know the details yet, but the framework is there already. Since she already knows that the characters will be entering Arcadia using a river as a geographical boundary, she decides that this will become the Wounded River once they cross the Threshold, making it the first story element to be encountered. They will then encounter a Transference act that takes them either to Arduinna (initiating a Reconnaissance) or Lofanneth (initiating a Receipt).
+
+#### Pitfalls in Player-Run Stories
+
+Player-driven or player-influenced stories are an effective storytelling technique, but the storyguide must be careful not to allow her players to dominate the story. She must be prepared to veto any player input that threatens to unbalance the game or wreck her plotlines. However, this power of veto should be used sparingly, else why bother with player input in the first place? Remember that player-driven elements cannot determine the *role* of any given element, only its *description*, so a player cannot create a plot-breaking device. A player-influenced device is similarly limited in that it can affect only a single scene (and only the player's own character), so there are no "get out of jail free" devices that bypass the challenge presented by the story.
+
+Another pitfall to avoid is familiarity. If the characters are (un)lucky enough to make another trip to the Faerie Realm, change the rules. If you used player-driven plots before, use player-influenced ones this time. Faerie in general — and Arcadia in particular — should never be predictable. 
+
+## Arcadia
+
+Arcadia is the face of the Faerie Realm where new stories are born. It can be a place of fanciful whimsy, abject terror, high fantasy, or gritty bloodshed, or perhaps all of these and more. Of the three faces of the Faerie Realm presented in this chapter, Arcadia is the one with which long-time players of Ars Magica will be most familiar, and for characters "in the know" it is the place that they usually mean when they speak of the Faerie Realm.
+
+The Path of Chance is so named since journeys into Arcadia have no plan (as there is in Elysium) or purpose (as there is in Eudokia). Primarily, therefore, it is a place of adventure and experience. Arcadia is responsive to the perceptions of those who experience it, and in contrast to many stories in a typical game session, the players have as much influence over the flow of the story as does the storyguide.
+
+### The Inhabitants of Arcadia
+
+Everything in Arcadia is potentially a faerie — the creatures, the objects, even the landscape the characters walk though. More precisely, every entity that comes to the attention of mortal characters has the potential to become an element in the story they experience while in Arcadia.
+
+Students of Faerie have debated as to whether Arcadia is the home to faeries, or their point of origin, or if it is independent of the faeries found in the mortal realm. Like the nature of the faeries themselves, such questions cannot be answered. The same types of faeries found in the mundane world are found in Arcadia, but here they all take on an additional role — The role is that imposed upon them by the presence of the characters. In the mundane world, a story is defined by the faeries who act it out; but in Arcadia, the story defines the faerie.
+
+### The Path of Chance
+
+Arcadia is the most common destination of mundanes entering the Faerie Realm because any of the conditions that attract a Threshold can lead to the Path of Chance. Trods — which are by far the most common routes into Faerie — almost all lead to Arcadia, as do extemporized works of artistic endeavor.
+
+#### Typical Arcadian Guardians of the Threshold
+
+Arcadian Guardians of the Threshold are most commonly animals or humans, although the other types of guardians do occur. It is common for the Guardians who block the Path of Chance to place some form of blessing or prohibition on characters who choose to continue on the path. Some examples follow.
+
+- A woman, unbelievably old, is wrapped in a warm woolen shawl. Those who accept her invitation for a meal in the safety of her hut miss the Threshold. Those who politely decline are given a friendly warning not to eat any food they're offered.
+- A terrapin who has fallen onto his back pleads with the characters to restore him to the safety of his pool, which he says is just around a nearby thicket. In reality, that path leads them back to the mundane world. He may curse the characters who pass him by, promising them misfortune near water.
+- A sibyl with a book under one arm containing her prophecies. She warns them to return to whence they came for she has foreseen a dire fate for them. If they inquire of this fate but are resolved to continue, the doom she utters is sure to come about.
+- A goose stands at the fork in a path. She states that one path leads to safety (without revealing that this equates to the mundane world), but the other leads to excitement and peril. Should they choose the latter, she'll grant them a gift to aid them against the dangers they will face.
+- A thicket of wild roses, the color of sunset. The tangle is almost impassable, and those who attempt it are sure to be pricked by the poisonous thorns, and yet make it through to Faerie.
+- A sphinx who declares that none shall pass unless they can tell her a riddle she cannot answer. Those who succeed are punished for their cleverness.
+
+### Arcadian Stories
+
+In Arcadia, the rambling Path of Chance can take the characters off in any number of directions, but an Arcadian adventure is perhaps not as random as some might think. The difference between it and an adventure in the mundane world is that the players play an equal role in determining the story with the storyguide. Note that this is an equal share — stories run in Arcadia are not necessarily player-led. The storyguide should plan the major elements of the story that she wishes her players to experience, but should not lock these plot elements into a rigid order or linear path.
+
+#### Planning Arcadian Stories
+
+Stories in Arcadia should be free-form and flexible. There should be no need to follow a logical order in acts in Arcadia; such chaos is a feature of many faerie tales. For example, take the following story elements: the Rye-King who has stolen a child; a Mouse who knows the King's only weakness; a Tree of Silver from which an arrow must be fashioned to kill him; and a Palace of Woven Grass that is the prison of the stolen child. While this might seem like the obvious order in which to encounter these elements, they can actually occur in any order. The characters might visit the Palace of Woven Grass first and rescue the child, and spend the rest of the story being pursued by the Rye-King. Else they might meet the Mouse first without realizing his true worth, and when they seek him out again the manner in which he was treated the first time determines how willing he is to assist.
+
+There is a simple method to put together a story in Arcadia that will have the feel of a faerie tale. Later on in this chapter are described a number of story elements — actors, props, and scenery. The relationships between each of these elements builds up the story. Pick a number of story elements — a good guide is to take one per story experience point you intend to hand out. These can be chosen from the accompanying lists, randomly determined on the tables, or invented from your own imagination. Determine whether each of the story elements will be a dramatis persona, or else take part in an act, or both. Now associate each of these elements with one to three other elements through a link of some description. This link might be another story act (such as Villainy, Trickery, or so forth), or it might be an emotion or weakness. Finally, determine which element will serve as the start point for the character's adventures. To run the story in Arcadia, the characters will travel from story element to story element along the links you have provided.
+
+### Elysium
+
+In the Land of Legend, all stories have already been told. Here, characters can encounter Roland fighting the Moors in Spain, take part in the abduction of Idun from Asgard, or stalk Theseus in the labyrinth in the place of the Minotaur. It matters not that a story is little-remembered in the current day; if it was told, and loved, then it lives on in Elysium.
+
+The reasons for coming to Elysium are varied. The most basic is to witness a great legend in action, although most player-characters do not make good spectators to such stories. There is a strong temptation to become involved — who would not relish casting spells with Merlin or fighting alongside Romulus? Such interference is usually harmless, and may form an important part in an Initiation Quest into a Mystery Cult. However, since all legends in Elysium derive from human-told stories, it is not possible to uncover secrets unknown to the tellers of the legend. The faerie copy of a local dragon legend cannot be used to discover the dragon's fatal weakness, unless that weakness is part of the legend. The words whispered by Odin to his dead son Balder will forever remain a mystery even if the characters witness the funeral first hand in Elysium. These stories are just faerie copies of the true tales, and encompass all the variants, twists, and permutations that have been added over the years.
+
+The stories in Elysium can serve a greater purpose than simply to echo a heroic deed, though. By stepping onto the Path of Destiny, a character can intentionally take the role of one of the dramatis personae in a suitable story that symbolizes a task for which he needs help. By completing the story in the manner prescribed by the tale, the "hero" acquires a vital boon to some fitting task. This boon is often an insight into the desired problem, but may also be some forgotten detail of the story, or else a supernatural item or power brought out of Faerie to complete its destined purpose.
+
+*For example, a magus is searching for the key to a long-forgotten tradition of necromancy (perhaps Canaanite Necromancy, from* Ancient Magic*, pages 30–34). However, his research has hit a dead end, so he chooses to embark on a quest in Elysium to acquire an insight. He targets the story of Orpheus and Eurydice, partially because it deals with the dead, and partially because the theme is the recovery of something that is lost. The magus takes on the role of Orpheus, and travels into the Faerie Realm. He negotiates his way past Kerberos and the Judges of the Dead, quiets the torment of the damned with his magic, and melts the heart of Persephone. When, as his final act in reenacting the story, he turns to face Eurydice at the mouth of the tunnel from Hades, instead of the fleeting ghost of his lover, he receives a vision of an ancient city, and knows now where he must go to put his research back on track.* 
+
+The aid provided by the successful conclusion of an Elysian quest is rarely direct, and it cannot be of a non-Faerie nature. For example, it could not grant an Insight (*Ancient Magic*, pages 8–9) into lost magic since this is a Magical process; nor could it result in simply being handed the answer to a problem. However, the hint or knowledge obtained is sufficient to point the characters in the correct direction.
+
+While an Elysian quest is an unusual way to advance a plot, it is an appropriately mythic one, and can provide insights or help where none is mundanely possible. It requires careful planning by the storyguide and the characters who intend to embark on the quest, for they must ensure that every act in the original story has the same overall resolution in their reenactment, even if the exact details are not right. In the example given above, it does not matter how Kerberos is evaded, or how Persephone is impressed, as long as these things occur.
+
+There are a large number of stories known to the inhabitants of Mythic Europe that make suitable stories for adventures in Elysium. Listed below are a number of stories that are appropriate to Elysian adventures; searching for these names in libraries and on the internet will reveal the full text, and more examples can be found in the sources listed in Chapter 8: Bibliography.
+
+#### The Bible
+
+It might seem surprising that biblical stories could be part of adventures set in the Faerie Realm. However, they fit all the requirements for Elysian stories, in that they are told often and they provoke an emotional response in the listener. The Old Testament, in particular, is filled with highly appropriate stories. Although many of the characters in these stories are suspected to have possessed Divine Powers, in Elysium they have Faerie Powers. Remember that these characters are not actually the prophets and kings of history, just faeries who are playing their roles. No-one has ever recounted an attempt to embark on an Elysian story taking the role of Christ, these being too blasphemous for most characters to consider. 
+
+- Lot's escape from Sodom and Gomorrah (Genesis 18–19)
+- Jael and Sisera (Judges 5–6)
+- Samson and Delilah (Judges 13–16)
+- David and Goliath (I Samuel 17)
+- King Jereboam and the Prophet (I Kings 13)
+- The Testing of Job (Job, passim)
+- The Conversion of Saul (Acts 9)
+
+#### Legends of Ancient Greece and Dead Rome
+
+The transmission of ancient Greek legends to the medieval period is far from complete, and only educated men are familiar with them. And even then, such stories are only commonly encountered as counter-examples to a good, Christian life. The later history of Rome — that is, outside of the legendary period and into the history books — also provides a wealth of stories.
+
+- The Sorrows and Labors of Hercules
+- The Sack of Troy
+- Theseus in the Underworld
+- Prometheus, Epimetheus, and Pandora
+- The Flight of Icarus
+- Romulus and Remus
+
+#### Pagan Legends
+
+The legends of pagan peoples were generally recorded by members of the clergy following the conversion of their country. In Ireland, for example, stories were gathered in the fifth and sixth centuries, in Wales in the eighth and ninth centuries, and in Scandinavia in the eleventh and twelfth centuries (Snorri Sturluson, the great compiler of the Norse myths, is still alive in Iceland in 1220). As folk tales, these stories of gods and pagan heroes live much longer in the popular memory, although some may have been cleaned of paganism to pacify the Church.
+
+- Cu Chulainn
+- Oisin and Niamh
+- Culhwch and Olwen
+- Pwyll, Prince of Dyfed
+- Thor and Thrym
+- Bard, the God of Snaefell
+
+#### Romances and Märchen
+
+The medieval fascination with the romances of King Arthur and his court has yet to reach its peak, and yet many stories are already well known in parts of Mythic Europe, particularly France and England. Sir Lancelot has yet to make an appearance in his familiar form, and the legend of the Grail Quest has not been fully realized, but many familiar elements are already in place. The *chasons de geste* of French-speaking lands and the *Märchen* of German lands constitute the principle cycles of non-Arthurian epics, which together with local folk tales constitute a rich heritage of storytelling in Mythic Europe.
+
+- Perceval
+- Gawain
+- The Song of Roland
+- Reynard the Fox
+- Huon of Bordeaux
+- Maugis d'Aigremont
+- Herzog Ernst
+
+#### A Thousand and One Nights
+
+Professional storytellers, or *rawis*, are a popular part of the culture of Islamic lands, and talented amateurs love to get their hand in wherever they can. The opposition from Islam regarding falsehood and deception has lead to elaborate circumlocutions: "It is said — but only Allah knows the truth — that ..." has become a clichéd, but necessary, way to open a story.
+
+- The Story of Es-Sindibad of the Sea and Es-Sindibad of the Land
+- The Story of the City of Brass
+- Prince Camaralzaman and the Princess Badoura
+- ' Antar, slave, warrior, and poet
+- Rustem, slayer of dragons and demons
+
+### The Road of Destiny
+
+It is unusual — although not impossible — for a group of characters to stumble onto the Path of Destiny by mistake; accidentally crossing the Threshold is much more likely to lead to Arcadia or Eudokia. Getting to Elysium requires a certain amount of forethought, since all the conditions affecting Threshold points must be specifically aligned toward the story the characters desire. The timing of the journey should coincide with an auspicious time (such as the feast-day of a god, the anniversary of a hero, etc.). Any Faerie auras should arise from an appropriate location, artistic endeavors employed should be in praise or commemoration of the target story, and so forth. Not all these elements must be present, but all sources of Threshold points that are inappropriate actually subtract from the total, rather than adding to it.
+
+#### Typical Elysian Guardians of the Threshold
+
+Elysian Guardians of the Threshold are most commonly of the kerberos type, taking the form of horrible monsters or seemingly dangerous challenges. An important function of the Elysian Guardian is to confer a symbol of the role of hero; this is usually accompanied by a boon (which is often a Virtue with a Charm, see Chapter 5: Touches of Faerie) and a prohibition.
+
+- A three-headed dog, the original Kerberos. He is chained to a post, but the characters cannot squeeze past. He can be put to sleep with honey cakes. After passing the creature the characters see a patch of blue flowers, the only thing within reach that the monster has left untouched. This herb can repel monsters.
+
+- A knight blocks the road; his armor is enameled in red, and his helm obscures his face. He demands single combat with a champion, else none shall pass. The Red Knight's combat scores are identical to those of the character, but any wounds he inflict heal like Fatigue levels after the fight. If the character wins, the knight cedes his sword, but admonishes his opponent to never refuse an honorable battle.
+- The baying of hounds and drumming of hooves heralds a large host ahead; a person is bound to be reminded of the Wild Hunt. If he continues, he is confronted merely by a strong wind.
+- An ibis, who looks at the characters with a cocked head and asks them if their hearts are pure enough to proceed. He weighs each heart against a feather plucked from his plumage. Ask each player whether her character's heart is pure. Those who fail do not receive their heart back, and can experience no emotions while in Faerie (although this may be a boon depending upon what they are fated to face).
+
+#### Identification as the Hero
+
+An important aspect of embarking on this road is that of identification. The character or characters, as soon as they pass the Guardian of the Threshold, must declare themselves to be the hero they wish to emulate. By standing in faerie and stating clearly and unequivocally “I am Prince Ivan,” the character is infused with the glamour of Elysium, and becomes Prince Ivan. Every faerie he meets from that point on will treat him as Prince Ivan. His clothes and possessions will change to signify the identification, although he does not acquire any magical accouterments that are significant in the story about to be embarked upon, and all his Characteristics, Abilities, and so forth remain the same. Identification with the hero in this manner costs the character a Confidence point, and thus is only possible for companions and magi. Simply identifying with the hero grants the character his first fable point, and thus a fable score of 1 (see Vitality in Faerie, earlier). This will prove useful in executing the functions of the hero. 
+
+>## Hermetic Legends
+> 
+> Even the stories of the Order of Hermes have been witnessed in Elysium. Magi have reported taking part in Merinita's first meeting with Bonisagus, the First Tribunal, and the Tempest that ended the Schism War. However, witnessing and participating in such stories cannot reveal secrets, for the components of such legends are constituted from the reportage of those who participated and told the tale to other mortals. Thus, the fate of Tytalus when he disappeared into the Maddenhofen woods cannot be illuminated in Faerie, since there were no spectators to this event. Similarly, conflicting stories of the same event (such as the many confused retellings of the Schism War) are equally true in Elysium. And the appearance of the actors (who are of course faeries) conform to the preconceptions of the talespinners — the character of Bonisagus in a story from his own house has a very different appearance than the same character born of a Flambeau tale.
+> 
+> Despite these limitations, Hermetic legends are still a popular topic among the few members of the Order who travel in Elysium. As most of these are members of House Merinita, that Founder is the most commonly witnessed. Those faerie magi who have conversed with an Elysian version of Merinita have come away with the distinct impression that their Founder is alive and well, and living in Faerie …
+
+If the character is not alone on his journey, then there are two options. Firstly, one character can take the role of the hero and be supported by the other characters. In this case the other characters are largely ignored by the inhabitants of Elysium. Any actions they perform to assist the hero in the completion of his tasks are assumed to originate from the hero. However, allowing other characters to overcome challenges on behalf of the hero means that he can never claim total victory for that scene. See later for more details of measuring success.
+
+The other way for multiple characters to take part in a Elysian story is for them to share the role of hero. Each must identify himself as the hero upon entering Elysium through a firm statement and the expenditure of a Confidence point. Following this, any of the identified characters can act in the role of the hero, but only one at a time. There must be some form of token — a sword, hat, cloak, or so forth — that the character currently taking the role of the hero must possess. The character who carries this token is treated as the hero. Even if the token is handed over in full view of a faerie, the faerie simply redirects his attention to the new character and seems not to notice the change in person. Note, however, that highly cognizant faeries (of which there are admittedly few in Elysium) recognize this change in role and may seek to prevent it, although will still accept it if it takes place. It is wise from a game management point of view to issue the players with a token as well (such as a stick or a hat), to indicate the current “owner” of the hero’s role. 
+
+### Elysian Stories
+
+A story on the Path of Destiny is very different than most stories in **Ars Magica Fifth Edition**, even than other stories set in the Faerie Realm. In an Elysian story, the characters already know how the story is going to play out. They are aware of the identity of the villain, and know what must be done by the hero to achieve victory. The focus of an Elysian journey is to recreate a story; to ensure that the same challenges are faced by the characters emulating the hero. The success of such an adventure is counted by the measure to which the characters have managed to walk the same steps as the legendary hero who is their role model.
+
+It is also usually the case that the players pick the story, rather than having it happen to them. Thus, there is no chance that the characters get the story wrong, end up in an inappropriate story, or fail to pursue the correct course of action through ignorance. A journey on the Path of Destiny must be carefully planned: first the story must be identified that relates the most appropriate theme to the insight required; then the characters must deliberately attract the Threshold to gain entry into Faerie; they must ensure that the Threshold is called using the most appropriate method to resonate with the story they desire; and they must then manipulate the events to ensure that the story is completed as planned. This is not to say that the story becomes purely player driven. The storyguide must still plan the particulars of each stage of the story, and then come up with ways that the characters can be confounded in their task.
+
+>## Example of Elysian Story Creation
+> 
+> The characters in Andrea's saga are in desperate need of a source of particular vis to maintain a ritual to safeguard the covenant. They elect to go on an Elysian quest to uncover clues to its location. The story decided upon is that of Reynard the Fox, who is desperately seeking food. The story breaks down into the following scenes:
+> 
+> **Scene 1:** Reynard raids the henhouse and catches Chantecler the cockerel, but is pursued by dogs. The cockerel escapes by appealing to Reynard's pride, making him open his mouth to speak. The characters must sneak into the henhouse and capture the vigilant chicken, then — ensuring that they have been spotted — let their prize go.
+> 
+> **Scene 2:** Still hungry, Reynard encounters a titmouse, who he persuades to give him a kiss, hoping to get a juicy mouthful of bird. He is tricked by the titmouse into revealing his true nature. The characters must continue to evade the dogs, which is the real purpose of this act; since deliberately *failing* to eat a small bird is hardly a challenge.
+> 
+> **Scene 3:** Reynard next encounters Tibalt the cat. Knowing where there is a snare trap, Reynard challenges Tibalt to a race, but fails three times to snare himself some supper. When the dogs from the henhouse incident catch up with Reynard, Tibalt trips him up and into the snare. Similarly to the previous challenge, deliberately losing a race is no fun. However, the storyguide decides that Tibalt fails to see the snare, and so the characters must prevent him from getting caught despite his own best efforts to do precisely that.
+> 
+> **Scene 4:** Caught in the snare, the farmer has his hands on the thieving fox, and prepares to give him a beating. Once again, Reynard escapes using his sharp tongue. The challenge is two-fold here — endure the beating handed out by the farmer, and outwit him to secure escape.
+> 
+> **Scene 5:** Finally, Reynard encounters Tiercelin the Raven, who has found some cheese. Reynard persuades Tiercelin to display his beautiful singing voice, thus he drops the cheese. Reynard finally gets to eat. Unfortunately for the characters, Tiercelin is unwilling to sing; he's wise to the fox's plan and will not be fooled in this manner. The characters must make him drop the cheese in a different manner.
+
+#### Planning Elysian Stories
+
+To create a mythological story for characters to emulate, first decide on the base tale that fulfills the needs of the story. This process is normally completed by the players on behalf of their characters. The storyguide should then take the chosen story and break it down into different stages or scenes. Most stories of decent length have five or more separate acts; one element per story experience point you intend to hand out at the culmination of the quest is a good guide. If the story is a short one, then more acts may need to be added; see later for details on this process. For each act, decide what constitutes successful completion, and what factors can prevent the characters from achieving this completion. These factors need not be attested to in the original story, but if complications are invented out of dramatic necessity, they cannot interfere with the original tale.
+
+*Example: In enacting the Arthurian Tale of the Barking Beast (see Chapter 4: Faerie Bestiary), the characters (playing the role of Sir Pellinore) must volunteer for the quest. However, another knight of Arthur's court might volunteer before they get the opportunity; so the characters must persuade him to withdraw, perhaps by dueling him for the honor of the quest.*
+
+#### Adding New Scenes
+
+Not all stories have sufficient scenes for the needs of a story. In such a situation, the storyguide can add new scenes that connect to existing acts. These extra scenes may have no independent measure of success, or they might be an important precursor to a later scene. In effect, the storyguide is creating a "director's cut" of the original story, expanding on the preexisting material and explaining some of the background to the characters, which may have been assumed in previous tales.
+
+*Example: The characters are enacting Thrym's theft of Thor's hammer, playing the role of Thor. However, in their first scene, it turns out that Thor has not yet received his wondrous hammer from the dwarfs. They must seek out and negotiate its purchase, because without the hammer they cannot complete the story.*
+
+*Example: In the story of Culwch and Olwen, Culwch is cursed to be miserable until he marries Olwen, and Olwen's father is cursed to die after his daughter is married. However, the characters discover that at the beginning of their tale, Olwen's father is yet to have received his curse. The original story has no information on the origin of this curse, so the characters must invent one by persuading a faerie to lay that curse for them.*
+
+#### Running Elysian Stories
+
+The important part of an Elysian story is preserving the narrative of the original tale. Whether the characters are taking part in a well-known story and interacting with the characters, or whether they are following an allegorical reflection of a particular tale, each story element must be resolved in the manner of the underlying story for the characters to succeed in their quest. Sometimes it might appear that the story drifts from its original plan due to the meddling of the characters, and that there is a danger that matters will not resolve as they should. For example, in the story of Gawain and the Green Knight, the characters take the role of Gawain. In the original story, Gawain smote the head from the shoulders of the Green Knight. But what if the character playing Gawain misses, or refuses to make an attempt? To complete the story (and thus escape from the Faerie Realm) they must find a way to complete their objective, and bring the story back on track even if the exact circumstances are no longer applicable. In the above example, they must perhaps challenge the Green Knight again, and repeat the intervening quests — this certainly has more flair (and is mythically more appropriate) than simply taking another swing at the knight's neck. The characters are also more likely to succeed in bringing their story back on track if their actions to rectify it generate fable points, since they are obeying the dictates of the story when doing such actions.
+
+>## A Twist to the Tale
+> 
+> An interesting twist on the Elysian story is for the characters to adopt a role other than that of the hero. For most stories, the only appropriate dramatis personae other than the hero are the roles of villain and princess — the remaining minor roles do not offer sufficient scope for stories
+> 
+> For example, in the story of Orpheus and Eurydice, the characters could take the role of Hades. They must ensure that Orpheus is sorely tested but succeeds, and also make sure that he looks back at just the right moment so that Eurydice is still lost to him.
+
+#### The Measure of Success
+
+In Elysium, it is important to keep the elements of the quest as similar to the mythological theme as possible. The storyguide should score the performance of the characters at negotiating each element of the theme, with the score reflecting how similar the resolution of the task was to the original story. This may mean that the characters have to deliberately fail in some tasks. This score simply translates into the total number of fable points earned by the Hero while pursuing the quest. If multiple characters played the Hero, count only points earned when in that role. Count all points earned, not just those converted into a fable score:
+
+| Fable Pts Earned | Reward               |
+|------------------|----------------------|
+| 0–3              | Failure              |
+| 4–6              | Mediocre Success     |
+| 7–9              | Accomplished Success |
+| 10+              | Unmitigated Success  |
+
+The reward level determines how much of the object of their quest the characters receive. For example, typical quests may have as their object a legendary sword, or the means to defeat the dragon Pan Caudarax, or a quest bonus to an Initiation Script of +3. A **mediocre success** is a single fact that was not hitherto known to the characters but does not directly contribute to the object of their quest. Alternatively, it is a small bonus, or an object that grants a slight advantage. For example, the characters discover the lair of the dragon, or gain a +1 bonus to the Initiation Script. An **accomplished success** partially answers the object of the quest, but is incomplete. The characters might discover where the legendary sword was last seen, or that the Chevalier De Panne fought Pan Caudarax and lived. An Initiation Quest grants a +2 bonus, and so forth. An **unmitigated success** reveals to the characters who the last owner of the sword was, or that Pan Caudarax has a weak spot in his hide (but not where that weak spot is), or an Initiation Quest that grants a +3 bonus.
+
+Upon leaving Elysium, the characters should receive the knowledge that they sought, or the object they quested for, or some token representing a numerical bonus (for example, to an Initiation Script). The source of the reward could be met during the final scene of their quest, in which case one of the actors in the quest acts as a Threshold faerie and sends the characters home. Alternatively, the Guardian of the Threshold could reappear following the final scene, and grant them the reward they have earned.
+
+It is important to note that regardless of how they have fared, the characters have not changed the basic legend that they reenacted. Rather, they have created a variant of that tale; which, seeing as they are the only people who know it, pales in comparison to the original story supported by the countless people who have heard it. Even if they recount their adventure far and wide so that it becomes the more-popular contemporary version of the tale, the original retains its potency since the variant cannot replace it in the minds of all those who have heard it in the past, or in written records, or in the memories of those who heard it in the original form. At best, both forms will exist in Elysium, and re-enacting the points that differ determines which is experienced in a quest.
+
+## Eudokia
+
+Eudokia is a land where personal dilemmas are faced. The wanderer on the Forking Path faces a series of encounters or tests that symbolizes some difficult decision or life change he is currently experiencing. These encounters often take the form of moral fables or teaching tales, which divine the character's commitment to a cause or idea, or a decision. Everyone embarking on a Eudokian path leaves the Faerie Realm changed — sometimes for the better, sometimes for the worse.
+
+### The Forking Path
+
+A character typically embarks upon the Forked Path if he strays into a Faerie Aura while on the verge of some major life change. The character might be about to experience dramatically altered circumstances — such when he's about to be married — or else he may be experiencing a personal threshold — such as adolescence, menopause, or senescence. Consequently, experiences in Eudokia tend to be solo affairs, although characters undergoing a similar change occasionally have such adventures together. An example might be a groom and the rest of his stag party, or a cohort of Hermetic apprentices about to take their Gauntlet.
+
+#### Typical Eudokian Guardians of the Threshold
+
+The Guardians of the Forked Path are most often physical barriers rather than animate faeries. It is particularly rare to meet *kerberoi* in Eudokia, since this world is less about adventure and more about personal discovery. Most Eudokian Guardians seek to scare off the wanderers.
+
+- A square-sided pillar blocks the path at a fork. One face points to the left hand path and says "Past me lies adventure and death," while the other faces the right hand path and reads "Past me lies peace and happiness." The right hand path leads out of Faerie.
+- A pile of stones surrounds a stake that bears the skull of a horse. Runes are engraved in blood on both the stake and the skull. One must walk past this ominous sign to enter Faerie.
+- The Guardian is the road itself. Looking to the left, the characters can see a fair filled with bustling customers, hawking merchants, and entertainers. To the right is a quiet glade with a still pool, the very essence of tranquility. The glade of course is actually in the mundane world.
+
+### Eudokian Stories
+
+Eudokian stories are typically mediated by a Threshold faerie, typically one who governs the particular transition that the character or characters are experiencing. So a pregnant mother attracts a birthing faerie, who inflicts upon her a story that either heightens or allays her fear of childbirth. An old man might meet a grave-faerie, and the result of the story is a peaceful death or a struggle to survive a few years longer.
+
+Eudokian stories tend to focus on a single character, which makes them difficult for most **Ars Magica** troupes. However, they need not be solo adventures, since anyone present when the Threshold arrives is taken into Faerie at the same time. Other characters can provide help and support, although usually only the focal character benefits directly from the story in any way other than Story Experience points. It is possible to have more than one focal character in a Eudokian story, though, if more than one character is undergoing a simultaneous transition of the same type. For example, children on the verge of adulthood might experience a Eudokian story together if they play near a faerie trod; a couple who meet (contrary to tradition) on the night before their wedding might be snatched away by the Threshold; and a group of apprentices about to take their Gauntlet might meet a faerie who claims to be the ghost of a famous member of the Order, perhaps even a Founder.
+
+#### Planning Eudokian Stories
+
+To create a Eudokian story, first decide on the theme of the journey on the Forked Path. Choosing the theme is important, as it will determine the reward meted out to the character at the quest's culmination. If the character is to be rewarded for courage and punished for cowardice, then the theme should be Bravery. However, if the character is rewarded for prudence and punished for rashness, then the theme is Caution. Both of these themes could have exactly the same encounters within them, but the consequences of each quest are different. The conditions of the Threshold and its Guardian determine the theme of the story that will take place in Eudokia, and this should always be clear to the character at the point he meets the Guardian. A character who enters Eudokia through a shrine to a war god should expect a theme of Bravery, and given the opportunity to refuse. Without this opportunity, a character with the Noncombatant Flaw would (rightfully) suspect the storyguide of presenting him with a no-win solution and an inevitable penalty. The nature of a Eudokian story is to play to the strengths of a character, or develop such strengths where none currently exist. They are tests of character, and there should always be a fair chance to succeed.
+
+Like the story creation method described earlier for Arcadia, stories in Eudokia are composed of a number of elements. In Eudokian stories, each story element presents a choice between moving closer towards the theme or further away from it. The order in which the story elements occur is not as important as the choices made at each step. To assemble a Eudokian story, first pick a number of story elements — typically one per Story Experience point you intend to hand out. These story elements can be chosen purposefully or determined at random from the sections later on in this chapter, or derived from your own inspiration. However, you may find that random elements are more difficult to integrate into a Eudokian story, which is so tied to a specific theme. Each story element presents a dilemma, and the story element cannot be abandoned until a choice is made. There may be more than two options deriving from each element, but only one choice is in concordance with the theme of the journey.
+
+>## Example Story Themes, and Virtues & Flaws
+> 
+> **Theme:** Courage
+> 
+> **Situation:** Eve of Battle
+> 
+> **Virtue:** Tough
+> 
+> **Flaw:** Fear
+> 
+> 
+> **Theme:** Fertility
+> 
+> **Situation:** Marriage
+> 
+> **Virtue:** Benediction (unusually fecund)
+> 
+> **Flaw:** Malediction (sterility)
+> 
+> 
+> **Theme:** Magic
+> 
+> **Situation:** End of Hermetic Apprenticeship
+> 
+> **Virtue:** Cautious Sorcerer
+> 
+> **Flaw:** Careless Sorcerer
+> 
+> 
+> **Theme:** Skill
+> 
+> **Situation:** End of Craft Apprenticeship
+> 
+> **Virtue:** Puissant Craft
+> 
+> **Flaw:** Clumsy
+
+The target for "success" on a Eudokian journey is to make over half of the right decisions. If the characters reach this target prior to encountering all of the story elements, then the characters meet a Threshold faerie who sends them home. Otherwise, the characters meet the Threshold faerie after they have encountered all the story elements.
+
+### Leaving Eudokia
+
+At the completion of the various challenges put in the way of the characters, it is customary for the Threshold faerie who is mediating the story to appear once again and send them back to the mortal realm with its Spirit Away power. This may not be as obvious as the sudden appearance of a faerie — the characters might just find the way out of the labyrinth that formed the Guardian in the first place, or they may follow a will-o' the-wisp over the hill and back home.
+
+#### Faerie Boons
+
+Characters who embark on a Eudokian journey often return with a blessing or a malediction. Since a journey on the Forked Path is precipitated by a life-changing event, the boon or bane granted by the fae pertains to that event, either on a personal or a community level. Every choice made by the character should be recorded, and a tally made of the number of choices that bring the character closer to the theme of the story ("correct choices") and further away ("incorrect choices"). Note that a correct choice has no moral designation. A story themed around Infidelity played out for a bridegroom has correct choices that lead to cheating and philandering. It might indicate that he is not ready for marriage, if he makes more "correct" choices in this quest. If the number of good choices outweigh the bad, then the overall experience has been positive. The character should adjust an appropriate Personality Trait by one point accordingly. Otherwise, the experience has been negative; again, adjust a Personality Trait to reflect the character's new outlook.
+
+If the character made more correct choices than incorrect choices, then he acquires a Virtue. If all the choices he made were correct, then the Virtue is Major, else it is Minor. All Virtues acquired in this manner are balanced by the Lesser Charm Flaw (for a Minor Virtue) or the Greater Charm Flaw (for a Major Virtue). The Virtue (and its Flaw) may be permanent or it may fade over time, depending on the desires of the troupe. In the latter case, the Virtue vanishes when its governing charm is uncovered, copied, or stolen. See Chapter 5: Touches of Faerie for more details on how Charms affect Virtues.
+
+However, if the character made more incorrect choices than correct choices, then he acquires a Flaw. If all the choices took him further away from the goal, then this Flaw is Major, else it is a Minor Flaw. These Flaws are not balanced with a Virtue, but they fade with time; the character bears the Flaw for an amount of time equal to the time that passed while the character was in Faerie.
+
+> # Example of Eudokian Story Creation
+> 
+> Andrea (the storyguide) is planning a story for Eudokia. The magi in her saga are about to embark on a campaign to exterminate a magical threat to the Order, and she wants to test their commitment to the cause. The theme for this story is Resolve. She randomly chooses five story elements, and constructs from these the following tests.
+> 
+> **An Ancient Wall:** The first story element is a physical barrier to the characters, and Andrea decides it will double as the Guardian of the Threshold. If they cannot surmount the wall, then they cannot even enter Eudokia. The Ease Factors for Athletic rolls get tougher as one gets higher. Magic can easily bypass the wall's barrier, but the wall remains unclimbed — every other act in this story is preceded by having to climb the wall until it is climbed properly.
+> 
+> **The Empty Forest:** Beyond the wall is a forest, the villain. The trees resent the presence of animals and has scared them away — after all, plants were created before mere animals (this mirrors the magical threat as an older tradition than the "upstart" Order). The Empty Forest is seemingly endless, but with enough perseverance against the vegetative foes raised against them, the characters will eventually meet ...
+> 
+> **The Leafy Counselor:** A tree that is at odds with its fellows (does this hint at a potential ally in the rival tradition?). The Counselor wants to help, but must be convinced to betray its leaf-mates (the Counselor acts as the Donor here) through a series of tasks. One of these tasks introduces them to ...
+> 
+> **The Son of the Coin:** A mercenary, who, as the False Hero, intends to incarcerate the characters and steal any honor they have in the eyes of the ruler of this realm. The characters are transferred to a distant place, and they must win their way back to the court of ...
+> 
+> **The Dying Lady:** An ancient ash tree, that has suffered animal attacks (she has serpents gnawing at her roots, deer stripping her bark, and squirrels stealing her seeds), and is the source of the forest's antagonism. She offers them a simple choice — either one character can return to the mundane realm, and win against the foe; or else all can return and they are sure to lose. Are they willing to sacrifice everything for victory?
+
+## Story Elements
+
+The adventures that take place in the Faerie Realm are made up of story elements and acts, as discussed in the previous sections. This section provides some example story elements that can be integrated into any trip to Faerie. Each follows the same template:
+
+#### Title
+
+A descriptive paragraph.
+
+**Path of Chance:** The literal interpretation of the story element, as most commonly discovered in Arcadia. Each story element has a link to the previous or next one.
+
+**Path of Destiny:** The mythological or metaphysical interpretation of he story element, as found along the many roads of Elysium.
+
+**Forking Path:** The figurative interpretation of the story element, leading to one of two (or more) choices.
+
+The story elements have been divided into three separate categories — Actors, Props, and Scenery. Any element in one of these three categories can take one of the roles described later (see Chapter 7: Telling Faerie Stories, Dramatis Personae), and/or become involved in one or more of the scenes (see Chapter 7: Telling Faerie Stories, Acts).
+
+### Actors
+
+The people of Faerie are the actors in its stories — protagonists, antagonists, or incidental characters. Those faeries who constitute a story element are never bit parts or walk-on roles, as such individuals draw no more notice than scenery (see later). In Elysium, the actors are the gods and heroes of antiquity, while in Eudokia they are caricatures of morality.
+
+#### The Pied Stranger
+
+A man whose clothing (or skin) is partly colored; his right side is white and his left side is black. Sometimes his sleeves, gloves, or footwear are counter-changed. He carries a musical instrument — pipes, or sometimes a harp.
+
+**Path of Chance:** As his pied clothing suggests, the man is a magpie — both a thief and an entertainer.
+
+**Path of Destiny:** The two halves are a façade; the Pied Stranger uses his music to steal, and he's after something in particular.
+
+**Forking Path:** His pied clothing echoes the choice: either to entertain the crowds, or to exploit them. The minstrel earns his money, whereas the thief takes it.
+
+#### Grateful Lions
+
+Two lions, indistinguishable from each other. They are impressive and fearsome creatures, but are as playful as kittens, and friendly. They have the ability to speak, and ask for assistance in a minor task (such as removing a thorn, or rescuing their son from a pit). Alternatively, this could be any predatory animal.
+
+**Path of Chance:** The lions offer friendship and aid.
+
+**Path of Destiny:** The questers must rescue the lions from peril to ensure that their help is bought for a later part of the quest.
+
+**Forking Path:** Not everything that is frightening is actually a cause for fear. Refusing the help of the lions will hurt their feelings, but characters might be too suspicious of ulterior motives to take what is offered freely.
+
+#### The Captive Princess
+
+A beautiful maiden imprisoned in a tower, pit, or dungeon. An essential companion actor is her guard — typically an ogre, a dragon, or a hedge of thorns. Her parents have placed her in this situation, for complex reasons of their own.
+
+**Path of Chance:** This is a straightforward rescue mission.
+
+**Path of Destiny:** The obstacles must be overcome and the princess rescued in precisely the right manner. Alternatively, the quester could be the princess, or the guard who must fail to stop the hero.
+
+**Forking Path:** Have the characters stopped to think as to why the princess is imprisoned? Perhaps there is a very good reason. Alternatively, this could be a test of obedience — is it not a father's right to dispose of his children as he sees fit?
+
+#### The Task-Setting Ogre
+
+A hideous giant, vastly bigger and/or more powerful than the characters, who forces them to perform seemingly impossible tasks under threat of violence. Such tasks might include: sorting barley from wheat in a mixed vat; cutting down a forest in a single day; filling a bucket with a sieve; eating more than a wildfire can consume; or catching a magical horse. Alternatively, the ogre could be any fierce monster, such as a dragon or a manticore.
+
+**Path of Chance:** The duty of the captive is to escape from bondage, coupled with possibly slaying his imprisoner.
+
+**Path of Destiny:** Each task must be completed, perhaps with the assistance of the ogre's daughter. The quester can thus escape from bondage.
+
+**Forking Path:** Are the characters so arrogant that they cannot admit that some tasks are meant to be impossible?
+
+#### The Mouse-Groom
+
+A tiny mouse, easily overlooked. He can talk, and takes a fancy to a female character, courting her with gifts and poetry. Alternatively, the mouse could be a different animal (such as a cat or frog), or a monster. Or the mouse could be a bride rather than a groom.
+
+**Path of Chance:** The Mouse-Groom is a distraction, nothing more. His devotion can be exploited by a canny group, as he is deft at creeping into small places, or stealing small objects.
+
+**Path of Destiny:** The Mouse-Groom offers to help in some difficult task, but in return he asks to marry a female character. At the completion of the task, the groom must be successfully transformed into human form through the actions of the characters.
+
+**Forking Path:** The character might expect a transformation in her groom, and be disappointed — sometimes a mouse is just a mouse. Does she still honor her promise?
+
+>## Further Ideas for Actor Story Elements
+> 
+> Other ideas include:
+> 
+> - The Cruel Stepmother
+> - The Queen of Otters
+> - The Green Knight
+> - The Boy Made from Iron
+> - The Evil Twin (or the Foolish Twin)
+
+#### The Ferryman
+
+A man in a gray cloak, his face hidden by a hood or a hat. He stands in a low skiff on the shore, a punting pole in his hand. The skiff is just big enough to carry the characters across the lake or river. Alternatively, the ferryman transports them in a different manner, such as by carrying them. The ferryman may also be a guardian of another threshold, such as a bridge or a doorway.
+
+**Path of Chance:** The ferryman must be persuaded to carry the characters across; they are not of a type that he usually transports (that is, they are alive, or humans, or so forth). There is no other safe way to cross.
+
+**Path of Destiny:** The ferryman is a king in disguise, and he must work as a ferryman until the one whom he is waiting for comes. He transports many interesting and dangerous passengers until that day comes. When the special passenger arrives, the ferryman must ensure he does not reach the other side, or else obey his every command.
+
+**Forking Path:** What is on the other side? Is it worth paying the price asked by the ferryman? Is it best to be content with what one has got rather than to wish for a future that may not arrive?
+
+#### The Pale Man
+
+An emaciated man with taut gray skin, red eyes, and prominent teeth. He is dressed in a burial shroud. The man is a vampire, who feeds on the living. Alternatively, the Pale Man is a woman.
+
+**Path of Chance:** The vampire is a ravaging monster who eats corpses and craves blood. Since he is already dead, he is difficult to defeat. Those who he has consumed alive can be rescued from his belly.
+
+**Path of Destiny:** The man is Death, or, at least, a death. He is a guide to the recently departed, who must be tricked into passing over his victim, or taking someone else instead.
+
+**Forking Path:** Does the man represent death, or the refusal to accept that one has died? The Pale Man can assist in grief, since he demonstrates that there are worse alternatives to dying.
+
+### Props
+
+In this category are all inanimate objects, although this does not make them less significant than the actors or the scenery. In Arcadia, a prop is often the carrier of a faerie power. In Elysium, the props are never incidental to the story, but play a pivotal role. They might be the vital ingredient of a sleep potion, a token of love to melt the princess' heart, or the goal of the quest in the first place.
+
+#### The Poisoned Apple
+
+A luscious fruit, half of it bathed in a horrible poison, half of it sweet and delicious. There is no magical way to determine the difference; one either knows or one does not. This prop typically occurs in a situation where it must be shared with another.
+
+**Path of Chance:** A random chance; does the character eat from the poisoned side or the safe side?
+
+**Path of Destiny:** The quester must either persuade another to eat of the poisoned side, or do so himself.
+
+**Forking Path:** Self-sacrifice or deliberate poisoning? Is it better to allow evil to live, or to commit evil in killing it?
+
+#### Mjollnir
+
+The hammer of the mighty Thor — a thunderbolt imprisoned in iron. It was designed as a war hammer but its handle is a little short, subtracting 2 from both Attack and Defense scores. A successful hit inflicts +30 damage from the lightning imprisoned within it, as well as normal weapon damage. The penetration of the lightning is equal to the Might of the wielder; for a magus, use his Auram score.
+
+**Path of Chance:** Who would not want to smite giants with Thor's hammer?
+
+**Path of Destiny:** The characters may be enacting Mjollnir's forging, its theft by the giants, or its retrieval from said giants.
+
+**Forking Path:** Finding Mjollnir creates a dilemma — it is a mighty weapon, but if it is not returned to Thor, then mankind's defense against the powers of winter and frost is deprived of his power.
+
+>## Further Ideas for Prop Story Elements
+> 
+> Some more ideas include:
+> 
+> - The Soul in the Egg
+> - The Magic Ring
+> - The Self-Filling Purse
+> - The Horn that Furnishes Soldiers
+> - The Helm of Invisibility
+> - The Word That Opens All Locks
+
+#### The Dragon's Tongue
+
+When first encountered, this prop will be in the possession of the dragon, although the beast may already be dead.
+
+**Path of Chance:** Eating the tongue of a dragon is said to grant magical powers, such as the ability to speak with animals. It is not always a good thing to know what creatures are saying about you, however.
+
+**Path of Destiny:** The heroes kill the dragon, and cut out its tongue as proof of their deed. An impostor cuts off the head from the corpse, which he later seeks to use as his own proof.
+
+**Forking Path:** The tongue symbolizes humility for one's abilities, whereas the dragon's head is a symbol of vainglory.
+
+#### The Swan Cloak
+
+A maiden owns a cloak of white feathers that causes her to take her true form, that of a swan. Alternatively, the prop is a different item of clothing, such as a hat or girdle. Alternatively, the cloak transforms the wearer into another animal, such as a seal or a wolf.
+
+**Path of Chance:** Stealing the cloak from the maiden allows the wearer to transform like she does. 
+
+**Path of Destiny:** A hero hides the cloak so that the maiden will remain in human form and wed him. When she finds the cloak again, she flees him, and he must quest to win her love for real.
+
+**Forking Path:** Hiding the cloak from the maiden ransoms her heart. Letting her choose between her love and her swan cloak is a truer expression of love.
+
+#### The Dull Knife
+
+An unremarkable blade, of crude manufacture. Its blade is so dull it can barely cut butter. Alternatively, this could be any tool that is unable to perform its function due to a defect.
+
+**Path of Chance:** In the contradictory way of Faerie, sometimes the dullest knife in the world is the only thing that can cut the uncuttable.
+
+**Path of Destiny:** The knife becomes rusty to indicate when another is in peril. At such a signal, the quester must ride to rescue his partner.
+
+**Forking Path:** As a gift, the Dull Knife is useless. Should this be interpreted as an insult on the part of the giver, or will the character accept it with grace?
+
+#### Snake Soup
+
+A bubbling cauldron of brown-gray liquid, with suspicious-looking meat and unknown vegetables. Alternatively, a green fluid in a bottle, or a knobbly fruit with red spots.
+
+**Path of Chance:** Suspicion over the safety of the soup might cause the characters to miss out on the magical powers it grants, or else save them from a horrible curse.
+
+**Path of Destiny:** The soup is served to her dinner guests by a crone, who gives her son the choicest portion with the meat of three white snakes. When eaten, they grant supernatural strength and resilience. The questers must ensure that they receive the magical portion, not the witch's son.
+
+**Forking Path:** It's all a matter of trust. What looks foul and unappetizing might be beneficial, but again it might also be exactly as it appears — disease-ridden swamp water.
+
+### Scenery
+
+The scenery should not be neglected as a story element. In the Faerie Realm, the scenery can be a villain as readily as any mustachio-twirling blackguard.
+
+#### The Market at the Crossroads
+
+Rough-built stalls line both sides of the two intersecting roads. Each stall displays the wares of the vendors, from the mundane to the fantastic. The market may be thronging with browsing customers, or else it might be eerily empty. The stalls, vendors, and other customers are all equally part of the scenery, although the characters may meet one or more actor story elements here, or they could be here to obtain a prop element.
+
+**Path of Chance:** An opportunity to spend one's hard-earned cash, but let the buyer beware! Faerie vendors rarely require silver in exchange for their goods; and that which is purchased is not always what it seems.
+
+**Path of Destiny:** The characters must obtain a specific item. Are they able to locate the vendor, and are they willing to pay the price demanded of them?
+
+**Forking Path:** The dilemma of the market is that the vendor wants the highest price he can get for his wares, while the buyer wants it as cheaply as possible. A fair deal leaves both satisfied. But an unfair deal will leave the buyer bilked or the vendor cheated.
+
+#### Winter
+
+Snow covers the ground, rime-frost coats every surface, and icicles depend from horizontal surfaces. The breath steams in the frigid air, and the heat is sapped from the body.
+
+**Path of Chance:** Winter is a passive guardian for the snow-bound castle, or a prison for those within. It is a challenge to be met, and overcome.
+
+**Path of Destiny:** Winter represents sterility and patience. Nothing grows and nature holds its breath before the promise of spring. It serves as a pause before the action, the lull before the storm. In the winter, the wicked queen ruled supreme, Demeter ceased her search for her daughter, and the men were softened for Ragnarok.
+
+**Forking Path:** Many rail against the chill of winter with fire and furs, but is it a fight that can be won? Perhaps it is better instead to submit to the inevitability of nature.
+
+> # Further Ideas for Scenery Story Elements
+> 
+> Consider these ideas, as well:
+> 
+> - Spring
+> - Autumn
+> - Beneath the Sea
+> - In the Kingdom of Death
+
+#### The Forbidden Chamber
+
+There is a room in a castle that everyone is forbidden from entering. It has an immensely strong door but no lock. On occasion, strange noises are heard from behind the door. Alternatively, it could be locked, and the key held by the castle's owner. Or, the chamber could instead be a chest, or a question that must not be asked.
+
+**Path of Chance:** The room contains either fabulous treasure or a hideous secret. Disobedience might be signified by a transformation in the interloper, or the sounding of an alarm.
+
+**Path of Destiny:** The inevitability of getting into the forbidden chamber is central to the quest. This may require the quester to obtain the key from its owner. The characters may not like what they find inside.
+
+**Forking Path:** This is a simple choice between curiosity and obedience. It may be made harder if cries for help are heard from beyond the door. If curiosity is not stronger, then perhaps chivalry is.
+
+#### Summer
+
+The sun shines bright on a green and pleasant land. Plants are at the height of growth, and animals are well fed and content. Bees drone among the flowers, and the air is still and fragrant.
+
+**Path of Chance:** In the Summerlands pies and sweetmeats grow on trees, the rivers run with mead and milk, and every need is catered to. It is a respite from hardship, and also a trap for the self-indulgent. 
+
+**Path of Destiny:** Summer is symbolic of bounteous times, of incipient action, and of vigor. It is in the Lands of Summer where one is forever young.
+
+**Forking Path:** The luxury of summer lulls one to sloth, but it is a season of action and adventure. Does one take a muchneeded rest, or spurn the seduction?
+
+#### The Glass Mountain
+
+A towering edifice of green glass as big as a hill. The glass is perfectly smooth, as if melted in place. At its summit is a castle — the destination of the characters. Birds of immense size circle the castle, watching for climbers upon which to drop rocks. Alternatively, the mountain may be made of ice, or guarded by snakes. Or, the summit might bear a tree with magical fruit, or the well of wisdom.
+
+**Path of Chance:** An obstacle to test the ingenuity of the characters. They can try chipping out handholds, or dipping their shoes in tar, or perhaps circumvent the glass entirely by flying to the top.
+
+**Path of Destiny:** The mountain must be attempted three times, each time assisted by a different magical animal. Only the third attempt is successful.
+
+**Forking Path:** How quickly do the characters give up trying to scale the mountain? Perseverance is the lesson here. If one tirelessly strives for one's goals, there is nothing that cannot be achieved.
+
+#### The Perilous Forest
+
+A dark and foreboding wood, where little light reaches through the canopy. Strange noises haunt the forest, along with half-seen, swiftly moving shapes. Alternatively, the trees could be dead, and all sounds are swallowed.
+
+**Path of Chance:** A forest can hide all sorts of ne'er-do-wells, mysterious hermits, magical trees, and fierce beasts.
+
+**Path of Destiny:** The traditional abode of the hag, the Ironwood is filled with her wolfish children.
+
+**Forking Path:** They say there is nothing to fear except fear itself. How true is that when one is lost among demonic-looking shadows and sharp-fanged critters?
+
+#### The Abandoned Shrine
+
+In the midst of a tangle of undergrowth, a single standing stone is found, carved with strange glyphs and leering faces. Circles carved into the ground hold traces of dried blood. Alternatively, the shrine could be found in a deep pit, or in a deserted town.
+
+**Path of Chance:** This is the place for the villain to hold his showdown, or for the priest to be forced to yield his faerie powers.
+
+**Path of Destiny:** The blood of an innocent will wake the god who slumbers in the shrine. **Forking Path**: Is it fair to let gods die? A powerful faerie who has protected his human worshipers for millennia risks death because his worship is considered idolatrous.
+
+>## Ten Thousand More Story Elements
+> 
+> Choose a descriptor and an object from the following two lists; or else roll two simple dice, once for each list.
+> 
+>### DESCRIPTORS
+> 
+> | Second Die | 1 on First Die | 2 on First Die | 3 on First Die | 4 on First Die | 5 on First Die | 6 on First Die | 7 on First Die | 8 on First Die | 9 on First Die | 10 on First Die |
+> |------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|-----------------|
+> | 1          | Green          | Iron           | Twin           | Howling        | Maker of       | Winged         | Sharp          | Farthest       | Fatal          | Sleepy          |
+> | 2          | Shiny          | Glass          | Huge           | Fiery          | King of        | Spiny          | Dull           | Best           | Straight       | Obnoxious       |
+> | 3          | Dirty          | Golden         | Minute         | Singing        | Servant of     | Leafy          | Icy            | Darkest        | Wrong          | Naughty         |
+> | 4          | White          | Ruby           | Newborn        | Furious        | Slayer of      | Donkey-eared   | Warm           | Brightest      | Blind          | Grieving        |
+> | 5          | Striped        | Fur            | Ancient        | Sleeping       | Eater of       | Wounded        | Unyielding     | Highest        | Final          | Obedient        |
+> | 6          | Variegated     | Woven          | Flawed         | Drunken        | Child of       | Hairy          | Soft           | Deepest        | Eldest         | Curious         |
+> | 7          | Black          | Emerald        | Perfect        | Smelly         | Sibling of     | Slimy          | Harsh          | Tallest        | Youngest       | Cunning         |
+> | 8          | Murky          | Wooden         | Broken         | Dreaded        | Parent of      | Strange        | Gentle         | Smallest       | Beautiful      | Impossible      |
+> | 9          | Blue           | Stone          | Empty          | Passionate     | Cousin of      | Scrawny        | Sour           | Fiercest       | Repulsive      | Motionless      |
+> | 10         | Invisible      | Makeshift      | Flat           | Dying          | Protector of   | Corpulent      | Floral         | Bravest        | Terrible       | Stormy          |
+> 
+>### OBJECTS
+> 
+> | Second Die | 1 on First Die | 2 on First Die | 3 on First Die | 4 on First Die | 5 on First Die | 6 on First Die | 7 on First Die | 8 on First Die | 9 on First Die | 10 on First Die |
+> |------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|-----------------|
+> | 1          | Queen          | Fox            | Eagle          | Drum           | Knife          | Acorn          | Child          | Mason          | Summer         | Fort            |
+> | 2          | Serf           | Mouse          | Salmon         | Bed            | Loaf           | Apple          | Page           | Weaver         | Autumn         | Wall            |
+> | 3          | Lady           | Weasel         | Robin          | Lute           | Key            | Willow         | Maiden         | Magistrate     | Lake           | Shack           |
+> | 4          | King           | Lion           | Frog           | Mirror         | Book           | Rose           | Soldier        | Counselor      | Sea            | Manor           |
+> | 5          | Prince         | Bear           | Ant            | Cauldron       | Sword          | May Blossom    | Hermit         | Orchard-Keeper | River          | Bridge          |
+> | 6          | Beggar         | Wolf           | Swan           | Shawm          | Shield         | Hazelnut       | Crone          | Smith          | Dawn           | Ditch           |
+> | 7          | Scholar        | Stag           | Bull           | Bottle         | Hammer         | Water Lily     | Holy Woman     | Dancer         | Shore          | Hill            |
+> | 8          | Priest         | Goat           | Bat            | Coin           | Chalice        | Seaweed        | Infant         | Flautist       | Battlefield    | Forest          |
+> | 9          | Merchant       | Ox             | Owl            | Gaming Piece   | Needle         | Thistle        | Father         | Shepherdess    | Harbor         | Desert          |
+> | 10         | Death          | Badger         | Partridge      | Candle         | Cloak          | Burdock        | Waif           | Knight         | Crossroads     | Marsh           |
+
+# Chapter Three : Faerie Characters
+
+Faeries are designed through a series of choices. A player creating a faerie can make these choices in any order, but in this section, they are laid out in the following sequence:
+
+- Is this a player or non-player character?
+- How powerful is this character compared to player character types?
+- What is the Might score of the faerie?
+- What is its physical form?
+- How cognizant is the faerie?
+- What is the role it is playing?
+- What powers does it have?
+- Does it have traditional vulnerabilities?
+
+## PC or NPC?
+
+Non-player characters may be far more powerful and versatile than freshly created player characters. Non-player characters do not need to balance their Virtues and Flaws, and may have more Pretenses — which substitute for Abilities, as described later — than starting player characters. The characters in Chapter 4: Faerie Bestiary are designed using the system below, as examples, but Troupes are encouraged to use a less-formal process of design if it suits their sagas.
+
+## Level of Power
+
+Players designing faerie characters should negotiate the aspects of their design with the other members of their troupe, because even faeries designed within the guidelines given in this chapter may reduce the enjoyment of the game by other members of the troupe. The enjoyment of the other players is representative of the attention and emotional attachment of their characters, which is of prime importance to a friendly faerie basking in their vitality.
+
+### Player Character Faeries Are Designed to Suit Game Play
+
+Faeries display a continuum of power, from mere shadows on nursery walls to the ancient gods of the Greeks and Norse. When designing a faerie character, a player is selecting a faerie that is approximately as powerful as a companion or magus. Within the Mythic European setting, these levels of power are unrecognized.
+
+#### Maximum Number of Virtues and Pretenses
+
+Faeries designed instead as player characters use values from the following formula.
+
+| Replaces  | Virtues/Flaws |
+|-----------|---------------|
+| Companion | Up to 10 points of Virtues balanced by Flaws. |
+| Magus     | 1 free, then up to 20 points of Virtues paid for with Flaws at 2 Virtues per Flaw. |
+
+The character has a number of Pretense points figured as follows:
+
+**Pretense Points: 15\* x (average age of magus player characters – 5) + 120 points**
+
+\* This multiplier may be changed by the Pretentious or Ostentatious Virtues, or Aloof Flaw, described in the section on Pretenses at this chapter's end.
+
+If the character's physical form has any inherent Abilities, you must purchase Pretenses for those first. For example, a human being typically begins with Living Language 5 and 45 points in specific Abilities associated with early childhood. Animals often have a set of required Abilities that represent instinctive behavior for the species.
+
+In Chapter 4: Faerie Bestiary, faeries designed for use as player characters assume that the magi in the campaign are 21 years old, which gives 360 points of Pretences.
+
+## Required Virtues and Flaws
+
+A character must have a Might score, a physical form, a level of cognizance, a Social Interaction Virtue, and a taboo. All faeries have certain innate powers, which may be traded away as Flaws.
+
+### Faerie Might Score
+
+Player characters begin with a Faerie Might score of 5, which may be varied by selecting appropriate Virtues or Flaws during character creation. The Might Score of a faerie represents its spiritual strength. The more powerful a faerie is spiritually, the greater the likelihood that it is at the center of stories, and that other faeries act as its servants. Better roles in stories tend to be claimed by the mightiest faeries.
+
+>## Quick Start Guideline
+> 
+> The quickest way to get through the new options in this character creation process is to select a faerie that replaces a beginning companion, can pass for human, has a Faerie Might of 10, and follows the stereotypical role of its faerie type. This results in the following:
+> 
+>### 7 Points of Characteristics
+> 
+> **360 Points of Pretences:** Spend them exactly like Ability points. Faeries don't need Virtues to get any Pretence (Ability).
+> 
+> **Virtues:** Faerie Sight, Humanoid Form, Increased Faerie Might. Each is a Minor Virtue.
+> 
+> **Free Choices:** Passes for Human, Narrowly Cognizant.
+> 
+> **Flaws:** Traditional Ward (whatever you like). This minor Flaw means that the character is made uncomfortable by the presence of whatever the ward is, and cannot touch someone who has the ward, either personally, with the faerie's equipment, or by using a power. Contact with the ward will burn the faerie. The faerie cannot regenerate Might in the presence of the ward.
+> 
+> Before play, balance up the Virtues and Flaws, paying attention to the Inappropriate Virtues and Flaws section. Skim the introductory text to each section, but pay particular attention to the powers of the faerie body. Read the detail of the Virtues and Flaws selected above. Select some Greater Powers if you like. They are based on a Major Virtue and allow your character to affect others mystically. Faerie Speech may prove especially useful if your faerie interacts with characters who speak a diversity of languages.
+
+This observation is, however, not useful for determining the Might of particular faeries. Faeries that have interacted regularly for hundreds of years with humans may have very high Might scores, and yet remain interested primarily in domestic stories. It is generally true that the queen of a faerie court has a high Might, and a household brownie a low Might, but there are individual faerie queens that have Might scores of 10, and a few brownie-like creatures have Might scores of 45. Faeries usually contain more vis if they have greater Might, so these tiny, magically resistant faeries are particularly valued by magi as prey.
+
+Faerie Might gives the character innate Magic Resistance equal to its Might Score. This does not stack with other forms of resistance. Faeries have Might Points equal in number to their Might score, which they spend to activate their powers. These are recovered at a constant rate, which would result in full recovery from zero over the course of 24 hours unless a Virtue or Flaw changes this rate.
+
+#### Virtues That Affect Might
+
+Some virtues alter the rate at which faeries recover after using their powers. Hermetic scholars are divided over whether these unusual features are linked to the role or the spirit of the faerie.
+
+##### Fast Might Recovery
+
+*Minor, Supernatural*
+
+This Virtue allows faeries to recover spent Might in a quarter of the normal time. Instead of completely refreshing its Might over the course of 24 hours, the character restores its entire Might Pool in only six hours.
+
+##### Feast of the Fae Minor, Supernatural
+
+This Virtue allows a faerie to recover 5 lost Might by receiving traditional sacrifices left from a human. Sacrifices include food left on doorsteps for the faerie to consume, but some dark faeries feed on the wards left to keep them at bay, accepting them as the price that humans pay for safety. This power can only be used once per day.
+
+##### Feast of the Dead
+
+*Minor, Supernatural*
+
+This Virtue allows a faerie to recover 2 lost Might after draining a Long Term Fatigue Level from, or causing at least a Medium Wound to, a human. Different fairies employ various methods to extract vitality from humans. This Virtue does not, of itself, cause damage. For example, a faerie that feeds on the blood of sleeping shepherds must make a successful Bite attack to drink sufficient blood from a sleeping shepherd to cause the loss of a Long Term Fatigue Level. The faerie's player can then claim 2 lost Might points.
+
+##### Increased Faerie Might
+
+*Major or Minor, Supernatural*
+
+As a Minor Virtue, this increases the faerie's Might Score by 5. As a Major Virtue, it increases Might by 15. With the approval of the troupe, this Virtue may be taken multiple times.
+
+##### Time or Place of Power
+
+*Minor, Supernatural*
+
+The character's Might Score is 10 points higher at a certain time or in certain places that are strongly linked to the character's role. The time or place is known to any character who makes an Intelligence + Faerie Lore roll of against an Ease Factor of 9. This Virtue may not be taken multiple times.
+
+#### Flaws That Affect Might
+
+Certain Flaws influence the rate at which faeries recover their Might.
+
+##### Decreased Might
+
+*Supernatural, Minor*
+
+The faerie has only 1 point of Might, instead of the usual 5. Faeries with this Flaw retain the use of powers that do not require the expenditure of Might, like regeneration and the ability to generate equipment that does not cause Encumbrance.
+
+##### Restricted Might
+
+*Supernatural, Major or Minor*
+
+The faerie is nearly powerless at certain times or under certain conditions. At the onset of these disadvantageous conditions, any ongoing supernatural effects that the creature has started with its powers immediately end, except for those that constantly affect the creature itself. As long as the conditions last, the creature is unable to spend or recover Might points.
+
+This Flaw may be Major or Minor. If it is Major, the creature's Might is restricted under relatively common circumstances, such as when exposed to daylight or during the winter. The conditions should be in effect at least one-quarter of the time. For the Minor version of this Flaw, the conditions are uncommon, such as during a thunderstorm or on the night of the new moon.
+
+##### Slow Might Recovery
+
+*Major, Supernatural*
+
+A faerie being with this Flaw recovers a single Might Point per day, rather than all Might Points over the course of a day. A variant of this Flaw occurs in some faeries that regain all of their Might at a certain phase of the moon, but at no other time.
+
+##### Might Recovery Requires Vitality
+
+*Major, Supernatural*
+
+The character must get a full night's rest and eat a meal to replenish its Might Points after they have been spent. This must be done within a human community by eating leavened bread, drinking beverages fermented by humans, feeding on human blood, or listening to humans sing or scream. For every eight hours the character rests, it recovers a number of Might Points equal to the prevailing Aura as modified by the Realm Interaction Table, or 1, whichever is greater.
+
+### Physical Form
+
+Faeries may appear human, but do not truly have human bodies. A faerie is a spirit that, unconsciously, draws matter about itself. This body may appear and feel convincingly human, particularly if the faerie has enjoyed lengthy, passionate interaction with mortals. When faeries die, however, few leave conventional corpses. They disintegrate into their original matter: leaves, or clouds of black feathers, or sea foam, or snowflakes. They may seem like statues of stone, or portraits in wood, or manikins of straw. Faeries with low cognizance do not know it, but they are only pretending to have bodies.
+
+There are several advantages to constructing a body of matter and glamour, then stealing vitality to animate it. Faeries cannot age or suffer Decrepitude unless they have a Flaw. They lack the ability to become fatigued, although some sleep for social reasons or because their role demands it of them. It is also very difficult for faeries to die.
+
+#### Equipment Without Encumbrance
+
+A faerie does not suffer Encumbrance for pieces of equipment traditional for the role it is playing, because these props are made of glamour. Props are treated as extensions of the faerie's body for magical purposes. If a prop is lost, the faerie withdraws its glamour from the matter in the prop, and reconstitutes it closer to hand. Lesser faeries do this without understanding the mechanism; they find their lost items under rocks, or behind trees, or simply use them without remembering that they were lost. Reconstituting a prop costs no Might, and requires a single round.
+
+#### Regeneration
+
+The bodies of faeries are often damaged, but they consider that insignificant. A faerie may be required by its role to feel pain, or simulate it in the case of highly cognizant faeries, but pain isn't meaningful to most faeries. They do not associate their pain with suffering in the way humans do. Some faeries report, how truthfully cannot be known, that when the Summer and Winter Courts make war upon the Equinox, the knights often chop each other to pieces. Once the battle has been won, they cease pretending to be human for long enough to reassemble themselves, then resume their roles and feast. If a human witness were present, this would not be possible: the bodies of the faeries would have to remain dead to suit their role. One of the faeries present often has a role that allows it to bring faeries back from the dead, if this occurs.
+
+>## Scale of Typical Might Scores
+>
+> The typical Might Scores in this table refer to creatures in Chapter 4: Faerie Bestiary.
+>
+> | Score | Example |
+> |-------|---------|
+> | 1–10 | An ordinary creature of a realm. |
+> | 1 | Black Terrors, Kubu |
+> | 5 | Brownie, Centaur, Dwarf, Faerie Dog, Faun, Kelpie, Satyr, Sprite |
+> | 10 | Barking Beast, Glanconer, Minor Knight, Triton, Unicorn |
+> | 11–20 | Moderately powerful. Comparable, at least, to a starting magus. Mormo, Orm (Size –2) |
+> | 20 | Ghula, Orm (Size 0), Valkyrie |
+> | 21–30 | Fairly powerful. |
+> | 25 | Faerie Champion, Gorgon |
+> | 30 | Fachan, Orm (Size +4) |
+> | 31–40 | Very powerful. Faerie lords, minor dragons, and the like. |
+> | 35 | Faerie Noble, Lamia, Orm (Size +6) |
+> | 41–50 | Extremely powerful. Pagan deities, major dragons, etc. |
+> | 45 | Lamashtu |
+> | 51–75 | Earth-shakingly important figures. Great dragons, Jove himself. |
+> | n/a | Black Faced Hermes |
+
+Faerie bodies regenerate as rapidly as is suitable to their story. Incognizant faeries heal swiftly and well, without die rolls, unless required to remain ill by their role. Narrowly and highly cognizant fairies can repair all but the cosmetic level of the damage their body has suffered, at will, once the scene they are participating in has concluded. Many do not even notice they are doing it, healing the superficial damage at a rate that appears reasonable to human viewers.
+
+If killed by humans, or with humans witnesses, faeries may eventually rebuild a body, although it takes time. The time taken to regenerate equals the faster of the Faerie Might Score in months or Faerie Might Score / Aura (as modified by the Realm Interaction Table) in months. An incognizant faerie that rebuilds its body believes itself to be linked to, but not actually, the previous faerie. It might, for example, believe that it is its own daughter or brother. Narrowly cognizant faeries may return with their memories intact, although the incident that caused their body to be destroyed is hazy. Highly cognizant faeries can change roles, at the player's discretion, between bodies, so that they appear as an entirely different type of faerie following their death. They retain the same number of Virtues, Flaws, and Pretenses, but may swap the ones they currently possess for a new set.
+
+#### Permanent Death
+
+Forces that are outside the story they are weaving can permanently kill faeries. A faerie whose Might Score is destroyed dies permanently. Miracles and agents of the Infernal can destroy faeries. If the vis from the faerie's anchor (described in Chapter 1: Nature of Faerie, Vis) is used, then it is permanently dead. Incognizant faeries appear to be destroyed if killed with mystical things they are antithetical to, as represented by the Sovereign Ward Flaw. Some Merinita magi suggest that faeries who appear to be dead are merely dispelled to Arcadia for thousands of mortal years. It is possible to seek such faeries in stories, although there is no way to tell if the creatures found are the original faeries or merely skilled impersonators.
+
+#### Magic Resistance Against Faeries
+
+The bodies of faeries are made of matter arranged by glamour, which is a mystical force. Faerie bodies, and the other props created by the same process, are not, however, blocked by the Parma Magica or other forms of Magic Resistance. This is not unique to faeries: elemental spirits of the Magic Realm and demons construct bodies of incidental matter, and the physical attacks of these creatures are not resisted, either. Magi do not agree on why this is the case, but some suggest that the construction of bodies is part of the essential nature of faeries, so the power cannot be alienated from them by Hermetic magic.
+
+Spells that target the material the faerie is made from, like *Circular Ward Against The Faeries of the Wood*, or the spiritual nature of the faerie, like the *Aegis of the Hearth*, are effective against faeries.
+
+The powers of faeries that have Might costs and ranges greater than Personal are, in most cases, opposed by Magic Resistance.
+
+### Varieties of Form
+
+Many faeries are able to take several forms. If the character's physical form has any inherent Virtues or Flaws, as most animals do, a player must select as many of them as possible before selecting others.
+
+#### Human and Animal Forms
+
+A humanoid faerie has 7 points with which to buy Characteristics, as per the table on **ArM** page 30. Faeries in animal form should be guided by the statistics provided in the "Book of Mundane Animals" appendix of *Realms of Power: Magic*, or be constructed as mundane animals are, using the rules presented in the Bjornaer chapter of *Houses of Hermes: Mystery Cults* (pages 38-43).
+
+Many lesser faeries, including those with human shapes, lack true Intelligence. Unintelligent faeries are not suitable as player characters, however. A player who selects an animal form for a character may trade the beast’s Cunning score for Intelligence. This is a Free Virtue.
+
+#### Hybrid Forms
+
+Most hybrid forms are simply human forms with animal elements grafted onto them. These elements may be simply cosmetic — in which case they do not change the character's scores — or they may represent Minor Virtues. The physical anomalies of the bodies of faeries are not Flaws unless they limit the faerie in stories. As an example, the serpent's tail that a faerie has instead of legs is not a Flaw if she spends most of her time in Arcadia or her cave in the hills, since it's only a detriment if it is going to terrify humans that she'd prefer were civil.
+
+Some faeries have animal parts that they use for combat. This uses the Brawl Ability and the statistics on the following table. Minimum Strength, Load, and cost do not apply to these weapons. Having natural weapons does not, in itself, require a Virtue.
+
+|             | Init | Atk | Dfn | Dmg |
+|-------------|------|-----|-----|-----|
+| Teeth       | 0    | +3  | +1  | +1  |
+| Large Teeth | 0    | +4  | +1  | +3  |
+| Tusks       | 0    | +4  | +2  | +5  |
+| Claws       | –1   | +2  | +3  | +2  |
+| Large Claws | 0    | +5  | +3  | +4  |
+| Horns       | +1   | +3  | –1  | +2  |
+| Large Horns or Antlers | +2 | +3 | +2 | +3 |
+| Hooves      | +2   | +2  | +2  | +1  |
+
+#### Glamorous, Immaterial Forms
+
+All faeries have bodies made of matter, glamour, and vitality, but some prefer to interact with humans through forms made solely of glamour, and draw matter to themselves only when wishing to alter the physical world. Some theorists argue that all faeries dwell as pure spirit when humans are not watching, but this class of faeries is willing to use this power in the presence of humans. This makes them appear ghostly, but to the educated or those with the Sight, magical spirits and faeries are quite distinctive.
+
+Immaterial faeries are invisible to those without magical aid, and can pass through solid objects. Some may interact with humans simply by shedding species with glamour — that is, they may make illusory bodies for themselves. These bodies cannot, however, move objects. To move objects, they must take on matter. While taking on matter the faerie can continue to move and act, but cannot pass through objects. While in material form, the faerie's spirit is bound to the matter it has taken on. If the body is destroyed, the matter returns to its initial state, with the spirit of the faerie still attached to it as vis.
+
+To design an immaterial faerie, instead design the characteristics for the physical body it takes on when it dons matter and select the Intangible Flesh Flaw, described in the nearby insert. The Loosely Material minor faerie power may suit the character.
+
+#### Size
+
+Players of humanoid characters select a size from the following options. Characters outside the range of Size +2 to –3 are difficult to accommodate in sagas, and should be carefully scrutinized by the Troupe.
+
+**Modifier:** +3 or more
+
+**Size:** Huge
+
+**Must Select:** (Size–1) times +(2 x Size) Strength, –(Size) Quickness
+
+**Modifier:** +2 **Size:** Huge
+
+**Must Select:** +4 Strength, –2 Quickness
+
+**Modifier:** +1 **Size:** Large
+
+**Must Select:** Characteristics aren't adjusted
+
+**Modifier:** 0 **Size:** None
+
+**Must Select:** Characteristics aren't adjusted
+
+**Modifier:** –1 **Size:** Small Frame
+
+**Must Select:** Characteristics aren't adjusted
+
+**Modifier:** –2 or –3 **Size:** Little
+
+**Must Select:** –(2 x Size) Strength, +(Size) Quickness
+
+**Modifier:** –4 or more **Size:** select Little twice
+
+**Must Select:** –(2 x Size) Strength, +(Size) Quickness
+
+Faeries may not have flaws like Dwarf or Giant Blood, which are for mortals whose bodies are structured slightly differently from those of other humans. Faerie bodies only pretend to follow the mechanical principles of organic life.
+
+Nonhuman characters that have a base Size other than zero do not usually select Virtues and Flaws on the table above. An adjustment for the Size of creatures is, for example, contained within the rules for creating mundane animals given in *House of Hermes: Mystery Cults*, and has been invisibly included in the "Book of Mundane Beasts" in *Realms of Power: Magic*. A similar adjustment is found in the rules for objects as player characters given in *Realms of Power: Magic*. Characters deviating from their base size by 1 do not change Characteristics, but those deviating by more than 1 are adjusted as indicated by the table above.
+
+>## What Do Size Scores Represent?
+>
+> | Size | Height | Weight | Comparison | Wound Penalties |
+> |------|--------|--------|------------|-----------------|
+> | –11 | an inch | less than 1 oz. | butterfly | Dead (1+) |
+> | –10 | 4–5 in. | 1 oz. | mouse | Dead (1+) |
+> | –9 | 6–7 in. | 1.5 oz. | bat, frog | Dead (1+) |
+> | –8 | 8–9 in. | .25–.5 lbs | mole, toad | Dead (1+) |
+> | –7 | 10–11 in. | .5–1 lb | rat | Incapacitated (1), Dead (2+) |
+> | –6 | 12–13 in. | 1–2 lbs | lizard | –5 (1), Incapacitated (2), Dead (3+) |
+> | –5 | 14–15 in. | 2–5 lbs | rabbit | –3 (1), –5 (2), Incapacitated (3), Dead (4+) |
+> | –4 | 16–20 in. | 5–10 lbs | adder | –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+) |
+> | –3 | 21–32 in. | 10–22 lbs | baby, cat | –1 (1–2), –3 (3–4), –5 (5–6), Incapacitated (7–8), Dead (9+) |
+> | –2 | 2'9"–3'9" | 22–46 lbs | child, sheep | –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+) |
+> | –1 | 3'9"–4'9" | 46–100 lbs | adolescent human, wolf | –1 (1–4), –3 (5–8), –5 (9–12), Incapacitated (13–16), Dead (17+) |
+> | 0 | 4'9"–6'2" | 100–215 lbs | adult human, pig | –1 (1–5), –3 (6–10), –5 (11–15), Incapacitated (16–20), Dead (21+) |
+> | 1 | 6'2"–8' | 215–465 lbs | big human, pony | –1 (1–6), –3 (7–12), –5 (13–18), Incapacitated (19–25), Dead (26+) |
+> | 2 | 8'–10' | 465–1000 lbs | horse, bear, lion | –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+) |
+> | 3 | 10'–13' | 1000–2150 lbs | aurochs, moose, warhorse | –1 (1–8), –3 (9–16), –5 (17–24), Incapacitated (25–32), Dead (33+) |
+> | 4 | 13'–17' | 2150–4600 lbs | elephant | –1 (1–9), –3 (10–18), –5 (19–27), Incapacitated (28–36), Dead (37+) |
+> | 5 | 17'–22' | 2½–5 tons | killer whale | –1 (1–10), –3 (11–20), –5 (21–30), Incapacitated (31–40), Dead (41+) |
+> | 6 | 22'–28' | 5–10½ tons |  | –1 (1–11), –3 (12–22), –5 (23–33), Incapacitated (34–44), Dead (45+) |
+> | 7 | 28'–37' | 10½–23 tons | small dragon | –1 (1–12), –3 (13–24), –5 (25–36), Incapacitated (37–48), Dead (49+) |
+> | 8 | 37'–47' | 23–50 tons |  | –1 (1–13), –3 (14–26), –5 (27–39), Incapacitated (40–52), Dead (53+) |
+> | 9 | 47'–61' | 50–107 tons | humpbacked whale | –1 (1–14), –3 (15–28), –5 (29–42), Incapacitated (43–56), Dead (57+) |
+> | 10 | 61'–79' | 107–230 tons |  | –1 (1–15), –3 (16–30), –5 (31–45), Incapacitated (46–60), Dead (61+) |
+
+##### Huge
+
+*Major Virtue, General (faeries only)*
+
+The character is far larger than usual. Its Size score is increased, its Characteristics are adjusted, and its Body levels change, as detailed in the inserts accompanying this section.
+
+##### Little
+
+*Major Flaw, General (faeries only)*
+
+The character is far smaller than usual. Its Size score is decreased, its Characteristics are adjusted, and its Body levels change, as detailed in the inserts accompanying this section.
+
+#### Virtues For Physical Forms
+
+Characters must take a Virtue that defines the usual form of the faerie. There is no free Virtue that defines physical form, because all faerie forms have abilities beyond those of mortals, such as regeneration. Players are reminded that faeries can also take Virtues that suit humans. Many faeries that are drawn to stories in which humans enjoy the thrill of combat have Tough forms, for example.
+
+##### External Vis
+
+*Minor or Major Virtue, Supernatural*
+
+The faerie's spiritual essence (anchor) resides in one of the props traditional for its role, and this can be carried far from the faerie's body without the faerie suffering ill effects. There is an Arcane Connection between the object containing the faerie's spiritual essence and the faerie's body. If this connection is broken, or if the object is destroyed, the faerie's distant body disintegrates, but the essence can construct a new body, given sufficient time. If the vis in the prop is used, the faerie is permanently destroyed.
+
+When selected as a Major Virtue, the prop provides its bearer with any one Minor Virtue, selected at creation. This provides the faerie with a little additional power, but its main advantage is that humans who discover the object are far more likely to treasure it, and keep it safe. This provides the faerie with time to form a new physical body and reclaim his object.
+
+As an example, a faerie warrior with a Might of 20 uses his sword as his spiritual anchor. A character that defeats the warrior finds that the sword contains 4 pawns of vis, but also finds that the sword has no Encumbrance and grants a human wielder a +2 bonus on the Single Weapon Ability. The bonus comes from the Grant Puissance power, described later. If the human keeps the weapon, then eventually the faerie can generate a fresh body, and seek out the wielder and challenge him to a duel.
+
+##### Faerie Beast
+
+*Minor Virtue, Supernatural*
+
+The character appears to be an animal. It has all of the advantages of being a faerie, and having a faerie body. The innate limitations of an animal form, such as having no hands and being unable to pronounce human words, may not be taken as Flaws. Faerie beasts that wish to speak like humans may take Language Pretenses, or the Faerie Speech Virtue.
+
+#### Faerie Sight
+
+*Minor Virtue, Supernatural*
+
+This Virtue, which works constantly at no cost to the faerie, is used in conjunction with the Awareness Pretense. It allows faeries to:
+- Tell mundane from glamourous things. (Automatic success: no roll required.)
+- See the borders of glamour, so that they know which faerie that props and territories belong to. (Automatic success: no roll required.)
+- See Arcane Connections, so that they know which objects belong to a human (automatic success), and also to which human they belong. (If human and object can be observed, automatic success.)
+- Read each other's glamour. Faerie Lore is a body of knowledge that humans learn through experience, so very few faeries have it. (Ease Factor = Might of other faerie/5) Faeries use the ability to read each other's glamour to guide their interactions, instead of using Faerie Lore.
+- See mundane things hidden by glamour. (Ease Factor = 3 + (Might of Faerie causing the glamour – Might of the faerie attempting to see through the glamour)/5)
+
+##### Faerie Speech
+
+*Minor Virtue, Supernatural*
+
+Many faeries have a Pretense called Faerie Speech, which they use instead of acquiring human languages. Faeries seem to know the same languages as whomever they are talking to. If speaking to a group that has demonstrated mixed linguistic skills, the faerie may select which language to speak in.
+
+This effect occurs whenever the faerie speaks and costs no Might. It is not magically resisted, because the effect only alters the behavior of the faerie. If the faerie has not heard a person from its audience speak, it may only use whichever language it last used with humans. Once its audience speaks, the faerie may then converse in the correct language for its audience.
+
+In the bestiary chapter, Faerie Speech is frequently given to characters designed as NPCs. Characters designed for possible use by players have this Virtue more rarely, to free up a Virtue slot, but it is still appropriate for a wide variety of faeries.
+
+##### Humanoid Faerie
+
+*Minor Virtue, Supernatural*
+
+The character has a material body of roughly human shape. It has all of the advantages of being a faerie, and of having a faerie body.
+
+##### Hybrid Form
+
+*Minor Virtue, Supernatural*
+
+The character has a material body that mixes human and animal elements, and lacks a humanoid structure. It has all of the advantages of being a faerie, and of having a faerie body.
+
+##### Immune to (Source of Damage)
+
+*Minor or Major Virtue, Supernatural*
+
+The bodies of faeries are made of matter held together by rules, and this means that they are vulnerable to injury according to those rules, not the usual rules of human physiology. A faerie with this Virtue takes no damage from natural or magical examples of the nominated force. This is a Minor Virtue if the thing is rare, or only likely to be employed by the environment or magi — examples include cold or lightning. It is Major Virtue if it is a force that mobs of mundanes might employ to assault the faerie — like fire, iron weapons, or wooden weapons. Immunity to entire Forms sometimes occurs, but only where the faerie is so strongly tied to an element that any person with Common Sense could tell that the weapon will be ineffective, like wooded weapons against a forest god or metal weapons against a dwarfish blacksmith. Immunities to entire Forms are Major Virtues.
+
+##### Improved Damage
+
+*Minor Virtue, Supernatural*
+
+One of the character's natural weapons has been enhanced by a story event before play begins, making it sharper, heavier, or somehow more dangerous. Before each combat, the player nominates how much additional damage the weapon does, up to +5. If the player chooses a score above +2, then those watching the combat can deduce that the weapon is supernatural after it causes injury. This requires an Intelligence + Awareness roll against an Ease Factor of 11–Damage amount chosen.
+
+##### Improved Initiative
+
+*Minor Virtue, Supernatural*
+
+One of the character's natural weapons has been enhanced due to a story event before play commences, making the character more likely to act first in combat. Increase its Initiative score by 3.
+
+##### Improved Soak
+
+*Minor Virtue, Supernatural*
+
+The character's natural protection is magically enhanced, making it more effective at warding away blows and physical injury. Increase the character's Soak by 2. This Virtue may be taken more than once.
+
+##### Puissant Pretense
+
+*Minor Virtue, Supernatural*
+
+The character's form is well suited to a particular Pretense, gaining a +2 bonus on roles in its use. For example, a character that has a body designed for combat gains +2 Attack and Defense for a single combat Pretense.
+
+##### Residual Power
+
+*Minor Virtue, Supernatural*
+
+When the character's body is destroyed, one of its faerie powers is automatically triggered. This often has the useful effect of preventing the faerie's vis from being gathered, so that the faerie eventually regenerates.
+
+#### Flaws for Physical Forms
+
+Players who select Flaws that inhibit combat effectiveness must convince their troupe that these Flaws do not, effectively, simply describe a character who has the Noncombatant Flaw. Combat effectiveness flaws are only permitted for those characters who expect to regularly be involved in battle.
+
+##### Intangible Flesh
+
+*Major Flaw, Supernatural*
+
+The character is immaterial, and cannot physically influence the world. Characters with this Flaw should consider the Eidolon and Loosely Material powers.
+
+##### Poor Combatant
+
+*Minor Flaw, Supernatural*
+
+The character's form is well suited to a role that involves combat, but the character's role makes it incompetent. It loses 2 Attack and Defense for a single combat Pretense. This flaw may not be taken more than once.
+
+##### Reduced Damage
+
+*Minor Flaw, Supernatural*
+
+One of the character's natural weapons has been blunted by a story or event before play commences, making it less damaging or dangerous. Decrease its Damage score by 2, but only if it is naturally greater than 0.
+
+##### Reduced Initiative
+
+*Minor Flaw, Supernatural*
+
+One of the character's natural weapons has been slowed due to a story or event before play commences, making the character less likely to act first. Decrease its Initiative score by 3, but only if it is naturally greater than 0.
+
+##### Reduced Soak
+
+*Minor Flaw, Supernatural*
+
+The character's natural protection has been damaged by contact with a Ward, making it more vulnerable to physical damage. Reduce the character's Soak by 2, but only if it is greater than 0. This Flaw may be taken multiple times.
+
+##### Role Requires Suffering
+
+*Minor Flaw, Supernatural*
+
+The character's role requires both frequent injury and that it feels pain and physical debilitation. The character retains the faerie ability to regenerate all but superficial damage, but it experiences pain as if it bore the wounds that its injuries superficially resemble. If the faerie attempts to use its Pretenses, including the Penetration Pretense for its powers, it suffers the negative modifiers that a human would for the equivalent level of injury or exhaustion.
+
+##### Susceptible to Deprivation
+
+*Minor Flaw: Supernatural*
+
+The character's role limits it, so that it suffers human consequences if it lacks air, food, and water. The character is still immune to aging.
+
+##### Vulnerable to (Substance)
+
+*Supernatural, Minor or Major Flaw*
+
+The body of the character, and all of its accouterments, are made of matter held together by glamour. The character's glamour provides no defense against a particular source of damage. This is particularly problematic, as the faerie's armor contains glamour. The character has a Soak score of 0 against this substance. This is a minor Flaw if it is something that people would not consider using unless prompted by a wise person with the Faerie Lore Ability — examples include weapons smeared with garlic, bunches of fennel, sharpened rocks, and burning brooms. Major Flaws suit characters vulnerable to obviously dangerous things — like iron weapons or fire, or to entire Hermetic Forms.
+
+### Social Interaction Virtues and Flaws
+
+The Social Interaction Virtues and Flaws taken by faeries govern only their interaction with humans and replace Social Status Virtues. When dealing with other faeries, player characters are usually treated as representatives of the humans they are with, and treated as the social status of the humans requires.
+
+##### Monstrous Appearance
+
+*Major Flaw, Social Interaction*
+
+Something about the character looks strange and frightening to others, giving the character a –6 penalty in all social situations where its appearance is a factor.
+
+##### Negative Reaction
+
+*Minor Flaw, Social Interaction*
+
+People find something about the character disturbing. This causes a –3 on all social rolls. In many communities, all obvious faeries suffer this reaction.
+
+##### Passes for Human
+
+*Free, Social Interaction*
+
+The character suffers no social consequences, as it can seem human. The character lives at the margins of human society and does not mimic prestigious human roles; to do so requires the Infiltrator Virtue, described later.
+
+##### Positive Folktales
+
+*Minor Virtue, Social Interaction*
+
+The character's type of faerie is described in local folklore, and because of this, the character is treated with respect, caution, and deference when its nature is obvious.
+
+##### Infiltrator
+
+*Minor or Major Virtue, Social Interaction*
+
+An Infiltrator is a faerie who, during most stories, lives as if he were a human being. This costs the same as the Social Status the Infiltrator is mimicking. If the revelation that the character is a faerie would destroy the character's status in mortal society, then the player should consider the Dark Secret Flaw.
+
+### Cognizance
+
+The concept of cognizance is described in detail in Chapter 1: Nature of Faerie. Cognizance is significant when designing faeries for two reasons. The character's cognizance may influence his goals during the story: he may seek vitality in a way that allows him to change roles. The faerie's cognizance also limits the faerie's potential to develop new powers during the course of a story or saga. Characters of low cognizance do not consciously attempt to improve their statistics during the saga. Those of middling cognizance may transform predictably into a more powerful being. Those of high cognizance are the most flexible, and might change roles between scenes in stories, with the assistance of a human, as described later.
+
+>## Unspecialized Role
+> 
+> Faeries do not require the Virtues that allow characters to have Martial, Arcane, or Academic Abilities to have Pretenses for them. These Abilities tend to be used by skilled professionals, and faeries attempting to use these pretences in military camps or universities are rapidly detected as fraudulent and supernatural.
+
+#### Virtues and Flaws Concerning Cognizance
+
+All fairies must have one of the following levels of cognizance.
+
+##### Incognizant
+
+*Minor Flaw, Supernatural*
+
+The character is not aware that it can change its role, although it may develop additional Pretenses by assisting humans in stories. Incognizant faeries do not, however, notice that they are more skilled than they once were, and cannot consciously seek developmental opportunities.
+
+##### Narrowly Cognizant
+
+*Free Choice, Supernatural*
+
+The character is able to improve itself in ways traditional for characters of this type. A dwarf may seek to become a dwarf king, for example. Or a faerie maid may wish to steal a child to raise as her own.
+
+##### Highly Cognizant
+
+*Minor Virtue, Supernatural*
+
+The character is aware that creative humans can generate change in faeries, and can actively seek out such changes.
+
+### Taboos
+
+Individual faeries can be repelled with symbolic objects or actions, defined in their glamour. These Flaws are the basis of faerie taboos — lists of actions that faeries are forbidden to take by their glamour. Taboos relate to symbolic objects or actions, and broad classes of taboos are described after the Flaws.
+
+##### Traditional Ward
+
+*Minor Flaw, Supernatural*
+
+If a taboo is selected as a Minor Flaw, then the faerie may not touch a thing protected by the ward with its glamour. The faerie is likely uncomfortable in the presence of the ward, but is not compelled to flee. The faerie cannot regenerate Might points in the presence of a traditional ward. If forced to touch the ward, the glamour holding the faerie's body together begins to break down: its body begins to flake away. Prolonged contact with the ward destroys the body of the faerie by unpicking the glamour holding its body together.
+
+This may appear to humans as if the ward is burning the faerie. The damage to the faerie's body can be simulated with the Heat and Corrosion rules found on page 181 of **ArM5**. Assume that the object acts as a source of damage with an intensity of +6.
+
+If a faerie receives an Incapacitating wound from an item that is a Traditional Ward, then in addition to the usual effects of Incapacitating wounds (**ArM5**, page 178–179) the faerie cannot spend any further Might points. It can still activate powers with a zero cost, though. If the character has constant-effect powers with a non-zero cost, they expire at the next sunrise or sunset and cannot be reactivated until the character is no longer Incapacitated. The character may heal at a human rate, or may remove the injury with an appropriate story event.
+
+##### Sovereign Ward
+
+*Major Flaw, Supernatural*
+
+If a taboo is selected as a major flaw, the faerie may not harm a person or thing that is defended by the ward. "Harm" is defined very broadly in the faerie's glamour. A faerie that is vulnerable to religious symbols, for example, can not work around the symbol by putting mundane poison in the food of the wearer, or burning his house down around him. The person is completely safe from the faerie. The faerie must attempt to flee the ward, and its body is destroyed instantly by the ward's touch.
+
+#### Folk Charms
+
+Folk charms are trinkets made to protect people by repelling faeries. In Italy, for example, people make a finger sign as a charm, while in Greece they often paint eyes on things instead. A character with this taboo cannot face folk charms, deliberately used, from any culture; faeries from the Yorkshire do not emigrate to Italy to escape witch bottles, and Greek faeries cannot merely leave Greece to escape their weakness before the sign of the evil eye.
+
+Objects that were once the focus of worship may maintain their power over faeries, despite having no supernatural strength, insofar as Hermetic magi can detect it. On the Isle of Man, for example, it is traditional to plant a species of tree once sacred to the god Thor by the door, and carry a fishbone that looks a little like Thor's hammer, to dissuade faeries. The locals no longer revere Thor, but the bones and trees continue to ward off faeries.
+
+Individual people may have folk charms that those skilled in Faerie Lore would not recognize, because they are not part of a traditional tale. These are items that are precious and meaningful to the human, and in whose power to grant aid the human devoutly believes. These items are an Arcane Connection to the human. They vary from "lucky" clothes, through the toys of children that scare away nursery bogies, to ships that never founder in unnatural seas.
+
+#### Herbs
+
+The herbs that repel a faerie are based on that faerie's role, so the faerie is unable to vary them, except by changing roles. Matching the fairy to an effective botanical ward requires the Faerie Lore skill or the ability to read its glamour. In the same way that a faerie is unable to escape its vulnerability to folk charms by moving to a different ethnic community, so faeries find that the underlying symbolism of herbs can be transferred. For example, a vampiric faerie from Slavic lands may flee garlic, but when it moves to the Alps it would find that wild mountain roses also repel it. This is because, in each community, the herb is known to ward against spirits of plague through its strong smell.
+
+#### Iron
+
+Iron is a supremely magical metal that is easily bent to the will of humans. It is woven into the stories of many faeries, as a ward. Some faeries refuse to negotiate with humans who carry iron, even if they will not suffer from contact with it, because they know it is intended to poison them and so take its presence as an insult. Many other faeries are entirely comfortable around iron, particularly the various styles of miners and crafters. Urban faeries are usually resistant to iron.
+
+#### Names
+
+If a faerie has this taboo, and a character knows its name, the character can force the faerie to leave it alone. Many powerful faeries prefer to go by titles and roles when in the presence of humans for this reason. Conversely, in many areas people misbelieve that a person loses one year of life when he says the word "fairy," because it is a failed attempt at naming a specific faerie. People often use slightly flattering euphemisms for faeries, as well — they call them "the good neighbors," for example.
+
+#### Payment or Thanks
+
+Some faeries must leave human service if paid or thanked. They do this because, for that particular faerie, payment or thanks means that the continuing relationship between the human and the faerie has reached its point of emotional equilibrium. Everything that one owes the other is in balance. Some refuse payment because masters pay servants — the offer is a claim that the human is the faerie's lord and master. So the faerie departs, seeking humans that suit it better.
+
+Other faeries leave because they have been made complete by the payment their story is over. A brownie that was once an unbaptized child left to die of exposure, is made complete when offered clothes. It moves on to a new role. Note that such a faerie has probably been accepting bowls of rich cream for years, but does not see this as payment because it does not complete the faerie's role.
+
+A few faeries, once released from service by thanks, return to their destructive natures and attack their previous employers. Examples — like jinn released from bottles who offer three wishes followed by death, and Yallery Brown, who was released from under a stone, did work in gratitude, and then tormented his master to death after receiving thanks — demonstrate that it is important not to sever the relationship with certain faeries.
+
+#### Places
+
+Flaws based on places must seriously inconvenience the character. Some faeries are so tied to their home that the rest of the earth acts as a Traditional Ward against them. They can travel foreign lands provided they do not touch the earth, which burns them. Some vampiric faeries rest in coffins lined with the earth of their homeland to allow their Might to regenerate. Characters tied to their home with a Sovereign Ward simply cannot leave, and are unsuitable as player characters in most sagas.
+
+#### Religious Symbols
+
+Faeries with this taboo flee church bells, but this is unusual in urban faeries. The Dutch, for example, believe that all of the oldest church bells in their country were made by faeries, as presents for early missionaries. A surprising number of English faeries are dedicated Christians, and yet one English saint was able to destroy a faerie bower with a bottle of holy water, disrupting its glamour so that it looked like a charnel pit.
+
+Many of the most powerful faeries cannot enter the Dominion, because God has not invited them in and they are unable to trespass. Certain Merinita magi dream of a day when they can get a bishop to do this, on God's behalf.
+
+## Optional Virtues and Flaws
+
+Faeries may take a wide variety of Virtues and Flaws, with some exceptions and modifications as given here.
+
+### Inappropriate Virtues and Flaws
+
+Faeries may not have supernatural powers associated with the Divine, Infernal, or Magic realms.
+
+Faeries may not have The Gift, or any Virtue or Flaw specific to Hermetic magi.
+
+Faeries do not have human Social Status virtues. If the faerie has a role that makes it appear part of human society, it should take the Infiltrator Virtue.
+
+Faeries do not have any human Virtue linked with having an appropriate upbringing or life experience.
+
+Many faeries are religious, and many more are amoral, but Virtues and Flaws linked to the Divine and Infernal should be taken only after close consultation with the Troupe. However, as noted above, Virtues and Flaws that grant Divine or Infernal powers are not permitted.
+
+### Modified Virtues and Flaws
+
+These are virtues and flaws from the **Ars Magica 5th Editio**n core rulebook that are modified when selected for faeries.
+
+#### Confidence
+
+Faeries do not have Confidence scores. They may have the Personality traits that are usually associated with confident people, but lack the internal spark of inspiration that allows them to live up to their self-image.
+
+** Reputation as Confidence **
+
+*Minor Virtue, Supernatural*
+
+Some faeries are forced, by their glamour, to live up to their Reputations. These faeries don't have true Confidence, but pretend to have it to such a skilled degree that the distinction does not matter. A faerie with this Virtue gains a number of false Confidence points equal to its highest reputation, and may spend them, one at a time, on rolls that support any Reputation. The faerie regains these points when a human would regain Confidence.
+
+Highly cognizant faeries may be aware of the link between their Reputation and their need to uphold that Reputation with Confidence; other faeries with this Virtue are not.
+
+#### Personality Flaws
+
+Faeries may have up to three Minor Personality Flaws and one Major Personality Flaw, so long as all of these Flaws come into play. Faeries often have Personality Flaws associated with their form or role that they must take. Added Flaws allow players to individualize their characters.
+
+#### Virtues Granting Faerie Powers
+
+##### Focus Power
+
+*Major Virtue, Supernatural*
+
+The character has a power that produces varied effects related to a theme, which is smaller than a Hermetic Form. The theme must be selected at character creation, but the effects within the theme are fluid, like those of spontaneous spells. The player receives 25 spell levels to spend on this power. This Virtue may be selected more than once to allow for more-powerful effects. Effects may not have a level higher than the faerie's Might Score unless they have been fortified with the Improved Powers Virtue, described below.
+
+This power has a Might Point cost of the magnitude of the effect, and an initiative score of (the character's Quickness – the power's maximum magnitude). Players should also note the Form or Forms associated with the focus, to evaluate Magic Resistance.
+
+Any spell levels that are left over may be used to increase the effect level of other Focus Powers, or they can be converted into Intricacy points.
+
+##### Greater Power
+
+*Major Virtue, Supernatural*
+
+The character has spell-like powers designed, at character creation, like formulaic spells. Taking this Virtue gives the character 50 spell levels to spend on these powers, and this Virtue may be selected repeatedly, to allow effects of higher level. Each power has a Might Point cost equal to (the magnitude of the effect / 2), and an Initiative score equal to the character's Quickness – (the magnitude of the effect / 2). Players should note the Forms associated with the effect, to calculate Magic Resistance.
+
+Any spell levels that are left over may converted into intricacy points, with 5 full spell levels equal to 1 intricacy point.
+
+##### Lesser Power
+
+*Minor Virtue, Supernatural*
+
+The character has spell-like powers, which are designed at character creation like formulaic spells. Each effect's Might Point cost is equal to the magnitude of the effect. The initiative of the power is equal to Quickness – (2 x Magintude).
+
+Any spell levels that are left over may be used to increase the effect level of other Lesser Powers, or converted into intricacy points, with 5 full levels of effects equal to 1 intricacy point.
+
+##### Personal Power
+
+*Minor Virtue, Supernatural*
+
+The character has a spell-like power, which is designed at character creation like a formulaic spell. Personal powers must have Personal Range.
+
+This Virtue grants the character 25 levels to spend on a power, and may be taken multiple times to allow for effects of higher level. Personal Powers have a Might Point cost equal to (the magnitude of the effect / 2), and an initiative score equal to the character's Quickness – (the magnitude of the effect / 2). Players should note the Forms associated with the effect, to calculate Magic Resistance.
+
+>## An Exemplary Catalog of Faerie Powers
+> 
+> Faerie powers that could be simulated by Hermetic magic are designed using the Virtues given in this section and summarized in the adjoining table. Each Virtue gives a number of spell levels, a Might cost, and an Initiative score for the powers it permits. There are many other powers, collected from folklore, that are designed on a less-structured basis, but if they merely imply that faeries have targets or ranges that are inaccessible to Hermetic magi, they use these rules to help guide their cost. Faeries gain one use of a power each time they spend its cost in Might.
+> 
+> Penetration for a Faerie Power is calculated as shown on page 191 of **ArM5**: Might Score – (5 x Might Point cost) + Penetration bonus. This means that to increase a power's Penetration Total, you must decrease the power's cost, increase the character's Might Score, or improve the character's Penetration score.
+> 
+> Wound and Fatigue penalties do not apply to powers unless the character has the Role Requires Suffering Flaw, described in the Flaws for Physical Forms section above, although some faeries pretend that they are inconvenienced by wounds so that their story can be finished with a heroic victory by a human.
+> 
+> A character whose Might pool has reached zero can no longer activate any powers unless it has a cost of zero. Powers that have already been activated continue until their duration expires. If they're constant-effect powers with a non-zero cost, they cease at the next sunrise or sunset unless the character has regenerated sufficient Might points in the intervening period to reactivate them.
+> 
+> Faeries that are in an area dominated by another Realm cannot use powers with range greater than Touch unless they have an Arcane Connection to the target, or have been invited in. See the Gaining Admittance section in Chapter 1: Nature of Faerie for more detail. Faeries find it easy to create Arcane Connections to humans by tricking them into breaking taboos, particularly the taboo against speaking to faeries.
+> 
+>### Intricacy Points
+> 
+> Intricacy points represent portions of the character's glamour, which support a particular power, that are more complex than average. An intricacy point spent on any non-Focus Faerie Power either makes it activate faster by increasing its Initiative by one, or drain less vitality by reducing its Might Point cost by 1. Intricacy points may increase the Initiative of a Focus Power, but may not change its Might cost.
+> 
+> Intricacy points may be purchased by selecting the Improved Powers virtue, or gained as a recompense for unspent spell levels when any of the Faerie Power Virtues are selected. Every 5 unspent levels equal an intricacy point.
+> 
+> Characters with Focus Powers may also spend 1 of these points to raise the maximum level of effect their focus power can produce by 5. Although this allows the character to generate effects with a level higher than the character's Might score, it does not grant Faerie Might or those things that flow from Might, like Might points and Magic Resistance.
+> 
+> At the storyguide's discretion, this Virtue can also be used to modify a power in the same way magi can master a Hermetic spell. Each time this Virtue is taken, the character's intricacy score with the power is increased by 1, and this gives the character a spell mastery special ability (such as those listed on page 87 of ArM5). Note that activating powers does not require a die roll, so many of the typical benefits of mastering a spell (such as reduced botch dice) do not apply to mastered powers.
+> 
+>### Odd Targets and Durations
+> 
+> There are few examples in this book, because it is intended to stand alone, but faeries may use any of the Ranges, Targets, or Durations available to Merinita magi in *Houses of Hermes: Mystery Cults*. One that is used repeatedly in this book is Until, a Duration that makes a spell last until a certain thing occurs. In this book it is treated as being equivalent to Year, but not requiring a Ritual. This is substantially more powerful than Merinita magic, and is a field of interested study by magi of that House. In some examples, two Durations are given. For example, a power might be marked as Sun or Until. In that case, the power's spell level is treated as Sun duration, and the power expires if either the Sun Duration is completed, or the condition of the Until duration is met.
+> 
+> The conditions of Until durations designed by players need to make narrative sense, and troupes should sternly enforce them.
+> 
+>### Faerie Power Virtue Comparison Table
+> 
+> | Virtue Name   | Spell Levels | Value         | Effect Type | Might Cost       | Initiative                 |
+> |---------------|--------------|---------------|-------------|------------------|----------------------------|
+> | Focus Power   | 25           | Major Virtue  | Spontaneous | magnitude        | Qik – maximum magnitude    |
+> | Greater Power | 50           | Major Virtue  | Formulaic   | (magnitude / 2)  | Qik – (magnitude / 2)      |
+> | Lesser Power  | 25           | Minor Virtue  | Formulaic   | magnitude        | Qik – (magnitude x 2)      |
+> | Personal Power| 25           | Minor Virtue  | Limited     | (magnitude / 2)  | Qik – (magnitude / 2)      |
+> | Ritual Power  | 25           | Major Virtue  | Ritual      | magnitude        | Qik – (magnitude x 2)      |
+> 
+
+Any spell levels that are left over may be used to increase the effect level of other Personal Powers, or converted into intricacy points, with 5 full levels of effects equal to 1 intricacy point.
+
+##### Ritual Power
+
+*Major Virtue, Supernatural*
+
+Players designing Ritual Powers should consult with their Troupes. The character has 25 spell levels with which to purchase Ritual-level effects. If this Virtue is taken multiple times, these spell levels can be combined into effects of greater magnitude. An effect needs to be a ritual if:
+
+- It would require a magus to perform a Ritual spell,
+- It has a level higher than 50, or
+- It breaks Hermetic limits in ways that faeries do not usually break Hermetic limits, as decided by the troupe.
+
+All Ritual Powers are at least Level 20, regardless of the actual level of the effect, and have a Might Point cost equal to the magnitude of the effect. The Initiative for the power is equal to the character's Quickness – (the magnitude of the effect x 2). The player should also note the Forms of the effect, to calculate Magic Resistance.
+
+Besides reducing the character's Might Pool, Ritual Powers also require the player to subtract one from the character's Might Score for each point in the Might cost, whenever it activates the effect. This lost Might may return over time, at the storyguide's discretion, but at a much slower rate than recovering lost Might Points. For example, the character may regain a single point for each story in which it plays a decisive role.
+
+Any spell levels that are left over after the Ritual Power is designed may be used to increase the effect level of other Ritual Powers, or converted into intricacy points, with 5 spell levels equal to 1 intricacy point. These may be spent like the intricacy points gained from the Improved Powers Minor Virtue on any of the character's Ritual Powers.
+
+##### Improved Powers
+*Minor Virtue, Supernatural*
+
+This Virtue gives the character 5 intricacy points to spend on any of its powers. This Virtue may be taken more than once.
+
+#### Flaws Limiting Powers
+
+##### Reduced Power
+
+*Minor, Supernatural*
+
+Subtract 5 intricacy points from any of the character's powers. Each lost intricacy point increases the number of Might Points needed to activate a power by 1, or subtracts 1 from the character's Initiative score for a power. This Flaw may be taken more than once, but the activation cost for a power may not exceed the character's Might Score, and you cannot reduce a power's Initiative below 0.
+
+>## Constant Powers
+> 
+> A Greater, Lesser, or Personal Power can be made constant, triggering automatically at both sunset and sunrise and continuing perpetually as long as the character has a Might Score and the Might Points needed to activate it. The effect must be designed with Sun duration, and costs an additional magnitude. If the power has a Might cost, it is subtracted from the character's Might Pool each time the sun rises or sets, whether the character is aware of it or not. If the character does not have enough Might Points, the power is temporarily interrupted until the next activation.
+
+##### Slow Power
+
+*Minor, Supernatural*
+
+One of the character's powers is very slow, so that it requires an additional round of preparation to activate. This Flaw may be taken more than once, if the character has multiple powers, but all powers affected must be used in situations such that the Flaw seriously reduces their effectiveness.
+
+#### Ritual Faerie Powers
+
+##### Binding Oath
+
+10 points, Init (Qik – 20), Vim
+
+Enforces the power of a solemnly sworn oath or contract between two or more parties. All parties must agree to the oath of their own free will, and the power must penetrate the Magic Resistance of all parties to take effect.
+
+If one participant attempts to act in direct contravention to the oath, the other participants are immediately aware of this. Humans who attempt to break their oaths are given a warning. This warning often takes the form of a memory or sensation this is reminiscent of the faerie’s motif. If the human fails to understand, or disregards, this warning he suffers a Major or Minor Flaw at the discretion of the Troupe.
+
+The Troupe should assign the Flaw based on the powers of the faerie, the nature of the oath, and the seriousness of the transgression within the framework of the story. This Flaw can be removed by powers that destroy mystical effects. The character may also end the Flaw by fulfilling the conditions of the oath, swearing a new oath with the wronged faerie, or destroying all of the oath's other participants.
+
+Faeries cannot break their oaths, although some roles allow them to seek loopholes and alternative interpretations.
+
+Costs 50 levels. Special, No Hermetic equivalent (R: Touch, D: Mom, T: Group, Ritual)
+
+##### Grant (Major Virtue)
+
+10 points, Init (Qik – 20), Vim
+
+Imposes the named Major Virtue upon a target. Each creature may have more than one power of this type, each bestowing a different Virtue. The creature can decide to bestow the Virtue permanently or temporarily. If permanent, the power is a ritual-like power and costs points from the creature's Might Score as well as Might pool (see Ritual Power, above). If temporary, the Might Points spent on this power are only recovered when its effects are withdrawn. The faerie may do this at any time simply by choosing to, but it also often occurs when a prohibition placed at the time the blessing was made is broken. The prohibition is often just a time limit, like a year and a day.
+
+If the Virtue requires Might to use, a human may instead spend a Fatigue level for every five Might required. Many enchanted objects given by faeries are actually uses of this power with a suitable prop generated from glamour. The material effects of the blessing do not disappear when the effect is over: fertile crops do not wither, and money earned from faerie gold does not vanish.
+
+Costs 50 levels. Special, No Hermetic equivalent. (R: Touch, D: Mom, T: Ind, Ritual)
+
+##### Grant (Minor Virtue)
+
+5 points, Init (Qik –10), Vim
+
+Imposes the named Minor Virtue upon a target. Each creature may have more than one power of this type, each bestowing a different Virtue. The creature can decide to bestow the Virtue permanently or temporarily. If permanent, the power is a ritual-like power and costs points from the creature's Might Score as well as Might pool (see Ritual Power, earlier). If temporary, the power only costs points from the Might pool.
+
+Might Points spent on this power in its temporary form are only recovered when its effects are withdrawn. The faerie may do this at any time simply by choosing to, but it also often occurs when a prohibition placed at the time the blessing was made is broken. The material effects of the blessing do not disappear when the effect is over.
+
+This Virtue can allow humans to use faerie powers. If the power requires Might to use, the human may instead spend a Fatigue level for every five Might required. Many enchanted objects given by faeries are actually uses of this power with a suitable prop generated from glamour. Popular granted powers include regeneration, water breathing, flight, and the Virtue Puissant (Single Weapon).
+
+Costs 50 levels. Special, No Hermetic equivalent (R: Touch, D: Mom, T: Ind, Ritual)
+
+##### Grant (Major Flaw)
+
+10 points, Init (Qik – 20), Vim
+
+Imposes the named Major Flaw upon a victim. Each creature may have more than one power of this type, each bestowing a different Flaw. The creature can decide to bestow the Flaw permanently or temporarily. If permanent, the power is a ritual-like power and costs points from the creature's Might score as well as Might pool (see Ritual Power, earlier). If temporary, the Might points spent on this power are only recovered when its effects are withdrawn. If this power can affect families, bloodlines, households, or villages add 5 levels to its price at character creation, and add 1 to the Might cost for each use.
+
+Curses can have immediate effect, or be triggered by an action like breaking an oath or stealing an object. The material effects of the curse do not disappear when the effect is over: burned crops do not magically regenerate, and lost stock is not found. Traditional curses cause pain, visions, paralysis, madness, nightmares, petty annoyances, and poverty. It is not possible to use this virtue to kill a victim directly. Players should recall that the props traditional to a faerie's role, made of glamour, extend the Touch range of the faerie.
+
+Costs 50 levels. Special, No Hermetic equivalent (R: Touch, D: Mom, T: Ind, Ritual)
+
+##### Grant (Minor Flaw)
+
+5 points, Init – 10, Vim
+
+Imposes the named Flaw upon a victim. Each creature may have more than one power of this type, each bestowing a different Flaw. The creature can decide to bestow the Flaw permanently or temporarily. If permanent, the power is a ritual-like power and costs points from the creature's Might score as well as Might pool (see Ritual Power, earlier). If temporary, the Might points spent on this power are only recovered when its effects are withdrawn.
+
+>## Conversion
+> 
+> To quickly convert any of the Greater Powers listed here to Lesser Powers, do the following:
+> 
+> If the cost in spell levels is a **multiple of ten**, double the Might cost and quadruple the Initiative penalty of the power.
+> 
+> If the cost in spell levels is **not a multiple of ten**, then the cost and initiative of the Greater Power were rounded up when they were calculated. For these Greater Powers, the Lesser Power equivalent has a Might cost of (double the current cost –1) and an Initiative modifier that needs to be calculated from scratch (equal to twice the effect's magnitude.)
+
+Add 5 levels and 1 Might to the costif the curse can affect families, bloodlines, households, or villages.
+
+The material effects of the curse do not disappear when the effect is over.
+
+Costs 50 levels. Special, No Hermetic equivalent (R: Touch, D: Mom, T: Ind, Ritual)
+
+### Greater and Lesser Faerie Powers
+
+Every effect that can be created as a Greater Power can also be created as a Lesser Power. Lesser powers have advantages and disadvantages compared to Greater powers. A Lesser Power gives more spell levels for the spent Virtue slot than a Greater Power, and is easier to earn as the character develops. On the other hand, each use costs twice as much Might as the equivalent Greater Power. Lesser Powers also have slower Initiative than Greater Powers.
+
+Storyguides creating faeries for single encounters, like combat, may simplify the process by ignoring Lesser Powers. Nonplayer characters do not need to balance their Virtues and Flaws, so Lesser Powers have fewer advantages for them than for player characters.
+
+The Initiative bonus for a power is the listed bonus, plus the individual faerie's Quickness Score. The powers below have all been created as Greater Powers, and have not been tailored using intricacy points, as described in the insert above. It is common for faeries with Lesser or Personal Powers that cost 15 spell levels or less to convert the unspent spell levels into intricacy points, and then use them to reduce the Might cost of their power to 0.
+
+##### Adhere
+
+1 point, Init –1, Corpus
+
+Takes control of the muscles of the lower body of the target. He cannot dismount the faerie animal unless it wishes, which is of aid when riding friendly flying animals, but is dangerous with animal-like kelpies.
+
+Costs 5 spell levels (ReCo Base 3 +1 Touch +1 Conc.)
+
+##### Allure
+
+1 point, Init –1, Mentem
+
+This power causes the faerie to seem more attractive and pleasant than it really is, granting a +3 bonus on all rolls that involve impressing or convincing others.
+
+Costs 10 spell levels (Base 3 +1 Touch +2 Sun)
+
+##### Cause Fatigue
+
+2 points, Init –2, usually Corpus but varies This faerie can cause a human to lose a fatigue level. The mechanism that harms the human varies by faerie. Some harvest faeries cause heatstroke, for example.
+
+Costs 20 spell levels (Base 10 +2 Voice)
+
+##### Cause Drowsiness
+
+1 point, Init –1, Corpus or Animal
+
+Allows the faerie to cause a human it touches to fall asleep. Versions that are slightly more powerful allow the faerie to affect people at Voice range, or keep them asleep until a certain time.
+
+Costs 5 spell levels for Touch range (Base 4 +1 Touch),
+
+Costs 10 spell levels for Voice range (Base 4 +2 Voice). Costs 1 Might, Init –1.
+
+Add 20 spell levels for Until duration. Cost rises by 2 Might points and Initiative has further –2 penalty.
+
+##### Cause Sickness
+
+3 points, Init –3, Corpus
+
+The faerie can cause a specific, serious illness with its touch, or poison objects it touches so that they harm humans who consume them. See **ArM5** page 133 for guidelines.
+
+Costs 25 spell levels (Base 20 +1 Touch)
+
+##### Craft Magical Trinket
+
+10/15 points, Init 0, as per target
+
+The faerie may create an object, from glamour, that allows the character with the trinket to use a particular Virtue once. The Virtue that the faerie's trinkets permit is selected at character creation. The faerie does not automatically regain the Might spent to produce a trinket, but may refresh itself if it has Virtues that allow it to regain Might by consuming sacrifices or humans.
+
+The trinket ceases to function when a condition placed at the time of creation is met, or when it spends an entire day when no human with a passionate intention to use it for a specific purpose beholds it. This makes stockpiling trinkets impossible except in dire situations. In exceptional circumstances, large numbers of trinkets are possible: for example, in a covenant that knows it will soon have to withstand a Mongol siege, it might be possible for the faerie to give a trinket to each of the covenfolk.
+
+A trinket costs 10 Might points if it invokes a Minor Virtue, and 15 points if it invokes a Major Virtue.
+
+Costs 50 spell levels (Special)
+
+##### Damaging Effect
+
+2 points, Init –2, By weapon
+
+Causes all of the faerie's weapons, which are part of its glamour, to take on a more deadly aspect for two minutes. The danger of the aspect varies according to the motif usual for the faerie, but always increases the weapon's Damage by +5. Faeries that produce mounts from their glamour can improve the Damage of those mounts with this power, since they are effectively weapons of the faerie.
+
+Costs 15 spell levels (Base 5 +1 Part +1 Diameter. This Base is lower than might appear usual in Hermetic magic, because faeries are creatures of stories, and conflict is such a useful tool in roleplaying games.)
+
+##### Eidolon
+
+2 points, Init –2, Imaginem
+
+Creates an illusionary form that is visible and audible. The creature can create a single form for each version of this power they possess. The image can move and speak as directed by the faerie, and lasts until the faerie has no further use for it. This power is particularly favored by tiny faeries who wish to interact with humans.
+
+Costs 20 spell levels (Base 2: +2 move at direction, +1 Touch, +2 Sun, +1 intricacy)
+
+##### Enthralling Sound
+
+3 points, Init –3, Mentem
+
+Allows a faerie to create a particular emotion in any group of people that can hear it. Fear, loyalty, and infatuation are popular choices. This power also increases the intensity of an emotion that already exists. A stress roll with an appropriate Personality trait against an Ease Factor of 9 allows a victim to overcome this power's effect.
+
+Costs 30 spell levels (CrMe Base 4 +2 Voice +2 Sun +2 Group)
+
+##### Enthrallment
+
+4 points, Init –4, Mentem
+
+Allows a faerie to take complete control of a single human's mind for a day, by making eye contact.
+
+Costs 40 spell levels (ReMe as *Enslave the Mortal Mind*, **ArM5** page 152)
+
+##### Fearful Flaming Eyes
+
+2 points, Init –2, Corpus
+
+Completely paralyzes a human who makes eye contact with the faerie.
+
+Costs 15 spell levels (Base 5, +1 Eye, +1 Conc)
+
+##### Grant Puissance in (Ability)
+
+2 points, Init–2, Corpus
+
+Bestows the faerie ability to feign prowess in an activity. For every Might point invested, ten men can be given a +1 to all rolls in a general situation (such as combat, or woodcraft); or 1 man can be given a +3 to a specific Total or Ability (such as Soak or Hunt). Might points spent on this power are only recovered when its effects are withdrawn. If a character has received the +3 bonus, other humans who have a score of 5 of more in the affected Ability can detect that the character is receiving supernatural aid by making a Perception + Awareness roll against an Ease Factor of 9. A faerie cannot use this power to grant aid to a second faerie unless the giver has a Pretense Score that exceeds the receiver's Pretense by at least the value of the bonus.
+
+MuCo 20 (Base 2, +2 Voice, +2 Sun, +2 Group)
+
+3 points, Init –3, Mentem
+
+Subtly influences a group of beings towards a specific course of action. Some creatures can use this power to direct the movement of a group, taking it to a desired location. Other creatures can guide humans towards rash or brave or wise actions. Each time this power is used, it can subtly influence the actions of a single person for up to a day. The storyguide should provide advice to the character in a similar way to the Common Sense Virtue, except that the advice serves the creature's agenda, not that of the character. There is no compulsion to follow this advice.
+
+Costs 30 spell levels (ReMe Base 5, +2 Voice, +1 Conc, +2 Group)
+
+##### Hands of the Animal
+
+2 points, constant, appropriate Form
+
+This allows an animal to manipulate and carry an item as if it had human hands and a Strength of +5. The character must concentrate to do anything other than carry the object, and to drop it or take something else.
+
+Costs 15 spell levels (ReTe Base 3, +1 Touch, +2 Sun, +1 constant)
+
+##### Hound
+
+2 points, Init –2, Corpus
+
+Allows the faerie to know the direction and distance to its human quarry.
+
+Costs 20 spell levels (InCo Base 3, +4 Arc, +1 Conc)
+
+##### Illusionary Home
+
+4 points, Init –4, Imaginem
+
+This comprehensive use of glamour makes a place look, sound, smell, and feel like a suitable home for the role the fairie is playing. Not all faeries use this ability — it is usually restricted to faeries who travel within the Dominion, and cannot extend their glamour over their homes. Within the altered space, the sense of taste is also affected.
+
+Costs 40 spell levels (MuIm Base 5, +1 Touch, +4 Until, +2 Room) an alternative that also costs 40 spell levels is (MuIm Base 5, +1 Touch, +2 Sun, +1 Constant, +3 Structure)
+
+##### Image Phantom
+
+2 points, Init –2, Imaginem
+
+Allows the non-principal faerie of an area to coat an object with illusion, making it seem to be some other thing of approximately the same size and shape.
+
+Costs 20 spell levels, as spell of the same name ArM5 page 146. (Base 5 +1 Touch +2 Sun)
+
+##### Kiss of Forgetfulness
+
+4 points, Init –4, Mentem
+
+Causes the person touched to forget his mortal life until he sees a particular object, or class of object, associated with his home.
+
+Costs 40 spell levels (Base 15 +1 Touch +4 Until)
+
+##### Kiss of Frost
+
+2 points, Init –2, Ignem
+
+Allows the person touched to survive the cold above the snowline on mountains until he treads upon grass.
+
+Costs 15 spell levels. (Base 2 +1 Touch +4 Until)
+
+##### Kiss of the Mermaid
+
+3 points, Init –3, Aquam
+
+Allows the person kissed to breathe under water until he walks upon dry land.
+
+Costs 30 spell levels (Base 4 +1 Touch, +4 Until, +1 Part)
+
+##### Loosely Material
+
+Variable points, Init –5, appropriate Form (usually Corpus)
+
+This power allows a faerie that is generally immaterial to take on matter, over the length of a combat round, and produce a specific body of flesh, wood, or elemental matter. Some faeries have many versions of this power, and can form more than one physical shape, but can still only inhabit one at a time.
+
+Each body has defined physical Characteristics and a fixed Might cost. For each Might point spent on this power, 5 characteristic points are available to spend on the four physical Characteristics of Strength, Stamina, Dexterity, and Quickness. A faerie's material body can have any Size up to a maximum of its Presence unless it spends additional Might points on Size. Every 5 extra points increases its Size by 1. Wound ranges for humanoid forms are as per the Size table.
+
+A faerie may maintain the material body indefinitely. If slain, the body contains pawns of vis equal to the faerie's Might/5, of an appropriate Art. When the faerie returns to immateriality, which takes an uninterrupted combat round, it regains the Might points spent to activate this power. If it then takes on matter again, it does not carry over the wounds caused to its previous body.
+
+Costs 25 spell levels (special)
+
+##### Pine Away
+
+3 points, Init. –3, Corpus
+
+This ability causes the target to slowly
+
+lose both the will to live, and the vitality that permits life. This is treated as a major disease, with an Ease Factor of 9 that causes a Light Wound, but either Faerie Lore or Medicine may be used to treat the effects. Many versions of this power exist, with both weaker and stronger effects.
+
+Costs 30 spell levels (Base 20 (5 +15 for virulence), +2 Voice)
+
+##### Repel Animals
+
+1 point, Init –1, Animal
+
+Like *Circle of Beast Warding* (**ArM5** page 120) Costs 5 spell levels (Base 2, +1 Touch,
+
++2 Ring)
+
+##### Send Message
+
+2 points, Init –2, Imaginem
+
+This power allows the faerie to send short verbal messages to beings to which it has Arcane Connections.
+
+Costs 15 spell levels. (CrMe Base 3, +4 Arcane)
+
+##### Spirit Away
+
+Variable points, n/a, Vim
+
+Allows the faerie to act as a threshold guardian, as described in the Chapter 2: Faerie Realm.
+
+Costs 50 spell levels (Special)
+
+##### Spreading a Mantle of Snow
+
+3 points, Init –3, Auram
+
+Covers an area a mile across in snow, much like *Clouds of Summer Snow*, **ArM5** page 126.
+
+Costs 25 spell levels. (Base 2,+3 Sight, +1 Conc, +2 Group, +1 Size)
+
+##### Steal Judgment
+
+2 points, Init –2, Mentem
+
+Makes the target believe almost any lie that the faerie tells, by diminishing his capacity for doubt. An Intelligence roll against an Ease Factor of 6 is permitted to resist, with easier rolls for truly incredible lies.
+
+Costs 15 spell levels (Base 4, +1 Eye, +2 Sun).
+
+##### Torrent from the Lungs
+
+3 points, Init –3, Aquam
+
+As *Curse of the Desert.* Draws the water forth from the human body, causing +15 Damage that armor does not protect against. If the target does not drink within a few minutes, he dies. The name comes from the surprising quantity of water that pours out of the victim's mouth.
+
+Costs 25 spell levels (PeAq Base 10, +2 Voice +1 Part) See ArM5 page 123.
+
+>## Powers of Transformation
+> 
+> If a character is able to transform a specific substance into another specific substance, like weaving straw into gold, then that is best designed as a Greater Power. If the character is able to turn a wide variety of substances into a specific thing, like turning everything it touches into gold, then that is best designed as a Focus Power. Similarly, if the character is able to turn a specific thing into a wide variety of substances, then that is best designed as a Focus Power. Faeries can also cloak objects in illusions and use misdirection, substituting one object for another and claiming they transformed the original into the new.
+
+##### Transform Victim into (Animal)
+
+3 points, Init –3, Animal
+
+Turns a target who can hear the voice of the faerie into a land animal for Sun duration. The animal's type is nominated at character creation.
+
+Costs 30 spell levels (Base 10, +2 Voice, +2 Sun); although many faeries have a variation with Until Duration that costs 40 spell levels, 4 points per use and has an Init modifier of –4.
+
+##### Transform Victim into (Bird or Fish)
+
+4 points, Init –4, Animal
+
+Turns a target who can hear the voice of the faerie into a bird or fish for Sun duration. The type of bird or fish is nominated a character creation.
+
+Costs 40 spell levels (Base 20, +2 Voice, +2 Sun)
+
+##### Transform Victim into (Object or Plant)
+
+5 points, Init –5, as per object
+
+Turns a target who can hear the voice of the faerie into a solid inanimate object or plant for Sun duration. The object is selected at character creation.
+
+Costs 45 spell levels (Base 25, +2 Voice, +2 Sun)
+
+Many faeries have a variation with Until Duration. It costs 5 Might per use and has an Init of –5. This more powerful version has Touch Range, to keep the level of effect at 50 — the highest a Greater Power may have without becoming a Ritual Power. Players should recall that the traditional objects of a faerie's role extend the faerie's power of touch.
+
+Costs 50 spell levels (Base 25, +1 Touch, +4 Until).
+
+#### Focus Powers
+
+Focus powers can have broad application, and should be discussed with the Troupe when selected. Each use of a focus power has a Might Point cost equal to the magnitude of the effect, and an Initiative score of (the character's Quickness – the power's maximum magnitude). Players should also note the Form or Forms associated with the focus, to evaluate Magic Resistance.
+
+##### Domestic Work
+
+Performs household tasks from a distance. This focus allows some aggressive behavior. A domestic faerie can kindle fires, boil water, and move household objects not held or fastened down — all of which, with a little planning, can be used to hurt humans.
+
+The most aggressive domestic faeries hurl objects. For 1 Might point up to five pounds can be moved, and every additional Might point doubles this. If the faerie has a thrown weapon Pretense, the object may be hurled with force. Blunt objects inflict +5 damage per Might point spent. If the faerie could use the object as a weapon, then it may use the object to strike foes while using this power. All physical attacks with this power must penetrate Magic Resistance. The power lasts until the faerie releases the object.
+
+##### Father of Serpents
+
+Duplicates any non-Ritual Creo, Intellego, Muto, or Rego spells pertaining to snakes at a cost of 1 Might point per magnitude of the effect. Like many focus powers, the limiting factor is the faerie's motif. For instance, a lion who was the ruler of a woodland glade could define exactly the same Virtue as including the entire Hermetic Form of Animal, perhaps ignoring Intellego instead of Perdo. Troupes are cautioned to only allow Focus Powers broad enough to make their saga interesting.
+
+##### Manifestation
+
+Manifests the faerie's consciousness among animal and plant life its glamour touches, temporarily controlling their actions. This power allows the character to simulate any Creo Animal, Rego Animal, Creo Herbam, or Rego Herbam, or Rego Herbam effect with a value of 25 spell levels or less, targeted at the animals within its glamour and suiting its motif. A lord of a wild hunt, for example, may manifest through the wolves of a forest, but would not manifest through squirrels or trees.
+
+##### Shrinking
+
+The character can reconfigure the matter and magic in its body into a series of increasingly tiny frames. The character may choose any Size smaller than or equal to the basic form and use the modifiers for the new Size. Players desiring a small faerie who can grow massive should design the faerie as if its basic form was massive, and select this power. Players should generate a table with the appropriate combat statistics for each Size, so as not to slow the game during play.
+
+This can simulate the effect of any size-changing spell of level 25 of less. This power simulates selecting a spell that shrinks the character by 1 Size, then another that shrinks the character by 2 Size, and so on, plus a spell that returns the character to normal size.
+
+Utterly changing the size of a person has a Base level of 3. If these are personal effects with Sun duration, then the maximum level of effect from this focus is 5. This allows the character to claim 20 spare levels as 4 intricacy points, which are explained in the Improved Powers Minor Virtue.
+
+##### Smithying
+
+Duplicates any non-Ritual Creo, Muto, Rego, or Perdo spell pertaining to the Terram Form, at a cost of 1 Might point per magnitude of the effect, limited by the motif of the faerie.
+
+##### Miser's Midas
+
+This power turns any living thing the character touches, excepting himself, to stone. This power requires two Virtues to get enough levels. The most combat-worthy of these effects — turning a human into stone for more than a few minutes — is level 35 (Base 20, +1 Touch, +2 Sun). A player who selected the Virtue twice could trade 15 spell levels for another focus power or for 3 intricacy points, as described in the insert earlier.
+
+#### Personal Powers
+
+The powers below have not been tailored using intricacy points. It is common for faeries with Personal Powers that cost 15 spell levels or less to convert the unspent spell levels into intricacy points, and then use them to reduce the Might cost of their power to 0.
+
+##### Appear Human
+
+1 point, constant
+
+Allows a humanoid faerie of size –2 to +2 to look and feel human. This power is not required by humanoid faeries, only by shapeshifters who spend the majority of their time in a non-human form. This is an illusion, unlike Transform into Human, later, so a centaur that used it would still be unable to wander inconspicuously through a crowd, ride a horse, or avoid leaving hoof prints.
+
+Costs 5 spell levels (Base 2, +2 Sun, +1 constant)
+
+##### Extended Glamour
+
+0 points, constant, Mentem
+
+Grants awareness of everything that happens within the bounds of a specific domain chosen by the faerie. In essence, the faerie is coterminous with its associated landscape feature, so it is present simultaneously everywhere within its boundaries. The faerie's Might score determines the size of area possible: a Room (5–10 Might), a Structure (15–25 Might), or a standard Boundary (30+ Might).
+
+The area controlled by the faerie can produce a yearly harvest of (Might/10) pawns of vis of an appropriate Form, which manifests as physical objects within the controlled region. Removing this vis does not harm the faerie if it is bargained for. This is the power that allows faeries to extend auras about themselves, as described in Chapter 1: Nature of Faerie.
+
+Costs 25 spell levels: may be taken as a Lesser Power on its own, or as part of a package of Greater Powers. (Special)
+
+>## Power Design: An Example
+> 
+> Neil wants to design a faerie like the German doppelganger or Scottish fetch. These faeries appear to people as their exact duplicates, and drive them slowly mad. Neil's troupe thinks this is an interesting idea, and so Neil designs a basic humanoid faerie, but needs to give it powers to spice up its opportunities in play.
+> 
+> The first power he needs is one that allows his faerie to impersonate specific individuals. He uses the spell *Disguise of the Transformed Image* as a basis for his new power (**ArM5** page 146,) but modifies it slightly so that it has Personal Range and Moon Duration (which does not change the level, 15).
+> 
+> Since this power has Personal Range, Neil builds it as a Personal Power. To do this, he selects the Personal Faerie Powers Virtue, which grants him 25 spell levels of powers, then works out the cost of this power using the table given earlier. Personal powers cost (magnitude/2) points, rounding up, and have an Initiative score of his character's Quickness – (magnitude/2, rounding up). With Personal and Greater Powers Neil finds it easier to just divide the spell level by 10 and round up for cost, and then apply the same number to his Quickness to work out Initiative. In this case, it's a cost of 2 and since his character has a Quickness of 0, the Initiative score is –2. This costs him 15 of the 25 spell levels that the Personal Faerie Powers Virtue buys him. He can either buy another power to consume the 10 spare spell levels, or he can convert them to 2 Intricacy points. If he does this, he can spend them to make his power cheaper or faster, or a little of both. He uses the spare Intricacy points to reduce the cost of the power by 2, to 0. (Players designing a power based on this example should note that perfect illusory copies require a Perception + Finesse roll against an Ease Factor of 12).
+> 
+> There's a ritual in *House of Hermes: Societates* called *Donning the Mask of Another*, that allows the user to duplicate the memories of a particular individual (page 97). Neil considers it, but since it is level 35, it doesn't work. He'd need to buy the Ritual Faerie Powers Virtue twice to get his 30 spell levels, and he'd lose 6 Might for an extended period each time he used it. It would also be very slow (Initiative of –12). Neil reworks the spell description, dropping the Duration to Moon and the Range to Personal. This makes it a level 25 effect that can be purchased with the Personal Faerie Powers Virtue. It has a cost of 3 and an Initiative modifier of –3.
+> 
+> Neil wants one final power: a sort of selective invisibility so that he, or the person he touches, can only be seen or heard by the person he is driving mad, and by those in his group. Selective invisibility is discussed in *House of Hermes: Societates* (page 64), and Neil's troupe agree that what he's trying is similar to *Ambush on the Deserted Road*, but with a Duration of Sun and a Target of Individual, making it level 20. Since this can affect others, but is not a ritual, it must be either a Greater or Lesser Power.
+> 
+> As a Greater Power, it has a cost of 2, and an Initiative modifier of –2. Neil must take the Greater Faerie Powers Virtue and has 30 spare spells levels, which can be spent on other powers or traded for Intricacy points. As a Lesser Power, it costs 4 points per use, and has an Initiative of –8. Neil decides to have this as a Lesser Power, despite the extra Might cost and relative slowness, because this is not a combat power, and it requires only a Minor Virtue. Since the Lesser Faerie Powers Virtue grants 25 spell levels, Neil has 5 spare. He trades them for an Intricacy point and uses that point to reduce the cost of his power by 1, to 3.
+> 
+> Neil thinks his character through, and notices that two of his powers — invisibility and duplicating a victim's appearance — are linked by a theme: they affect the character's personal appearance. He notes that the two powers could instead be replaced by a Focus Power. If he took a Focus Power, the character could produce any Imaginem effect, up to level 25, that altered its appearance. Each use of the Focus Power costs the magnitude of the actual effect produced, and has an Initiative Modifier equal to the maximum magnitude the power can produce, which is –5 in this case. Neil's troupe initially vetoes this focus because the selective invisibility power can be used on others, so it doesn't fit his theme. He counters by redesigning the effect so that it has Personal Range, which lowers the level to 15 and fits the theme.
+> 
+> The character's two powers are both based on level 15 spells, which means each costs 3 points to use, and has an Initiative modifier of –5. The Focus Power Virtue grants 25 spell levels. Neil decides to trade away 10 levels for 2 Intricacy points, which he wants to use to reduce the cost of his Focus Powers by 2, but his Troupe points out that Focus Powers are unique: you can't reduce their costs with Intricacy points. He reconsiders and decides, instead, to think up some new effects; in the end he uses the extra 10 levels in his Focus Power, and trades the points back.
+
+##### Flight
+
+2 points, constant, appropriate Form
+
+The character is capable of flight. The character may use the Athletics skill to simulate difficult maneuvers, but may not engage in combat while flying incredibly swiftly. The faerie may not fly when heavily encumbered, or with a passenger of its Size or more, unless assisted by another faerie that shares the load.
+
+Costs 15 spell levels: (ReFo Base 4, +2 Sun, +1 constant. This base is deliberately lower than Hermetic magic might suggest.)
+
+##### Immateriality
+
+4 points, Init –4, as suits faerie's body Makes a faerie immaterial until sunrise or until nightfall.
+
+Costs 40 spell levels. (Base 30, +2 Sun)
+
+##### Invisibility
+
+2 points, Init –2, Imaginem
+
+A personal version of *Veil of Invisibility*, as per **ArM5** page 146.
+
+Costs 15 spell levels. (Base 4, +2 Sun, +1 for moving image)
+
+##### Shift Human Shapes
+
+1 point, Init –1, Corpus
+
+Allows the character to change its appearance to any other human configuration, although this cannot be used to replicate the features of a specific person. If the human shape selected is related to a form other than Corpus in some way, the power costs 5 extra spell levels and an added point per use. As an example, some faerie knights use this power to don armor by transforming the outer layers of their bodies into layers of metal.
+
+Costs 5 spell levels (Base 3, +2 Sun)
+
+##### Silent Motion
+
+1 point, constant, Imaginem
+
+Allows the character to move without making a noise.
+
+Costs 10 spell levels (Base 3, +2 Sun, +1 constant)
+
+##### Sight Beyond Sight
+
+3 points, Init –3, appropriate Form
+
+All five senses of the creature operate at a distance, as far as the creature can see. This makes the creature supernaturally aware of everything that occurs; and it is exceptionally difficult to catch it by surprise.
+
+Costs 30 spell levels (InIm Base 5, +1 Conc, +4 Vision), so requires the Virtue to be selected more than once.
+
+##### Size Reduction
+
+1 point, Init –1, Corpus or Animal
+
+The character can reconfigure the matter and magic in its body into a far smaller frame. The player chooses a single alternative Size less than 0 on the Size Chart and, when in the smaller form, uses the modifiers for the new size. Players desiring a small faerie who can grow massive should design the faerie as if its basic form was massive, and select this power.
+
+Costs 10 spell levels (Base 3, +2 Sun, +1 Constant)
+
+##### Supernatural Agility
+
+3 points, constant
+
+This power allows the character to perform minor supernatural feats when using its Athletics Pretense. These might include swiftly scaling walls, leaping from the ground onto the back of a galloping horse, and dropping great distances to the ground without harm.
+
+Costs 25 spell levels (Base 10, +2 Sun, +1 constant)
+
+##### Transform into Animal
+
+2 or more points, Init –Might cost, Animal
+
+Transforms the character into a specified land animal of human size or smaller. Faeries retain the power of speech in animal form.
+
+Costs 20 spell levels (Base 10, + 2 Sun)
+
+Costs 25 spell levels (Base 10, +2 Sun, +1 size) to turn into a larger animal, like a horse. This costs 3 Might per use.
+
+Costs 30 spell levels (Base 10, +4 Until) for a version with an Until Duration, which requires 3 Might per use.
+
+##### Transform into Bird or Fish
+
+3 points, Init –3, Animal
+
+Transforms the character into a specified bird or fish. Faeries retain the power of speech in animal form.
+
+Costs 30 spell levels. (Base 20, +2 Sun)
+
+A version with an Until Duration requires 4 points per use, costs 40 spell levels, and has an Init of –4.
+
+##### Transform into Human
+
+This power costs non-human faeries whatever it would cost a humanoid faerie to transform into the character's native shape, using one of the other transform powers.
+
+##### Transform into (Solid Object)
+
+4 points, Init –4, as Form of object
+
+Transforms the character into a specified object. In object form, the character is capable of speech and limited movement.
+
+Costs 35 spell levels. (Base 25, +2 Sun) Some faeries prefer a version with an Until Duration, which requires 5 points per use, costs 45 spell levels, and has an Init of –5.
+
+##### Transform into (Environmental Effect)
+
+4 points Init –4, as Form of effect
+
+Transforms the character into a wave, breeze, cloud, fire, or other nebulous thing.
+
+Costs 40 spell levels. (Base 30, +2 Sun) Some faeries prefer a version with an Until Duration, which requires 5 points per use, costs 50 spell levels, and has an Init of –5.
+
+## Pretense: Faerie Abilities
+
+Few faeries can teach humans. A faerie knight with Pretense as a swordsman may look blindingly swift to a novice, but a skilled duelist will notice that his sword doesn't necessarily travel the complete distance through the space between his strikes and blocks: it may rapidly flicker from place to place. The faerie can't teach this to a human because no human can cheat the way that faeries do.
+
+Some exceptional faeries are able to teach Abilities to humans. Faeries that are linked to the dead seem disproportionately able to do this, for example. It is theorized by those who accept that faeries are, in some cases, the pagan dead, that these faeries are able to teach the Abilities they had in life. They cannot develop their Abilities further, though, enhancing them as Pretenses instead.
+
+##### Faerie Instructor
+
+*Minor Virtue, Supernatural*
+
+Some faeries have the ability to take human Abilities when striking bargains. If the faerie has this Virtue, these Abilities can be stored, then given to favored humans. The faerie imparts the Ability by trading it for the Ability that the student currently has. It does this either by giving the human a prop and claiming it is a magic item, which allows the faerie to easily trade the Abilities back when the story is over, or by pretending to teach the human. Human teachers know that faeries are faking, because their training is too swift to be natural, and too similar to mystery initiation to be effective. It focuses on the trainee reaching an appropriate mental state, rather than the repetitive practice required for real learning.
+
+##### Faerie Trainer
+*Free Virtue, Supernatural*
+
+The character has one or more human Abilities, rather than Pretenses, and so it may train humans using conventional methods. The faerie can develop these abilities further using human methods, or can convert them to Pretenses and increase them as a faerie would. Once an Ability has been advanced as a Pretense, the maximum level at which the faerie can train humans has been reached.
+
+#### Player-Defined Pretenses
+
+Some faeries have pretenses that correspond to their story role, rather than specific human abilities. These player-defined pretenses must be negotiated with the troupe. The faeries in the Bestiary chapter do not have unusual pretenses because there is insufficient space to detail the limitations that would arise from the negotiation of each pretense.
+
+#### Resistance and Pretenses
+
+Faeries use magical powers instead of Abilities, but because these powers affect the faerie, rather than the magus, they are not resisted by Parma Magica.
+
+As an example, consider a faerie using its guile Pretense to try to lie to a magus. The faerie is not targeting the magus with magic. Instead, the faerie is using magic to guide its actions: to know what deception is, what human language is, and how humans deceive each other. Since this inner knowing does not cross the Parma Magica that protects the magus, it is not resisted.
+
+Some Pretenses, such as those for combat or medicine, guide the use of tools. These tools may be resisted in certain situations described more fully in the earlier section on the glamourous body.
+
+### Increasing Pretense
+
+A character's Pretenses become more skilled as it observes humans with the abilities that it is copying. In any given season, a faerie may select a single person who is having a momentous personal experience and gain the same amount of experience toward a Pretense that the person gains toward Abilities, provided that the faerie's Pretense is not already higher than the human's Ability. During this season, the faerie must be closely involved in the person's story. Faeries cannot gain experience from study, training, or practice: they cannot learn through repetition, as mortals do.
+
+Faeries may gain adventure experience. They take experience in any Pretense that is equivalent to any Ability raised by any character who participated in the adventure, including adversaries, provided the Ability being copied is equal to or higher than the Pretense.
+
+Most player characters can only arrange to increase their Pretense about half the time. Characters who through luck, flexibility of role, or good planning can increase their Pretenses more often require a Virtue. Similarly, characters who pay little attention to humans and do not develop their Pretenses at this rate have Flaws.
+
+##### Aloof
+
+*Minor Flaw, General*
+
+Aloof fairies play roles in which they do not find humans particularly interesting, and so rarely increase their Pretenses. Over the course of a saga, these characters can be expected to gain Pretenses for around one season per year. During character creation, an Aloof faerie has a Pretense multiplier of 10.
+
+##### Freshly Sprung
+
+*Minor Flaw, Supernatural*
+
+Subtract 50 experience points from the character’s pool for purchasing Pretences. This represents the character losing some of its glamour. This Flaw may be taken more than once, but players cannot select this Flaw unless the character has at least 50 pretense points to lose. 
+
+>## Player-Defined Pretense Example: Chivalrous Combat
+> 
+> A player, Dave, asks his troupe to allow his faerie knight to have a Pretense called Chivalrous Combat, which rolls together the ability to use a sword and a lance. His troupe members express concern that this seems broader than a standard Ability. Dave agrees, and suggests that his knight may become confused in combat that is non-chivalrous, like ambushes and tavern brawls, so that he is unable to use his Chivalrous Combat Pretense, and must use Brawl instead. His troupe agrees.
+
+##### Observant
+
+*Free choice*
+
+A typical faerie player character increases its Pretenses in two seasons per year. In the other season, it completes the tasks set by its role.
+
+character's pool for purchasing Pretences. This represents the character losing some of its glamour. This Flaw may be taken more than once, but players cannot select this Flaw unless the character has at least 50 pretense
+
+##### Ostentatious
+
+*Major Virtue, General*
+
+A character with this quality is closely interested in the bubbling vat of emotion that is the life of a human community. It finds ways of involving itself in useful stories every single season, and gains Pretense appropriately. During character creation an ostentatious faerie has a Pretense multiplier of 25 instead of 15.
+
+##### Pretentious
+
+*Minor Virtue, General*
+
+A character with this quality is closely interested in a particular family or group of humans, and regularly finds ways to increase its pretense by aiding them through life's challenges. It increases its Pretense, on average, for three seasons every year. During character creation a pretentious faerie has a Pretense multiplier of 20 instead of 15.
+
+## Faerie Afvancement Through Change
+
+To alter its role so that it gains additional powers, a faerie requires several contributing factors. It requires the potential to change within its glamour, represented by the cognizance Virtues. It also needs sufficient mystical energy to change, which is stolen from humans and represented by Pretense points. Finally, it needs a human collaborator to provide the creativity required to design the changes in its glamour.
+
+### Cognizance
+
+A faerie's cognizance determines its attitude to advancement. Incognizant faeries have goals, but these are not related to becoming more mystically powerful. Narrowly cognizant faeries know that a certain situation or possession will bring contentment. The goal they work toward completes their role, but again they do not see this in terms of personal power. Only highly cognizant faeries understand that they can use human vitality and creativity to tailor their roles in amusing ways. This is not to say that faerie player characters do not advance: they do. It is simply that the faerie does not understand the process unless it is highly cognizant. Many incognizant faeries behave in ways that incline them toward the acquisition of greater power, but in incognizant faeries this is instinctual, rather than strategic, behavior. 
+
+### Vitality
+
+Whenever a character gains Pretenses, the player may choose not to spend those points, instead storing them for character advancement. When the character has sufficient Pretenses, which represent human vitality stored in its glamour, the faerie tends to seek humans who can evoke this potential. Only highly cognizant faeries are aware that they are deliberately seeking a human to provoke changes in their role, but all faeries have an instinct, when change is possible, to seek humans.
+
+The amount of vitality that a faerie requires to change its role varies — the greater the new power, or Mightier the role that the faerie seeks, the more its glamour must change. The more that a faerie's glamour must change, the more vitality it requires. Faeries who already have complex glamours find the process of change more difficult, because their glamours are more rigid and constraining than those of simpler spirits. When the character is exposed to creativity, it may consume vis to reduce resistance caused by the current complexity of its glamour, however.
+
+This desire to consume vis at a particular time is why faeries encase vis, as described in Chapter 1: Nature of Faerie, rather than simply eating it like bread and beer. Faeries often hoard vis, placing a layer of their glamour over it so that other faeries will not steal it. This glamour makes the value of the vis obvious to human onlookers, however, so they may see it as mundanely valuable materials, like a pot of gold. This hoard disappears when the faerie uses it, and it reduces the Pretence Cost in the nearby table by 1 for every pawn of vis consumed, to a maximum of the faerie's Might score.
+
+A faerie may only use encased vis for advancement where the outcome is determined by a creative human. If the faerie has left part of its glamour in Sleeping vis, then the presence of a creative, helpful human allows it to reincorporate its glamour and resume its old role.
+
+>## Story Seed: Advancement
+> 
+> Several years ago, a narrowly cognizant faerie was drawn to a young woman prone to daydreams, and made straw into gold for her. She is used this gold to marry a local prince, offering, in exchange, to give the faerie her firstborn. Now that the child has been born, the faerie has relented to her pleas and given her a loophole: she may keep the child if she guesses its name. The magi travel to the faerie's home at her bequest, but discover that it has no name.
+> 
+> The reason for the change in price is that the faerie has reached the point where it is able to develop the Highly Cognizant Virtue. On an instinctual level, the faerie desires a personal identity of its own even more than it wants the enormous vitality expressed within the fate of the heir to the kingdom. The reason the girl's attempts to name it keep failing is that the human names she is offering are too mundane to resound through the faerie's glamour and spark its transformation into a new, cognizant, role. The name the girl, or her magical advisers, choose needs to promise the faerie attention once it is cognizant, so that the faerie claims it willingly.
+> 
+> When the faerie accepts its name, it will scream and rage and be consumed by the Earth, because its old role needs to end dramatically. Eventually, however, the same faerie will return with its new name and shape, perhaps as an ally of the royal family or the covenant who helped it, in order to keep the story of its old role alive for another faerie to follow.
+
+>## Using Abilities On Faeries
+> 
+> This section summarizes how different Abilities apply to faeries.
+> 
+> **Animal Handling:** This Ability is useful for knowing how to take care of a being with an animal form, though not for social interactions with a faerie in an animal shape. To predict how such a creature might behave, use Faerie Lore.
+> 
+> **Animal Ken:** This is a Supernatural Ability with an effect that allows communication with any animal, and it also allows communication with faeries that have animal forms, or have hybrid forms with animal-reflective personalities.
+> 
+> **Bargain, Carouse, Charm, Etiquette, Guile, Intrigue, and Leadership:** These can be used with any intelligent being.
+> 
+> **Faerie Lore:** This may be used like Folk Ken when attempting to understand the motivations of a faerie's role.
+> 
+> **Folk Ken:** This is an understanding of human beings only, though it may give insight into the motivations of human-like beings or faeries who were once human. Some faeries have this as a Pretense, letting them understand human societies.
+> 
+> **Language:** Any Faerie with a score in Faerie Speech can understand any language.
+> 
+> **Teaching:** Faeries cannot be taught, since they do not learn by doing.
+
+### Creativity
+
+Faeries must have the aid of a creative human to change their glamour. The faerie opens its glamour to the human, who uses his Abilities to develop it by creating a symbolically related object or performance. The process can be as brief as the impromptu performance of a song, or as extended as the design and carving of a sculpture.
+
+If the human fails to match the Ease Factor given below, he has wasted the vitality that the faerie has stored. The temperament of the faerie determines whether it will harm the human, but regardless the human is unable to alter this faerie’s glamour at any future time. The Ease Factor should be reduced by 3 if the faerie’s role has drifted away from the folklore of the area, and the change the human is making would draw the faerie closer to what is expected. This often happens to incognizant and narrowly cognizant faeries in areas where communities have been displaced.
+
+Once the faerie has opened its glamour to the human, it must accept the changes the human makes. Faeries do not tell humans this, but to those that make an Intelligence + Faerie Lore roll against an Ease Factor of 6, it is obvious once they begin to alter the faerie’s glamour that they control the stuff of which its identity and attitudes are made. A human who has successfully assisted a faerie to advance in the past, and is aware he is manipulating the faeries’ glamour, may include a single change in the faerie’s motif, attitude, or memory without the faerie noticing. This requires a roll with against an Ease Factor equal to (the Ease Factor of change the faerie has requested be made – 6). If the faerie is a principal, then its servants will notice major changes. If the faerie’s glamour has been substantially altered, their glamours might not remain sympathetic and the area may fall into dispute.
+
+| Ease Factor | Pretence Cost | Effect of Collaboration |
+|-------------|---------------|-------------------------|
+| 6  | 0 + Might  | Lose a Virtue or Flaw and gain another of equal value |
+| 9  | 5 + Might  | Gain a Minor Virtue and a Minor Flaw |
+| 12 | 10 + Might | Gain a Minor Virtue or lose a Minor Flaw |
+| 15 | 15 + Might | Gain a Major Virtue and a Major Flaw |
+| 18 | 20 + Might | Transform a Minor Virtue into a Major Virtue, or a Minor Flaw into a Minor Virtue, or a Major Flaw into a Minor Flaw |
+| 21 | 25 + Might | Gain a Major Virtue and a Minor Flaw |
+| 24 | 30 + Might | Gain a Major Virtue or lose a Major Flaw |
+
+Roll Bonuses
+
++3 if for a Virtue like Inspirational or Free Expression. May only be claimed once, multiple Virtues do not stack.
+
++3 if the local Reputation of the faerie better suits the character after the change than its current state. 
+
+At the troupe’s discretion, the faerie’s player, rather than the artist’s player, may make these dice rolls, given their vital importance.
+
+>## Why Isn't My Faerie a Genius At Every Ability?
+> 
+> Faeries live forever, and so they can theoretically accumulate enormous experience. Starting faeries do not have enormous experience. There are several reasons for this:
+> 
+> A faerie character that is the center of a story is not gaining vitality from that story. Even the pagan gods used to send heroes out to do impossible things, so that they would be supporting characters in stories. Being more skilled than humans makes a faerie unable to feed on their Ability-earning experiences.
+> 
+> The faeries selected as player characters are, arbitrarily, those drawn toward stories with magi, which implies a certain level of power and ability compared to magi.
+> 
+> Faeries often lose Pretenses. Incognizant faeries lose their Pretenses if they lose their role. They have the basic Pretenses of their new role instead, even if both roles are the same type of faerie. Fairies that are narrowly cognizant lose some of their Pretenses when they complete their role and move to another. Highly cognizant faeries often lose and regain Pretenses as they change roles.
+> 
+> Faeries want vitality, and they want to enjoy themselves. They do not require their Pretenses for their professions, which they lack, or to extend their lives, which are limitless. Shedding Pretenses, and becoming someone else in a new story, is amusing. Like a roleplayer who decides to retire a character once it has ceased to present novel challenges, some faeries just give up their Pretenses, knowing they can earn them back in other stories.
+> 
+> The Divine casts down faeries that become too powerful, because it has granted dominion over the Earth to humans. It is difficult for faeries to judge what "too powerful" is, because it seems to vary over time and place.
+> 
+> And some magi suggest that once faeries become mighty enough, they cease to feed on human vitality. They head out into Deep Arcadia and are lost. The faeries humans see are a perpetually renewed batch of recently-generated faeries.
+
+# Chapter Four: Faerie Bestiary
+
+The authors of this book encourage you to use modern faeries in your stories, but they are not included in this chapter. Storyguide and players, it is assumed, are familiar with fantasy literature and, given the limited space available in this book, would prefer creatures that are both more historically appropriate and less familiar. Medieval versions of faeries, to readers raised on modern stories, should seem alien, threatening, and intriguing.
+
+This chapter uses modern, rather than period, names for many of the creatures. Players find these easier to say, and it avoids the use of terms that have been co-opted by stock characters from modern fantasy fiction. Greek and Roman names are often used for types of faerie, but this doesn't mean those faeries are only found in Greece or Italy just that when those of the Order of Hermes discuss them, they use a classical term.
+
+## Faeries Drawn To Life Stages
+
+Human lives go through several stages, and as each transition approaches, the human becomes more mutable. This surge of vitality attracts faeries. And so, disproportionate number of humans who interact with faeries are either just about to begin, or have just completed, the transition to the next stage of their lives. The Church protects each of these life stages with a sacrament, which in some communities discourages the faeries from interrupting the transition.
+
+A variety of beings prowl the borderlands of life, childhood, adulthood, mastery, and mortality. Some faeries facilitate the transition from one life stage to another. Others try to prevent the character from maturing, reflecting their incomplete natures in the lives of human victims. Sometimes, two faeries make a contest of a person entering a life stage, with one pulling toward maturity, and the other holding it back.
+
+A classic example of this occurs when a young person is swept away by faeries to a feast. The leader of the faeries asks the human to partake of the food while another, often a dead friend or an ancestor, counsels him not to. If the human eats, he is trapped in Arcadia, halted forever in adolescence. If he refuses to eat, he is returned home, and is able to continue into adulthood.
+
+>## Two Borders
+> 
+> Many faeries are creatures of two borders simultaneously: an infant stolen away to the forest by a faun, and a man who finds a selkie wife at the shoreline have both encountered a faerie that expresses both physical and developmental borders. Faeries that reside on multiple borders increase their chances of harvesting the vitality of the humans they encounter.
+
+These faeries are, in folklore if not truly, people who have themselves failed to move into the new stage of life. They repeat their incompleteness in the lives of others. This is particularly notable in faeries that kill children.
+
+### Birth
+
+Humans, just after birth, are bundles of tremendous vitality. Faeries can harvest this potential in several ways. The most direct way of harvesting the vitality of a child is to kill and eat it. This method is rare, but so horrible that it is widely famed. A related way to harvest attention is to refuse to harm children protected by a particular ritual, and accept the performance of the ritual as worship. Some faeries steal and try to raise children, who then provide an endless harvest of attention if they survive. More beneficent faeries bless children at their birth.
+
+#### Child Killers
+
+Child killers are some of the most common faeries in medieval folklore. But their variety is tremendous. The stories that surround them often suggest that they are the spirits of women whose own children have died, and they seek the lives of other children either from malice, or to ease the pain of their loss. These faeries are designed as human sized, and many of them are naturally incorporeal and able to become invisible. Most strangle, although some suck the breath from babies, or kill by suckling. Other child killers are babies who were never named: that is, unbaptized infants.
+
+Some child killers have very little Might, and can be kept at bay by simple folk charms. Others kill to force the traditional wards to be employed. Many children die despite wards, though, which causes ill-feeling when mothers blame their supplier for poor wards, and the folk witches blame the grieving mothers for some form of spiritual pollution that reduced the efficacy of the charm.
+
+##### Lamashtu
+
+Lamashtu is not designed as a player character. She is an ancient Babylonian goddess of stillbirth.
+
+**Faerie Might:** 45 (Animal)
+
+**Characteristics:** Int +1, Per +1, Pre +3, Com –3, Str +6, Sta +2, Dex –1, Qik –2
+
+**Size:** +2
+
+**Virtues and Flaws:** 2 x Greater Faerie Powers, Huge, Faerie Sight, Faerie Speech, Feast of the Dead\*; 8 x Increased Faerie Might, Improved Initiative (clawed hands), Improved Powers, Lesser Faerie Power, 2 x Personal Faerie Powers; Incognizant, Traditional Ward (Minor – Pazuzu)\*\*
+
+**Personality Traits:** Vindictive +3, Hungry +1
+
+**Combat:**
+
+*Clawed Hands:* Init 0, Attack +10, Defense +10, Damage +8\*\*\*
+
+*Donkey Bite:* Init –2, Attack +11, Defense +8, Damage +7
+
+*Owl Talons*: Init +1, Attack +13, Defense +11, Damage +10\*\*\*
+
+**Soak: +4.**
+
+**Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15– 21), Incapacitated (22–28), Dead (29+)
+
+**Pretenses:** Athletics 5 (flight), Brawl 9 (while airborne), Faerie Speech 5 (potential victims).
+
+**Powers:**
+
+*Fatal Menses*: 0 points, constant: (5 intricacy points on cost) A poison, like that of scorpions, drips continually from Lamashtu. This creates a fine mist as she flies. Lamashtu poisons wells as she flies over them, so that all who drink of them for the next week fall terribly ill. Her venom can also cause personal illness of sufficient virulence to kill the infirm, or fetuses in utero. Crops and animals die as she flies over them, if she wishes. (This has been treated as a level 50 effect, based on *Treading the Ashen Path*, which is PeHe 30, +10 (added requisites for humans and animals) +10 change Mom duration to Sun, +5 constant, -5 no longer a fancy effect. Treat this power as a magical force, rather than a poison.)
+
+*Enthralling Sound*: 0 points, Init–4, Mentem: (3 intricacy points on cost, 1 on Initiative) Her terrible roar arouses fear.
+
+*Flight*, 0 points, constant, Corpus. (2 intricacy points on cost)
+
+*Invisibility*: 0 point, Init –4, Imaginem. (2 intricacy points on cost).
+
+*Loosely Material:* 1 point, Init –5 Corpus (Animal)
+
+**Equipment:** Often depicted carrying snakes, or suckling a dog and a pig.
+
+**Vis**: 9, a dead owl
+
+**Appearance:** Lamashtu is a tall woman with the head of a lion, the teeth and ears of a donkey, and the feet of an enormous owl. She has leathery, tanned skin that is sometimes furred. She does not require wings to fly.
+
+- **\*** Lamashtu causes stillbirth by touching the belly of a pregnant woman seven times. She also feasts on the flesh of young men, and rips babies from the womb with her talons to consume, although this most often occurs to travelers. She prefers to kill slowly with repeated touches, or by suckling babies to death.
+- \*\* Lamashtu fears and flees images of the Babylonian disease spirit Pazuzu.
+- \*\*\* Lamashtu's breasts ooze a poison that does +10 Damage. She smears this on her claws and talons if she anticipates battle.
+
+> # Story Seed: The Battle of Child Eaters
+> 
+> A Seeker has found an ancient tablet that makes reference to a "demoness" called Lamashtu, rival of the Faerie gods of Babylon. Now that her story has been rediscovered — and retold to the grogs by a companion with Free Expression — a faerie near the covenant has taken her form. Can the characters find a way of calming Lamashtu, or destroying her story?
+> 
+> Once Lamashtu becomes active, another faerie becomes involved in the affairs of the magi. Lamia is an ancient, and yet more modern, telling of Lamashtu's story. Lamia is insane and does evil things because of her madness, but she gladly acts as an ally for the characters against another spirit trying to steal her biography. Lamia can become rational if steadily supplied with magically created eyeballs. As her mind returns, Lamia realizes what a monster she has become, and what terrible things she has done. If coaxed to destroy Lamashtu by a suitably skilled artist, Lamia may be able to change role.
+
+##### Lamia
+
+Lamia is not designed for use as a player character.
+
+**Faerie Might:** 35 (Corpus)
+
+**Characteristics:** Int +1, Per +1, Pre +3, Com –1, Str +2, Sta 0, Dex 0, Qik +2
+
+**Size:** +1
+
+**Virtues and Flaws:** 2 x Greater Faerie Powers, 2 x Improved Characteristics, 6 x Increased Faerie Might, Faerie Sight, Faerie Speech; Hybrid Form, Large, Lesser Faerie Powers, 3 x Personal Faerie Powers; Narrowly Cognizant
+
+**Personality Traits:** Befuddled +2.
+
+**Combat:**
+
+*Claws:* Init +1, Attack +8, Defense +8, Damage +4\*
+
+\* If Lamia grapples successfully, she can wrap her body around a target and do constriction damage of +6 per round, while she retains her Grappling Advantage.
+
+**Soak:** +6 (scales)
+
+**Wound Penalties:** –1 (1–8), –3 (9–16), –5 (17–24), Incapacitated (25–32), Dead (33+)
+
+**Pretenses:** Awareness 9 (faeries), Brawl 6 (humans), Faerie Speech 5 (those expecting prophecy), Folk Lore 9 (aspirations)
+
+**Powers:**
+
+*Enthrallment*: 3 points, Init –2, Mentem. (1 intricacy point on cost)
+
+*Extended Glamour***:** 0 points, constant, Mentem.
+
+*Hound:* 2 points, Init 0, Corpus. Lamia's power allows her to detect the direction and distance of unattended babies, even if she lacks an Arcane Connection to them. It also connects her to humanoid creatures using her story, like lesser lamiae and Lamashtu. This is the remnant of Lamia's power to scry the future.
+
+*Immateriality*: 1 point, Init. –2, Corpus/Animal. (2 intricacy points on cost)
+
+*Invisibility:* 1 points, Init 0, Imaginem (1 intricacy point on cost)
+
+*Silent Motion*: 0 point, constant, Imaginem. (1 intricacy point on cost)
+
+*Steal Eyes*: 4 points, Init –2, Corpus: This power removes the eyes of the victim, and places them in Lamia's head. It has Touch range. (PeCo(Re) base 20, +1 Part, +1 Touch, +1 Rego requisite, +1 Finesse)
+
+**Equipment:** Rich jewelry, and contingency plans that perfectly suit the weaknesses of player characters.
+
+**Vis:** 7 Intellego in two bleeding eyeballs (3 in the right, 4 in the left).
+
+**Appearance**: Lamia has sharp fingernails that act as claws. Her form is serpentine from the waist down, and may attack by constriction. She has the ability to move silently and slip through walls. She uses these powers to see when mothers leave their babies unattended. Her eyes are usually bloodshot.
+
+Long ago a queen of Libya was a lover of Zeus. She became repeatedly pregnant, but had each of her babies save one, Scylla, die in accidents arranged by the goddess Hera. Then Hera went further: she cursed the queen with eternal insomnia. Driven mad with exhaustion and grief, the queen died and became a faerie. Lamia's lower body now appears to be that of a great serpent. She took her current name "Lamia" when she transformed. It means "gullet," as her only food is other people's children.
+
+Zeus took pity on Lamia, but was unable to undo Hera's harm. Instead he gave her a power: whenever her unsleeping eyes become so red and painful that it hurt less to rip them out than continue with them, she could steal a fresh set of eyes from a human. Lamia still haunts the world, stealing children and eating them. She is still mad with sleeplessness, and when her eyes become too red for her to bear, she steals fresh ones from her sleeping victims. In ancient times there was a shrine to Lamia in Corinth, and characters facing her may find valuable information there.
+
+Lamia was able to predict the future in ancient times. A strange supernatural event, called the Silencing of the Oracles, destroyed the capacity of faeries to predict the future. Learned magi suggest this was an act of God, to prepare the world for a new age with the coming of his Son.
+
+##### Lamia Variants
+
+In Greece there are spirits called lamiae that eat babies and are said to be the children of this Lamia. They aren't: Lamia's curse is that she can't have children. These lesser lamiae have the bodies of goats or snakes, human torsos and heads, paws on the front legs, cloven hooves on the rear, and hissing voices. They are less-powerful faeries, which survive by drinking blood and do not need fresh eyes. Injuries from a lamia do not heal until the character seeks out the lamia again and hears her hissing. More generally, vampires are sometimes called lamiae, but these use the statistics for ghulas. 
+
+##### Kubu
+
+**Faerie Might:** 1 (Mentem)
+
+**Characteristics:** Int 0, Per 0, Pre 0, Com 3, Str n/a, Sta n/a, Dex n/a, Qik n/a.
+
+**Size:** usually appears to be –2
+
+**Virtues and Flaws:** Faerie Speech, Faerie Sight; Restricted Might (Major – sunlight), Decreased Might, Intangible Flesh, Incognizant.
+
+**Personality Traits:** Playful +3, Lonely +1
+
+**Pretenses:** Charm 6 (children), Guile 6 (children), Faerie Speech 5 (children)
+
+**Powers:** n/a
+
+**Equipment:** Phantasmal toys
+
+**Vis:** 1 Mentem, The skull of a tiny baby
+
+**Appearance**: A small child, dressed well, and with a surprising number of toys in a bag.
+
+Kubu is an infant-sized faerie that is believed to have been a child who died without being named in ancient times. He often kills other children before they reach confirmation, by calling them to play in the middle of the night. Kubu may visit a child repeatedly, to gain its confidence to wander further and further from home. He leads them off into the wilderness, there deserting them to die of exposure. He cannot stand the light of the sun.
+
+Kubu is not designed as a player character, but may be modified to become one easily. His Flaws need balancing, possibly with powers. He needs extra Pretenses, and a motivation that is more useful for troupe stories than loneliness.
+
+#### Child Stealers
+
+The children stolen by faeries often share a few distinctive features. Single parents are usually raising them, in a household that faerie areas instead of being stolen. Children who survive being stolen have a Touch of Faerie, as described in Chapter 5.
+
+Many types of faerie are unable to reproduce. The most human–like — the kings and queens of the courts of faeries — yearn for children and steal them from humans. Each king or queen has a distinctive set of powers, based on the demesne of which her or she is ruler. Many are neglectful parents, and the children they steal often die for lack of milk, warmth, or shelter. Sometimes the death of a child generates a dependent role: a minor courtier that is the heir of the noble. Scholars differ on whether this is the spirit of the dead child, or just a faerie pretending to be.
+
+Many faeries that steal children leave behind an enchanted stick or statue that seems to be a sickly version of the child. It simulates death, allowing the faerie time to steal the child away. But, more importantly, it may severe the bonds of longing that could otherwise allow the family and child to find each other again.
+
+##### The Man in Black with a Sack on His Back
+
+The Man in Black with a Sack on His Back is not designed as a player character.
+
+**Faerie Might:** 10 (Herbam)
+
+**Characteristics:** Int 0, Per +3, Pre 0, Com 0, Str –2, Sta +2, Dex 0, Qik +1
+
+**Size:** 0
+
+**Virtues and Flaws:** Greater Faerie Powers, Faerie Sight, Faerie Speech, Humanoid Faerie, Increased Faerie Might, Immune to Bashing Weapons\*, Personal Faerie Powers; Incognizant, Restricted Might (minor – direct firelight).
+
+**Personality Traits:** Gregarious +3, Likes stealing things +1
+
+**Combat:**
+
+*Brawl (hands)*\*: Init +1, Attack +2, Defense +2, Damage 0
+
+*Brawl (2 x Bludgeon)*\*: Init +2, Attack +4, Defense +2, Damage +1
+
+**Soak:** +2 against slashing weapons. Immune to bashing weapons.
+
+**Wound Penalties:** –1 (1–5), –3 (6–10), –5 (11– 15), Incapacitated (16–20), Dead (21+)
+
+**Pretenses:** Brawl 2 (children), Carouse 3 (suspicious adults), Faerie Speech 5 (suspicious adults)
+
+**Powers:**
+
+*Appear Human,* 1 point, constant, Imaginem.
+
+*Immure to Bashing Weapons*:*\** 0 points, constant, Herbam: This faerie has the body of a scarecrow, and is undamaged by weapons that cause harm through crushing force.
+
+*Invisibility*: 1 point, Init –1, Imaginem (1 intricacy point on cost)
+
+*Squirming Sack*: 1 point, Init –1 Corpus: Moves a child up to 50 paces away who has made eye contact with the man into his sack. (Base 15 + 1 Eye, 1 intricacy point spent on cost)
+
+*Still Sack*: 0 points, Init –1, Mentem (2 intricacy point on cost): A powerful version of the Cause Drowsiness Power that keeps children unconscious until they are removed from the sack. (Or Sun, whichever comes first)
+
+\* Hands do damage as gauntlets because they are made of wood. When not pretending to be human, the man uses his forearms as if they were wooden clubs, using his Brawl skill.
+
+**Equipment:** Clothing, large sack, an endless supply of straw.
+
+**Vis:** 2 Herbam in a tattered old sack.
+
+**Appearance**: The Man in Black with a Sack on His Back always appears foreign, and seems to be able to blend into darkness. He often takes the form of a scarecrow. He carries a sack, or sometimes a backpack, and he puts naughty boys and girls in it, and carries them away. People are not entirely sure what he does with them, but eating is a distinct possibility.
+
+The Man in Black with a Sack on His Back is found in a surprisingly large area of Mythic Europe. In most areas he is a nursery terror, but in others he steals children. He is a dark mirror image of the pleasanter Yuletide faeries, who carry presents for good children.
+
+#### Faeries that Prey on New Mothers
+
+Most fairies interested in the threshold of birth want to seize the vitality that flows forth from the newborn child, but some faeries prefer, instead, to steal nurturing from the new mother.
+
+**Changeling (Gerontified Faerie):** Some faeries steal a child so that there is a place in a mortal household for a changeling. A changeling is a faerie who has become so withered and unhealthy that it is exchanged for a mortal baby. The changeling appears, using illusions, to be the stolen child, but it becomes needy, sickly, and forever hungry. The nurturing given by the mortal mother rejuvenates the faerie, allowing it to resume a younger version of its form. The stolen child is usually not killed or neglected, so there may still be some sort of connection between the life of the child, and the usefulness of the life the changeling has stolen.
+
+There are several traditional ways of forcing changelings to reveal themselves. Many of these, if accidentally performed on a human child, are horrific forms of child abuse. The torture continues until the changeling agrees to bring the child back, in exchange for its safety and freedom. In many cases, the changeling is left in an abandoned place so that the faeries can trade the children back. The Church has passed strict laws against leaving children in deep holes in the earth or on roofs because they are sickly, but the practice continues.
+
+In some cases, the faerie can be tricked into speaking by showing it something marvelous: these faeries usually accept the marvel as a trade for the return of the child. These items tend to contain vitality or express human craftsmanship. A returned child, particularly one returned through trade, is likely to have future dealings with his or her fairy twin.
+
+In some areas it is believed that the faeries make a tithe of souls to Hell. They give their children away, as changelings, so that when the demons come to collect they take human children instead. The faerie horrors that lie at the edge of Infernal spaces also appear around Magical places that local custom mis-assigns to the Infernal realm.
+
+#### Nursery Terrors
+
+Adults use tales of these faeries to guard the border between civilized and wild behavior. These faeries also lurk around budding adolescents because adults, generally, do not truly believe that they exist. Nursery terrors usually do not kill children; they prefer to terrify them night after night.
+
+**Black Terrors:** The weakest faeries ever observed by a member of the Order. They are dark, ghastly shapes, lacking mass, that form worrying patterns on the walls of children's bedrooms. They gain vitality from the fear they provoke. Each has 1 point of Faerie Might, lacks the power to become material, and has no powers beyond those common to all faeries. Black Terrors contain 1 pawn of vis each, so magi are keen to find them. Some magi find it profitable to enslave these creatures, to use as messengers.
+
+**The Cyclopes:** Used by the ancient Greeks to scare their children into submission. They are cannibalistic giants with a single eye in the middle of their heads. They use the statistics for any other giant, with a –3 on all rolls requiring depth perception. Some magi say that these cyclopes are mere reflections of the real cyclopes, which are primordial giants associated with the Magic realm. A kind of cyclops, the licho, is still used as a nursery terror in Slavic lands. It is described later, in the section on Roads.
+
+**Jenny Greenteeth:** Jenny is one of the many nursery terrors that are encountered outside the house. They represent both the boundary between obedience and disobedience, and the boundary between safe places and dangerous ones. When adults say "If you lean too far over the well, Jenny Greenteeth will catch you in her claws and drag you under," they do not believe the story they are telling. The story is only effective, however, because children do. Regional variants include: the Grindylow of Yorkshire, which inhabits pools and marshes; Nellie Long Arms, who is much like Jenny but has incredibly long arms; the Morgan of Wales, which is a freshwater merman; and the Pontarf of Ireland, which is a giant fish.
+
+**Lammikin:** An ugly, humanoid faerie from Scotland. He torments children by stabbing and pinching them. If they cry out, it waits and ambushes their mothers, slicing their throats and drinking their blood while the children watch. His story is told to children to prevent them from waking their parents.
+
+##### Gorgon
+
+Gorgons are not designed as player characters.
+
+**Faerie Might:** 25 (Mentem)
+
+**Characteristics:** Int +1, Per +6\*, Pre –3, Com 0, Str 0, Sta 0, Dex 0, Qik +3
+
+\* Due to Dozens of Eyes power.
+
+**Size:** –1
+
+**Virtues and Flaws:** 2 x Greater Faerie Powers, 4 x Increased Faerie Might, Faerie Sight, Faerie Speech, Hybrid Form; Incognizant, Small Frame
+
+**Personality Traits:** Vain +3, Iconoclastic +1
+
+**Combat:**
+
+*Brass Claws:* Init +2, Attack +5, Defense +7, Damage +2
+
+*Tusks:* Init +3, Attack +7, Defense +6, Damage +5
+
+*Serpent Hair:* Init +2, Attack +8, Defense +5, Damage +1\*
+
+\* Gorgons have mid-back-length hair, so they may only use their hair snakes to engage targets close together. Theoretically, she has 18 snakes able to strike at any time on her head, although usually she only uses three at a time. See also the venomous bite power.
+
+**Soak:** 0
+
+**Wound Penalties**: –1 (1–4), –3 (5–8), –5 (9 –12), Incapacitated (13–16) Dead (17+).
+
+**Pretenses:** Brawl 3 (humans)
+
+**Powers:**
+
+*Enthralling Sound,* 3 points, Init 0, Mentem: A gorgon can utter the scream of the dead, creating terror in those who hear it. The low hissing of her snakes can create the same effect.
+
+*Deadly Gaze:* 1 point, Init –2, Terram: (4 intricacy points on cost) The gorgon can transform into stone any person or animal with which she makes eye contact. Creatures so changed revert to life if the gorgon dies or is stripped of its Might. (Base 25, +1 Eye, +4 Until)
+
+*Dozens of Eyes*\*, 0 points, constant, Animal: The gorgon has dozens of pairs of eyes, which scan her surroundings, in all directions, constantly. This grants her extraordinary Perception.
+
+*Venomous Bite\**, 0 Points, Init 0, Animal: When the gorgon’s hair attacks, compare its Attack Advantage to the victim’s armor Protection (not his Soak). If the gorgon’s advantage is higher, the victim suffers the effects of adder venom as listed in the Poison Table on page 180 of ArM5, regardless of whether the bite inflicts an actual wound. The storyguide may adjust the required Attack Advantage for special circumstances. 
+
+\* This is a power of the gorgon's Hybrid Form, and does not need to be paid for with the Personal Faerie Power Virtue.
+
+**Vis:** 5 Mentem, a mask
+
+**Appearance:** A woman of slight build, with a hideously deformed face, tusks, and brass claws. Snakes replace her hair. Some gorgons are stunningly beautiful (Per 0, Pre +6, lose the omnidirectional vision or spend an extra Major Virtue), and some can fly on bat–like wings.
+
+In ancient Greece, the gorgons were nursery terrors. The name gorgon means *terrible,* and terror is something a young boy would need to overcome to be a man. A true Greek warrior would learn to seize control of fear, and use it against his enemies, much as Perseus used the head of the gorgon. After achieving this, the head of the gorgon becomes a traditional symbol that wards off evil, called the gorgoneion. She is the faerie that humans use as a folk charm to scare away lesser faeries. Thus, the name Medusa means "protector."
+
+##### Mormo
+
+Mormo is not suited for player characters.
+
+**Faerie Might:** 15 (Mentem)
+
+**Characteristics:** Int +1, Per +1, Pre 0, Com +1, Str 0\*, Sta 0\*, Dex 0\*, Qik 0\*.
+
+\* These statistics are provided by Mormo's host.
+
+**Size:** 0 (as host)
+
+**Virtues and Flaws:** Focus Faerie Powers (Possession, see below), 2 x Increased Might, Loosely Material\*; Incognizant.
+
+\* Modified to a minor Virtue: may only take forms using possession power.
+
+**Personality Traits:** Playful +3, Thinks children are scrumptious +3
+
+**Combat:**
+
+*Bite\*:* Init +0, Attack +8, Defense +6, Damage +1
+
+\* Modified by the body's statistics. The bite marks Mormo's hosts leave are like those of horses.
+
+**Soak**: 0
+
+**Wound Penalties**: –1 (1–5), –3 (6–10), –5 (11–15), Incapacitated (16–20), Dead (21+)
+
+**Pretenses:** Brawl 5 (infants), but may use the Pretenses or abilities of the host.
+
+**Powers:**
+
+*Possession*, 1 or more points, Init +2, Mentem: If this power penetrates, the victim is possessed by Mormo and is under her direct control. Any attempt to force the victim to act contrary to her nature, or to use any of the host's own magical powers requires that Mormo spends Might. A supernatural power (including spell-casting) requires 1 Might point per magnitude to produce. A questionable action that is contrary to the nature of the host requires Mormo to exceed the possessed being's Personality Trait roll on a stress die + Might points spent. The storyguide may give a modifier to the Personality Trait roll based on the nature of the command (see the Entrancement power, **ArM5** page 65, for suggestions). Both Might costs must be met if the use of a supernatural power is also contrary to the victim's nature. If Mormo is in direct control of its host's actions, the host acquires Mormo's Magic Resistance, but is also affected by wards that would normally exclude her. If the host is acting under her own free will, then she does not benefit from Mormo's Magic Resistance, but may also walk through wards with impunity.
+
+This power's costs are not based on the Hermetic system of magic. It is instead based on material in *Realms of Power: Magic*.
+
+**Equipment:** Someone else's body, all of their material goods.
+
+**Vis:** 3 Mentem, in the saliva of the possessed victim.
+
+**Appearance:** Mormo does not have a material body, but if seen with Faerie Sight, or Second Sight outside a body, she seems to have a horse's head. This is incongruous with her lupine name, indicating that this was possibly changed at some time by a human. It may be, in some way, symbolic of her changed personality.
+
+Mormo is a faerie who bites children and babies who are being naughty. A mother, on the faerie's behalf, often playfully delivers Mormo's bites.
+
+Mormo was initially a mother who lost her children, and became a werewolf (*mormulukeion*) to seek revenge. Somehow she lost her body, and became a possessing spirit, like the faerie that causes the tortoise game described in the nearby insert. In time, she became less dangerous and more playful. This may be the result of a human reworking her role with creativity, turning her attacks into a game like peek-a-boo between a mother and child. Mormo still possesses mothers and encourages them to playfully nibble at their children.
+
+>## Story Seed: The Tortoise Game
+> 
+> The ancient Greek writer Errina describes a game that the children at the covenant have begun to play. Girls sit in a circle, with a girl in the middle. She is called the "tortoise." Each girl in the circle asks the tortoise a question, which she answers with the first thing that comes into her head. When any girl asks "How did your baby die?" the girl in the middle screams while chasing the questioner around the circle. If the questioner makes it back to her place she is safe, but if she is tagged, she becomes the new tortoise. This game is based on the actions of a faerie that takes advantage of postnatal
+> 
+> tiredness to possess a mother, and make her kill her baby, and perhaps eat it. It then feeds off the negative attention the murderess suffers, until she dies.
+> 
+> Some faeries that dwell inside bodies can pass through the Aegis that defends the covenant, if the human they are residing within chooses freely to enter. That the girls of the covenant are playing the game indicates that the Tortoise is present, and is seeking a victim. What do the characters do? As the characters hunt the Tortoise, it takes refuge in a variety of women, or female animals, always seeking to get closer to children that it can murder.
+
+Mormo's presence, like that of the Tortoise, causes the mother to continually refer to her child as if it were food, with names like "honey," "sweetie," "dumpling," and "apple." Mormo's statistics may be used for the Tortoise, her more-dangerous role mate.
+
+Mormo sometimes uses weapons, and at other times seems incapable of it. This may indicate there are several faeries that take the role of Mormo, but that makes her change from devouring mother to nursery terror more difficult to explain.
+
+#### Protectors
+
+Protectors are faeries that watch over small children. They are fervently courted by mothers and, once their charges are grown, are kept vital by occasional visits to the children they have helped.
+
+**Faerie Godmothers:** A godmother is a person who promises to guard the child from the wiles of the Infernal, and to raise it in the Christian faith. Godparents also traditionally give gifts to their godchildren, and may adopt them if their parents die. These are some of the most innocuous faeries, but they can turn nasty if they feel slighted, using their intimate knowledge of the godchild to cause them enormous pain.
+
+Faerie godmothers can be designed as Courtly Faeries, the statistics for which are given later. Fairy godmothers are particularly noted for supplying magical gifts to their godchildren, so the statistics of the Courtly Faeries might be modified to allow for this. Godchildren raised by faeries have a Touch of Faerie, as given in Chapter 5.
+
+**Imaginary Friends:** Characters who gain the Faerie Friend virtue at this age often have friends that are toy-like, or belong to one of the classes of faerie that children believe in, but not adults.
+
+##### Toy Soldier
+
+The toy solider could replace a beginning companion with alteration. It requires a Social Interaction Virtue or Flaw, and needs to balance its Virtues and Flaws. The soldier requires another 90 points of Pretenses. The Improved Damage Virtue or Damaging Effect power would raise the toy soldier's damage to +1. Although it could not afford to enter combat, it could act effectively as an assassin sent to kill sleeping humans, or guard animals that use smell to detect threats, like dogs. A horde of enhanced toy soldiers could overcome human foes. Removing one of the Little Flaws, and raising the character's Size to –2, would make the character far more durable and allow it to inflict heavier damage.
+
+**Faerie Might:** 5 (Herbam)
+
+**Characteristics:** Int 0, Per +1, Pre 0, Com 0, Str –9, Sta 0, Dex +2, Qik +8
+
+**Size:** –6
+
+**Virtues and Flaws:** Faerie Sight, Faerie Speech, Humanoid Faerie, 2 x Improved Characteristics, Observant; 2 x Little, Dependant (child), Incognizant
+
+**Personality Traits:** Brave +3, Loyal +3, Proud +1
+
+**Combat:**
+
+*Tiny Wooden Sword*: Init +9, Attack +10, Defense +15, Damage –6
+
+**Soak:** +4
+
+**Wound Penalties**: –5 (1), Incapacitated (2), Broken (3+)
+
+**Abilities:** Athletics 3 (running), Awareness 6 (night terrors), Faerie Speech 5, Single Weapon 6 (tiny wooden sword)
+
+**Equipment:** Painted uniform, tiny wooden sword
+
+**Vis:** 1 pawn Herbam, tiny wooden sword
+
+**Appearance:** This foot-tall wooden soldier is the veteran of many imaginary campaigns, and stands guard over his lord while he sleeps. He has the good fortune to be a Traditional Ward against certain nursery terrors, but he puts the retreat of such monsters down to their fear of his prowess.
+
+### Reason
+
+Children that are just about to come into the state of reason, generally defined in Mythic Europe as occurring around the age of seven, develop the ability to feel wonder. They have not been jaded by experience, so their wonder is a source of pure, and easily evoked, vitality. Children repeatedly influenced by faeries at this tender age are often marked for life, which provides the faerie with regular attention.
+
+#### Guides to Adventure?
+
+Child stealers for this life stage are similar to those for babies, except that they must gain the assent of the child before it can be stolen. This assent can be verbal, but can also be expressed by actions, like running away with the faerie, or lifting the latch to the faerie so that it can take the child away. Children who are lured away are sometimes replaced with changelings.
+
+The one difference is that many child stealers for this age group are willing to bring the children back, once they have completed a story. This can seem charming to the child, but any adult would notice that the guide is continually putting the child in dangerous situations. If the child dies, then the guide feels miserable, but the story must go on. The guide simply befriends a new child, and sends it on the same adventure, recruiting as many children as the story requires for conclusion. Some guides return the bodies of dead children, others simply don't bother.
+
+Most guides provide children with a method of rapid travel. This is sometimes a spell made up of nonsense words, that works through the power of the faerie. Other faeries give the child a magical device, often a piece of clothing or furniture, which allows travel. The most popular choice is carrying the child. Some faeries allow humans to ride them, on their backs if in animal form, or on their shoulders if human shaped. Others put the child in a container and carry that.
+
+#### Faerie Animal Companions
+
+Characters who gain the Faerie Friend Virtue at this age often have friends in animal shapes. Sometimes a single faerie in animal shape adopts a magically significant number of children and surreptitiously takes them all on thrilling, which is to say dangerous, adventures without parental supervision. The most skilled faerie animal companions have sufficient powers that they can control the minds of adult adversaries, to prevent them from just murdering interfering children.
+
+### Adulthood
+
+Characters entering puberty feel the first flame of adult passions. These permit new opportunities for emotional expression. Adulthood also allows characters to change social roles, choosing professions and spouses.
+
+#### Entrapping Lovers
+
+Young people lack the discernment to know the superficial from the actual. Faeries are able to put a patina of beauty upon themselves, which humans take as a promise of eternal happiness. Older, wiser humans who are taken by the faerie lovers fight them, and if they cannot escape count themselves among the dead.
+
+**Nymphs:** Folklore is filled with beautiful women who take knights as lovers, and turn them into the most comfortable sort of prisoner. The Lady of the Lake captures Merlin in a cave beneath a rock, stripped of his powers. Triamore takes a knight as lover, but robs him of the power to talk of her and so save himself from slander, and then later the power to leave her home and act as a knight should. True Thomas' Queen strikes him dumb, so that he cannot use his poetical tongue to break free of her realm. Calypso, whose name means "hidden," offers Odysseus an eternal life of domestic bliss, if he gives up his fame, his kingdom, his family — any chance he will be remembered by anyone. His glory must forever be hidden. Nymphs are not creatures of the wilderness — they live at the edge of the domesticated land outside cities. They may represent a natural feature, like a stream or an oak, but they require humans, and live near their communities. Many of the nymphs that live closest to humans do not physically entrap their lovers. Instead, they prefer to be the first, idealized love that captures the vitality of the emerging sexuality of a string of adolescents from the nearest village.
+
+##### Lesser Nymph
+
+The nymph described here is one of the weaker of her kind. Nymphs that are more powerful are designed using the statistics for courtly fairies, given later.
+
+This maiden is one of a group that gathers to dance in the deep woodland. Like many nymphs, she lacks effective combat skills. This occasionally makes her prey to insecure and cruel men. She has satyr allies she can summon if in difficulty, using her glamour, which touches theirs.
+
+Minor nymphs can replace companion characters. Players are advised to swap out the Extended Glamour Lesser Faerie Power. The nymph below needs three more Flaws to be balanced, and needs a Social Interaction Virtue or Flaw. Her *Coils of Entangling Plants* power could also be modified. The Music and Athletics Pretenses should be lowered and combat Pretenses added. The Personality traits should also change to something more suited to interaction with other player characters.
+
+>## Happily Ever After is Just a Pleasant Sort of Death
+> 
+> Players struck by the portrayal of nymphs in other roleplaying games may not understand how a character could object to an immortal life filled with sex. Characters in Mythic Europe have an afterlife, so they are in an important sense already immortal. They have greater ambitions than finally finding someone who will sleep with them regularly. Just as unnamed babies become faeries that try to kill other babies before baptism, so nymphs, who are on the verge of becoming young women, are incomplete adults, and make the people they trap similarly eternally adolescent. An eternal life in which nothing significant ever happens is identical to the classical Hades.
+
+**Faerie Might:** 10
+
+**Characteristics:** Int 0, Per 0, Pre +3, Com +1, Str 0, Sta 0, Dex 0, Qik 0
+
+**Size:** –1
+
+**Virtues and Flaws:** Greater Faerie Power, Cognizant Within Role, Faerie Sight, Faerie Speech, Humanoid Faerie, Increased Faerie Might, Lesser Faerie Powers, Observant, Restricted Might (winter), Sovereign Ward (folk charms), Small Frame
+
+**Personality Traits:** Shy +3
+
+**Combat: n/a**
+
+**Soak:** 0
+
+**Wound Penalties** –1 (1-4), –3 (5-8), –5 (9- 12), Incapacitated (13–16), Dead (17+)
+
+**Pretenses:** Athletics 5 (dancing), Awareness 3 (humans), Carouse 3 (parties), Charm 3 (potential dancers), Etiquette 2 (faerie court), Faerie Speech 5 (conversation), Music 6 (harp)
+
+**Powers:**
+
+*Extended Glamour:* 0 points, constant, Mentem.
+
+*Coils of the Entangling Plants:* 2 points, Init.–2, Herbam: as the spell of the same name, **ArM5** page 138.
+
+*Enthralling Sound:* 3 points, Init –3, Mentem: May create infatuation with the sound of her dancing or running.
+
+**Equipment:** Bells on her toes.
+
+**Vis:** 2 pawns Imaginem, a leaf tangled with a spider web
+
+**Appearance:** A beautiful maiden who dances in the woods, with others of her kind and with passing strangers.
+
+##### Nymph Variants
+
+Some nymphs maim their lovers, either to trap them or because they are a variant of the sexual predators described in the next section.
+
+#### Sexual Predators
+
+A few faeries rape humans, colonizing their bodies with faerie babies. When the baby is about to be born, the mother is often drawn to the home of the father to deliver the child. Some try to kill the woman, but many faeries, like the scarlet-robed stranger in the *lai* of Sir Degare, provide a patrimony for their sons. In this case, his father leaves Degare a pair of magical gloves and a sword with a broken point that later allows him to recognize his son. These faeries are often knights, and use the statistics in the Courtly Faerie section.
+
+Many of these stories have an ending that many players find shocking: the woman forgives her attacker, and is reconciled with him as his wife. The same is true in stories like *Sir Gawain and the Green Knight*, where the mortal hero rapes a faerie queen, who curses him at the beginning of the story and is, in some versions, married happily to him by the story's end.
+
+Many faeries use their sexual attractiveness to lure mortals to their doom.
+
+**Jezinkas:** Beautiful female faeries in Bohemia that steal eyes after lulling men to sleep with an apple, a rose, or by combing their hair. Jezinkas cannot touch brambles, or break bonds made of them, and can be drowned if bound with them. Jezinkas have the power to return any eye they have stolen into any socket, giving odd abilities to mortals.
+
+#### Faeries Who Eat Their Spouses
+
+A surprising number of faeries take human spouses, and then eat them.
+
+##### Ghula
+
+Ghulas are not designed as player characters.
+
+**Faerie Might:** 20
+
+**Characteristics:** Int 0, Per 0, Pre +5, Com +1, Str +1, Sta 0, Dex 0, Qik +1
+
+**Size:** 0
+
+**Virtues and Flaws:** 2 x Greater Faerie Powers, Infiltrator (Wealthy, orphaned merchant's daughter); Faerie Sight, Faerie Speech, Feast of the Dead, Humanoid Faerie, 3 x Increased Faerie Might, Personal Faerie Powers; Narrowly Cognizant; Restricted Might (Major – daylight).
+
+**Personality Traits:** Demure/Ravenous +3
+
+**Combat:**
+
+*Claws*: Init 0, Attack +11, Defense +10, Damage +5
+
+*Fangs*: Init +1, Attack +10, Defense +8, Damage +4
+
+**Soak:** 0
+
+**Wound Penalties:** –1 (1-4), –3 (5-8), –5 (9- 12), Incapacitated (13–16), Dead (17+)
+
+**Pretenses:** Charm 6 (men), Brawl 6 (in dark areas), Stealth 9 (urban areas)
+
+**Powers:**
+
+*Cause Drowsiness:* 2 points, Init –2, Corpus, (Touch Range, Until Duration, 1 intricacy point spent on cost)
+
+*Illusionary Home:* 0 points, Init –3, Imaginem (4 intricacy points on cost): variant that has a constant effect on a structure.
+
+*Transform Into Human:* 0 points, Init.0, Animal (3 intricacy points on cost, 2 on initiative): This power transforms the character between human and feasting form. It is treated as a Personal level 25 MuCo(An) effect.
+
+**Equipment:** Perfume, wardrobe
+
+**Vis:** 4 pawns Imaginem, rat skulls
+
+**Appearance:** Ghula usually look like beautiful women. To attract husbands, ghula pretend to be wealthy widows or orphans of good families, in need of husbands. Ghulas often pretend to be members of communities displaced by war, as it gives their story verisimilitude. The eyes and the insides of the mouths of Arabic ghula are always green. Male ghuls exist, but are the servants of the ghula, and rarely play the role of seducer.
+
+These spirits may rise from, or impersonate, those who die of thirst in the desert. They are surprisingly common in Europe, because the magicians of Arabia can identify and defeat them. Europeans are less well prepared. Philostratus, who records in detail a conflict between one of these creatures and the ancient magician Apollonios of Tyana at a wedding in Corinth, calls them *lamiae*.
+
+These spirits seek virile and wealthy husbands. They drain the blood of their husbands as they sleep. Once sufficient vitality has been consumed, the ghula can have a baby. The baby appears to share the characteristics of the human parent, but it is a faerie — a ghula like its mother. Baby ghuls are born with teeth.
+
+The ghula in a city sneak out of their houses while their husbands sleep. They gather in graveyards to feast, cavort, and drain the blood from corpses. In most versions of their story, the husband of a ghula discovers these night meetings, and destroys the nest of ghuls, but cannot bring himself to kill his children. The young ghuls grow to adulthood and tyrannize the city, forcing the man who discovered the ghuls to flee. This old, sick, broken man lives near the town, warning travelers away, and reciting his role in his home's downfall. In doing this, he spreads the fame of the ghuls, which gives them vitality.
+
+##### Ghula Variants
+
+A related story says that ghula are the ghosts of prostitutes, given solid form, and that they are simpler in their predatory be havior. They merely eat the dead, and lacking fresh prey eat corpses. They use their wiles to lure men of weak faith to hidden places, and have a power that causes sleep, allowing them to crush the heads of their victims with stones. 
+
+##### Ghaddar:
+This creature has the power to entice men, and to cause paralysis. She lures a victim to an isolated spot, and then tortures him for an extended period, culminating in the consumption of his genitals. These forms of ghula police a moral boundary.
+
+##### Glanconer
+
+Glanconers are only slightly outside the range of companion player characters, but are a form of sexualized serial killer, and so are difficult to place in sagas.
+
+**Faerie Might:** 10
+
+**Characteristics:** Int +1, Per +1, Pre +3, Com +3, Str +1, Sta +1, Dex 0, Qik 0
+
+**Size:** 0
+
+**Virtues and Flaws:** 2x Greater Faerie Powers; External Vis (minor), Faerie Sight, Faerie Speech, Human Form, 3x Improved Characteristic, Increased Faerie Might; Sovereign Ward (sunlight); Incognizant, Non-combatant. Traditional Ward (folk charms, religious charms)
+
+**Personality Traits:** Predatory +4
+
+**Combat**: n/a
+
+**Soak:** +1
+
+**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20) Dead (21+)
+
+**Pretenses**: Athletics 3 (climbing walls), Awareness 3 (at night), Bargain 5 (for lover's favor), Carouse 2 (alone with young woman), Charm 3 (young women), Folk Ken 2 (courtship), Guile (women) 5, Faerie Speech 5 (flattery), Stealth 2 (stalking)
+
+**Powers:**
+
+*Allure*: 0 points, Init –1 Mentem (1 intricacy point on cost)
+
+*Pine Away*: 3 points, Init –3, Corpus: The glanconer version of this power has Arcane Connection range, and causes only a Light wound, but is used repeatedly over successive days. Part of the glanconer's glamour is that the Arcane Connection must come from an item that was knowingly given as a love token — it cannot be stolen or an arcane connection to an enemy. This reduces the spell's effective level and cost.
+
+*Guide*: 0 points, Init –3, Mentem (3 intricacy points on cost): A limited form of this power, which works at Voice Range and only on an individual who has given the glanconer a love gift.
+
+*Steal Judgment*, 0 points, Init –2, Mentem, (2 intricacy point on cost).
+
+**Equipment:** Garments that give the impression that the glanconer is a prosperous man, but not one of such high class as to be unattainable by his victim.
+
+**Vis:** 2 pawns, usually kept in the trinket given as a favor.
+
+**Appearance:** A handsome man, generally said to be tall and dark, who is only seen at night. He hunts girls who go places they should not go, and so in some sense is a nursery terror for teenage girls. If unable to find sufficient victims in lonely places, he may try to lure girls from their bedrooms, although he prefers not to.
+
+A "love talker" is a sort of faerie that appears as a handsome stranger and courts a girl. When she offers her love, it asks for a token of affection. It uses this Arcane Connection to harvest the vitality of the girl, until she pines to death, or, in some cases, she commits suicide so that she can be with her lover forever.
+
+Glanconers, in some areas, have a distinguishing disfigurement, usually of the feet.
+
+Glanconers flee combat because they see no point in it. There will always be another village, with another lonely girl.
+
+**Glanconer Variants**
+
+**Kelpies:** Some glanconers are kelpies — faerie horses that drown their victims. Before the drowning, glanconers get a cunningly worded consent to take the human's life. Questions like "Do you want to be with me forever?" or "Will you do anything for our love?" are examples of the creature seeking consent.
+
+#### Faerie Spouses Trapped by a Trinket
+
+Some men find a spouse at the edge of the wilderness. These faeries visit the land of humans, and can be trapped here if made incomplete. The faerie bride is made incomplete by the theft of the thing that she most prizes, or that represents her dual nature. It is usual for the lady to leave when she finds her skin again, or when the husband breaks a taboo, such as striking his wife, or yelling at her.
+
+**Selkies:** Faeries that are made into mortal wives by the theft of the seal skin that allows them to change into their aquatic shape.
+
+**Bird W**omen: Faeries who are forced to become spouses when their cloaks of feathers are stolen away.
+
+**Nymphs:** These faeries become wives when their headscarves are stolen.
+
+Faerie spouses, in their trapped form, have the statistics of human women, although their personality traits are unusual. Their children have strong faerie blood, which makes itself obvious. The children of a selkie wife, for example, are likely to be skilled doctors, but have webbing between their fingers.
+
+The trinket itself can be represented by several Virtues and Flaws. For example, the character may have the Restricted Might Flaw, the loss of her skin being the condition that invokes it. The character might have the Skinchanger Virtue, and not be able to manufacture a new skin because faeries find it difficult to create real things. Or the trinket might contain the External Vis of the character.
+
+#### Guarded Spouses
+
+Another way that a faerie can guard adulthood is by guarding the perfect spouse for the character. The Rapunzel story uses a witch in this role, but giants are also common. They often guard their beautiful daughters from young princes. In other cases, the perfect spouse is guarded by transformation.
+
+**Coinchenn:** A giantess from Ireland who is the mother of a beautiful daughter. But because a prophecy has stated that she will die if her daughter is wooed, she has beheaded all of the girl's suitors. She places the heads on bronze stakes around her castle. Coinchenn has the head of a dog, for reasons that are not clear in the original story.
+
+**The Dragon-Maiden:** In a cave in Asturia lives a beautiful woman who angered a nymph with her laziness. The lazy girl's mother warned her not to comb her hair near the nymph's spring, but she ignored the warning and one of her hairs fell upon the water's surface, causing ripples. As punishment, the nymph turned the girl into a cuelebre — a sort of dragon — until a man so pure of hear that he felt no fear of the transformed girl, and loved her regardless, should come.
+
+#### Mentors
+
+A faerie mentor allows the character to move from his immature, adolescent self to his potent adult self. Mentors are difficult to find, and often initially reject the character, forcing him to prove his suitability for training through arduous tasks. The mentor then provides the wisdom and power necessary to complete the task that allows the character to take his adult place in society. The mentor may also provide the student with a symbolic gift that suits the challenge faced, like a sword, or magical fruit that produce jewels when broken open.
+
+#### Exceptional Servants
+
+A type of faerie that is related to the mentor is the exceptional servant. These are treated by humans as if they were supporting characters, when it is clear to the outside observer that the point of the human in the story is to observe and benefit from the marvelous things that the faerie can do. These faeries usually take an adolescent man, or far more rarely a woman, on an adventure. At the adventure's conclusion, the young person has excellent prospects. The faerie then feeds on the vitality exhibited by this family, reveling in its fortunes and, sometimes, intervening if they decline. These are annoying non-player characters: they make the player characters into observers and the players into an audience.
+
+##### Centaurs (Hippocentaurs)
+
+In the statistics here, the centaur's statistics have been purchased as if for a human character. This is because the base form, the horse, has poor Intelligence and Communication, both of which are significant to the centaur in its mentor role. Rulers of courts of centaurs have higher Might and more Powers than the creature described here.
+
+The centaur below has two Virtues too many to substitute for a companion. The Improved Damage, Faerie Speech, or Faerie Sight Virtues could be removed. This is particularly suited for those centaurs that think they are a mundane race of beings driven to near extinction by humans. An adolescent centaur, Size +2, could retain these powers but trade away one pick of the Huge Virtue. The centaur needs additional flaws, including the Social Status Flaw of Monstrous Appearance. Centaurs as companions take advantage of their size and the innate powers of a faerie form, rather than additional powers that cost Might to use. The Pretenses of this centaur are correct for a beginning companion, but players should modify them to emphasize, or reduce, the character's skill in combat.
+
+There is no disadvantage, for a faerie, in selecting far heavier armor than that which the centaur her wears. This centaur has boiled leather armor and a small round shield because that's how people imagine centaurs when their stories are told. Some centaurs have recently been observed with heater shields and lances — magi interested in these things say it is only a matter of time before centaurs with full chain armor and horse barding are observed.
+
+**Faerie Might:** 5 (Animal)
+
+**Characteristics:** Cun 0, Per 0, Pre 0, Com 0, Str +6, Sta +3, Dex +1, Qik –1
+
+**Size:** +3
+
+**Virtues and Flaws:** 2 x Huge, Hybrid Form, 2 x Improved Characteristics, Faerie Sight, Faerie Speech; Lesser Power, Incognizant, Sovereign Ward (The Dominion)
+
+**Personality Traits**: Curious +2, Brave +1
+
+**Combat:**
+
+Each centaur has a Single Weapon Pretense with a score of 5 and a specialization bonus of 1. Each has either the Bow or Thrown Weapon Pretense.
+
+Each centaur also has Brawl, with a score of 2 and a bonus of 1 for specialization. The statistics here assume the centaur is specialized in each weapon. For a specialized brawler, add 3 to Attack and Defense for Brawl (fist) and Brawl (kick), and subtract 3 from any one other weapon.
+
+*Bow (shortbow):* Init –2, Attack +10, Defense +5, Damage +17\*
+
+*Brawl (fist):* Init –1, Attack +4, Defense +2, Damage +11\*
+
+*Brawl (hooves):* Init +1, Attack +6, Defense +4, Damage +12\*
+
+*Single Weapon (club and round shield):* Init 0, Attack +9, Defense +8, Damage +20\*
+
+*Single Weapon (lance and heater shield):* Init +1, Attack +11, Defense +8, Damage +20\*
+
+*Single Weapon (short spear and round shield):* Init +1, Attack +9, Defense +8, Damage +20\*
+
+*Thrown (javelin):* Init –1, Attack +9, Defense +5, Damage +16\*
+
+\* Includes +5 for Damaging Effect.
+
+**Powers:**
+
+*Damaging Effect:* 1 points: Init –7, Terram (supernaturally sharp) or Herbam (poisoned), 2 intricacy points spent on cost. This is designed as a Lesser Power. More powerful centaurs may have this as a Greater Power (Cost 2, Initiative –3, possibly with the cost adjusted down using intricacy.), or may have Improved Damage on a preferred weapon, or may stack Improved Damage and Damaging Effect.
+
+**Soak:** +8 (Leather scale armor)
+
+**Wound Penalties**: –1 (1-8), –3 (8-16), –5 (17-24), Incapacitated (25–32), Dead (33+)
+
+**Abilities:** Athletics 4 (long-distance running), Awareness 3 (noises), Bow or Thrown 5 (shortbow or javelin), Brawl 2 (kick), Carouse 2 (drinking), Chirurgy 2 (centaurs)\*, Craft (any) 2, Faerie Speech 4 (oratory), Hunt 1 (humans), Single Weapon 5 (club or lance), Survival (grassland) 2
+
+\* Like most faeries, centaurs heal supernaturally quickly. They don't, however, notice this.
+
+**Equipment:** Weapons, barding.
+
+**Vis:** 1 pawn Animal, discarded riding gear
+
+**Appearance:** A composite of horse and human, joined so that the human torso emerges where the neck of the horse would usually connect.
+
+Hippocentaurs interest Hermetic magi, because they are almost certain that the original centaurs, who fought the Lapiths in ancient Thessaly, were aligned with the Magic Realm. It's clear that at least one — Cheiron, who mentored Herakles and became the constellation Centaurus — is a powerful astrological spirit aligned to the Magic realm. Modern hippocentaurs are faerie duplicates can be found in the writings of the ancients who state that there were no female centaurs, while in Mythic Europe, they have often been observed.
+
+Noble centaurs embody the struggle, in young people, between the bestial and spiritual elements of human nature. They guide the young hero to the adult state. Bestial hippocentaurs are an excellent example of how faeries can take over the stories of an extinct tribe. Further proof that modern centaurs represent the danger of the unbridled passions of adolescence when coupled with the power of an adult body and social position.
+
+##### Centaur Variants
+
+**Nuckalevee:** The Irish Nuckalevee is like a flayed centaur that lairs in the sea, and forages for human victims ashore. Its breath causes plague, and it is terrified of fresh water. It represents the division of between potable and salt water. The point on rivers that is closest to the coastline, but where the water is still potable, is often the site of settlement, so the nuckalevee is a dire threat. The point where freshwater turned back the salt was also significant in the folklore of the pre-Christian Celts.
+
+#### Rivals
+
+Characters who have faerie rivals have suffered an emotionally charged injury, which has given form to a faerie that represents the effects of that injury. The rival needs to be overcome, in the field that the character is most interested in, for the character to claim his or her birthright, or adult role. Rivals can take any shape that suits the character's emotional injury.
+
+### Mastery
+
+Some faeries allow young people to rise to the top of their professions, and gain the glory and status due an elder within their community. These faeries are relatively rare, but they focus their attention on player characters disproportionately. People happy to rest comfortably within the mediocrity of their professions rarely encounter these spirits, but player characters are often outside the community, and strive to be exceptional. These humans are perfect audiences for faeries that guard the borders of mastery.
+
+#### Creatures Designed to Die in Combat
+
+Many faeries expect humans to kill them. The faeries gain vitality from this process, but for the story to be complete, they must not use the same role until sufficient time has passed for their actions to constitute a new story. So, a faerie knight known for doing battle every midsummer's day may die in combat once a year, but the giant from *Jack and the Beanstalk* cannot return to Jack's country in its original form. Perhaps it returns as the giant's wife, or son, or brother, or chooses to go to a different kingdom, and tell the beanstalk story again with a new boy.
+
+##### Fachan
+
+Fachans could conceivably be player characters, but their story potential is limited by their ugliness and their narrowly focused Pretenses.
+
+**Faerie Might:** 30
+
+**Characteristics:** Int 0, Per 0, Pre –3, Com –3, Str +3, Sta +3, Dex +3, Qik +1
+
+**Size:** +1
+
+**Virtues and Flaws:** 2 Greater Faerie Powers, Faerie Sight, Faerie Speech, 5 x Increased Faerie Might, Large, Hybrid Form; Missing Eye, Missing Hand, Incognizant.
+
+**Personality Traits:** Hates humans +3, Bloodthirsty +2
+
+**Combat:**
+
+*Club:* Init +2, Attack +14, Defense +11, Damage +6
+
+*Fist:* Init +1, Attack +13, Defense +11, Damage +3
+
+*Flail:* Init +3, Attack +16, Defense +11, Damage +10\*
+
+\* Poisoned: see powers section
+
+**Soak:** +5
+
+**Wound Penalties:** –1 (1–6), –3 (7–12), –5 (13–18), Incapacitated (19–24), Dead (25+) 
+
+**Abilities:** Awareness 3 (humans), Brawl 5 (humans), Faerie Speech 3 (primitive threats), Penetration 3 (poisoned weapons), Single Weapon 9 (club or flail)
+
+**Powers:**
+
+*Lurching heart:* 4 points, constant, Corpus: The fachan is so terrible to look upon that characters who see it must make a Brave roll against an Ease Factor of 9. If they fail, their heart flutters uncontrollably until they gather their courage. This cramping in the heart is treated as a fresh Light wound every round until the Brave roll is made. The great kings of the fachans can strike men dead with fear simply by being present, and some magi have encountered fachans who cause more grievous harm than described here. (35 spell levels (Base 5 +3 Sight +2 Sun +1 Constant) +15 xp in Penetration from intricacy points.)
+
+*Poisoned Weapons:* 4 points, constant, Animal. The weapons of the fachan are smeared with deadly poison. Its Ease Factor is 9. See **ArM5** page 180 for more details. (35 spell levels (Base 20 +2 Sun +1 constant) +15 xp in Penetration from intricacy points.)
+
+**Equipment:** Flail or club, belt
+
+**Vis:** 6 pawns, a decayed apple
+
+**Appearance:** A fachan looks like a human, but has a single eye in the middle of its head, a single arm extending from its sternum, and a single leg. Fachans also have a black, feathered crest that runs from the top of their heads along their spines. The mouth of a fachan is inhumanly large.
+
+The fachans are faeries of distant lochs and valleys, found in Ireland and Scotland. They are rarely seen, but hate humans. Many fachans fight with clubs, but many others use iron flails, with up to twelve chains and fifty weights, dipped in poison. Fachans wear a cloak of sticky feathers that provide light armor.
+
+##### Fachan Variants
+
+**Fer Caille:** A similar creature, the Fer Caille, is found in Ireland. He acts as a faerie herdsman, and is accompanied by a hag.
+
+**Direach:** In the Scottish Highlands a version of the Fachan called the Direach can be found, which is gigantic.
+
+##### Knight (Minor)
+
+Faerie knights, converted to companions, require a Social Interaction Virtue or Flaw. They have 1 Flaw which is not balanced by Virtues. Infiltrator (knight) is highly suitable.
+
+**Faerie Might:** 10 (Corpus or Terram)
+
+**Characteristics:** Int 0, Per 0, Pre –2, Com –2, Str +3, Sta +2, Dex +2, Qik +1
+
+**Size:** +1
+
+**Virtues and Flaws:**
+
+Faerie Sight, Faerie Speech, Humanoid Faerie, 2 x Improved Characteristics, Increased Might (minor), Large, Lesser Faerie Powers, Narrowly Cognizant, Observant, Personal Faerie Powers; Sovereign Ward (varies), Vow (Chivalrous conduct), Oath of Fealty, Overconfident.
+
+**Personality Traits:** Arrogant +3, Courteous +3
+
+**Combat:**\
+
+*Brawl (gauntlet):* Init +1, Attack +6, Defense +6, Damage +5
+
+*Long Sword and Heater Shield\*:* Init +8, Attack +13, Defense +12, Damage +9
+
+*Mace and Heater Shield\*:* Init +2, Attack +12, Defense +11, Damage +11
+
+*Lance and Heater Shield\*:* Init +3, Attack +13, Defense +11, Damage +9
+
+\* Does not include +3 to Attack and Defense for being mounted.
+
+**Soak:** +9\*
+
+Faerie metal scale, made of glamor using the Shift Human Shapes Power.
+
+**Wound Penaltie**s: –1 (1-6), –3 (7-12), –5 (13- 18), Incapacitated (19-25), Dead (26+)
+
+**Pretenses:** Awareness 1 (enemies), Brawl 3\* (knights), Carouse 3 (feasts), Charm 1 (ladies), Etiquette 3 (chivalrous combat), Faerie Speech 5 (boasting), Hunt 2 (humans), Leadership 2 (guards), Ride 3 (horses), Single Weapon 4\* (varies).
+
+\* Many knights have far higher scores than this. These statistics are correct for faeries that plan to improve their Pretenses by losing to a character, then mirroring his experience gain for the season.
+
+**Powers:**
+
+*Damaging Effect:* 1 point, Init –4, as per motif of court (2 intricacy points spent on cost)
+
+This is designed as a Lesser Power. More powerful knights may have this as a Greater Power (cost 2 points, Initiative –1, possibly with the cost adjusted down using intricacy), or may have Improved Damage on preferred weapon, or may stack Improved Damage and Damaging Effect.
+
+*Flight,* 2 points, constant, Corpus
+
+*Shift Human Shapes:* 1 point, Init 0, Corpus. Allows the knight, who is usually armored to demonstrate his role, to remove the armor simply by thinking about it.
+
+**Equipment:** Arms and armor. Has a faerie horse constructed of the knight's own glamor, so it flies when the knight does, and shares the knight's Magic Resistance. Courtier as squire.
+
+**Vis**: 2 pawns, often rusty pieces of armor that the knight has poured its glamor into.
+
+**Appearance:** A knight clad in silver leaves of metal, astride a fine horse. These knights often display the motif of their court on their surcoat, shield, and pavilion.
+
+These faeries are often encountered outside courts, on lonely roads, and guarding bridges. They seek out defeat by humans as a way of gaining additional combat Pretenses. They are never seen with their armor off, so they may be a role that other faeries take on when they wish to enjoy some blood sport. Faerie Knights are more bound to the rules of chivalry than real knights, and so they do not use the Damaging Effect Power on their weapons against worthy foes.
+
+#### Masters of Skills
+
+These faeries seek out mortals who are at the peak of their profession, and either raise them up, or cast them down. Many of the faeries in this chapter might play the role of master of skills.
+
+**Faerie Knights:** These creatures seek out great warriors for combat.
+
+**The Fatae:** Faeries who humble women who boast of their weaving.
+
+**Selkies:** Faeries who have captured the souls of drowned fishermen can be convinced to free them if beaten in drinking contests.
+
+A master of skills has the disputed Ability as a Pretense with a score of at least 9, and may have additional Virtues which aid in the use of the Pretense, like Improved Dexterity.
+
+##### The Barking Beast
+
+The beast is not designed as a player character.
+
+**Faerie Might:** 10
+
+**Characteristics**: Cunning +5, Per +3, Pre –2/+2\*, Com –5, Str +1, Sta n/a\*\*, Dex +3, Qik +5
+
+\* Some versions of the beast are strangely beautiful.
+
+**\*\*** Most faeries have stamina scores because their roles make it necessary for them to seem to tire; not so the barking beast.
+
+**Size**: +2
+
+**Virtues and Flaws:** External Vis (minor), Faerie Sight, Greater Faerie Powers, Highly Cognizant, 4 x Improved Characteristics, Increased Faerie Might, Large, Sharp Ears
+
+**Personality Traits:** Loves being hunted +5, Likes rewarding hunters +3
+
+**Combat:**
+
+*Bite:* Init +5, Attack +12, Defense +11, Damage +4
+
+**Soak:** +5
+
+**Wound Penalties**: –1 (1-7), –3 (8-14), –5 (15- 21), Incapacitated (22-28), Dead (29+)
+
+**Pretenses**: Athletics 6 (running), Awareness 6+3 (hunters), Brawl 5 (bite), Stealth 5 (when being hunted)
+
+**Powers:**
+
+*Spirit Away:* variable points, n/a, Vim: allows the faerie to act as a threshold guardian, as described in the Faerieland Chapter.
+
+**Vis:** 2 pawns, usually buried well away from the hunt.
+
+**Appearance:** There are two different versions of the questing beast. The more monstrous, which has been described by the statistics here, has the head and neck of a snake or possibly a dragon, the body of a leopard, the haunches of a lion, and the feet of a stag. The baying of sixty hunting hounds comes from its belly while it moves. The second version is usually smaller than a fox, although a gigantic version may exist. It is pure white, and beautiful. The baying within it comes from its unborn young, who tear it asunder when they emerge.
+
+This is sometimes read as an anti-Semitic religious allegory, or as an allegory for various forms of heresy and impiety, including disruption of the Mass.
+
+Barking beasts are the greatest test of the skill of a hunter. They are an interesting study for Hermetic scholars, because it is clear that the original barking beast was the product of a human copulation with a demon. Once it was hunted down and destroyed, other barking beasts, some of which are aligned to the Divine realm, appeared. Hermetic magi have also discovered faerie barking beasts. These are likely to be faeries drawn to the role by the passionate attention it provides.
+
+The barking beast lives to be chased, not caught, and although it allows its body to be destroyed, it works very hard to make its External Vis source inaccessible. To reward its hunters for the frustration of chasing it, it often leads them through places where enemies of the hunter are meeting, or where valuable resources are available, while the chase continues. If the hunter brings retainers who can leave the hunt, these resources can be collected, or marked for later use. Some hunters claim that while they have chased the beast they have traveled into distant parts of Europe, and that the retainers they have left to gather resources sometimes return to them from distant ports. This may be true, but it might also be that the beast simply fools the retainers with glamour and has them wander faerie for a time.
+
+The barking beast is not malicious, but damages crops if ignored, to force people to hunt it. In T. H. White's *The Once and Future King* there is a beautiful scene featuring one of these creatures. The knight charged with hunting the beast has forsaken the quest, because he has become a Christian and put away worldly concerns. He chances upon the beast, pining away for want of attention and too sick to flee him, so he nurses it back to health and begins the quest again.
+
+##### Barking Beast Variants
+
+**Zlatorog:** A similar creature, the Zlatorog, is found on Mount Triglav in Slovenia. It is a white chamois with horns of gold. Hunters seek its horns, but it tricks them into falling over precipices. If the blood of the Zlatrog is spilled, a red flower grows from it. When the Zlatrog eats this flower, it is immediately healed.
+
+### Death
+
+Just before death, the spirit flares as it flexes free of the body. This attracts the presence of many different types of faerie. This section does not concern itself with faeries who kill to feed on the fleeing spirit. Instead, it details faeries who wait for the person's natural time of death and interact then, or with faeries that seem to cross to the mortal world from the lands of the dead.
+
+#### Psychopomps
+
+A psychopomp is a faerie that leads the spirits of the dead to an afterlife. It was a role of the god Hermes in classical times. Psychopomps are now rare in Mythic Europe, because of the general prevalence of the Dominion.
+
+##### Valkyrie
+
+Valkyries are not designed as player characters.
+
+**Faerie Might:** 20
+
+**Characteristics:** Int 0, Per 0, Pre 0, Com 0, Str 0, Sta 0, Dex +3, Qik +1
+
+**Size:** 0
+
+**Virtues and Flaws:** 3 x Increased Faerie Might, Faerie Sight, Faerie Speech, Humanoid Form, Personal Faerie Power; Incognizant, Visions\*
+
+\* Valkyries know where and when worthy men are likely to die.
+
+**Personality Traits:** Brave +5, Judgmental +3
+
+**Combat:**
+
+*Axe and Round Shield (unmounted):* Init +2, Attack +16, Defense +12, Damage +6
+
+*Axe and Round Shield (mounted):* Init +2, Attack +19, Defense +15, Damage +6
+
+**Soak:** +9
+
+**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20), Dead (21+)
+
+**Pretenses:** Awareness 9 (battlefields), Brawl 9 (einherjar), Ride 5 (wolf), Single Weapon 9 (giants)
+
+*Fly:* 0 points, constant, usually Corpus but sometimes Animal (2 intricacy points on cost)
+
+**Equipment:** Arms, armor, wolf mount, vast quantities of wine.
+
+**Vis:** 4 Corpus, a dead vulture
+
+**Appearance:** Shield maidens or crones that ride wolves above battlefields, and select the worthy dead. They have excellent equipment and extraordinary training.
+
+These minor goddesses of the Norse pantheon are no longer worshiped in Mythic Europe, but have been encountered by magi in Arcadia, and in their ancient places of power in Scandinavia. Their name means "Chooser of the Slain," because they are believed to choose who lives and dies during battle, and which spirits are worthy of transformation into einherjar — spiritual warriors awaiting Ragnarok. They also act as serving maids in Valhalla. Many have names that evoke the tumult of battle. They ride through the sky, invisibly, on wolves.
+
+##### Wolf Mount
+
+**Faerie Might:** 20 (made of the glamour of the Valkyrie and shares her Might pool)
+
+**Characteristics:** Cun +2, Per 0, Pre –2, Com 0, Str +2, Sta +3, Dex +2, Qik –4
+
+**Size:** +3
+
+**Virtues and Flaws:** Gigantic, Improved Characteristics (x2), Faerie Sight, Ferocity (when hungry) Sharp Ears
+
+**Personality Traits:** Brave +3, Cowardly +3
+
+**Combat:**
+
+*Teeth:* Init –2, Attack +9, Defense +9, Damage +3
+
+**Soak:** +7
+
+**Wound Penalties**: –1 (1-8), –3 (8-16), –5 (17–24), Incapacitated (25–32), Dead (33+)
+
+**Abilities**: Athletics 5 (distance running), Awareness 3 (smell), Brawl 5 (teeth), Hunt 4 (track by smell), Survival 3 (winter)
+
+**Powers:**
+
+When the valkyrie uses *Fly* the wolf, as part of her glamour, flies too. The valkyrie can carry a passenger with the aid of her wolf.
+
+**Vis:** None, as the wolf is an extension of the valkyrie.
+
+**Appearance:** A wolf the size of a horse, with saddle and harness. Its thick fur gives it a Protection of 1, and it wears leather covers that act as partial barding.
+
+#### Returned Dead
+
+The returned dead are faeries that either are, or pretend to be, humans that have passed from this life into the next, and then return. They are not, like many magical ghosts, driven by an obsessive need to finish a single task. Many believe they died at an unnatural time, or were not laid to rest in the most efficacious way. They hope that when their true hour comes, they will rise to Heaven, or pass to some pleasant other place in Arcadia.
+
+**Aoroi:** This class of restless ghosts, waiting just the other side of death and able to come back to speak with the living, were called the aoroi by the ancient Greeks. They were thought to be waiting on the worldly side of the Styx, unable to cross until their mortal hour had passed, or they found an obol for their fare. The aoroi — the summonable dead — were particularly important for divination, and were often called by the cthonic cult that eventually led to the formation of the Houses of Tytalus and Tremere.
+
+More-recently dead people seem to return to earth to finish their story. Ghosts, including faerie ghosts, have been described in great detail in *Realms of Power: Magic*.
+
+**Rusalka:** The rusalka, a type of water nymph, demonstrates a type of returned dead that comes back so that their tragedy can be replayed.
+
+#### Ancestral Spirits
+
+These faeries believe that they are the ancestor of all people within a particular family. They take on attributes from the family's history and symbolism, although they sometimes misappropriate or misunderstand them. They believe themselves to be the ancestral dead, though, so they refuse to believe more-accurate information if it is presented to them.
+
+The banshee (whose name means “faerie woman,” or literally “woman of peace”) and the bean nighe (washer woman) are such faeries that foretell deaths. These are designed as courtly faeries, with high or low Presence depending on their regional variant, and the Visions Flaw. They shouldn’t be used as magical wishing genies, though: they can’t just grant anything a character desires.
+
+**Banshee:** The Irish form of this creature, the banshee, is both a faerie and the ghost of a woman. She appears to sing the death lament for one of her descendants. In certain circumstances, it is possible to discover how a person will die from the banshee, and attempt to cheat fate. She gives a wish to anyone claiming to be her foster child. In some areas, banshees are thought to leave their combs for mortals to find, so that they can spirit them away.
+
+**Bean Nighe:** The washerwoman, who appears in both Scotland and Ireland, is seen washing the bloody clothes or armor of one who is soon to die. A character may claim a wish by sneaking up on the bean nighe and suckling from her drooping breasts.
+
+**Tomte:** The tomte, a powerful sort of brownie, believes it is the ghost of the first ancestor to clear that land on which the farm it inhabits is built. It is found in Scandinavian lands.
+
+Many Courtly Faeries, fauns, and nymphs also claim descendant families.
+
+#### Life Stages for Magi
+
+The life stages through which magi pass are different from those that mundane people experience. Many faeries that seek children as victims mistakenly assail magi, because some magi have not been marked as adults by rituals the faeries recognize, like first communion or marriage. Other faeries that interact with magi reflect their unusual lifestyle by guarding the borders of the life stages unique to Hermetic culture.
+
+The first threshold is being taken as an apprentice:
+
+**Black Faced Hermes:** This faerie comes down the chimney to take away unnatural children, still abducts the Gifted and leaves them at the doors of covenants.
+
+**The Mournful Maga:** While growing up, apprentices face the Mournful Maga, a
+
+**The Seducer:** Just before the Gauntlet, an apprentice may meet the Seducer, a faerie that tempts him with a life of social acceptance and domesticity.
+
+Young magi entering middle age often face a pack of unpleasant faeries, as well:
+
+**Ravagers:** Ravagers hunt magi wanting to find their longevity formula.
+
+**The Retiarius:** This faerie chases potential familiars with his nets, to force them to fight in the faerie arenas.
+
+Many Mystery Cults have faeries that guard their secrets, as well. An apprentice, if found, must be guided past the creatures that the magus has conquered, and any others that have been drawn by the covenant's vibrant life.
+
+And some archmagi, it is rumoured, state that in the depths of Arcadia dwell faeries who are a challenge even for their great might. Giants and Titans — Magic creatures imprisoned in the Faerie Lands since the Titanomachy and Gigantomachy — struggle against their chains, held in place by terrible faerie guardians.
+
+**The Master of Challenges:** A creature called the Master of Challenges torments magi who come this deep into Arcadia. It intermittently claims to be Tytalus, forced to serve as the jailer of the creatures he hoped to release, but it has a half dozen other origin stories, and none of them need be true.
+
+## Faeries Interested in Social Distinctions
+
+These faeries dwell on the borders between different types social classes of human. When examining these faeries, it is important to recall that although they appear human, their motives are guided by an alien set of internal rules. A faerie pretending to be a lord or a knight may be attempting to communicate to the characters that it wants them to behave toward it in the same way they would toward a real knight or lord. The tone of the interaction having been set, what the faerie actually desires may bear little resemblance to what a real lord or knight would want. Alternatively, the faerie may want what a lord wants, but have no practical use for the thing, seeking it merely to fulfill a role that, once complete, makes the thing valueless to the faerie.
+
+### Bringers of Riches or Humility
+
+Some faeries manipulate the social positions of people, because status is closely tied to powerful human emotions. They may treat well those humans who fulfill their roles perfectly, while punishing those that fail to meet their standards. Faeries may support people who wish to ascend to a higher social class, because it causes such joy and ire among surrounding humans. Others enforce the boundaries of social class, feeding on the crushed hopes of the poor. A few pull down the wealthy.
+
+##### Brownies
+
+Brownies are fragile, and so they are not strongly suited to conversion to player characters. Players who would like to play a brownie need to select two Virtues to balance the current Flaws, and if they do not select another Virtue or Flaw that governs the rate they gain Pretenses, they must select the Observant Virtue.
+
+The basic brownie has spent 10 spell levels from its Personal Faerie Powers Virtue on intricacy points A player may trade them back, so that the Invisibility power costs 2 points. It has also spent 10 spell levels from its Focus Power Virtue. A player may trade those back, but this severely restricts the value of the Focus Power. The brownie has the correct Pretense scores for a beginning companion character.
+
+**Faerie Might:** 5 (Corpus)
+
+**Characteristics:** Int 0, Per 0, Pre 0, Com 0, Str –12, Sta +1, Dex +3, Qik +3
+
+**Size:** –6
+
+**Virtues and Flaws:** Focus Power (Domestic Work); Feast of the Fae, Faerie Sight, Humanoid Faerie, Personal Power (Invisibility), Positive Folktalkes; Narrowly Cognizant; 2 x Little, Sovereign Ward (clothes) 
+
+**Personality Traits:** Loyal +3
+
+**Combat:**
+
+*Thrown Knife or Stone:* Init+3, Attack +7, Defense +6, Damage –10.\*
+
+\* Damage is +5 when using a human-sized knife and Focus (Domestic Work) power.
+
+**Soak:** +1
+
+**Wound Penalties**: –5 (1), Incapacitated (2), Dead (3+)
+
+**Pretenses:** Athletics 2 (climbing), Awareness 2 (intruders), Charm 2 (women), Folk Ken 5 (farming), House Lore 3 (lost items), Speak 5 (Local language), Profession: Household Servant 6 (indoors), Thrown Weapon 3 (knives).
+
+**Powers:**
+
+*Focus (Domestic Work):* up to 3 points. May create effects up to level 15. (2 intricacy points raise maximum level)
+
+*Invisibility*: 0 points, Init +1, Imaginem (2 intricacy points reduce Might cost)
+
+**Equipment:** None, and it is known for being nude.
+
+**Vis:** 1 pawn, balls of hair and dust
+
+**Appearance:** Brownies are domestic faeries. They look like shaggy men around a foot tall. They are frequently nude, although some wear brown clothes.
+
+##### Brownie Variants
+
+Brownies are found in many locations under a variety of names.
+
+**Boggart**: In England the boggart, a trickster spirit that causes havoc in the home, is simply a brownie that has decided to be malicious.
+
+**Portune:** This is a tiny faerie, half the size of a thumb, which acts like a brownie but delights in roasting frogs on the fire when his humans are asleep.
+
+**Ellyon:** In Wales the ellyon perform similar service, but vanish forever if they become aware they are being spied upon.
+
+**Heinzelmännchen:** In Germany, similar creatures are called heinzelmännchen. They look a lot like dwarfs, but the word is often translated as "elves" in English. The "Elves and the Shoemaker," by the Grimms, contains heinzelmännchen. For a time, every house in Cologne had one of these servants, but they were scared away when a curious housewife broke their taboo. She spilled peas on her floor in order to make one fall over so she could have a look at it. The best described of these creatures appeared as a child in a red coat, but when it showed its true form to a maid, it was the ghost of a child who had been chopped apart with swords.
+
+**Domovoi:** In Slavic lore the equivalent of a brownie is called a domovoi, and lives beneath the threshold or the stove. He looks like a hairy little man with a tail and horns, or takes the shape or a domestic animal, or even appears as the owner of the house. He can predict the future, and gives warnings by laughing or moaning. The wife of the domovoi is called the kikimora, and she helps with the chickens and the spinning, although to see her spinning is a presentiment of death.
+
+**Tomte:** The most mystically powerful of the brownie variants is the tomte. The tomte is the Sandinavian form of the brownie, and is believed to be the spirit of the person who cleared the tomt, the block of land, on which the house rests. A tomte may vary his size from that of a mouse to larger than a human, and may make himself invisible. Tomtes, seen with faerie sight, look like wizened little men with full beards. Tomtes aid the fertility of the land, and dwell just underneath it, so farmers are required to shout a warning if they spill hot water. Tomtes also take particular care of horses.
+
+**Feoderee:** The most physically imposing brownie is the Feoderee of the Isle of Man. He was a Courtly Faerie, but was cursed to become a giant hairy monster after his courtship of a mortal girl made him miss a soiree with the other faeries. He has the statistics of a giant, but is in all other respects a brownie: he stops serving at a farm if given clothes, for example.
+
+**Ùruisg:** The ùruisg is a tiny satyr that serves much as a brownie does. They are found in Scotland, and have a taste for dairy products and the charms of dairymaids.
+
+#### Liberators of the Underclass
+
+Many faeries allow characters to move over the border from poverty into wealth.
+
+The mechanism that provides wealth varies by place. English faeries, for example, seem often to know the location of buried treasure, while Scottish faeries teach skills like divination and healing that allow a poor person to earn a living. Little folk with hidden treasure are described later under Guardians of the Entrances of the Earth. Animals that take a young man or woman on an adventure, so that they are wealthy when it concludes, are described in the Human Sidekicks section.
+
+### Courtly Faeries
+
+Called the "sidhe" in Ireland, courtly faeries gather in large groups to fulfill roles similar those found among humans in centers of political power. A faerie court's members usually have a unifying theme in their roles, which highlights the threshold that this court inhabits. Humans who interact with a faerie court are usually acting above their social station, which means they are also crossing a threshold that is considered very important in Mythic Europe. One of the methods humans use to hold that border is elaborate rules of etiquette that separate those raised in a social class from those who merely have money. Faeries are made of rules, and courtly faeries adopt a version of human etiquette fastidiously.
+
+Faerie courts are usually ruled by a monarch, or pair of monarchs. This monarch is served by lesser faeries, sometimes called nobles or the gentry. These in turn, have servants and faerie animals. Most courts are guarded by creatures that are designed as giants, but altered to suit the theme of the court. The statistics of courtly faeries can be used as substitutes for those of many other humanoid faeries.
+
+#### Faerie Monarchs
+
+For a faerie to challenge the power of a group of senior magi, unaided, it requires a Faerie Might score of around 60, and the Penetration Pretense, to allow it to project its powers through the Parma Magica. Monarchs of this highest degree of power are rare, and many have a Might score of 40. These can challenge magi in their middle years, if aided by a court of less-powerful beings.
+
+##### White Lady (Dame Blanche)
+
+White Ladies are not designed as player characters.
+
+**Faerie Might:** 40+10 (Aquam)
+
+**Characteristics:** Int +4, Per 0, Pre+4, Com +3, Str +2, Sta +2, Dex 0, Qik +1
+
+**Size:** 0
+
+**Virtues and Flaws:** 2 x Focus Power, 3 x Greater Faerie Powers, Highly Cognizant, Faerie Sight, Faerie Speech, 2 x Great Characteristic, Human Form, 6 x Improved Characteristics, 7 x Increased Faerie Might, 2 x Personal Faerie Powers, Place of Power (kingdom); Traditional Ward (The Dominion)
+
+**Personality Traits:** Fond of seducing mortals to their doom +2
+
+**Combat:**
+
+*Brawl (fist):* Init +1, Attack +1, Defense +2, Damage +2
+
+They prefer to use magical effects rather than weapons.
+
+**Soak:** +2
+
+**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11- 15), Incapacitated (16-20), Dead (21+)
+
+**Pretenses**: (Area) Lore 6 (sites of historic significance or power), Artes Liberales 3 (history), Animal Handling 2 (one of horses/hawks/dogs/fish/seabirds), Athletics 6 (dance), Awareness 2 (ambushes), Bargain 7 (magi), Brawl 1 (escaping), Carouse 6 (dancing), Charm 6 (men), Concentration 3 (while killing things), Craft: (varies, often weaving) 6 (varies), Etiquette 7 (forcing others to be rude), Faerie Speech 6, Finesse 6 (Rego), Folk Ken 2 (customs of surrounding area), Guile 3 (men), Intrigue 4 (against magi), Leadership 6 (in warfare), Order of Hermes Lore 5 (conflicts), Penetration 6 (using Arcane Connections), Swim 9 (home waters).
+
+**Powers:**
+
+*Extended Glamor:* 0 points, constant,
+
+*Focus Power (Water within her realm):* up to 10 points, Init –9, Aquam. Some of the Ladies have other focuses. This is the most common. They have been known to kill with versions of *Ice of Drowning, Mighty Torrent of Water, Pull of the Watery Grave*, and *Tower of Whirling Water* using this power. Note that in character creation, the same focus power has been selected twice to gain this higher level.
+
+*Touch of the Mermaid:* 3 points, Init –2, Aquam: *Kiss of the Mermaid,* for characters too regal to kiss a magus for ease of transport.
+
+*Torrent from the Lungs:* 3 points, Init –2, Aquam: The Ladies often live in kingdoms of salt water, where this spell and a skin of potable water can be used as negotiating tools.
+
+*Transform into (one of Current/Wave):* 2 points, Init –4, Aquam: (Until Duration) (3 intricacy points to reduce cost)
+
+*Transform Victim into (one of Seagull/Crab/Salmon):* 2 points, Init –3, Animal. (2 intricacy points to reduce cost)
+
+Each lady also has distinct, individual powers. *Pine Away* is the most common of these, but *Enthrall* and *Spirit Away* are also common. These have not been included in the Virtue section.
+
+**Equipment:** A small kingdom of faerie servants. Mystical artifacts which at a minimum include a scrying pool (see **ArM5** page 122 for a spell that simulates this device). Centuries of shipwreck treasure. Clothed in white wool, with flowers in her long hair. Often carries a comb and mirror.
+
+**Vis:** 8 pawns Rego, a comb, +2 if in kingdom
+
+**Appearance:** A beautiful woman with long hair and fiery eyes, in a robe of the finest wool.
+
+"White Lady" is a euphemism used in the Normandy Tribunal, much as "good neighbours" or "wee folk" are used in other places, to refer to the faeries without offending them. The White Ladies of Normandy are various types of faerie, ranging from the lesser nymphs of wells to the powerful creatures described here. The White Ladies are, in a sense, guardians of a division of space, because of their connection to waterways. The most powerful White Ladies are, however, courtly faeries with retinues, who interact with player characters in their role as queens.
+
+The most powerful White Ladies claim they were nine sorceresses, the princesses of the Celtic tribes that inhabited Normandy before the Romans came. Pushed back, first by Roman military power and then by the Dominion, they took refuge in the waters. Some keep wells that lead to Faerie, while others command kingdoms of faeries beneath the waves. The White Ladies are of particular interest to magi because they are steeped in Druid lore, but some supported House Diedne in the Schism, and they do not love the proudly Roman Order of Hermes.
+
+White ladies often steal children, and some of these are lucky enough to survive into adulthood. They also make bargains with drowning sailors for things that can only be found on land, or for the sailor's children.
+
+##### Faerie Noble: The Privy Counselor
+
+The statistics given for the Privy Counselor have been kept within the range that a player might substitute for a beginning magus, but this makes it weak compared to other faerie nobles, who have too many Virtues and Pretences to balance beginning characters. To play the Privy Counselor, a player must give the faerie a Social Interaction Virtue or Flaw and the Observant Free Virtue. This set of statistics has 25 points of Virtues and 12 points of Flaws, so for play it needs to trade back at least 4 points of Virtues and 2 of Flaws.
+
+**Faerie Might:** 35 (Imaginem)
+
+**Characteristics:** Int +3, Per +1, Pre +2, Com +2, Str 0, Sta 0, Dex 0, Qik 0
+
+**Size:** 0
+
+**Virtues and Flaws:**
+
+External Vis (Venus' Blessing, his signet ring), 3 x Greater Faerie Powers, 6 x Increased Faerie Might, Faerie Sight, Faerie Speech, Humanoid Faerie, 2 x Improved Characteristic, 3 x Personal Faerie Powers; Restricted Might (major – in the presence of honest people), Sovereign Ward (places or objects sacred to Saint Thaddeus, the patron of penitent thieves), Sovereign Ward (crossing the Aegis of the Hearth), Oath of Fealty (monarch), Incognizant, Traditional Ward (keys).
+
+**Personality Traits:** Charming +3, or Sarcastic +3, once discovered
+
+**Combat:**
+
+*Brawl (bludgeon):* Init 0, Attack +2, Defense 0, Damage +2
+
+*Long Sword:* Init +2, Attack +5, Defense +2, Damage +6
+
+**Soak:** 0
+
+**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11- 15), Incapacitated (16-20), Dead (21+)
+
+**Pretenses:** Awareness 1 (amusing things), Carouse 3 (feasts), Charm 1 (criminals), Brawl 1 (when surprised), Etiquette 4 (merchants), Faerie Speech 6 (speeches), Intrigue 3 (against magi), Order of Hermes Lore 3 (covenant administration), Penetration 1 (Enthrallment), Ride 1 (horses), Single Weapon 1 (dirty fighting).
+
+**Powers**
+
+*Enthrallment:* 4 points, Init -1 Mentem (3 points on Initiative +1 point for Penetration)
+
+*Illusionary Home:* 4 points, Init –4, Imaginem: (Room or structure variant depending on role)
+
+*Image Phantom:* 2 points, Init –2, Imaginem.
+
+*Steal Judgment:* 2 points, Init –2, Mentem.
+
+*Allure:* 0 points, Init –1 Mentem: (1 intricacy point on cost)
+
+*Invisibility:* 0 points, Init –2, Imaginem (2 intricacy points on cost)
+
+*Shift Human Shapes*: 0 points, Init 0, Corpus: (1 intricacy point on cost and Initiative)
+
+*Transform into Coin*: 4 points, Init –4 as form of object: the faerie often takes the shape of a coin to spy on its enemies.
+
+(This example does not use the *Extend Glamour* power, but it is recommended for principal faeries of minor courts.)
+
+**Equipment:** Sumptuous clothing, and effortless wealth.
+
+**Vis:** 7 pawns, in hat (External Vis Virtue).
+
+**Appearance:** The privy counselor looks like a young nobleman, and often claims to be the bastard of a duke who sent him away, but set him up in business. He uses his powers to maintain an apparently sumptuous home, after finding a site in a city where the Dominion is weaker than usual. He gains real money to fund his role, by stealing it using shapeshifting and enthrallment.
+
+Faerie nobles vary widely in appearance and power. They serve as the monarchs of lesser faerie courts, or as the principal agents of great monarchs or pagan gods. Faerie nobles can superficially be mistaken for their human counterparts, particularly by the poor, who rarely see mortal nobles.
+
+The Privy Counselor is a trickster and saboteur that an angered faerie monarch sends to strike at the covenant's interests in the mortal world. The Privy Counselor cannot merely cause the covenant to decline, through surreptitious sabotage, over decades. It must strike the covenant in ways that the magi feel, and it must, eventually, engineer a confrontation to feed from them. The faerie gives clues to the identity it has assumed, and once it has been discovered it may flee, but it always returns in new guises to strike at, and mock, the characters. It lacks the cognizance to change its role. This prevents the Privy Counselor parleying with the magi to change sides and strike at its monarch.
+
+##### Champion: Sir Excelsis
+
+The faerie champion cannot be taken as a player character, except to replace advanced magi. Players desiring a less powerful knight should consult the Creatures Designed to Die section.
+
+**Faerie Might:** 25 (Ignem, in this case, but usually Corpus or Terram depending on what's under the armor)
+
+**Characteristics:** Int +1, Per +1, Pre +1, Com +1, Str +9, Sta +1, Dex +2, Qik 0
+
+**Size:** +2
+
+**Virtues and Flaws:** Huge, 4 x Increased Faerie Might, Cognizant within Role, Faerie Sight, Faerie Speech, 2 x Great Characteristic, Humanoid Faerie, Observant. 3 x Improved Characteristic, Improved Damage (sword), 2 x Personal Faerie Powers, Puissant Pretense; Enemies (other knights who want this role), Puissant Militant Pretense, Sovereign Ward (spilled blood of a noblewoman), Sovereign Ward (The Dominion)
+
+**Personality Traits:** Loyal +3, Proud +3.
+
+**Combat:**
+
+*Brawl (gauntlets):* Init 0, Attack +2, Defense +4, Damage +11
+
+*Greatsword:\*\** Init +2, Attack +18, Defense +13, Damage +23
+
+*Lance and Heater Shield:* Init +2, Attack +17, Defense +14, Damage +23
+
+*Great Sword and Heater Shield:\*\** Init +2, Attack +17, Defense +15, Damage +20
+
+*Mace and Heater Shield:\** Init +1, Attack +16, Defense +14, Damage +17
+
+\* Various weapons have been described here to speed customization. Unusual weapons that suit the motif or the court may use the scores above, with slicing weapons in lieu of swords and bashing weapons in lieu of maces. These statistics do not include the +5 Damage bonus the champion gains when using the Damaging Effect power, or the bonus of +3 to Attack and Defense gained when fighting mounted, or the +1 for fighting on the tourney field. They do include the effect of the Puissant Pretense Virtue in all cases, so if the champion is forced to swap away from his preferred weapon, he suffers a –2 penalty on the Attack and Defense scores listed above.
+
+\*\* Also includes +5 for Improved Damage
+
+**Soak:** +10
+
+**Wound Penalties**: –1 (1-7), –3 (8-14), –5 (15- 21), Incapacitated (22-28), Dead (29+)
+
+**Pretenses:** Area Lore 3 (hunting spots), Awareness 5 (enemies), Brawl 6 (knights), Carouse 4 (feasts), Charm 3 (ladies), Etiquette 5 (faerie court), Faerie Speech 6 (boasting), Folk Ken 3 (surrounding humans), Hunt 5 (humans), Intrigue 3 (against other knights), Leadership 9 (tournaments), Ride 6 (horses), Single Weapon 9+2 (tourney field).
+
+**Powers:**
+
+*Damaging Effect:* 2 points: Init –6, Terram (supernaturally sharp) or Herbam (poisoned), 2 intricacy points spent on cost. This is designed as a Lesser Power. More mystically endowed knights may have this as a Greater Power (Cost 2, Initiative –2, possibly with the cost adjusted down using intricacy) and may stack it with Improved Damage.
+
+*Glide:* 2 points, constant, Corpus. A renaming of the *Flight* power, this allows Sir Excelsis to move through the waters of the subaquatic kingdom as a flier would through air. This enables him to swim and fight at the same time, for example. It does, technically, still allow him to fly.
+
+*Shift Human Shapes:* 0 points, Init –1, Corpus. Allows the champion to don or remove armor simply by willing it. (1 intricacy point to reduce cost)
+
+**Equipment:** Armor of magical scales of faerie iron. Lance with pennant and other weapons. Attendant as squire. Trappings marked with the burning fern motif. The champion's glamor produces a faerie horse for him, which has the statistics given below for faerie horses, except that it shares his vis, Might, and Magic Resistance. As it is an extension of his glamor, the champion's mount flies when he does.
+
+**Vis:** 5 pawns Ignem, a rusty piece from human–sized armor. For other champions, storyguides might consider a rusty weapon, and add the External Vis virtue.
+
+**Appearance:** An immense human figure clad in scaled armor of metal fern fronds, that can turn into a huge, but superficially charming man. His fastidious chivalry exceeds that of the humans he impersonates, and he enjoys challenging humans to duels over minor shortfalls.
+
+Sir Excelsis is the most powerful faerie knight in the White Lady's kingdom. He is treated as a noble by the other faeries, despite his lack of Might. He is less physically imposing than her gigantic guards, due to his human appearance, but he has greater magical resistance, better equipment, and more Intelligence than they do.
+
+#### Lesser Courtly Faeries
+
+Lesser faeries can be designed as player characters. Many have the Place of Power Virtue. These faeries have the roles of minor nobles, or their attendants. Courtly faeries also often have faerie animals as servants. Most courts have animals that suit mortal nobility, like horses, hounds, and hawks, but the court of the Lady has horses, eels, and gulls.
+
+Some ancient Roman writers talk of "mimic dogs," which were creatures that could be taught to repeat human actions. These were probably a type of servant faerie that has been destroyed by the coming of the Dominion.
+
+##### Sprites
+
+Sprites are challenging as player characters, because a single strike in combat destroys one. A character that emphasizes the spying and sniping elements of the role survives longer. Players are advised to select the power set that allows multiple magical arrows per day. Sprites as described below lack a Social Interaction Virtue or Flaw and need a Virtue like Observant to govern character development. The statistics below have one more Flaw than Virtue. The Pretenses given are correct for a new character.
+
+**Faerie Might:** 5 (Corpus)
+
+**Characteristics:** Int, Per 0, Pre 0, Com 0, Str –20, Sta +1, Dex +3, Qik +10
+
+**Size:** –10
+
+**Virtues and Flaws:** Greater Faerie Power; Faerie Sight, Faerie Speech, Humanoid Faerie, Personal Power (Flight) or Faerie Ally; Narrowly Cognizant; 2 x Little, Oath of Fealty, Traditional Ward (smoke, in this case, or as per court)
+
+**Personality Traits:** Loyal +3
+
+**Combat:**
+
+*Bow:* Init +8, Attack +12, Defense +15, Damage –12\*
+
+\* Often used in conjunction with Grant Flaw, some other power, or poison.
+
+**Soak:** +6 (tiny jerkin)
+
+**Wound Penalties**: Dead (1+)
+
+**Pretenses:** Area Lore (court) 5 (intruders), Athletics 3 (flight), Awareness 5 (intruders), Bow 5 (intruders), Carouse 1 (feasts), Charm 1 (as ambassadors), Etiquette 2 (faerie) Faerie Speech 5, Hunt 1 (humans).
+
+**Powers:**
+
+*Cause Sickness:* 0 points, Init +9, Corpus. (3 intricacy points spent on cost, 2 on initiative): This power usually causes strokes when used by sprites, but in this court, fevers are caused instead. The strike of a messenger's arrow can cause this effect. Strokes have an Ease Factor of 6, but cause a Heavy wound. The fevers caused by these sprites have an Ease Factor of 9 and cause a Light wound.
+
+*Flight:* 0 points, constant, 2 intricacy points reducing Might cost. (See Sir Excelsis for modifications to this power for the White Lady's court.)
+
+A faerie that wishes to use magical arrows often, for combat, might trade its Greater Power for the following selections:
+
+Improved Damage Virtue (+5 Damage)
+
+Improved Soak Virtue (+2 Soak)
+
+Damaging Effect Lesser Power: 1 point, Init +4: (2 intricacy points on cost), Provides a mystical effect based on the court's motif, that increases the damage of the messenger's arrows by +5 for 2 minutes.
+
+It retains Personal Power (Flight), as above.
+
+**Equipment:** Bow, jerkin with the mark of the burning fern. Some faeries of this type fly using mounts, purchased as the Faerie Ally Virtue, in lieu of the Fly power. They have Pretenses of 2 in Ride and 1 in Animal Handling, and lower their Athletics to 2 and their Etiquette to 1.
+
+**Vis:** 1 pawn Ignem, dead bug. In many other courts this would be Corpus.
+
+**Appearance:** These faeries are tiny humanoid figures that can fly, a power they use to perform interesting feasts of gymnastics for their lords. They are armed with tiny bows, and prefer to attack in confusing swarms.
+
+The nobles of the court use these tiny faeries as envoys and saboteurs. Sprites also pose a danger when they attack in swarms. Note that winged faeries are not known in much of Mythic Europe. If your saga proceeds as history did, they do not enter English literature until the 18th century. Most faeries fly either simply by wishing to, or by riding mounts that fly.
+
+##### Regional Courtly Faerie Variants
+
+Most of the regional variants of these faeries reflect the culture either of the group currently living in the area where they are found, or the culture of the humans who were displaced when the current culture invaded the area. Courtly faeries are often divided into fertile and infertile courts, which have seasonal connections, although the symbols used to represent their allegiance vary between communities.
+
+>## Story Seed: The Deluded Hero
+> 
+> A young man who lives near the covenant is undergoing a difficult adolescence, made worse by a faerie queen who keeps giving him missions. She tells the young man that these difficult, if not really very dangerous, tasks are vital to the safety of his village, which the young man feels he has saved several times. The boy, on the cusp of manhood, becomes so emotionally agitated during his quests that his patron can feed deeply on his vitality.
+> 
+> The faerie eventually seeks the aid of the magi, though, because its meddling has so changed the personality of the boy that he has attracted a minor demon of Pride. The faerie wants the player characters to defeat the demon and tell the boy the truth. It wants to protect him, but it also wants to feed on his disillusionment. The boy's quests have bought him faerie equipment and unusual skills, so he would prove a useful companion.
+
+## Divisions of Time
+
+Faeries are encountered at the borders of the year and seasons. These faeries may lead static lives, trapped in a single repeating day, or may lead circular existences, as part of a mystical clockwork. Faeries associated with divisions of time are some of the most human-seeming faeries: many of them use the statistics for courtly faeries given in the preceding section.
+
+#### Summer and Winter: Fertile and Infertile
+
+Mythic Europeans live in an agrarian society. They live and die by the strength of their harvests, and this concern draws faeries.
+
+The courts of summer and winter, in many areas, fight battles on the Equinoxes. Summer defeats winter, and then later in the year, is in turn defeated. The members of each court are dressed as appropriate for their season. The faeries of winter often seem harsh, while the faeries of summer are happy, and it is easy for the untutored to mistake these two sides for good and evil. Players may be forced to intervene if the seasonal battles are disrupted. This is because the faeries involved believe they are vital for agriculture, so their roles force them to destroy crops with unseasonal frost or droughts.
+
+##### Cailleach Bheur (Cally Berry)
+
+The blue hag is not suitable as a player character.
+
+**Faerie Might:** 40+10 (Auram)
+
+**Characteristics:** Int +3, Per 0, Pre –3, Com +2, Str +5, Sta +1, Dex 0, Qik –1
+
+**Size:** +3
+
+**Virtues and Flaws:** 3 x Focus Power, Greater Faerie Powers, 7 x Increased Faerie Might, Faerie Sight, Faerie Speech, Humanoid Form, Large, Time of Power (winter); Restricted Might (major summer), Improved Powers, Incognizant, Sovereign Ward (summer turns her to stone)
+
+**Personality Traits:** Cruel +2
+
+**Combat:**
+
+*Brawl (razor sharp fingernails):* Init –1, Attack +7, Defense +7, Damage +7
+
+**Soak:** +1
+
+**Wound Penalties:** –1 (1-8), –3 (9-16), –5 (17-24), Incapacitated (25-32), Dead (33+)
+
+**Pretenses:** Scotland Under The Snows Lore 9 (faerie auras), Awareness 6 (distant events), Bargain 5 (with questioners), Brawl 5 (when ambushed), Charm 3 (those who come with questions), Faerie Speech 5 (gullible people), Guile 3 (answering questions), Penetration 2 (Focus Power (Ice))
+
+**Powers:**
+
+*Extend Glamour:* 0 points, constant, Mentem: the Cailleach Bheur's glamour is unusual in that it covers far more than a Boundary.
+
+*Focus Power (Ice):* up to 5 points, Init –6, Auram (3 points on Penetration)
+
+*Focus Power (Storms):* up to 10 points, Init –11, Auram
+
+*Spreading a Mantle of Snow:* 1 point, Init –4, Auram: (2 intricacy points spent on cost). The hag pounds her staff — or mallet, in some areas — onto the ground so that it becomes hard and coated in ice.
+
+*Conjuration of the Indubitable Cold*: 0 points, Init –4, Ignem: (3 intricacy points spent on cost). As the spell of the same name on **ArM5** page 142.
+
+**Equipment:** Her plaid, which covers the land.
+
+**Vis:** 8 or 10 Auram, a rotten plaid
+
+**Appearance**: The Cailleach Bheur has blueblack skin, like a corpse, and is hideously ugly. In some areas she turns to stone during the summer months.
+
+In some areas, single creatures represent summer and winter. In many parts of Ireland and Scotland, for example, the winter is represented by the blue hag, the Cailleach Bheur. The blue hag is the guardian of the streams and wells, and the protectress of wolves, goats, deer, cattle, and many other animals. She washes her plaid at a particular spot until it is pure white, then spreads it over the land until summer, when her power passes to a rival. In ancient times this was often the goddess Brigid, but in other areas she keeps the summer as her prisoner.
+
+The Cailleach Bheur's glamour extends to much of the land, so she is aware of many important things happening in distant places. This ability makes her unsuitable as a player character in most sagas, but makes her a valuable ally to magi.
+
+#### Spring and Autumn: Sowing and Reaping
+
+Spring is a time of natural vitality, and faeries seek out the pleasure this gives to humans. The faeries of the spring are lighthearted, and heartening. Some seem to be able to feed from the natural magic of the world, and not be interested in humans at all.
+
+The season of harvests is both a season for joy and happiness that draws faeries, and of banefires to keep curses away.
+
+##### Południca
+
+If redesigning Południca as a player character, note that she has 5 spell levels in Personal Faerie Powers that have been converted to a intricacy point to reduce the cost of her whirlwind power by 1. She has 30 spell levels in Greater Faerie Powers that have been used to reduce the cost and increase the speed of her Cause Fatigue power from 4 points, 0 Init. These might be reclaimed for a new power.
+
+Południca's Virtues and Flaws are not balanced: she requires an additional Minor Flaw. She also requires a Social Interaction Virtue or Flaw. She currently has the equivalent of eight Minor Virtues.
+
+**Faerie Might:** 10 (Auram)
+
+**Characteristics:** Int +1,Per 0, Pre +3/–3, Com 0, Str 0, Sta 0, Dex 0, Qik 0
+
+**Size:** 0
+
+**Virtues and Flaws:** Greater Faerie Powers; Faerie Sight, Faerie Speech, Humanoid Faerie, Increased Faerie Might, 2 x Personal Faerie Powers; Incognizant, Restricted Might (major – winter), Sovereign Ward (running water), Traditional Wards (questions)
+
+**Personality Traits:** Curious +3
+
+**Combat:**
+
+*Scythe:* Init +5, Attack +6, Defense +6, Damage +5
+
+**Soak:** +0
+
+**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20), Dead (21+)
+
+**Abilities:** Awareness 3 (laziness), Charm 2 (rural people), Faerie Speech 5 (rural people), Local Farms Lore 6 (stewardship), Profession: Farmer 6 (stewardship), Single Weapon 3 (rural people)
+
+**Powers:**
+
+*Cause Fatigue:* 0 points, Init 0, Ignem: (2 points each on cost and Initiative) Causes the loss of a long-term fatigue level via heatstroke.
+
+*Shift Human Shapes*: 1 point, Init –1, Corpus (beautiful to hideous within a range of +3/–3 Presence)
+
+*Transform into Whirlwind*: 3 points, +2 Init, Auram (1 intricacy point on cost, 2 on Initiative)
+
+**Vis:** 2 pawns (scythe, Ignem)
+
+**Appearance:** This faerie may appear as a beautiful maiden, a crone, or an adolescent girl. She wears a white dress and carries a scythe or shears. She may travel as a dust devil, and is used as a nursery terror to frighten children so that they do not harm crops.
+
+Południca usually appears around noon on hot days, and asks farmhands difficult questions, or engages them in conversation. If the farmhand tries to change the topic of their conversation, or cannot answer one of the faerie's questions, she gives him heatstroke. If particularly annoyed at this farmhand, she might instead drive him insane, or cause his death from hyperthermia.
+
+> # Story Seed: Południca
+> 
+> There is a little girl in a village near the covenant who has an imaginary friend. Her friend is a hyperthermia faerie, like Południca. The girl, through an artistic temperament, some luck, and an invitation to play, has convinced the spirit that it should express emotional, rather than atmospheric, warmth toward the girl. The girl's friendship with the faerie keeps it close to her village, and does not alter its attitude to other humans, so she poses a terrible risk to her neighbours. The girl can be used as bait to ambush the faerie, though, and destroy it.
+> 
+> Skilled characters might, instead, trap the faerie and alter it over the course of years. They would need to find a way to feed it sufficient vitality that it can change role, spread stories about the faerie that make the change of role easier, defend the role against other faeries that attempt to fill it, then coach the girl to collaborate with it, so that it becomes a more-helpful harvest faerie.
+
+#### Christmas
+
+Faeries are particularly attracted to the ebullient energy of celebrating humans, and many are drawn to Christmas celebrations. They include **kallikantzaroi**  in Greece, the **jolarsveniar** in Norway, the **trows** in the Shetland Islands and the **drekavac** in Serbia.
+
+##### Kallikantzaro
+
+Kallikantzaroi make poor player character because they are trapped within the Earth for most of the year. The statistics for kallikantzaroi could, however, be used as the basis of a player character faerie of some other type. The character would require a Social Interaction Virtue or Flaw, and then sufficient Virtues to balance the many wards this character suffers from. It needs another 245 points of Pretenses. It requires three additional points of Characteristics from the table on page 30 of **ArM5**, and has 10 levels of unspent Personal Faerie Power.
+
+**Faerie Might:** 5 (Corpus)
+
+**Characteristics:** Int –1, Per +1, Pre –2, Com 0, Str –6, Sta +1, Dex +3, Qik +3
+
+**Size:** –3
+
+**Virtues and Flaws:** Faerie Sight, Faerie Speech, Feast of the Fae, Hybrid Form, 2 x Personal Faerie Powers; Little, Sovereign Ward (Religion), Incognizant, Traditional Wards (fire, counting games, burning shoes in some places)
+
+**Personality Traits:** Destructive +3
+
+**Combat:**
+
+*Brawl (bite):* Init +3, Attack +10, Defense +9, Damage –1
+
+*Brawl (talons):* Init+2, Attack +11, Defense +9, Damage –2
+
+**Soak:** +3
+
+**Wound Penalties**: –1 (1-2), –3 (3-4), –5 (5- 6), Incapacitated (7-8), Dead (9+)
+
+**Abilities:** Athletics 1 (climbing)\*, Awareness 1 (shiny things), Brawl 3 (each other), Faerie Speech 5
+
+\* Has virtue allowing supernatural athletics.
+
+**Powers:**
+
+*Silent Motion:* 1 point, constant, Imaginem. These faeries are capable of silent motion, but make noise by damaging things in the excitement of their revels.
+
+*Supernatural Agility*: 0 points, constant, Animal (3 intricacy points spent on cost).
+
+**Vis:** 1 pawn (Animal)
+
+**Appearance:** Kallikantzaroi have different appearances in different areas, but they are generally small faeries that have mixed human and animal characteristics. They are usually black and furred, with glowing red eyes and extended tongues. They often have the ears of donkeys or goats, and many have animal feet. They may have tusks and have sharp, curved claws.
+
+Kallikantzaroi are faeries that live under the Earth, where they saw away at the World Tree. Each year, as their labor is nearly complete, Christmas arrives and they are allowed onto the surface of the Earth until the Epiphany, and the Blessing of the Waters, which occurs on January 6. When they return home, they find that the tree has regenerated and begin their labor again. In some areas it is believed that children born in the period when the Kallikantzaroi are active become kallikantzaroi themselves during the festive season, their spirits straying from their bodies to raise havoc. This can be prevented with folk charms, like binding the child in special herbs, or singeing its toenails.
+
+Kallikantzaroi often prefer to break into a house by crawling down the chimney, so it is traditional to leave the fire burning for the whole of the Yule period, and sometimes to hang sausages or sweetmeats in the chimney, as a bribe to encourage them to go away. A person being chased by a kallikantzaro can divert it by dropping a colander or spilling grain, because it is forced to stop and count the holes in the colander, or the number of grains.
+
+##### Kallikantzaro Variants
+
+A variant form of Kallikantzaroi is a version of the faun. They also attack the World Tree, and revel during the Christmas season. They are terrified of sunlight, and so anyone who can fool them into dancing until the sun rises is free of their depredations. These Kallikantzaroi may be up to 25 feet high, and use faun or giant statistics.
+
+## Divisions of Space
+
+Many faeries live on the edges of human communities. This is, in part, a practical response to two competing needs: faeries must remain near humans, but many faeries prefer to avoid the Dominion. Faerie lands are sometimes described as a ring that lies between the safety of the Dominion and the disinterested Magic of the wilderness. Faerie lands are dangerous, but a cautious character with an ear for folklore can navigate them far more safely than the Magical lands that lie beyond. Magical creatures usually do not care about human desires, passions, or lives. Faeries do, so some form of payment for safe passage might be arranged.
+
+Faeries also live at the edges of communities because they are often dangerous places, and the hint of danger arouses human emotions. The community stops at the forest, or the river or the ravine precisely because accidents happen there. When a place is avoided because it is dangerous, stories grow up to explain the danger, and these stories attract faeries that suit the locale. Faerie wolves may fill a forest. Faerie bandits may camp in a ravine. Faerie dwarfs may haunt an unsafe mine. Traditional gifts or wards for these dangerous faeries are likely to be discovered following their emergence. And characters with sufficient folklore usually know ways of crossing the territory of these creatures, or of meeting safely with them.
+
+Faeries also dwell at the borders of communities because humans want them there. For many faeries, it is important that humans desire their existence. It is far easier to desire the existence of an ogre that eats wicked children, or a faerie queen that whisks men away for nights of bliss and death, if they are believed to live a safe distance away.
+
+### Roads
+
+Crossroads are places of faerie power, because where four roads meet, two roads cross. A crossroad is made of two borders, each transgressed by the other. Similarly, a bridge is a place where two borders cross. They do not transgress each other, but do touch in the darkness beneath the bridge.
+
+##### Faerie Hounds
+
+Faerie Hounds are not suited as player characters.
+
+**Faerie Might:** 5 (Animal)
+
+**Characteristics:** Cun 0, Per +2, Pre –4, Com 0, Str 0, Sta +2, Dex +1, Qik +2
+
+**Size:** +1
+
+**Virtues and Flaws**: Greater Faerie Power (varies), Faerie Beast, Faerie Sight, Improved Characteristics, Sharp Ears, Large; Incognizant, Reckless, Traditional Wards (varies)
+
+**Personality Traits:** Loyal +3, Reckless +3, Brave +2
+
+**Combat:**
+
+*Bite (small teeth):* Init +2, Attack +10, Defense +9, Damage +1\*
+
+\* In some cases, faerie hounds have the Lesser or Greater Faerie Power Damaging Effect, which adds +5 to the damage score of their bite. This is usually visually obvious, for example as their spittle ignites tiny flames on the ground, or their breath puffs like smoke because their teeth freeze like ice.
+
+**Soak:** +2
+
+**Wound Penalties**: –1 (1-6), –3 (7-12), –5 (13-18), Incapacitated (19-24), Dead (25+)
+
+**Pretenses:** Athletics 5 (distance running), Awareness 6 (keeping watch), Brawl 5 (bite), Hunt 6 (track by scent)
+
+**Powers:**
+
+For rapid character generation, select from the following Greater Powers. Many others are known, but these are the most common. Take a total of 50 spell levels of powers. Trading 5 full levels allows the character to spend an intricacy point to reduce the cost of each use of a power, or the Initiative penalty for the power, by 1.
+
+*Damaging Effect:* 2 points: Init 0, Varies
+
+*Enthralling Sound:* 3 points, Init –2, Mentem: Used to cause terror and panic with its howl.
+
+*Enthrallment:* 4 points, Init –2, Mentem
+
+*Fearful Flaming Eyes:* 2 points, Init –2, Corpus
+
+*Hound:* 2 points, Init 0, Corpus
+
+Many also have the Personal Faerie Power of Flight. For this, add the Personal Faerie Powers Virtue.
+
+*Flight:* 0 points, constant +2, Animal (2 intricacy points on cost)
+
+**Vis:** 1 pawn Animal, dog corpse
+
+**Appearance:** Faerie hounds are usually of chunky hunting breeds. Many have shining eyes, and almost all have black, white, or green fur. These statistics also suit the hunting hounds of the courtly fae. This type of faerie hound often has a white coat, red ears, and blue eyes.
+
+Huge faerie dogs haunt the roads of much of Mythic Europe. They terrify, and sometimes kill, travelers. Some can run rapidly, while others run upon their hindlimbs when chasing humans, so as to have their teeth closer to the victim's throat.
+
+##### Faerie Hound Variants
+
+In part of France, this role is filled by a terrifying goat.
+
+**Aufhocker**: Found in German-speaking areas, this creature acts as a kelpie, and uses its adhere power to cling to foes while goring them so that its weight adds 6 to their combat Load.
+
+**Kludie:** From Belgium, this is the most-powerful variant of this beast. It can take monstrously large versions of the forms of dog, cat, bat, horse, or frog. It walks on its back legs, with a dancing movement as it sprints toward its victim. It is preceded by supernatural blue flames. Kludie knows the trick of bouncing on the back of his quarry and using the adhere power to drag his prey down. It also does the kelpie trick, dunking or drowning those who mount him in horse form.
+
+##### Kelpie (Water Horse)
+
+Kelpies are not suited as player characters.
+
+**Faerie Might:** 5 (Animal)
+
+**Characteristics:** Cun –2, Per 0, Pre 0, Com –4, Str +2, Sta +3, Dex +1, Qik +1
+
+**Size:** +1, in this case, although some are fullsized horses (Size +3, add +4 Str, subtract –2 Qik, adjust combat statistics and body levels)
+
+**Virtues and Flaws:** 2 x Great Characteristics, 3 x Improved Characteristics, Greater Faerie Powers, Faerie Beast, Faerie Sight, Feast of the Dead; Aloof, Incognizant, Fear (loud noises), Traditional Ward (sign of the cross).
+
+**Personality Traits**: Brave +2
+
+**Combat**:
+
+*Hooves:* Init +2, Attack +7, Defense +6, Damage +3
+
+**Soak:** +3
+
+**Wound Penalties**: –1 (1-6), –3 (7-12), –5 (13-18), Incapacitated (19-24), Dead (25+)
+
+**Abilities:** Athletics 5 (long-distance running), Awareness 3 (noises), Brawl 3 (predators)
+
+**Powers**:
+
+*Adhere*: 0 points, Init 0, Corpus. (1 intricacy point on cost)
+
+*Guide:* 1 points, Init –2, Mentem. (2 intricacy points on cost)
+
+**Equipment:** None.
+
+**Vis:** 1 pawn, straps of water weed
+
+**Appearance:** A black, or perhaps dark green pony with a shaggy coat. Some of these horses are able to walk on their back legs.
+
+Kelpies are pony-like faeries that encourage people to mount them. The rider is held to the back of the water horse, which plunges into the nearest lake. Usually this drowns the human and provides the kelpie with a meal, but some kelpies instead take their vitality from the wounded emotions of pompous, rich people that they dump in marshes in order to destroy their fine clothes.
+
+Some kelpies take the form of young men, and seduce girls into climbing on their backs: use the Galconer statistics for the character's human form, and add the *Transform into Human* Personal Power to the statistics.
+
+##### Kelpie Variants
+
+**Grant:** A Scottish faerie horse able to walk on its back legs. It appears just before important buildings catch fire. It is not clearer if it creates the blazes or warns people that they are about to occur. It is sometimes reported as having burning hooves, a flaming mane, or fiery eyes.
+
+##### Licho
+
+Licho is not suited for player characters.
+
+**Faerie Might:** 5 (Mentem)
+
+**Characteristics:** Int +1, Per +1, Pre –3, Com +2, Str +3, Sta 0, Dex +1, Qik +1.
+
+**Size:** 0
+
+**Virtues and Flaws:** Greater Faerie Powers, Faerie Sight, Faerie Speech, Humanoid Form; Missing Eye, Incognizant
+
+**Personality Traits:** Enjoys inflicting misery +3
+
+**Combat:**
+
+*Claws:* Init +2, Attack +9, Defense +9, Damage +5
+
+**Soak:** 0
+
+**Wound Penalties:** OK, 0, –1, –3, –5, Unconscious.
+
+**Pretenses:** Area Lore 3 (lonely roads), Awareness 3 (gifts), Brawl 6 (wrestling), Faerie Speech 5 (threats), Folk Ken 5 (gift giving) Stealth 4 (stalking prey)
+
+**Powers:**
+
+*Adhere:* 0 points, Init 0, Corpus: Licho uses the adhere power to cling to the neck of her victims, or to make them unable to drop an item created from her glamor. Penetration +8 due to spent intricacy points.
+
+**Vis:** 1 pawn Corpus, a skeletal hand.
+
+**Appearance:** The licho looks like an old, skinny woman dressed in black, with a single great eye in the middle of her forehead.
+
+Licho personifies ill-fortune, and either eats her victims or tricks them into grievous self-harm. She might, for example, ride on the neck of a victim, and convince him that he should jump into a lake to drown her. She is a faerie, and needs not breathe, so her victim drowns instead. Sometimes she pursues a victim, who grabs an item that seems likely to aid against her, and then cannot put the item down. She convinces the victim she will hunt him until he gives the item away, so he cuts off his own hand. The licho can be given away: a character who presents a large, undeserved gift to another person can pass the licho to him, as well. The licho can occasionally be tricked, much as the cyclops in the Odyssey was.
+
+##### Road Faerie Variants
+
+A donestre looks like a human with the head of a lion. They are particularly skilled at Faerie Speech, and use their eloquent ability to mimic humans to draw travelers off the roads, into wild places, where they are eaten. Some donestres have the *Guide* power, while others have the power to *Enthrall*. Donestres do not eat the heads of their victims. Instead, they sit beside them, quietly weeping, after the feast. This may represent the donestre's crossing the border from human to animal, then back to human again.
+
+#### Waterways
+
+The shore is a dangerous place — to step over the high tide mark is to enter a world where humans are not the masters. Many fisherfolk are deeply superstitious, because their superstitions offer them some promise of being able to manipulate the moods of the waters. The ancient Irish claimed that Arcadia began seven waves in any direction from Ireland, a view that is no longer true, but is still indicative. The sea is a wonderful and terrible place, and the stories people tell of it take beautiful and hideous forms.
+
+###### Tritons
+
+Merfolk are finicky to convert to companions. Players may wish to trade out the Flaws Aloof and Restricted Might, gaining 80 Pretense points. They then need to spend the Pretense points, select a Social Interaction Virtue or Flaw, and then select additional Flaws to balance up the many Virtues. There is still a little space for additional Flaws, if added Virtues are desired.
+
+The merfolk described here are not optimized for combat: player character merfolk, or those designed primarily as a force for the player characters to combat, should have higher weapon Pretenses, and powers or Virtues than increase their effectiveness in combat.
+
+**Faerie Might:** 5 (Corpus or Animal depending on type of merfolk)
+
+**Characteristics:** Int, 0 Per 0, Pre +2, Com 0, Str +1, Sta +1, Dex +1, Qik +1
+
+**Size:** 0
+
+**Virtues and Flaws:\*** 2 x Greater Faerie Powers; Faerie Sight, Faerie Speech, Hybrid Form, Personal Faerie Power; Sovereign Ward (folk charms), Restricted Might (on land); Aloof, Incognizant.
+
+\* Cannibalistic merfolk often have Feast of the Dead.
+
+**Personality Traits:** Greedy +1
+
+**Combat:**
+
+*Brawl*: Init: +3, Attack +3, Defense +1, Damage +5
+
+*Trident and Net:\** Init:+3, Attack +3, Defense +1, Damage +5
+
+*Trident (thrown):* Init+1, Attack +5, Defense +3, Damage +5
+
+\* When one of the merfolk uses a net, it reduces its rival's Attack score by half the net wielder's Thrown Weapon Pretense. Nets do not work the same way for humans.
+
+Soak: +3\*
+
+\* Leather clothes.
+
+**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16–20), Dead (21+)
+
+**Abilities:** Area Lore: Fishing Grounds 2 (productive spots), Awareness 2 (fish), Bargain 2 (for catches), Brawl 1 (underwater), Charm 2 (fisherfolk), Faerie Speech 5, Folk Ken 2 (fisherfolk), Guile 2 (about origin), Music 2 (singing), Profession: (fisher) 3, Single Weapon 1 (spear), Swim 3 (endurance), Thrown Weapon 3 (spear)
+
+**Powers:**
+
+Merfolk from various regions display a wide variety of powers. One variety has the following powers. Some, more powerful, merfolk are able to cause storms or grant wishes for wealth.
+
+*Enthralling Sound:* 3 points, Init –2, Mentem: Merfolk, mermaids in particular, can cause fascination in sailors who hear them sing. They usually allow the men to return to shore, with instructions to purchase them beautiful things that cannot be made in the sea, like glass mirrors. Cannibalistic mermaids lure ships onto rocks.
+
+*Kiss of the Mermaid*: 3 points, Init –2, Aquam
+
+*Push of the Gentle Wave*: 2 points Init –1, Aquam: Similar to the spell of the same name (**ArM5** page 124), but has a longer effect, allowing the faerie to appear to tow small boats or swim assisted by a magical current. Costs 15 spell levels (Base 4, +1 Touch, +2 Sun)
+
+*Conversing with the Sea:* 3 points, Init –2, Aquam. Allows the faerie to ask questions of its local part of the ocean. Similar to *Voice of the Lake*, **ArM5** page 122, except that faeries can converse with portions of genuine lakes and seas. Costs 25 spell levels (Base 15 +1 Touch +1 Concentration)
+
+*Transform into Human:* 3 points, Init: –2, Corpus. This has been treated as a level 25 effect, slightly easier than a complete transformation into a fish (level 30). Some faeries have this power due to an External Vis Source. Humans finding this source, which is often a red hat, can turn into merfolk. If designing one of these faeries, add the External Vis Source Virtue, then add a power worth 25 spell levels to replace this.
+
+**Equipment:** Fishing gear (trident, net, bag over shoulder, personal trinkets)
+
+**Vis:** 1 pawn, rusty fish-hooks (or, suiting the External vis virtue, a red hat.)
+
+**Appearance:** Merfolk are generally human from the waist up, although some of the fairies in the Mediterranean tell of an ancient epoch when they were the other way around. They have fishlike scales, but these provide no defensive advantage. Merfolk men are handsome in Scandinavia, but hideous in Britain.
+
+Tritons, more usually called merfolk in English, seem to live in clans beneath the waters in areas where fishing is good. They resent humans who treat their fishing grounds poorly. Triton fishers sometimes trade on shore for human baubles. They also trade for alcohol, which makes them surprisingly drunk. In trade, they offer fish or cargoes salvaged from wrecks.
+
+A few merfolk are man-eaters that deliberately cause shipwrecks or pretend to be drowning to lure rescuers into the water. They are believed to be more active just before storms, or perhaps cause them. A few live as humans, and gain their fish tail by placing magical red caps upon their heads when traveling through the waters. Theft of this cap allows them to be captured as spouses. Selkies and merfolk seem to live amicably: some stories indicate that they form alliances against mutual enemies.
+
+##### Triton Variants
+
+The following variants may also suit your game.
+
+**Abgal:** The abgal were merfolk, possibly aligned with the Magic realm, who became tutors for the earliest humans. Modern mermen may be based on stories passed down from the time of this lost race. The mermen in *Realms of Power: Magic* are, perhaps, degenerate abgals. Characters could seek the undersea kingdoms of these creatures, long abandoned.
+
+**Gigantic Sovereigns:** The rulers of the merfolk are increasingly large. It is recorded in *The Book of Four Masters* that the corpse of a mermaid was washed ashore in AD 887. She was 160 feet long, had hair 18 feet long, and fingers seven feet in length. She was pale white all over.
+
+**Havfrue:** Similar to other mermaids, but those who lie with a havfrue may be led to their deaths. Sighting a havfrue is a warning of imminent storms. She is a herder, driving her white cattle to pasture on terrestrial grass during fogs and storms.
+
+**Hakennman:** This merman is divided slightly differently than normal: he has the body of and tail of a fish, and has the torso and head of a human rising from the front of that body.
+
+**Icthyocentaur**: A creature with the torso and head of a human, the tail of a fish or dolphin, and the front legs of a horse.
+
+**Liban:** In part of Ireland there is a hagiography that indicates that a woman was changed into a mermaid by the goddess Danu. She lived for 300 years, and then was baptised, at her request, by a monk. After her death she entered Heaven as a Holy Virgin, and miracles were done through her intercession.
+
+##### Selkie King
+
+Selkie kings might substitute for magi as player characters, but require substantial alteration. They are Aloof, so the player may wish to remove that Flaw, gaining 80 Pretense points, but requiring an explanation. The character requires a Social Interaction Virtue or Flaw, and then requires Flaws to balance its many Virtues. If the character remains a king of the selkies, then the troupe needs to negotiate why the character does not have a private army of faeries constantly on call. An exiled faerie prince, for example, might be a suitable character. The Secret Hiding Place Virtue is suitable for selkies who can flee their landbound enemies to undersea grottos. The intricacy points spent on powers might be traded back into spell levels, to pay for additional effects.
+
+**Faerie Might:** 15+10 (Animal)
+
+**Characteristics:**
+
+*Human Form:* Int, +1, Per +1, Pre +2, Com +1, Str +1, Sta +1, Dex +1, Qik +1
+
+*Seal Form*: Int +1, Per +1\*, Pre 0, Com –4\*, Str +4\* , Sta +4 , Dex +2, Qik +2
+
+\* Higher than usual for a seal due to Improved Characteristics Virtue.
+
+**Size:** +1
+
+**Virtues and Flaws:** Greater Faerie Power; 2 x Increased Faerie Might, External Vis (minor), Faerie Sight, Faerie Speech, Humanoid Faerie/Faerie Beast, Improved Characteristics, Large, Skinchanger, Place of Power (behind low tide mark), Residual Power (Spill Blood); Narrowly Cognizant; Restricted Might (above high tide line), Sovereign Ward (folk charms). When on shore often has Dark Secret – selkie king and Infiltrator (itinerant laborer)
+
+**Personality Traits:** Self-centered +3, Romantic +2
+
+**Combat:**
+
+*Brawl (bite – seal form):* Init +3, Attack +9, Defense +6, Damage +8
+
+*Brawl (bludgeon – human form):* Init +2, Attack +6, Defense +4, Damage +3
+
+**Soak:** +1 or +6
+
+**Wound Penalties**: –1 (1-6), –3 (7-12), –5 (13-18), Incapacitated (19-25), Dead (26+)
+
+**Pretenses:** Brawl 3 (bite), Athletics 3 (acrobatic turns), Awareness 3 (fisherfolk), Faerie Speech 5, Hunt 3 (fish), Swim 5 (pursuit) 
+
+**Powers:**
+
+*Always Hear the Waves:* 2 points, Init –1 or 0, Aquam: The faerie always knows the direction and distance to the Palace of the Selkie King. 15 spell levels (Base 2 +4 Arcane +1 Concentration)
+
+*Steal Judgment:* 2 points, Init –1 or 0, Mentem: The target believes almost any lie that the faerie tells, although an Intelligence roll against an Ease Factor of 6 is permitted to resist, with easier rolls for truly incredible lies.
+
+*Spill Blood:* 2 points, Init –1 or 0, Auram: When a selkie's blood is spilled on the ocean, it creates an effect similar to *Clouds of Rain and Thunder*, but with a longer duration. When acting in concert a group of selkies shedding blood on the waters can cause tremendous storms like *Wrath of Whirling Winds and Water*, **ArM5** page 126. This is used to avenge mass slaughters of seals, or the death of other selkies. 20 spell levels (Base 3 +1 Touch +2 Sun +2 Group)
+
+**Equipment:** Seal skin.
+
+**Vis:** 3 pawns, skin of a seal
+
+**Appearance:** Selkies are human-shaped faeries who live beneath the waters, or on distant islands, and change into seal shape to travel through the sea. They take the form of any large seal, avoiding only the shape of common seals. If their seal skins are stolen they may be forced to become spouses, as detailed in the Spouses Captured by Trinkets section earlier. Male selkies, particularly their king, come ashore intermittently to seek brides. It is unclear if their brides live in happiness with them in the depths, or if the blonde hair of the brides is used to thatch the roofs of the selkie king's palace. Women may conjure up selkie lovers by crying seven tears into the ocean.
+
+##### Selkie King Variants
+
+**Roane:** The Highland version of this creature, the roane, is smaller and far less bloodthirsty.
+
+##### Seal Statistics
+
+Seals can hold their breath for twice as long as normal, and the bonus from its Long-Winded Virtue adds to rolls to withstand deprivation of air. When using the seal as an alternate form for a selkie, disregard the Fatigue levels. Faeries don't need to breathe, so the Long-winded Virtue is unnecessary.
+
+**Characteristics:** Cun 0, Per 0, Pre –2, Com –5, Str +2 , Sta +3 , Dex +1, Qik +1
+
+**Size:** +1
+
+**Virtues and Flaws:** Improved Characteristics, Long-Winded, Puissant Swim; Carefree
+
+**Qualities:** Amphibious, Pursuit Predator, Tireless, Tough Hide
+
+**Combat:**
+
+*Teeth:* Init +1, Attack +8, Defense +6, Damage +3
+
+**Soak:** +5
+
+**Fatigue Levels:** OK, 0/0, –1/–1, –3/–3, –5, Unconscious
+
+**Wound Penalties**: –1 (1-6), –3 (7-12), –5 (13-18), Incapacitated (19-24), Dead (25+)
+
+**Abilities:** Brawl 3 (bite), Athletics 3 (acrobatic turns), Awareness 3 (fish), Hunt 4 (fish), Swim 4+2 (pursuit), Survival 3 (at sea)
+
+#### Marsh
+
+Marshland lies in the border between land and the water. Marshland is, agriculturally, sterile, and yet it is naturally fecund. It just has a fertility that people cannot use. This fertility may take faerie form as an expression of the uncivilizable fertility that marshlands possess.
+
+##### Fool's Fire
+
+Fool's fire is not a creature that's suitable as a player character.
+
+**Faerie Might:** 5+10 (Imaginem)
+
+**Characteristics:** Cun 0, Per 0, Pre 0, Com 0, Str n/a, Sta n/a, Dex 0, Qik +10
+
+**Size:** –10
+
+**Virtues and Flaws:** Greater Faerie Powers, Feast of the Dead, Place of Power (swamp); Glamorous Flesh, 2 x Little, Incognizant.
+
+**Personality Traits:** Homicidal +3
+
+**Soak:** 0
+
+**Wound Penalties**: Immaterial, but any damage to immaterial things snuffs the fire out (Dead (1+))
+
+**Powers:**
+
+*Guide:* 0 points, Init +6 Mentem: 4 intricacy points spent on cost, added magnitudes for Sight Range and Sun Duration.
+
+**Equipment:** One large swamp
+
+**Vis:** 1 pawn, rapidly dissipating gas, Mentem
+
+**Appearance:** This faerie looks like a distant, flickering flame. It dances away from those who seek it, drawing them further and further from aid.
+
+Fool's fires are tiny lights, also called will o' the wisps, that guide lost travelers into dangerous terrain. Some fool's fires act as lure on behalf of more powerful faeries. In some German areas they are thought to be the ghosts of people who have moved border marking stones.
+
+#### Rivers
+
+Rivers are the lifeblood of medieval cities, and many were worshiped as goddesses in pagan Europe. The most powerful of these was **Danu**, who was the goddess of the Danube, the Don, the Deipnier, and many other places. The courtly faeries of Ireland, called the **Tuatha de Danu**, are her children. Rivers are guarded by **merfolk**, and by **nymphs**.
+
+#### Lakes and Wells
+
+Lakes seem bottomless, and may link to the lands of the dead. The surfaces of lakes are reflective, so what lies beneath the lake can reflect what lies within the viewer. A character wading into a lake is stepping through a mirror, and into is own reflection.
+
+A well is a dark hole that leads to the underworld. It's a source of water, which is life, but at its depths any manner of thing might lurk. Children, particularly, should be kept away from wells, because you never know where their shafts might lead, or what might be watching from the depths, that the children might draw up.
+
+### Wastelands
+
+Lands that lie at the edge of settlements, that people venture into only occasionally, suit faeries perfectly. When swineherds graze pigs on acorns in forests, of fisherfolk seek catches in swamps during spawning season, they are entering places infested with faeries.
+
+#### Forest
+
+Forests have deep and powerful meanings for mythic Europeans. The forest is where natural chaos runs as it will, and where enemies and predators may hide. In the forest the way forward is never clear, and it is easy to become lost. The forest is also the source of windfall riches: wood and food, and the secrecy to do things that others would not approve of. Forest faeries are a subtle mixture of danger and allure, just like their home.
+
+##### Great Lezi
+
+The great lezi described here is not suited as a player character.
+
+**Faerie Might:** 40 (Herbam)
+
+**Characteristics:**
+
+*For Size 0:\** Int +3, Per +3, Pre –2, Com 0, Str +6\*, Sta +3, Dex 0, Qik 0\*
+
+\* For every +1 Size, add +2 Strength and subtract –1 Quickness. For every –1 in Size, subtract –2 Strength and add +1 Quickness.
+
+**Size:** Varies from –10 to +7. A Lezi may change size in increments of fractions of an inch, if it wishes.
+
+**Virtues and Flaws:** 3 x Focus Power, 3 x Great Characteristic, 7 x Increased Faerie Might, 7 x Huge; Faerie Sight, Faerie Speech, Highly Cognizant, 6 x Improved Characteristics, Humanoid Faerie, 6 x Personal Faerie Powers; Sovereign Ward (may not leave forest), Some Lezis, particularly those with backward feet, are unable to harm humans who have turned all of their clothes backwards.
+
+**Personality Traits:** Loves Forest +5
+
+**Combat:**
+
+*2 x Brawl (club):\** Init 1+(Size x –1), Attack 8, Defense 7+(Size x –1), Damage +9+(Size x 2)
+
+*\** The lezi's arms are made of solid wood, and do damage like a club. They are wielded with the Brawl Pretense, even if the lezi generates clubs to use in battle*.*
+
+**Soak:** +15
+
+**Wound Penalties:**
+
+*For Size –10*: Dead (1+)
+
+*For Size –5:* –3 (1), –5 (2), Incapacitated (3), Dead (4+)
+
+*For Size –3:* –1 (1-2), –3 (3-4), –5 (5-6), Incapacitated (7-8), Dead (9+)
+
+*For Size 0:* –1 (1-4), –3 (5-8), –5 (9-12), Incapacitated (13-16), Dead (17+)
+
+*For Size +1:* –1 (1-6), –3 (7-12), –5 (13-18), Incapacitated (19-25), Dead (26+)
+
+*For Size +3:* –1 (1-8), –3 (9-16), –5 (17-24), Incapacitated (25-32), Dead (33+)
+
+*For Size +7:* –1 (1-12), –3 (13-24), –5 (25-36), Incapacitated (37-48), Dead (49+)
+
+**Pretenses:** Animal Handling 9 (woodland creatures), Athletics 3 (striding), Awareness 9 (damage to forest), Bargain 3 (from position of strength), Brawl 6 (human interlopers), Carouse 3 (wine), Charm 2 (forest folk), Faerie Speech 5, Folk Ken 3 (forest folk), Forest Lore 9 (locations), Guile 2 (about woodland dangers), Leadership 9 (woodland creatures), Swim 3 (streams).
+
+**Powers:**
+
+*Extended Glamour:* 0 points, constant, Mentem: Constantly in touch with the forest.
+
+*Focus Power (Manifestation):* 5 points, Init –5\*, Animal or Herbam.
+
+*Focus Power (Woodland Change):* 5 points, Init –5\*, Herbam: Muto and Intellego effects only in Herbam and Animal.
+
+*Focus Power (Size Reduction):* 5 points, Init –5, Corpus or Animal: Are considered to naturally be Size +7, and use powers to live at a smaller Size.
+
+*Transform into Animal:*\*\* 3points, Init. –3\*, Animal
+
+*Transform into Bird or Fish:*\*\* 3 points, Init: –3\*, Animal
+
+*Transform into Human*: This power costs the Lezi whatever it cost to transform away from the human shape. For character creation purposes, its cost and Initiative must be equal to the most expensive the character will use it to reverse, in this case Transform into Object (Plant).
+
+*Transform into Object (Plant*):\*\* 4 points, Init –4\*, Herbam
+
+- \* Add appropriate Quickness modifier, based on Size.
+- \*\* Lezi are extraordinary in that they can change into any animal or plant from their woodland: they do not specify alternative forms as other creatures do.
+
+**Equipment:** Can fabricate an endless variety of material from the woodland.
+
+**Vis:** 8 pawns, External vis, club
+
+**Appearance:** The Forest Lord, or great lezi is found in Slavic lands. He usually appears as a tall, pale, bearded man with emerald eyes, but can take the shape of any plant or animal. He may change his size from that of a blade of grass to that of a tall tree. Many lezi have feet that face backward, and many are faunlike. Great lezi command woodland animals, particularly wolves. The term "great" is used to compare this creature to the more-common lezi, which is a form of faun.
+
+##### Great Lezi Variants
+
+**Basajauns:** Gigantic fauns are found in the Basque country in Iberia. Once they were much like other fauns, although even then they had striking red fur. When humans won the right to till the country, these fauns became agricultural faeries. They use their great height to plan agricultural improvements, perform feats of remarkable engineering, and shout warnings when predators approach. In that region they are called Basajauns, but this is confusing because Basajaun is a large, wild faun in the folklore of the surrounding peoples, who keeps house with his wife and human slaves.
+
+##### Fauns
+
+As potential player characters fauns require some adaptation. They require a Social Interaction Virtue or Flaw, and have many Virtues not balanced by Flaws. Wards might help to limit the faun, as might increasing the number of Weaknesses. The Pretense points given below are correct for a starting character.
+
+**Faerie Might:** 5
+
+**Characteristics:** Int –1, Per 0, Pre +2, Com +1, Str +2, Sta +3, Dex +1, Qik +2
+
+**Size:** +1
+
+**Personality Traits:** Lusty +5, Hasty +2
+
+**Virtues and Flaws:** Greater Faerie Powers, Faerie Speech, Faerie Sight, 3 x Improved Characteristics, Hybrid Form, Large, Lecherous (major) or Greedy (wine - major), Aloof, Incognizant, Weakness (music or sex or wine), Traditional ward (religious).
+
+**Combat:**
+
+*Kick (brawl):* Init +4, Attack +8, Defense +9, Damage +5
+
+*Horns (brawl):* Init +3, Attack +9, Defense +6, Damage +6
+
+*Spear:* Init +4, Attack +7, Defense +6, Damage +7
+
+*Spear (thrown):* Init +2, Attack +7, Defense +6, Damage +7
+
+**Soak:** +3
+
+**Wound Penalties**: –1 (1-6), –3 (7-12), –5 (13-18), Incapacitated (19-24), Dead (25+)
+
+**Abilities:** Athletics 2 (dancing), Awareness 2, Brawl 5 (wrestling), Carouse 6, Charm 2 (taking liberties), Guile 2 (women), Local Language 3, Music 3 (flute), Single Weapon 3 (spear), Thrown Weapon 3 (spear)
+
+**Powers:**
+
+*Grant Puissance in Combat:* 2 points, Init 0, Mentem: Fauns can play wild, violent music, giving those who hear it +3 on Weapon Skills (affecting Attack and Damage rolls) and Brave totals for the rest of the scene.
+
+*Endless Wine:* 0 points, constant, Herbam: (1 intricacy point spent on cost). Any vessel the faun touches fills with wine, if the faun so wishes. Note that fauns prefer human wine, because it has vitality. Fauns give this wine to humans so that they act in vital, uninhibited ways. This effect also makes vines laden with grapes spring up in places where fauns dwell, in some cases. (Base 2, +1 Touch, +2 Sun, +1 constant.\* )
+
+\* This power lasts for the length of the party. These usually break up at dawn, so it has been given Sun Duration. Note that harm caused to people by effects that vanish does not, itself, vanish, so phantom wine can create real hangovers.
+
+*Steal Judgment:* 2 points, Init 0, Mentem *OR*
+
+*Endless Wine:* 0 points, constant, Herbam.
+
+*Enthralling Sound:* 0 points, Init –1, Mentem: (3 intricacy points spent on cost) Faun dancing music makes listeners more riotous and merry, increasing Personality traits like Reckless, Lustful, and Impulsive for the rest of the scene.
+
+**Vis:** 1 pawn Animal, goat horn
+
+**Appearance:** Fauns are rugged, wild men with two sharp horns and goat's legs and hooves. They have the ears and tails of horses. They are very hairy, their whole bodies covered in short, dark fur, and they often sport scraggly beards. They are also a little larger than normal men. In spite of all this, they are still very attractive in a wild, virile way, for they embody pure masculinity in everything they do.
+
+Fauns represent the freedom granted by the secrecy that the forest provides. Fauns are braver than satyrs, described later, and represent what people can get away with in the woods, while satyrs represent what petty people wish they could get away with. Both are dangerous, particularly to women, but satyrs more so when in groups.
+
+##### Faun Variants
+
+**Satyrs:** A variant that is distinct enough that its statistics have been included separately, following this section.
+
+**Glastig:** The glastig, also known as the Green Maiden, is a Scottish faerie that appears to be a very attractive, blonde woman. She wears a green dress to conceal her goat limbs, although she can shift into an entirely human, or completely caprican form. Some glastig simply lead travelers astray, while others seduce, murder, and drain the blood from their victims. Some act as household spirits, and others as announcers of death, like banshees.
+
+**Iopontes:** Like fauns and satyrs, but they have the lower parts of horses.
+
+**Panes:** Satyrs with goat legs and tails.
+
+**Satyriskoi:** Child-satyrs.
+
+**Seilenoi:** Aged satyrs — satyrs who have maintained their role since ancient times and are treated as fathers by modern satyrs. They often have ox horns, and fluffy, white fur. Many seilenoi refuse to relinquish their role, because they are highly cognizant. They know that fauns represent whatever humans do not feel is moral: the lusts they must hide in the woods. Current humans are far more repressed than the humans of ancient times, and so modern satyrs have a narrower set of vices. Elderly satyrs have no desire to find so many of their darker passions forbidden them.
+
+**Tityroi:** Those satyrs that play magical shepherd's pipes. In some areas all fauns and satyrs play pipes, in others only a special caste of these creatures do.
+
+##### Satyrs
+
+Satyrs are weaker than fauns, so they require less modification to suit beginning player characters. A new satyr character requires a Social Interaction Virtue or Flaw, and additional Flaws to balance its Virtues. The Pretense points given below are correct for a starting character. The player may wish to make his or her satyr less timid than usual.
+
+**Faerie Might:** 5
+
+**Characteristics:** Int 0, Per 0, Pre +2, Com +2, Str 0, Sta +1, Dex 0, Qik +4
+
+**Size:** –1
+
+**Personality Traits:** Proud +3, Lusty +2, Brave –2\*
+
+\* Satyrs are less timid when in groups, or by driven by their compulsions.
+
+**Virtues and Flaws:** Great Characteristic, Greater Faerie Powers; Faerie Sight, Faerie Speech, 2 x Improved Characteristics, Hybrid Form, Observant; Lecherous (major) or Greedy (wine – major), Aloof, Incognizant, Small Frame, Traditional Ward (folk charms), Weakness (music or sex or wine).
+
+**Combat:**
+
+*Kick (brawl):* Init +4, Attack +6, Defense +6, Damage +2
+
+*Horns:* Init +5, Attack +3, Defense –1, Damage +2
+
+*Spear (thrown):* Init +4, Attack +7, Defense +9, Damage +5
+
+**Soak:** +4
+
+**Wound Penalties**: –1 (1-4), –3 (5-8), –5 (9- 12), Incapacitated (13-16), Dead (17+)
+
+**Abilities:** Athletics 2 (dancing), Awareness 2 (humans), Brawl 1 (escaping), Carouse 6 (party games), Charm 2 (taking liberties), Guile 2 (women), Local Language 3, Music 3 (flute), Thrown Weapon 5 (spear)
+
+**Powers:**
+
+*Enthralling Sound:* 0 point, Init +2, Mentem: (3 intricacy points spent on cost, 1 on Initiative) Satyr dancing music makes listeners more riotous and merry, increasing Personality traits like Reckless, Lustful, and Impulsive for the rest of the scene.
+
+**Vis:** 1 pawn in a phallic-looking reed
+
+**Appearance:** Satyrs have human bodies, including the legs, but have but have the ears of donkeys and the tails of horses.
+
+Satyrs embody the cowardice of the common man, in heroic stories. They appear in many Greek plays, and their role is to promise to support the hero, and offer to do great deeds, but to fail because they are stupid and cowardly. This re-enforces the belief that heroes are a separate and better class of human, which was important to Greek audiences. Satyrs are similar to fauns, and most Mythic Europeans use the word interchangeably for what this chapter calls a faun, but satyrs are far smaller, and their machismo is mere bravado. Both fauns and satyrs are notorious for sexual violence, but satyrs tend to be violent more often, and also attack children more frequently.
+
+#### Mountains
+
+Mountains are borders, in the most emphatic sense. They are land that can be seen, but never touched. They are the border of every surrounding culture, because with few exceptions there is no point in settling above the snowline of the mountain. Faeries dwell on, and in, the mountains. They are also active in mountain passes, where travelers on a road transgress the border that the mountain range embodies.
+
+#### Snows
+
+Many cultures in Northern Europe tell stories of the creatures that dwell in the desolate, snowbound lands of the North.
+
+##### Koerakoonlane
+
+Koerakoonlased are suited for play as companions. Characters divided vertically should take the Missing Eye Flaw, and depend less on missile weapons than dog-headed (cynocephalus) koerakoonlased. The statistics given below have unbalanced Virtues and Flaws, but the Pretenses are correct for beginning characters.
+
+### Faerie Might: 5
+
+### Characteristics:
+
+*Vertically Divided:* Int 0, Per +1, Pre –3, Com 0, Str +2, Sta +3, Dex 0, Qik +2
+
+*Cynocephalus:* Int 0, Per +2, Pre –2, Com 0, Str 0, Sta +3, Dex +1, Qik 0
+
+**Size:** 0, varies within human range.
+
+**Virtues and Flaws:** Faerie Sight, Faerie Speech, Observant; Hybrid Form, Incognizant.
+
+**Personality Traits:** Brave +2, Cruel +2
+
+**Combat:**
+
+For the leader of a raiding party, add +3 to all Attack and Defense bonuses to represent superior Pretenses.
+
+*Vertically Divided*
+
+*Bite:* Init +2, Attack +6, Defense +6, Damage +3
+
+*Club:* Init +3, Attack +7, Defense +8, Damage +5
+
+*Javelin:* Init +2, Attack +7\*, Defense +7, Damage +7
+
+\* Missing eye not included
+
+*Cynocephalus*
+
+*Bite:* Init 0, Attack +7, Defense +4, Damage +1
+
+*Club:* Init +1, Attack +8, Defense +6, Damage +3
+
+*Javelin:* Init 0, Attack +8, Defense +5, Damage +5
+
+**Soak:** +6
+
+**Wound Penalties**: –1 (1–5), –3 (6–10), –5 (11–15), Incapacitated (16–20), Dead (21+)
+
+**Pretenses:** Animal Handling 3 (dogs), Awareness 2 (slaves), Brawl 2 (bite), Carouse 1 (on spoils of raid), Faerie Speech 4 (making demands), Hunt 3 (humans), Ride 5 (sled), Single Weapon 4 (club), Survival 3 (icy conditions), Thrown Weapon 4 (javelin),
+
+**Equipment:** Sled, team of dogs, furs, club, javelins. These faeries eat, although they do not die of starvation, and carry rations made by, or from, humans.
+
+**Vis:** 1 pawn, the frozen corpse of a dog.
+
+**Appearance:** A hybrid of both dog and human features.
+
+The koerakoonlased are faeries of the frozen north, who sweep out of the storms into isolated human settlements to take prisoners. They march their captives north to their distant home, where the humans serve as slaves and as cattle. Individuals sometimes attack isolated farms, but raiding parties, usually made of up 12 koerakoonlased, more frequently attack settlements cut off from outside aid. Migrations involving clans with 40 warriors and their dependents have been reported.
+
+A koerakoonlane warrior usually fights with a club and javelins, and wears thick furs that provide limited protection. Most do not use shields. Many ride in sleds pulled by five dogs. When engaging in combat they may swiftly unharness their teams to allow them to attack a foe. This tactic is, however, rare. The warriors prefer to pursue and kill their own prey, and only unleash their dogs if they face skilled opposition, or if they need their dogs to chase down fleeing potential slaves.
+
+More-powerful koerakoonlased have been observed. Some act as war leaders, and these have the *Spreading a Mantle of Snow* Power. Unnatural snow is often the first warning that a raid is imminent. It allows the faeries to prepare the ground for their sleds, which they use as mounts for warfare, and to carry away booty. Others are able to apply the *Kiss of Frost* power with their whips. This allows the slaves of the koerakoonlased to survive their march into the northern wastes.
+
+##### Koerakoonlane Variants
+
+Variations of the koerakoonlane are reported in Baltic countries. In some areas they have human bodies down one side, and dog bodies down the other, with a single eye in the middle of their heads. In others they are human from the neck down, with dog heads. Hermetic magi who study faeries would be interested in how this drift in their appearance occurred, if they were less dangerous to approach.
+
+>## Saga Seed: Escape, Then Fortify
+> 
+> Before the koerakoonlased mount a major invasion of the warm lands, they make additional raids, then concentrate their slaves into work camps. A campaign might start with the non-magi trapped in such a camp, and detail their escape to the south. When the Order discovers that an invasion of the tribunal is imminent, they send a force of magi, again player characters, to respond. The characters build a covenant slightly south of the koerakoonlased, tasked with sending warning south if the faeries mass in force again, and holding their castle against koerakoonlased besiegers, as a mustering space for the tribunal's forces.
+
+**Hemicynes:** These peaceful, dogheaded people are said to come from the far north. They appear in western European folklore. They may be magical creatures of which the koerakoonlased are faerie variants, or the converse.
+
+**Naval Koerakoonlased:** The hero Kalevipoeg tried to sail to the Underworld, and discovered an island filled with koerakoonlased, but these creatures were peaceful farmers and did not have human slaves. After Kalevipoeg destroyed their crops they became fishers, but no naval attacks by koerakoonlased have been reported.
+
+### The Entrances to the Earth
+
+Mythic Europeans have a mixed relationship with caves. They are useful, for shelter and for storage of goods, but they are also dangerous places, on the verge of a different world. In parts of Italy, people use caves to store wine and cheese, and when they are ready, the grotto becomes a tavern. In Roman times, many of these taverns were guarded by statues of Cerberus, the guardian of the gate of Hades. Caves are like tombs: revels within them may lead to contact with creatures that guard the border of the deep earth, or the land of the dead.
+
+##### Dwarfs, Gnomes, & Goblins
+
+Dwarfs make excellent player characters, but require slight adjustment before they can be used. The player must choose which powers the dwarf has, and pay for them with Virtues. Many regional variants of dwarfs do not have Immunity to Terram, and instead have narrower immunities. They also have different Crafts. The dwarf requires a Social Interaction Virtue or Flaw, and they then require Flaws to balance the Virtues.
+
+**Faerie Might:** 5 (Terram)
+
+**Characteristics:**
+
+*For Size –2:* Int 0, Per +2, Pre –3, Com –2, Str –1, Sta +3, Dex +2, Qik +4
+
+*For Size –3:* Int 0, Per +2, Pre –3, Com –2, Str –3, Sta +3, Dex +2, Qik +5
+
+*For Size –4:* Int 0, Per +2, Pre –3, Com –2, Str –5, Sta +3, Dex +2, Qik +6
+
+*For Size –5:* Int 0, Per +2, Pre –3, Com –2, Str –7, Sta +3, Dex +2, Qik +7
+
+**Virtues and Flaws:** Immunity from Terram, 2 x Great Characteristic; Faerie Sight, Faerie Speech, Humanoid Faerie, 2 x Improved Characteristic, Observant; Little (once or twice), Traditional Ward (offerings)
+
+**Personality Traits:** Vengeful +3
+
+**Combat:**
+
+For every Size less than –2, subtract –2 Damage and add +1 Initiative and Defense.
+
+*Brawl (fist):* Init +4, Attack +9, Defense +11, Damage +3\*
+
+*Pick/Tool (two handed):* Init +7, Attack +8, Defense +11, Damage +11\*
+
+\* Includes +1 for pretense specialization
+
+**Soak:** +6, Immunity from Terram
+
+**Wound Penalties:**
+
+*For Size –2:* –1 (1-3), –3 (4-6), –5 (7-9), Incapacitated (10–12), Dead (13+)
+
+*For Size –3:* –1 (1-2), –3 (3-4), –5 (5-6), Incapacitated (7-8), Dead (9+)
+
+*For Size –4:* –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+)
+
+*For Size –5:* –3 (1), –5 (2), Incapacitated (3), Dead (4+)
+
+**Pretenses**: Athletics 2 (digging), Awareness 2 (hazards underground), Bargain 5 (with mortals), Brawl 6 (fist), Craft (smith) 5 (weapons), Great Weapon 5 (pick, as pole arm)
+
+**Powers:** Many cause rock falls, but this may be through physically damaging the mine's supports, rather than with a power. Some faeries seem to have the power to make people tiny, so that they can enter the faeries' miniature subterranean kingdoms.
+
+**Equipment:** Professional gear
+
+**Vis:** 1 pawn, in main tool or body residue.
+
+**Appearance:** In many areas, dwarfs are small bearded men. Dwarfish women may be hideous or beautiful, by region.
+
+Dwarfs, gnomes, and goblins are subterranean versions of the small faeries described in other sections of this chapter. In many countries, the equivalent of a brownie is merely an antisocial dwarf who lives alone in a human homestead. The dwarfs in this section are those that live in communities that guard the entrances to the earth. They are found in caves, barrows (ancient tombs), and in mines. They also dwell in Arcadia. There are many legends of the gnomes, but they all seem to center on two facts: they are cunning smiths, and they have access to the treasures of the Earth.
+
+Dwarfs, like most faeries, lack the capacity to innovate. They can, however, make excellent versions of currently known things, remake items so that they appear magical, and create objects that express the inner natures of their owners. They are able to grant the External Vis Virtue to other faeries.
+
+The little folk known in many tales as having a pot of gold that they must surrender if caught are a type of dwarf. In Mythic Europe these creatures tend to dress in red, and sometimes have the habit of sending dreams that are addictive. They make their victim dig for treasure at a certain spot until they lose their profession, then their health, then their life. Some gnomes live just beneath the Earth, and are able to affect the fertility of plants, through their roots, leading to conventional affluence.
+
+>## Story Seed: Searching For Sanctuary
+> 
+> An itinerant tailor related to one of the grogs has sought out the covenant because he feels safe within its walls. One night while drinking with faeries, he became afraid he would be trapped forever, so he placed one of his needles in the goblet of the minor goblin king he was toasting with. The faerie swallowed his needle, which wedged in his throat and choked him, so that the tailor could flee. Since that time, whenever the tailor touches a thread it breaks, a curse that is alleviated while within the covenant. The tailor would like his needle back, and the Arcane Connection between the tailor and the part of his life wedged in the goblin's throat can guide the characters to the site where the court of mining faeries dwells.
+
+### Dwarf, Gnome, & Goblin Variants
+
+Dwarfs are found in the Germanic and Norse spheres of Mythic Europe. Other known variations include the following.
+
+**Barbegazi:** These are dwarfs of the snows. They are found in burrows on the mountaintops in many areas. They are all male, and have beards of icicles and broad feet that they can use to slide across the snow. Their cries can cause avalanches. They are well-disposed toward humans who meet their standards of goodness and politeness, but often murder people they think are "bad" by crushing them to death.
+
+>## Story Seed: The Covenant's Reputation
+> 
+> A covenant that develops an evil reputation in surrounding areas eventually attracts faeries who represent that evil. Evil is often framed, in medieval storytelling, in terms of the Infernal, so faeries that have the distinctive folklorisitic marks of demons may begin to interact with all of the communities that surround the covenant, raising the ire of the Church and the Quaesitores. Characters cannot fight these demons in the conventional way: there are always new faeries to fill vacant roles in a popular story. The characters need to find symbolic acts that change the perception of the covenant in the minds of surrounding people.
+
+**Dvergar**: These Norse dwarves were originally maggots in the corpse of the giant Ymir, from whom the world was made. The Norse gods chose to give them intelligence and their human shape. They flee sunlight, which can reduce them to stone. They were the crafters of many of the treasures and weapons of the gods, and were powerful workers of magic. The curse of a dwarf on the Rhine gold is a major contributor to Ragnarok, and the son of the dwarf king, Fafnir, is able to turn himself into a dragon to express his greed for the treasure he has obtained.
+
+**Gnome**: This term is not used in Mythic Europe, except perhaps for earth elementals by some magi. Creatures who resemble gnomes, even down to the pointy red hat, are known, but have a variety of names in local languages.
+
+**Karzełek**: These creatures are Polish dwarfs with green grass for hair, who ride their diminutive horses over field hands who go to sleep when they should be working. This is often fatal. Karzeleks are not consistently nasty — they aid those who farm dedicatedly — but they are extremely violent in response to relatively minor infractions like going to the toilet in a field, or swearing while harvesting.
+
+**Knockers:** These are Cornish spirits, who are said to warn miners of coming collapses by knocking. Knockers are thought by many to be the souls of dead Jewish miners. Although this is not true, the faeries who perform this role play along with the expectations of humans they encounter.
+
+**Kobolds:** Thse German mine faeries lace mines with arsenical ore, and cause other minor trouble. Some are helpful, as the whim takes them.
+
+## The Borders of Supernatural Spaces
+
+Some faeries guard the border of supernatural spaces, feeding on the fear that humans fear toward the uncanny. Faerie monsters are also common at the edge of Infernal, Magical, and Divine areas.
+
+**Fauns:** Faeries that prowl the borders of Infernal spaces often include twisted fauns. These fauns look very similar to demons, and are virtually indistinguishable to most medieval people.
+
+> # Story Seed: A Monstrous Protector
+> 
+> In a lake in Switzerland that has a gateway to hell at its base, there is a faerie that pretends to be a demon. Butatschah-iglis is a vast amorphous sack, like a stomach, coated in clusters of eyes that emit beams of fire. It lives by consuming the fish of the lake, and any fishermen foolish enough to come close to the gate.
+> 
+> This faerie is like a nursery bogie, but for adult fishermen instead of children. Its story, which explains the lack of fish in the lake through the presence of the monster, hides the existence of the gateway to Hell, while keeping people safely away from the danger.
+> 
+> But the characters discover a clue in the diaries of the Founder Jerbiton, that indicates that there is no Infernal gateway in the lake. This too is merely a story, circulated to the more-educated members of the community with an injunction not to panic the common folk with the truth. The lake was created during the years of disorder after the fall of the Western Empire. It is the result of a magical battle that left a great hollow gouged from the Earth. Jerbiton's diaries do not describe the magical stronghold that lay there in any detail, and give no account for the real reason that the lake never contains fish, but it does mention that something terrible may be living in the depths: something even more terrible than its guardian faerie.
+
+## Oft-Repeated Forms
+
+The following physical forms have been gathered together here because they are used in many stories, to guard a variety of borders.
+
+#### Giants and Other Gigantic Humans
+
+These generic statistics suit player character giants, but require the addition of a Social Interaction Virtue or Flaw, and then the balancing of the selected Virtues with Flaws. The player may wish to reduce the giant's Stamina and redistribute the Characteristic points spent on it, but this alters the giant's combat statistics and Soak. Similarly, the player may wish to reduce the giant's combat Pretenses to spare experience for purchasing social skills like Bargain and Charm.
+
+**Faerie Might:** 5+10 or 10 (Corpus) or more
+
+**Characteristics:** Int 0, Per 0, Pre 0, Com 0, Str 0\*, Sta +3, Dex +1, Qik 0\*
+
+\* For every +1 Size, +2 Strength and –1 Quickness.
+
+**Size:** Varies from +3 to +10. Although larger giants exist, they are not well-represented by the Ars Magica combat system.
+
+**Virtues and Flaws:** Huge (at least twice), Faerie Sight, Faerie Speech, Human Form, Increased Might (for a raider) or Place of Power (for a giant the characters seek out in its lair); Incognizant
+
+**Personality Traits:** Destructive +3
+
+**Combat:**\
+
+*Size 3 (10 to 13 feet tall)*
+
+*Brawl (fist):* Init –3, Attack +7, Defense +3, Damage +6
+
+*Club:* Init –2, Attack +10, Defense +5, Damage +9
+
+*Thrown Rocks:* Init –3, Attack +6, Defense +1, Damage +8
+
+\* Includes +1 for Pretense specialization in particular weapon. If using an alternative weapon, Attack and Defense fall by 1.
+
+For every additional Size: –1 Initiative, –1 Defense, +2 Damage. Giants larger than Size +3 tend to kick human sized targets instead of punching them.
+
+Examples include:
+
+*Size 5 (17 to 20 feet tall)*
+
+*Brawl (kick):* Init –6, Attack +7, Defense 0, Damage +13
+
+*Club:* Init –4, Attack +10, Defense +3, Damage +13
+
+*Thrown Rocks:* Init –5, Attack +6, Defense –1, Damage +12
+
+*Size 7 (28-37 feet tall)*
+
+*Brawl (kick):* Init –8, Attack +7, Defense –2, Damage +17
+
+*Club:* Init –6, Attack +10, Defense +1, Damage +17
+
+*Thrown Rocks:* Init –6, Attack +6, Defense –3, Damage +16
+
+**Soak:** +3\*
+
+\* Thick leather clothing provides this protection. A handful of giants have roles that allow them to manifest human-style armor from their glamour. This is a tremendous advantage, because glamorous armor has no Load rating. The giant can have metal armor far thicker than humans wear, without weight penalties.
+
+**Wound Penalties**
+
+*Size +3:* –1 (1-8), –3 (7-16), –5 (8-24), Incapacitated (25-32), Dead (33+)
+
+*Size +5:* –1 (1-10), –3 (11-20), –5 (21-30), Incapacitated (31–40), Dead (41+)
+
+*Size +7:* –1 (1-12), –3 (13-24), –5 (25-36), Incapacitated (37-48), Dead (49+)
+
+**Abilities:** Awareness 3 (small moving things), Brawl 5 (fist for Size +2 or +3, kick for larger)\*, Carouse 2 (drinking), Faerie Speech 5, Folk Ken 3 (threats), Single Weapon 6 (club)\*, Thrown Weapon 3 (rocks)\*.
+
+**Vis:** 1/5th Might in human bones, Corpus
+
+**Appearance:** Huge men, usually uncivilized and bestial looking. There are female giants, but they tend to be beautiful and smaller than the males.
+
+Huge humans — giants, ogres, trolls, and many others going by less-modern names — are a typical guard for any space in faerie stories. All of these huge humanoids use the statistics here, but are differentiated with powers and through superficial appearance.
+
+Faerie giants differ from Magical giants in several ways. Faerie giants are drawn to humans, despite the known danger from magi. They tend to cause terror and pain, so that they can harvest vitality. This makes them far more destructive than their Magical counterparts. Faerie giants also tend to recur: they regenerate unless their vis is used, so they plague regions periodically. Faerie giants often have daughters who are beautiful and human-sized, since this facilitates their role as love interest for heroes who come to slay the giant.
+
+#### Giant Variants
+
+These variations might be appropriate for your game.
+
+**Cliff Ogres:** These large faeries haunt roads that run along cliff tops. The ogres attack travelers, throwing them onto the rocks below, where the ogres' disgusting children squeal for human flesh.
+
+**Dev:** The Dev are Armenian giants with up to seven heads, each with a single eye. Some can change shape into dragons or other monsters.
+
+**Gello:** This is an ogress from Italy, whose breasts drain the blood of children. She has been Vulnerable to the Divine since the early years of the Church, when three missionaries, in one version of the story, forced her to return blood to a child she had drained, by miraculously throwing up the milk they had received as babies. Similar child-eating ogresses are found throughout Europe. A German version, for example, is called "Kinderschrecker" ("child guzzler"). It does not have exsanguinating breasts.
+
+**Guardian of the Fishes:** A huge, humanshaped faerie from the Baltic Sea. It is covered in scales and with the fins, gills, and eyes of a fish. It has a serrated ridge down his spine and is able to walk on its rear fins, although it rarely leaves the water.
+
+**Jack's Beanstalk Giant:** This giant is a bit of a ham — he seems to be entirely aware that a boy who wants to kill him is present, and does silly things to allow the boy to become famous. The giant does not, for example, just rain castle bricks down from the clouds, to crush the boy and his home. He has been known to drop golden eggs from the sky onto people who intend to interfere with "his" boy. The beanstalk giant is assisted by his wife, who is able to take the form of a witch, and gives simpleton boys magic beans. Jack's giant is the most anachronistic of the faeries in this supplement. The most similar to him, in the medieval period, is Red Ettin.
+
+**Red Ettin:** A three-headed giant that took the princess of Scotland prisoner. He has the power to turn people into stone, and can sense the presence of humans by smell. He announces their presence with a little rhyme, much as Jack's Giant does, although he lacks the power to determine nationality by smell. A person who can answer his riddles has completed Red Ettin's Sovereign Ward, and can kill him without risk.
+
+**Troll:** This is a difficult term, with three divergent meanings. In historical Europe it does not appear until 1276, and then means a barrow-faerie that serves as an ancestral spirit. In the north of Scandinavia, a troll is a shaggy giant that is usually solitary. They are often turned to stone by sunlight, and are unable to face the Dominion. In Southern Scandinavia, a troll is a small faerie that is usually social. The name occurs wherever the Norse settled, so there are trows in Orkney, for example, that are little mound dwellers that dance under the stars on significant nights and steal away musicians.
+
+**Muilearteach:** A sea giantess who comes ashore during storms in the shape of a hag, knocking on doors and begging piteously for shelter. If offered sanctuary, she swells to her full size and eats her benefactors. The border this faerie guards is an odd one that modern players may not recognize — among other things, she represents the moral imperative of never giving charity to outsiders when it could be given to family. This giantess can cure injuries with a pot of magic ointment, and is believed to be able to bring back the recently dead.
+
+**Multiheaded Giants:** These are found in many areas of Mythic Europe. They are either easily confused, because each head has its own personality, or incredibly cunning.
+
+**Vörys-mort:** An unusual giant, who breaks the general rule that as giants get larger, they become slower. Vörys-mort is so tall that he can look over the forest. He moves so swiftly that if he runs, humans and animals he passes are picked up and carried along in the slipstream of air he creates. He sometimes assists hunters in the Volga by driving animals toward their traps.
+
+#### Giants in Combat
+
+The combat rules are oriented toward characters of human size. Special considerations apply to combat between humans and giants. As noted on page 192 of **ArM5**, a three-point difference in size is approximately a tenfold difference in mass. This weight advantage also gives giants an advantage in certain combat situations.
+
+The storyguide can simply rule that attempting to punch, grapple, or disarm a giant is completely ineffective. For a morecomplicated approach, grant the giant a special defensive bonus equal to double the difference between its Size and a smaller opponent's. This can be applied to Defense rolls against scuffling, grappling, and being disarmed. This bonus does not apply against attacks with melee or missile weapons.
+
+Giants of Size +4 or larger must bend over double in order to reach a Size 0 human with their hands. In such situations, giants usually prefer to kick, or use weapons.
+
+Giants are subject to Corpus spells, but the base Individual Target for Corpus is a person of Size +1 or less. Most Corpus spells are not designed to affect anything as big as a giant.
+
+#### Orms and Other Dragons
+
+**Faerie Might:** *Size 0:* 20 (Animal). For every +2 Size, add 5 Might. For every –2 Size, subtract 5 Might
+
+**Characteristics:**
+
+*Size 0*: Int\* 0, Per –2, Pre –6, Com –6, Str +1\*\*, Sta +2, Dex +2, Qik 0\*\*
+
+- \* Non-player character orms are often Cunning rather than Intelligent.
+- \*\* For every +1 Size, add +2 Strength and subtract –1 Quickness. For every –1 in Size, subtract –2 Strength and add +1 Quickness.
+
+**Size**: –4 to Size +6
+
+**Virtues and Flaws**: Huge or Little (as suits size), Faerie Beast; Faerie Sight, Faerie Speech\*, Highly Cognizant\*, Increased Characteristics, 3 x Increased Might (adjusted with size increase or decrease), Personal Faerie Power (Constant Damaging Effect)
+
+\* If Intelligent. Cunning orms are Incognizant and lack Faerie Speech.
+
+**Personality Traits**: Inquisitive +3, Hungry +2
+
+**Combat:**\*
+
+Damage statistics above do not include the Constant Damaging Effect power, which adds +5 when appropriate.
+
+*Size 0*
+
+*Fangs*: Init (0–Size), Attack +14, Defense (+5–Size)\*, Damage (2 x Size)+2
+
+*Constriction*: Init 0, Attack +9, Defense +5\*, Damage +8
+
+*Claws* (if appropriate): Init –1, Attack +11, Defense +10, Damage +3
+
+- \* +6 to Defense against grapple attacks
+- \*\* An orm may grapple its own Size in Size 0 enemies.
+
+**Soak**: 6+Size
+
+**Wound Penalties:**
+
+*Size –4:* –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+)
+
+*Size –2:* –1 (1-3), –3 (4-6), –5 (7-9), Incapacitated (10–12), Dead (13+)
+
+*Size 0:* –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20), Dead (21+)
+
+*Size +2:* –1 (1-7), –3 (8-14), –5 (15-21), Incapacitated (22-28), Dead (29+)
+
+*Size +4:* –1 (1-9), –3 (10-18), –5 (19-27), Incapacitated (28–36), Dead (37+)
+
+*Size +6:* –1 (1-11), –3 (12-22), –5 (23-33), Incapacitated (34-44), Dead (45+)
+
+*Size +8:* –1 (1-13), –3 (14-26), –5 (27-39), Incapacitated (37-52) Dead (53+)
+
+**Powers:**
+
+*Constrict:\** When successfully struck with a constrict attack, the character is encoiled and unable to use mêlée weapons. The orm automatically does damage in each subsequent round, without requiring an Attack roll. The victim may still Soak damage. At the end of each round, including the round in which the constriction attack succeeds, the character may attempt to break free by an opposed Strength roll. To do this, he rolls Strength + a stress die, and compares it to the orm's Strength + a stress die. Success indicates he is free, and may attack normally in the following round. For each character assisting him to break free, he may add +1 to the Strength roll, but an assistant is unable to attack the orm in that round. A character unable to break free for 30 seconds (6 combat rounds) needs to make deprivation rolls, as described on page 179 of **ArM5**.
+
+*Constant Damaging Effect,* 3 points, constant, Auram: Many orms emit a noxious slime or have toxic breath, and poison their surroundings, but many other damaging effects are known. This effect does +5 Damage, but is always active. 25 spell levels (Base 5 +1 Part, +2 Sun, +1 Constant)
+
+*Venomous Bite:\** When the orm attacks, compare its Attack Advantage to the victim's armor Protection (not his Soak). If the orm's advantage is higher, the victim suffers the effects of adder venom as listed in the Poison Table on page 180 of **ArM5**, regardless of whether the bite inflicts an actual wound. The storyguide may adjust the required Attack Advantage for special circumstances.
+
+\* These are natural abilities of the faerie's form, and do not require the Personal Faerie Powers Virtue.
+
+Gwibers and other flying orms also have a Personal Faerie Power: *Flight,* 0 points, Init Qik+3, Auram\*
+
+**Pretenses**: Area Lore 3 (watering points for prey), Awareness 3 (prey), Brawl 7 (crushing), Hunt 4 (rodents), Faerie Speech 5 (threats), Folk Ken 1 (human prey), Stealth 3 (stalking prey)
+
+**Equipment: None**
+
+**Vis:** Might/5 pawns, in a snakeskin or a piece of lost string
+
+**Appearance**: Orms are vast snakes, normally smeared in toxic mucus.
+
+Most of the dragons of Mythic Europe are Magical or Infernal creatures, but one class of dragons, termed orms, are predominantly faeries. Orms, which means "worms," are usually faeries that take the role in the expectation that they will be destroyed.
+
+Orms can be distinguished from quite similar Magical dragons through their desire to eat vital things. Orms usually love cows' milk, and some demand that peasants leave out great pails of it in tribute, much as brownies expect a dish of milk. Others simply suckle directly from cows. Some orms eat only virgins. Some orms drain the vitality out of their surroundings so severely that they seem to be poisoning the landscape. Many take residence around wells or springs.
+
+##### Dragon Variants
+
+Some other variations for your game might include the following.
+
+**Alklha:** A Siberian dragon so large that its wings can block out the sun. It is a faerie that feeds on terror, and it does this by seeming to swallow the Sun. The gods, or perhaps shamans, of the area became sick of fighting it off, and so they sliced Alkhla in half at the base of its stomach, across the belly behind the wings. Alklha is a faerie, so this didn't kill it, but the shamans hid the lower body under a ward, so that it could not regenerate. Alkhla looks like the front half of an enormous dragon, and fights with claws and teeth, but cannot constrict and does not swallow creatures. Alklha has displayed another striking power when fighting magi: he can dispel Sun duration effects by licking them (Penetration +45).
+
+**Gwiber:** Most noted in Wales, this is an odd sort of dragon. It begins as an orm, and craves milk as all orm do. If an orm manages to drink even the tiniest amount of human breast milk, however, it grows leathery wings and becomes a gwiber. Some gwibers are poisonous. Magi report creatures similar to gwibers in Egypt, rivals to the ibis sacred to Thoth who was Hermes. This makes magi suspicious, even superstitious, about gwibers.
+
+**Horse-Headed Serpents:** In many parts of Mythic Europe, great serpents with the heads or forequarters of horses have been described. These serpents often have red or yellow eyes, and have fangs. Few leave the water.
+
+**Kalshedra:** An Albanian dragon that has the ability to breathe fire, and take the shape of a hag. It pollutes water with its urine, and causes drought. It accepts human sacrifices as payments to trouble some other town. It is a faerie that feeds directly on human vitality.
+
+**Pisuhänd**: A type of small dragon found on the Baltic coast that acts like a brownie.
+
+**Tatzelwurm:** An Alpine type of dragon, ranging in length from two feet to six feet. The tatzelwurm has a catlike head with large eyes. It has the body of a lizard, but lacks hind legs. It can breathe clouds of toxic vapour. One variant, the tunnel worm (Stollenwurm) is far longer and fights by raising itself on hind legs and attacking with its foreclaws. It towers over human-sized opponents. The scales of the Stollenwurm are bristly and venous.
+
+**Vishap:** This dragon, which resides on the top of Mount Ararat, must regularly fight human warriors. It keeps to itself and is not particularly destructive, but its blood is so poisonous that a weapon that has injured Vishap can strike any other creature dead with a single scratch. He is a Mastery Faerie.
+
+**Vouivre:** The Vouivre has the hindparts of a two-legged green dragon and the foreparts of a woman. Some vouivres have arms, while others lack them. The Alpine version of this creature can spit flame. Each vouivre has a single eye, which is a huge gemstone on the centre of her forehead. This is usually a diamond, but French vouivres often have rubies instead. Even hedge wizards know how significant this stone is — many believe it can turn iron into gold — and attempt to steal it while the Vouivre sleeps. Each also guards a horde of mundane treasure, a portion of which it is possible to steal when she leaves her cave, once a year, to bathe. While bathing, some vouivres remove and hide their eyes, making this a perfect opportunity for thieves to either raid the hoard or, more dangerously, seek the eye. The treasure of the French version of this creature includes gigantic gold pieces, a pearl crown that she wears, and a ring of gold about her tail.
+
+>## Story Seed: The Mother of Vis Sources
+> 
+> Serpents with gemstones in their faces, that lack the transformation power of the vouivre's eye, are found in the forest of Luchon, at the foot of the Pyrenees in France. Characters harvesting the vis from these serpents do not realise that they are the children of a vouivre. When she bathes, one of her surviving children informs her that they have been decimated by magicians, and she seeks vengeance. This calls all of the hedge wizards of the area together, because they want to take advantage of the vouivre's distraction by attempting to open the doors of her subterranean lair and take the treasures there. Terrible questions, after this dispute is settled, remain. Will any remaining serpents grow into vouivres? And what manner of creature was their father?
+
+**Wivere**: An odd French dragon, whose name unhelpfully means "serpent," which lacks wings and legs. It is notable because its Sovereign Ward is that it cannot harm naked people.
+
+# Chapter Five : Touches of Faerie
+
+This chapter details a number of ways in which characters can be affected by the power of the Faerie realm. Those humans who have an intense experience with Faerie are often left changed, and manifest Virtues and Flaws in ways different than other mortals. And some characters acquire special sympathy with the Faerie realm that allows them to perform different types of Faerie hedge magic.
+
+The most obvious expression of a touch of glamour in a mortal's life, though, is the Faerie Blood Virtue, and more information on this versatile Virtue is given here. Children who have been replaced with a changeling may similarly inherit fay qualities from their time with the Good Neighbors; these qualities may develop in a manner similar to Faerie Blood, but can also manifest in different ways, as well.
+
+Many characters in Mythic Europe have an interest in Faerie without actually being associated with the Faerie realm. They may be aligned with another realm, like magi, or perhaps they are unaffiliated with any realm at all. This chapter also includes a few ways that characters who are not especially faerie-oriented can still harness the power of the fae.
+
+Finally, the ways in which characters exposed to faerie powers tend to suffer Warping is discussed.
+
+## Sympathy
+
+When faeries seek out and draw vitality from humans, they often leave behind a supernatural connection to the things that the faerie represents. This is called **sympathy**. Concentrated sympathy is powerful, and allows characters to perform many different types of Faerie hedge wizardry. Any character who desires to harness this power of the Faerie realm can explore it through the use of Sympathy Traits and sympathetic influence.
+
+Sympathy represents a mystic relationship with a type of subject through the Faerie realm. It is not an Arcane Connection, and does not associate the character with any particular faerie. Faeries do not bring about sympathy in people on purpose; it is doubtful that most of them are even aware it exists. Like Personality Traits, sympathy is simply something about the character that particularly resonates with appropriate subjects, and is especially suited to faerie manipulation and powers.
+
+### Sympathy Traits
+
+When a character becomes sufficiently charged with faerie sympathy, usually from a Virtue or Faerie Warping, he receives a special sort of Trait called a Sympathy Trait. This describes the character's relationship to a particular class of subjects — usually a subset of one of the ten Hermetic Forms that also describe Faerie Might (Animal, Aquam, Auram, and so on). It cannot apply to an entire Form, or even the majority of targets associated with a Form. It might be circumstantial, similar to the Special Circumstances Virtue, or cover a variety of concepts like a Minor Magical Focus (see **ArM5**, page 46, for examples). Most Traits have a value of +1 to +3, and it is very rare for the value of a Trait to exceed +6. A score of +10 is exceptional, indicating a character who resonates so strongly with the power of the Faerie realm that she has nearly become a faerie herself.
+
+Sympathy Traits can affect non-Supernatural Abilities. When performing an action using an Ability to which the character's Sympathy Trait applies, you may add the value of the Sympathy Trait to the Ability instead of the +1 bonus for an applicable specialization. For example, a faerie huntsman with Animal Handling 3 and Hounds +3 could treat his Sympathy Trait as a specialization of Animal Handling, making his Animal Handling score a 6 whenever he sends out his dogs. This may be done at any time, but it always requires that the player rolls a stress die, rather than a simple die, and any botches on the roll will give the character Warping Points.
+
+Sympathy Traits are not cumulative when used as specializations to boost non-Supernatural Abilities, and only the score of the highest applicable Trait should be used to determine the effective bonus. For example, if a character has an Ice +2 Sympathy Trait and a Storms +1 Sympathy Trait, the most he could gain would be a +2 bonus on Ability rolls dealing with hailstorms.
+
+Some Sympathy Traits represent a negative relationship, one of opposition rather than attraction, and these Traits are given a negative value. In a sense, these represent ways that Faerie is "out to get" the character. When applicable, the strongest negative Trait must be subtracted from all of the character's Ability scores. For example, a character with an Iron –3 Sympathy Trait receives a –3 penalty to his Single Weapon score when fighting with an iron weapon. Negative Sympathy Traits also give the player a number of additional botch dice equal to the character's worst Trait on all botch rolls, as additional sources of potential danger for the character. Thus, the character with an Iron –3 Sympathy Trait would always roll at least three additional botch dice whenever he rolls a 0 on a stress die. The effects of these botches are often ironically related to the Trait; for example, the character might lose his footing and fall, and then realize that he has tripped over an iron horseshoe.
+
+### Increasing Sympathy Traits
+
+Sympathy Traits are typically gained from Virtues or Flaws, or as a result of Warping (see Faerie Calling, below). They can increase with experience points like Abilities, so long as the value of the Trait does not exceed the character's Warping Score. For example, a character with a Warping Score of 2 could increase all of his Sympathy Traits to +2 through practice or exposure, but no higher. Practicing a Sympathy Trait for a season yields 5 experience points towards that Trait.
+
+Negative Sympathy Traits can be improved with experience points as well, as long as the character's Warping Score exceeds the absolute value of the Trait. For example, a character with a Warping Score of 2 could improve a –1 Trait through experience, but not a –2 or –3 Trait. It costs 10 experience points to increase a negative Trait from –1 to 0, 15 experience points to move from –2 to –1, 20 experience points to increase from –3 to –2, and so on.
+
+Since faerie sympathy can be capricious and is generally unpredictable, Sympathy Traits can also change with the character's fortunes. Whenever a player using a Sympathy Trait rolls a 1 on a stress roll, the character immediately gains one experience point in each Trait associated with the roll. For each 0 rolled as a botch when using a Sympathy Trait, the character loses an experience point in each applicable Trait. These effects are reversed for negative Traits, so that a botch increases the penalty and a 1 decreases it. These fluctuations are not limited by the character's Warping Score.
+
+There is one other way that Sympathy Traits may be increased. If, through the course of an adventure, a character that has been touched by faerie makes a sacrifice that a faerie asks of him without question, or otherwise forwards the story in a way appropriate to faerie involvement, the storyguide may choose to allow the character to increase or decrease an appropriate Sympathy Trait by one experience point. This reward might be seen to be in lieu of gaining a Confidence Point for that session.
+
+When a character already has a Sympathy Trait and gains a new one, the player may choose to take a Trait that overlaps his existing Trait, but with a broader scope, like that of a Major Magical Focus instead of a Minor. The value of this new Trait cannot increase beyond that of the Trait with the narrower range, but otherwise develops exactly the same as the character's other Sympathy Traits. For example, a character with a Dawn +3 Sympathy Trait might gain a new Day +1 Trait, which would be limited to a score of +3 for as long as the character's Dawn +3 Trait remained unchanged.
+
+## Faerie Rank
+
+Players with characters who possess Sympathy Traits should also keep track of their Faerie Rank. This statistic measures the strength of the character's connection to Faerie, and is often important for determining how well a faerie wizard succeeds when his powers require faeries to assist him directly. It is the value of the character's highest positive Sympathy Trait, modified by the character's lowest negative Sympathy Trait. For example, if a character had Winter at +4 and Summer at –2, the character's Faerie Rank would be 2. A character with Sympathy Traits of Dancing +1 and Stone –5 would have a Faerie Rank of –4.
+
+>#### Sympathetic Influence
+>
+> | Ease Factor | Trait Value    |
+> |-------------|----------------|
+> | 9           | +1 or –1       |
+> | 15          | +2 or –2       |
+> | 24          | +3 or –3 (max) |
+
+Faeries generally like mortals with high Faerie Rank, as their collected sympathy indicates that they are more willing to do what faeries ask of them, and dislike characters with negative Faerie Rank, which suggests that they are willful and obstinate. While it is true that a character with a Winter +4 Sympathy Trait would get along better with faeries associated with winter than summer, this is not reflected by the character's Faerie Rank, which is only used to represent the character's relationship with Faerie taken as a whole.
+
+## Sympathetic Influence
+
+Another way for characters to develop Sympathy Traits, at least temporarily, is through the process known as sympathetic influence. This is when a character goes out of his way to associate with the subject over a period of time, or conducts a special faerie ceremony designed to inspire a sympathetic connection. If successful, this influence temporarily grants the character an appropriate Sympathy Trait.
+
+To begin, the character must identify a particular Sympathy Trait that he wishes to encourage. This might be related to another Trait that the character already possesses, or a Trait that the character does not have yet but would like to develop. Some Personality Traits are particularly conducive to Sympathy Traits, such as those that describe how the character feels about something else, such as "Like Strawberries" (Fruit or Taste) or "Afraid of Snakes" (Fear or Snakes). There are also Minor Personality Flaws that lend themselves well to Sympathy Traits. If the character does not have any appropriate Personality Traits, he cannot benefit from sympathetic influence.
+
+After a Trait has been identified, the character then engages in either ceremonial influence or practical influence. For ceremonial influence, the character performs a faerie ritual that takes him about ten minutes, and requires a leader with a Faerie Lore score of at least 1. This costs every character who participates in the ceremony a Confidence Point, and the effects last for only a short time without reinforcement, perhaps a week at most. For practical influence, during his free time between other seasonal work or study, the character must encourage the Trait, associating himself with the subject as much as possible. After a season the Trait will develop, and remain for as long as a year.
+
+Once the influence has been enacted, the player of the influencing character should make a roll: a simple die + Presence + Leadership. The results are applied to the following chart, which shows the value of the Sympathy Trait that the participating characters temporarily receive.
+
+**Sympathetic Influence:**
+**simple die + Presence + Leadership**
+
+Note that if the character already has an appropriate Sympathy Trait, it may be applied as a specialty to Leadership for this roll. This makes it slightly easier to increase an existing Trait with a low value for a short time than to develop a new one, as a +1 Trait might be temporarily increased to +2 or +3 through sympathetic influence. However, adding the Sympathy Trait also requires the player to roll a stress die and risk botching. Also note that unlike the influence associated with other realms of power, it is possible to affect an unwilling subject with practical influence, as long as that person has a Personality Trait or Flaw that is appropriate to the desired sympathy.
+
+Sympathy Traits gained through sympathetic influence cannot be increased with experience points and do not change when the player rolls a 1 on a stress die or 0 on a botch die, and so the limit of the character's Warping Score does not apply to them. Also, they do not modify the character's Faerie Rank.
+
+### Tinted Auras
+
+It is also possible to change a Faerie aura so that it resonates especially well with certain Personality Traits, so that everything in the aura is influenced by those Traits. This is called **tinting** the aura, and auras that have one or more Traits are called **tinted auras**. In a tinted aura, every character is strangely drawn to things that are associated with the tint, and repelled by things that are not. These manifest as temporary Personality Traits for all characters in the area, as long as they remain in the aura, with a score equal to the influencing character's Sympathy Trait. For example, in an aura tinted with a Children +3 Sympathy Trait, all characters would receive something like a "Drawn to Children" +3 Personality Trait.
+
+Tinting an aura is done in a manner similar to sympathetic influence. Using practical or ceremonial influence, the influencing character performs a ceremony or spends a season within the aura, after which time the aura receives the tint. However, the value of the new Personality Trait cannot exceed the value of the influencing character's Sympathy Trait, or the level of the Faerie aura. Once enacted, the tint becomes a special property of the aura, and does not need to penetrate Magic Resistance.
+
+Tinting uses a stress die instead of a simple die. Botches on this roll can lead to Warping or to other negative results for the characters who are involved, perhaps tinting the aura in a way other than they actually intended.
+
+**Tinting an Aura:**
+**stress die + Presence + Concentration**
+
+An aura can be tinted multiple times, so that some Faerie auras become a mishmash of different likes and dislikes. This causes a feeling of conflict in everyone the area, as a Faerie aura's tinting of Light +3 and Darkness +3 might pull a person towards both Light and Darkness at the same time. Many faeries like these circumstances, since they are often drawn to the boundaries that form between different tints.
+
+Tinting generally fades over time, with all Personality Trait scores reduced by one every day (for ceremonial tinting) or every season (for practical tinting). After three days, a +6 tinting brought about by ceremonial means will be only +3, and after a year a +4 tinting from practical influence will fade away completely. However, some faerie powers and faerie rites allow for semipermanent tints, and some faerie auras may have inherent tinting.
+
+|>#### Tinting an Aura
+>
+> | Ease Factor | Trait Value\*  |
+> |-------------|----------------|
+> | 3           | +1 or –1       |
+> | 6           | +2 or –2       |
+> | 9           | +3 or –3       |
+> | 12          | +4 or –4       |
+> | 15          | +5 or –5       |
+> | 18          | +6 or –6       |
+> | 21          | +7 or –7       |
+> | 24          | +8 or –8       |
+> | 27          | +9 or –9       |
+> | 30          | +10 or –10 (max) |
+>
+> \* Limited by aura and Sympathy Trait.
+
+A common application of tinting is for a character to use it to bestow a common Personality Trait to everyone in an aura, and then to use sympathetic influence to change it into a temporary Sympathy Trait. In this way, a character can give a Sympathy Trait to a subject that does not have an appropriate Personality Trait to influence.
+
+## Charms
+
+Any Virtue can be given a faerie twist by attaching either the Greater or Lesser Charm Flaw (see New and Modified Flaws, below). A charm is any product of human creative effort, whether it is a product of artifice, a work of art, a piece of music, a poem or song, or even an ointment or a potion; and these Flaws tie the exercise of a Virtue to the charm. Charms are taught to mortals by faeries with the Grant (Virtue) power (see Chapter 3: Faerie Characters), or through special faerie rites performed by faerie wizards (see Chapter 6: Faerie Wizardry).
+
+For most of the time, having a Charm Flaw has no effect on the operation of the Virtue; they are simple actions or rites that take a negligible amount of time to employ. However, secrecy is one of the sources of the power of a charm, and if other characters become party to the charm, the power vanishes like mist in the sunlight. Should this happen, the charm needs to be remade (for a Lesser Charm) or recovered (for a Greater Charm). It is not necessary to keep the existence of the affected Virtue a secret — many of them have overt effects, after all — but it is vital that the method of activation is kept personal. A character cannot even write down the words of a charm poem or the recipe of a potion, even if this written record is kept hidden. If the charm that activates the Virtue is obvious, then the character must take pains to conceal it, perhaps by hiding it among other, meaningless rituals or activations. A character who drinks from a special cup, mutters a few words, and then genuflects to the sky has successfully obfuscated the real charm.
+
+Virtues with charms are usually Supernatural Virtues, but can be any Virtue that obeys the following rules:
+
+- The Virtue cannot be a Social Status Virtue, or involve the background of the character.
+- The Virtue cannot affect experience points in any way (such as Educated or Affinity in (Ability)).
+- The Virtue must affect what the character can do, not who he is. In other words, it must be possible to take the Virtue away without making a fundamental change to his statistics. This can be a difficult category to judge, and relies on the discretion of the storyguide. Examples: Keen Vision does not affect all Perception rolls so is permissible, as is Puissant (Ability). However, Improved Characteristics and Large are both disallowed.
+- The Virtue cannot be a Hermetic Virtue, since these rely on expertise beyond the Realm of Faerie. Similarly, other categories of Magical, Divine, or Infernal Virtues are off limits, including Mystery Virtues.
+
+## Sympathetic Magic
+
+Some characters draw upon the faerie realm through Sympathy Traits and charms. Sympathy can be used in the Hermetic laboratory, with Hermetic spells, or to fashion small models that can be used to undermine faeries and their powers.
+
+### Folk Charms
+
+Any character with knowledge of Faerie Lore and possessing a Sympathy Trait can fashion a folk charm, even if the Sympathy Trait is temporary. (See Sympathy, earlier.) This is a form of craft work, and it takes the character a normal amount of time to create the object that acts as the focus of the charm. No special skill is necessary, but the power of the charm is dependent upon this object, and if it is ever taken from the character or damaged, the charm is no longer effective. (See Charms, earlier.)
+
+A folk charm can end the duration of any faerie effect, as long as the charm is somehow appropriate to the circumstances. The character must apply the charm to either the affected target, or to the being that cast the spell originally, and beat the level of the effect on (a stress die + Intelligence + Faerie Lore + aura modifier). Note that an applicable Sympathy Trait can act as a specialization to increase the character's Faerie Lore if he possesses that Ability.
+
+If the folk charm is applied to a target with Magic Resistance, the effect must penetrate, though he can add the value of his highest applicable Sympathy Trait to his Penetration score.
+
+**Folk Charm: stress die + Intelligence + Faerie Lore + aura**
+
+Activating a folk charm costs a Fatigue level and gives the character a point of Warping. If the character is immune to Warping or cannot expend Fatigue, he cannot activate the charm.
+
+### Hermetic Charms
+
+If a magus has been exposed to the Faerie realm to such an extent that he has gained sympathy with it, he may apply his Sympathy Traits to his work. If he has negative Sympathy Traits, he must apply the penalties where they are applicable.
+
+Sympathy Traits can be used as specializations to boost Abilities used to perform Hermetic magic, including Penetration and Magic Theory. When affecting Abilities that govern lab activities, such as when boosting Magic Theory, the magus must experiment to receive this benefit, and he automatically experiments if he possesses a negative Sympathy Trait that is applicable to his laboratory project.
+
+>## Examples of Charmed Virtues
+> 
+> **Virtue:** Entrancement
+> 
+> **Example:** The character requires a wand of rowan wood.
+> 
+> **Virtue:** Greater Immunity to Fire **Example:** The character must perform a salutation to the sun.
+> 
+> **Virtue:** Light Touch
+> 
+> **Example:** The character must wear a specific pair of gloves
+> 
+> **Virtue:** Puissant Single Weapon **Example:** The character must whisper a song to the blade before combat.
+> 
+> **Virtue:** Reserves of Strength
+> 
+> **Example:** The character must swig a magic potion to gain the bonus to his strength.
+> 
+> **Virtue:** Second Sight
+> 
+> **Example:** The character must smear a special ointment onto her eyes.
+
+When a magus with Sympathy Traits enchants a device, he may add the value of any of his Sympathy Traits that are appropriate to the shape or material to his Lab Total (limited by his score in Magic Theory, as usual). He may also attune his talisman to any of his Sympathy Traits that apply to its shape or material. For example, a magus with a +3 Oak Sympathy Trait could attune his talisman made of oak to use this Sympathy Trait. Note that this bonus is not fixed in the talisman like other attunement bonuses, but can vary depending upon the score the magus has in the related Sympathy Trait.
+
+An enchanted device can be designed as a charm. This allows the magus to add any Sympathy Traits that are appropriate to the effect to his Lab Total, but with the limitation that the device must always be activated in secret or it will cease to function. (See Charms, earlier.)
+
+When creating Hermetic charms and incorporating Faerie Sympathy into lab work, the player may treat the activity as either a Magic or Faerie effect on the Realm Interaction chart.
+
+## Faerie Blood
+
+Some humans are not wholly mortal, but somewhere in their family tree is a touch of glamour, expressing itself as either the Faerie Blood or Strong Faerie Blood Virtues. Whenever a faerie derives vitality from a human, the resultant glamour has the power to create a child with faerie blood, the most common method being procreation. Human activities surrounding the production of children — love, lust, intercourse, even fertility itself — are powerful source of vitality for many faeries. Some faeries seem to be as fertile as humans, and are able to produce children with a mortal man or woman. Faeries of this type are usually highly cognizant and deliberately produce children to further their own story in some manner. Such are the many stories of gods producing heroic sons and daughters with a mortal woman. Other faeries need to steal fertility from a mortal before they can generate children. For example, a story is told about the king of the merfolk who takes a human maiden as his wife. The bride drowns in the king's palace, but one of the king's sisters acquires the virgin's procreative vitality and bears a human child. Yet other faeries merely feign fertility, but instead touch fertile men and women with their glamour to produce children of their spirit rather than of their flesh. A faerie who repeats Merlin's trick — clothing Uther Pendragon in glamour so that he appeared to be the husband of King Arthur's mother Igraine — changes the child of such a union so that they have Faerie Blood. Faeries who have to steal fertility or influence a mortal conception are usually at least narrowly cognizant if not fully cognizant of their activities.
+
+Another manner in which faerie children are produced has nothing to do with fertility, but instead causes the manifestation of Faerie Blood apparently by accident. A faerie who derives vitality from a pregnant woman (for example, a blood-drinking faerie who feeds on her) might infect that child with its glamour and produce the symptoms of Faerie Blood. Such influence can also occur after birth, in that changelings are nearly always fae-touched in some manner. Such faeries are often incognizant of their actions, but this is not always the case. For example, a faerie queen who names a mortal child as her heir knows exactly what she is doing, and the child inherits both Faerie Blood and an exciting life ahead of it!
+
+Once Faerie Blood has been introduced into a human family, it can be inherited by the character's descendants. Faerie Blood manifests regardless of the number of generations between the first character to bear it and the current generation. It may ignore several generations and then resurface for no apparent reason. A character whose mother was directly influenced by a faerie might still possess the same strength of Faerie Blood as a character whose blood has been diluted by seven generations of mortals. The strength of the faerie taint (ie. possessing the Faerie Blood or Strong Faerie Blood Virtues) also bears little relation to the recency of the bloodline. However, the cognizance of the faerie involved in the bloodline seems to make a difference. A faerie with high cognizance more often produces "descendants" with Strong Faerie Blood than do faeries with low cognizance.
+
+Since Faerie Blood can be induced without ancestry, magi must either accept that it is not part of a character's Essential Nature, or else that Essential Nature does not limit the Faerie realm in the same way as it limits Magic. Most grudgingly accept that the latter is the most likely scenario.
+
+### Varieties of Faerie Blood
+
+This section describes some common varieties of the Faerie Blood Virtue. It repeats and expands the information found on page 42 of **ArM5**, as well as adding new varieties. The specific benefit of possessing Faerie Blood of each type is listed, along with the enhanced version for those characters who have the Faerie Legacy Virtue (see New and Modified Virtues, later). Note that this enhanced effect replaces the normal benefit of Faerie Blood, it is not in addition to it. Each listing also has some typical Sympathies (see Sympathy, earlier), and some suggestions for other Virtues and Flaws possessed by different faerie bloodlines; those marked with an asterisk are described in this chapter. Finally, since characters with Strong Faerie Blood gain a distinctive appearance from that Virtue, some common features are given. These could also be used for characters with regular Faerie Blood who also have the Disfigured Flaw, as well.
+
+#### Bloodcap Blood
+
+Bloodcaps are frightening faeries of cruel winter who haunt the wildernesses where blood has been shed, drawn to violence and death. Children with bloodcap blood most often come about when a woman is held captive by one of these faeries and subjected to a terrifying imprisonment while the faerie feeds off her fear. It is said that one of Mercere's grandchildren married a bloodcap in an unholy ceremony, and raised her children as Redcaps (see *Houses of Hermes: True Lineages*, pages 91, 104–105 for more details).
+
+**Benefits**: +1 bonus to Strength, but not to more than +3.
+
+**Legacy**: +1 bonus to Strength, can go as high as +4.
+
+**Sympathies**: Fear, Winter, Religious Symbols (negative).
+
+**Other Virtues and Flaws**: Frightful Presence\*, Reserves of Strength; Greater Malediction (crosses and scripture make teeth and nails fall out, causing a Light Wound each round); Lesser Malediction (crosses and scripture cause pain, requiring Concentration rolls of 9+ for stressful actions).
+
+**Appearance**: Long teeth and nails, character looks older than he actually is, long arms.
+
+#### Brownie Blood
+
+Couples that are fortunate to have a helpful faerie such as a brownie or portune would be wise to exercise caution before introducing a child to the family. Household faeries can be very jealous of babies and may take them in lieu of payment for their service . Such children, if retrieved, may bear the blood of a brownie. And even if it is wellinclined towards the child, the attention of a brownie can still taint an infant, leaving it with Faerie Blood.
+
+Characters with brownie blood are usually diligent by nature and hard workers. They often have an unnatural desire to help people out.
+
+**Benefits**: +1 bonus to all totals including a Profession Ability.
+
+**Legacy**: +1 bonus to all totals including a Profession Ability, except for one Profession Ability that receives a +2 bonus. This favored Ability must be chosen at character creation.
+
+**Sympathies**: Tools, Cleaning, Gifts (negative). **Other Virtues and Flaws**: Cautious with (Ability), Gossip, Light Touch; Meddler; Humble, Small Frame.
+
+**Appearance**: Short of stature, character looks older than he actually is.
+
+#### Dwarf Blood
+
+This variety of Faerie Blood can originate in any diminutive subterranean faeries. Dwarfs often make their homes close to mundane settlements. And mortals may profit from their labor, although not always with the consent of the dwarf. Subterranean faeries occasionally make charms that are bought or stolen from them . These charms induce fertility, health, or else are designed to ward a child from evil; but all can also cause Faerie Blood. Like their cousins the goblins, dwarfs are also prone to taking children in exchange for changelings (see Changelings, later).
+
+**Benefits**: +1 bonus to all totals including a Craft Ability.
+
+**Legacy**: +1 bonus to all totals including a Craft Ability, except for one Craft Ability which receives a +2 bonus. This favored Ability must be chosen at character creation.
+
+**Sympathies**: Jewelry, Weapons, Theft (negative).
+
+**Other Virtues and Flaws**: Reserves of Strength; Dwarf; Small Frame.
+
+**Appearance**: Short of stature, smooth skin like polished stone, duck's feet.
+
+>## Faerie Powers for the Faerie Blooded
+> 
+> At the option of the storyguide, a human character with Faerie Blood may have Virtues and Flaws normally only permitted to faerie characters. If this option is taken, only those Virtues from the following list can be taken, and the Virtue points taken must be paid for with Flaws taken from this list as well. Details of these Virtues and Flaws can be found in Chapter 3: Faerie Characters.
+> 
+> **Major Virtues:** Focus Power, Greater Power **Minor Virtues:** Faerie Speech, Improved Powers, Lesser Power
+> 
+> **Major Flaws:** Monstrous Appearance, Sovereign Ward
+> 
+> **Minor Flaws:** Reduced Power, Slow Power, Traditional Ward
+> 
+> For all powers granted by these Virtues, calculate the Might cost as normal, but instead of spending Might points, the character instead loses 1 Fatigue level for every 5 points (or fraction) of the cost. For the purposes of calculating the Penetration Total of powers, assume that the character has a Might Score of zero, although in reality he has no Might Score at all.
+> 
+> Only characters with Strong Faerie Blood should be allowed to take Major Virtues from this list. Those with Faerie Blood are restricted to just the Minor Virtues; but both types of character can buy their Virtues with Major or Minor Flaws from the above lists.
+
+#### Ettin Blood
+
+Ettins (also called ogres or trolls) are common in the stories of Germanic people. They are brutish giants that usually range from Size +3 to +5. Female ettins — called "troll-wives" — can often be exceedingly beautiful. Troll-wives are particularly prone to take husbands among heroic men who impress them, and their children are often powerful magicians. Some troll-wives steal Gifted children rather than giving birth to them, then raise them as their own. Trollwives are usually no more than 3 points of Size from their husband, or else are capable of adopting a human-sized form.
+
+Characters with ettin blood must be careful in bright sunlight, since it is often painful or can even turn the character to stone until sunset, although only direct sunlight can have this effect.
+
+**Benefits**: +1 to Stamina, but not to more than +3.
+
+**Legacy**: +1 bonus to Stamina, can go as high as +4.
+
+**Sympathies**: Mountains, Stone, Sunlight (negative).
+
+**Other Virtues and Flaws**: Giant Blood; Large, Tough; Greater Malediction (sunlight turns him to stone until nightfall); Clumsy, Lesser Malediction (sunlight is painful and gives a inflicts 2 Fatigue levels that do not recover until nightfall).
+
+**Appearance**: Craggy features, gray knobbly skin, bulbous nose, tiny eyes.
+
+>## Faerie Blood and the Soul
+> 
+> If faeries are the embodiment of stories, as some believe, then how can they produce children with mortal beings? More importantly, do these children possess souls, since one of their parents did not? All these questions have vexed those knowledgeable in fay things, particularly those who bear Faerie Blood themselves.
+> 
+> The fact that at least some faeries are rational beings — even if their logic is alien to mankind — has lead some to believe that faeries do have souls. The concept of faeries as living stories is the most popular of theories among the cognoscenti, but not the only one (see Chapter 1: Nature of Faerie, for alternate theories). Of course, only a fool would think that souls are heritable, and some Faerie-Blooded characters console themselves with the thought that a soul is a gift from God regardless of parentage. If He can choose to imbue some animals with a soul — such as Balaam's ass — then why not humans of fae heritage? Many Faerie-Blooded characters do not concern themselves with metaphysical issues such as these. They have either never considered that they might not have souls, or else are sure that they do without worrying about the ineffable question of why.
+
+#### Faerie God Blood
+
+Sometimes the gods of old — powerful faeries in their own right — had children with mortals, and legends abound with the stories of their exploits. Characters with this variety of Faerie Blood might be descendants of Zeus, Venus, Morrigan, Odin, Pelos, or any one of the host of the other gods of their people. With such noble blood in their veins, these characters rarely remain anonymous for long, and many believe that a great destiny lies before them. Picking Sympathy Traits appropriate to the specific god is very important, and they should relate to his or her principle attributes.
+
+**Benefits**: 1 point to spend on appropriate Sympathy Traits.
+
+**Legacy**: 2 points to spend on appropriate Sympathy Traits.
+
+**Sympathies**: Anything appropriate to the ancestor.
+
+**Other Virtues and Flaws**: Greater Benediction; Famous, Frightful Presence; Faerie Heritage, Supernatural Nuisance (creatures hostile to ancestor); Higher Purpose, Infamous.
+
+**Appearance**: Some key characteristic of the god in question.
+
+#### Ghul Blood
+
+The ghula are rapacious wasteland faeries of the Arabic world. Sexual encounters between human men and female ghula (see Chapter 4: Faerie Bestiary, Ghula) result in either another ghula (if the child is a girl) or ghul-blooded humans (if a boy is born). The sons of ghula can then go on to produce either girls or boys with ghul blood. This variety of faerie blood could also represent other violent faerie ancestors. Those with ghul blood are nearly always sinister-looking, born with teeth, and unusually aware of their surroundings.
+
+**Benefits**: Claws that can be retracted and extended at will, with the following weapon statistics: Init –1, Atk +2, Dfn +3, Dam +2.
+
+**Legacy**: As above, except that the claws are extra large, and the Damage bonus is +4 rather than +2.
+
+**Sympathies**: Wastelands, Stalking, Compassion (negative).
+
+**Other Virtues and Flaws**: Ways of the Desert; Skinchanger (hyena or vulture); Nocturnal, Poor Presence.
+
+**Appearance**: Dark skin, wrinkled, sharp teeth, green on the inside of the mouth, always have green eyes.
+
+#### Goblin Blood
+
+"Goblin" is the general term for a subterranean faerie of a destructive bent such as those found in caves or mines. More generally it is used to denote a malicious faerie of short stature. Goblin Blood nearly always enters a human lineage through changelings (See Changelings, later) who have been retrieved by their parents or else abandoned by the goblin troupe once the faeries lose interest.
+
+**Benefits**: +1 bonus to all totals including stealth.
+
+**Legacy**: +2 bonus to all totals including stealth.
+
+**Sympathies**: Caves, Mischief, Iron (negative). **Other Virtues and Flaws**: Light Touch, Sharp Ears; Afflicted Tongue, Hunchback, Nocturnal.
+
+**Appearance**: Short and twisted, hairless, long pointed nose, sharp teeth, red eyes.
+
+#### Huldra Blood
+
+The huldra (plural huldrene) is a variety of nymph native to Scandinavian lands, also known as a skogsrå or tallemaja. The rarer male form is called a huldu or huldrekall. They are often exceedingly beautiful from the front, although their backs are hollow like a canoe. Huldrene never wear clothes, and have the tail of a cow. Their most distinctive feature is their power to disappear from sight and remain hidden when no-one is watching. A man can unknowingly marry a huldra and raise children with her, but she always eventually leaves him when he discovers her secret. Some huldrene are sexual predators, rewarding those who please them and killing those who disappoint. Others are guardians of morality; if a man is unfaithful to his wife with a huldra, then the faerie punishes him by causing him to father huldrablooded children.
+
+**Benefits**: When she remains still, the character cannot be seen. She must concentrate to maintain the absolute stillness this requires; make a Stamina + Concentration roll against an Ease Factor of 9 every fifteen minutes. She cannot use this power if anyone is aware of her location, or if in a Divine aura.
+
+**Legacy**: As above, except that the character can disappear even when being watched.
+
+**Sympathies**: Concealment, Fidelity, Secrets (negative).
+
+**Other Virtues and Flaws:** Ways of the Forest; Great Presence, Puissant Stealth; Reclusive.
+
+**Appearance**: Cow's tail, long blonde hair, unearthly beauty, hollow from behind.
+
+#### Nymph Blood
+
+Nymphs haunt the borders of human settlement, and are the archetypal sexual predator. They are particularly attracted to young men on the verge of adulthood, and occasionally seek out young heroes with whom to mate. A nymph who has a child herself is transformed into a different type of faerie altogether, and abandons the child with its father. Consequently, some nymphs chose not to directly have children; instead, an encounter with the nymph leaves a man both exceptionally lustful and especially virile, and he often conceives a child with a mortal woman while still under the faerie's influence. These children always have nymph blood. Nymphs also partake in wild parties with satyrs (see Satyr Blood, later), and any girl children born to humans following such a party bear nymph blood.
+
+**Benefits**: +1 bonus to Communication, but not to more than +3.
+
+**Legacy**: +1 bonus to Communication, can go as high as +4.
+
+**Sympathies**: Trees, Love, Loyalty (negative). **Other Virtues and Flaws**: Entrancement, Ways of the Forest; Puissant Etiquette, Strong-Willed; Curse of Venus, Envious.
+
+**Appearance**: Dark green hair, pale green skin, leaf patterns over body. Other variants exist for nymphs tied to different elements.
+
+#### Padfoot Blood
+
+A padfoot is a faerie that takes the form of an immense black dog with glowing green eyes. Padfoots are commonly believed to be hostile to man, perhaps because a number of other faeries and demons take a similar form, but in actual fact they take it upon themselves to protect travelers from dangers such as treacherous bridges and bandits. Those whom they ward from these dangers are often terrified of the hound and oblivious of the danger they are in until later. Pregnant women who are protected by a padfoot may have a child who bears animal features.
+
+**Benefits**: +1 bonus to Perception, but not to more than +3.
+
+**Legacy**: +1 bonus to Perception, can go as high as +4
+
+**Sympathies**: Protection, Hounds, Friendship (negative).
+
+**Other Virtues and Flaws**: Animal Ken, Sharp Ears; Monstrous Appearance\* (dog's head); Lycanthrope; Dutybound (protect the weak), Faerie Friend (a padfoot), Nocturnal.
+
+**Appearance**: Large round eyes, black fur over body, tail.
+
+#### Satyr Blood
+
+Almost as common as mortal descendants of courtly faeries are those engendered by fauns and satyrs. These lustful faeries frequently force themselves on mortal women who meet them on the borders of the wilderness; but such encounters are about the sexual act, not procreation. However, on occasion satyrs and fauns hold bacchanalian parties with nymphs, and not all who attend are faeries. Mortal men and women are deliberately included in these orgies, although they are shrouded in the glamour to appear as fauns or nymphs, respectively. Children that are conceived at one of these parties have Faerie Blood — the boys have satyr blood and the girls have nymph blood.
+
+**Benefits**: +1 bonus to Communication and Presence totals when dealing with sexually compatible characters.
+
+**Legacy**: +2 bonus to Communication and Presence totals when dealing with sexually compatible characters.
+
+**Sympathies**: Music, Lust, Politeness (negative). **Other Virtues and Flaws**: Enchanting Music, Long Winded, Puissant Charm; Curse of Venus, Lecherous.
+
+**Appearance**: Excessively hairy, curly beard, goat's horns, cloven hooves, yellow eyes.
+
+#### Selkie Blood
+
+Selkies and their close cousins the swanmaidens can be trapped by mortal men, and become their brides (see Chapter 4: Bestiary, Spouses Captured by Trinkets). They derive vitality from their families by acting the part of wife and mother, and raise children with selkie blood. Should the selkie gain her freedom from the marriage (and they almost always do), then the child is often left to fend for itself while the father fruitlessly searches for his wife.
+
+**Benefits**: Receives a +3 to all rolls to avoid Deprivation.
+
+**Legacy**: Receives a +3 to all rolls to avoid Deprivation; when deprived of air, makes rolls every minute instead of every 30 seconds.
+
+**Sympathies**: Shorelines, Birds, Freedom (negative).
+
+**Other Virtues and Flaws**: Ways of the Sea; Skinchanger (seal, fish, swan), Well-Traveled, Wilderness Sense; Compulsion (travel), Feral Upbringing.
+
+**Appearance**: Webbed fingers (selkies), feathers in hair (bird women).
+
+#### Sidhe Blood
+
+The most common varieties of all Faerie Blood are derived from the courtly faeries (see Chapter 4: Faerie Bestiary), which in Ireland are called "sidhe." Highly cognizant faeries of this type often seek out humans for the specific purpose of producing a child who partakes in the faerie's own nature. The Faerie Heritage Flaw is therefore particularly common among those with sidhe blood. Stories are told of Faerie Knights who have a passionate encounter with a mortal woman but who then leave, unaware of the child conceived of their lust. When, many years later, the son tracks down his father the faerie does the honorable thing and marries the woman he has shamed. More sinister are the glanconers who abduct maidens from their homes. The woman never returns, but occasionally a child might appear on the doorstep of its grandparents' home.
+
+**Benefits**: +1 to Presence, but not to more than +3.
+
+**Legacy**: +1 bonus to Presence, can go as high as +4.
+
+**Sympathies**: Light, Nobility, Iron (negative). **Other Virtues and Flaws**: Frightful Presence\*, Great Presence, Piercing Gaze, Venus' Blessing; Envious, Faerie Heritage\*; Fragile Constitution.
+
+**Appearance**: Tall and fragile, pale skin, long blond hair, pointed ears, vividly colored eyes.
+
+**Benefits**: +2 bonus to any action taken under water, which will partially offset any penalty applied.
+
+**Legacy**: +2 bonus to any action taken under water, which replaces any penalty applied. **Sympathies**: Rivers, Fish, Clothing (negative). **Other Virtues and Flaws**: Greater Immunity to Drowning; Puissant Swim; Mute; Lesser Malediction (water dependence, requiring a Deprivation roll (ArM5, page 180–181) for every day that they are not immersed in water), Noncombatant; Monstrous Appearance\* (lower body of a serpent or a fish).
+
+**Appearance**: Pale almost-blue skin, webbed hands, large liquid eyes, green hair.
+
+#### Undine Blood
+
+Undines are those Courtly Faeries who inhabit rivers, particularly those rivers that form boundaries between countries or geographical features. They may be the progenitors of lineages of mortals in similar manner to other Courtly Faeries (see Sidhe Blood, earlier). Perhaps the most famous lineage of undine blood is that of the rulers of Lusignan castle, who had Mélusine as their ancestor (see *Lion and the Lily*, Chapter 6: Anjou and Aquitaine).
+
+A character with undine blood often needs to be immersed in water regularly, or else he suffers ill effects. This variety of Faerie Blood can substitute for a water-inhabiting faerie such as a mermaid, although those faeries that can change shape are best treated as a variety of selkie blood instead.
+
+>## Story Seeds: Faerie Blood
+> 
+>### The Nymph's Surrogate
+> 
+> One of the covenant's womenfolk (perhaps a Dependent of one of the characters) is captured by a nymph to serve as a surrogate mother for the child of her mortal lover. The woman is imprisoned in a Faerie regio, unable to escape on her own.
+> 
+>### Ettin Apprentices
+> 
+> A Redcap is selling Gifted children to members of the Order as apprentices. He seems to have a regular supply of them, although they all have Faerie Blood (of the Ettin variety). He is shadowing an ettin who is stealing Gifted children, and then stealing the children in turn from the faerie and selling them on, heedless of the Code that specifies that he must not molest the fae. A magus who receives one of these children may have to cope with the enraged ettin when she tracks down "her" child.
+> 
+>### Children of the Fauns
+> 
+> A troupe of fauns moves into a local wood, and an unusually large number of children with satyr and nymph blood are born. As they grow up, the children are able to sense each other's presence and they join up to form a band of their own. They then engage in their own enticement and subsequent imprisonment of fertile men and women.
+
+### Changelings
+
+Some instances of Faerie Blood are less dependent on faerie influence over the child's parents, and more on what happens to the child after it has been born. This desire for a human baby is a specific form of faerie theft (see Chapter 1: Nature of Faerie), and is by no means practiced by all of the Good Folk. The most common victim of child theft is an unbaptized child; a child without a name stands on the threshold between being part of its mother and a thing of its own, and is highly attractive to faeries.
+
+Babies are rarely just stolen — they are usually exchanged. The faeries leave behind either a faerie child, an ancient faerie, or else a crudely carved wooden image (called a stock) in place of the infant. Glamour is used to disguise the switch, at least in the short term. A baby that does not cry or one that seems wise beyond its years is commonly suspected of being a changeling; as are those struck by illnesses such as fits, or those who are mute. The result of faerie theft is either a child who has spent a short time in the company of faeries before being retrieved, or else a human child who is raised by faeries and who finds his way back to human society at an older age.
+
+#### Retrieved Changelings
+
+If a faerie is left in the stead of the child, then if the faerie can be tricked into revealing its true nature the parents can retrieve their child. One way this can be achieved is by deliberately performing a task wrongly until the exasperated faerie is driven to show how it is done. Other changelings are tormented by their human “parents” in the belief that the faerie will eventually use its powers to escape; and a dreadful amount of real suffering has been induced by the belief in changelings. Even the briefest stay with faeries as a child often leaves a character with the Second Sight Virtue, but children who are fed by faeries before being retrieved usually exhibit Faerie Blood of the variety of her kidnappers. 
+
+#### Faerie Upbringing
+
+Not all infants are fortunate enough to be retrieved by their real parents, and instead grow up among the fae. These infants always have the Faerie Upbringing Flaw and usually also have Faerie Blood; although some faeries steal mortal food for their child to eat and the latter does not manifest. Children raised by faeries are normally treated exceptionally well, since the faeries who take them derive vitality from being a host. As the child reaches puberty, she develops a natural curiosity about the world at the same time as the faeries find that she provides less and less vitality for them. The parting of the ways is usually amicable, but it is not unknown for a daring escape or rescue to take place.
+
+Due to the fact they have been raised in the absence of human culture — or in a shallow mockery of it at best — those with Faerie Upbringing often have the Ability Block Flaw covering facets of human interaction and upbringing. Choose any five Abilities from the following list as unavailable to a character with this Flaw: Animal Handling, Charm, Church Lore, Dominion Lore, Etiquette, Folk Ken, Guile, Leadership, Ride, Theology.
+
+#### Linked Lives
+
+Infants exchanged for certain trolls and trowies are strangely linked to the life of the faerie left in their place. The "child" growing up with human parents is the spitting image of the mortal child, although often wise beyond his years and resistant to discipline. If the parents notice the switch early, they have a chance of retrieving their own child, else they may bring the faerie child up ignorant of its true nature.
+
+The mortal child and the faerie changeling are fated to meet in the future. Theoutcome of this encounter will determine whether their mutual relationship is amicable (the Faerie Friend Flaw) or hostile (the Mistaken Identity Flaw). Whichever relationship occurs, the two beings are intrinsically linked with one another. A character whose life is linked to that of his changeling has the Faerie Blood Virtue (usually of the Dwarf or Ettin variety), and possibly the Faerie Upbringing Flaw (if he was never returned to his parents). His link to his faerie counterpart is represented by the Death Prophecy Virtue — that the character can only die if his faerie copy is killed first.
+
+An interesting option here would be for the faerie and human twins to be the characters of different players. In this case, the relationship between the two should be amicable rather than hostile.
+
+>## New and Modified Virtues
+> 
+>### Special
+> 
+> Faerie Doctor
+> 
+>### Supernatural, Major
+> 
+> Curse-Throwing
+> 
+> Empathy
+> 
+> Enchantment
+> 
+> Evocation
+> 
+> Faerie Sympathy
+> 
+> Greater Benediction
+> 
+> Strong Faerie Blood
+> 
+> Summoning
+> 
+>### Supernatural, Minor
+> 
+> Beguile Bonding Ceremony Conjure Dismissing Dream Faerie Blood Faerie Legacy Faerie Sympathy
+> 
+> Captivating
+> 
+> Familiarity with the Fae Frightful Presence
+> 
+> Grant
+> 
+> Lesser Benediction
+> 
+> Portage
+> 
+> Ware
+> 
+> Weal
+> 
+> Woe
+> 
+>### Supernatural, Free
+> 
+> Faerie Background
+
+#### Milk Brothers
+
+A gwiber (see Chapter 4: Faerie Bestiary) transforms into its winged form by obtaining a taste of human breast milk. Most often it laps up that which has been split, but occasionally it obtains the milk from the mouth of a human infant, or — even more rarely — directly from the source. These latter two cases form an unusual bond between the infant and the gwiber.
+
+A human who has shared milk with a gwiber does not normally acquire Faerie Blood from this contact, but does gain the ability to understand the language of animals (Animal Ken Virtue). Further, the bond between the gwiber and human manifests as the Faerie Friend Flaw, and the milk-brother is often the only human who can approach the gwiber safely. The human character might be forced to be constantly on the move, as any community he settles down in soon has to deal with his monstrous foster-brother.
+
+#### Nympholepts
+
+Children are not the only mortals stolen away by faeries. Young men, in particular, are prone to being taken by nymphs, and dwell with them for a number of years before winning or being granted their freedom. These individuals are known as "nympholepts," and in addition to the effects of Faerie Blood, often also have some prophetic power (such as the Premonitions Virtue, the Visions Flaw, or the Faerie Power of Dream).
+
+## Virtues and Flaws
+
+There are a number of different ways in which Virtues and Flaws can cause a character to bear a wisp of faerie magic. For example, any Supernatural Virtue can have a Faerie origin. A Virtue that has been designated by the backstory of the character as fay affiliates the character to the Faerie realm. This allows that a Virtue granting a Supernatural Ability receives bonuses to any rolls based on being a Faerie power on the Realm Interaction Table (**ArM5**, page 183). Likewise, characters with a Faerie Virtue or Flaw do not gain Warping from living in a Faerie aura.
+
+The Greater and Lesser Benediction Virtues (see later) and the Greater and Lesser Malediction Flaws (**ArM5**, pages 54 and 55) are typical products of interaction with faeries. These Virtues and Flaws are great catch-all categories that cover the wide range of gifts and curses handed down by the faeries.
+
+## New and Modified Virtues
+
+The following Virtues can be chosen by Faerie characters.
+
+#### Beguile
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Beguile with an initial score of 1.
+
+#### Bonding
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description. Choosing this Virtue gives the character Bonding with an initial score of 0.
+
+#### Captivating
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description. Choosing this Virtue gives the character Captivating with an initial score of 0.
+
+#### Ceremony
+
+*Minor, Supernatural*
+
+See Faerie Abilities, later, for a full description of this Supernatural Ability. Choosing this Virtue gives the character Ceremony with an initial score of 1.
+
+#### Conjure
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Conjure with an initial score of 1.
+
+#### Curse-Throwing
+
+*Major, Supernatural*
+
+Characters with this Virtue are able to cure diseases and remove curses by transferring them to another person. Choosing this Virtue confers the Supernatural Ability Curse-Throwing 1.
+
+#### Dismissing
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description. Choosing this Virtue gives the character Dismissing with an initial score of 0.
+
+#### Dream
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Dream with an initial score of 1.
+
+*Major, Supernatural*
+
+#### Empathy
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Method. Choosing this Virtue gives the character Empathy with an initial score of 1.
+
+#### Enchantment
+
+*Major, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Method. Choosing this Virtue gives the character Enchantment with an initial score of 1.
+
+#### Evocation
+
+*Major, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Method. Choosing this Virtue gives the character Evocation with an initial score of 1.
+
+#### Faerie Background
+
+*Free, Supernatural*
+
+Due to something unusual about the character's birth or childhood, the character has a strong resonance with one aspect of the faerie realm. It grants the character two Sympathy Traits, one positive and the other negative, with initial values equal to the character's Warping Score. These Traits should be appropriate to the character's faerie background; for example, a character raised by faerie wolves might have Fear (positive) and Courage (negative) Sympathy Traits, perhaps to represent wolves' love of causing fear and their tendency to back down when challenged. See the Faerie Sympathy Virtue and Faerie Antipathy Flaw, below, for information about how these Traits increase and decrease.
+
+Players with this Virtue may freely increase their character's Warping Score during character creation, though they should have some idea of what in the character's past caused this Warping to occur. This Virtue is especially appropriate for characters who have the Faerie Blood or Strong Faerie Blood Virtues, or the Faerie Upbringing Flaw; see the expanded descriptions of the different types of Faerie Blood, earlier, for suggested Sympathy Traits.
+
+#### Faerie Blood
+
+*Minor, Supernatural*
+
+(See **ArM5**, page 42)
+
+In addition, this Virtue raises the maximum score to which the character may increase Sympathy Traits by 1. Thus, a character with Faerie Blood and a Warping Score of 2 could increase a Sympathy Trait to +3.
+
+#### Faerie Doctor
+
+*Special*
+
+This Virtue makes the character into a Mythic Companion. It grants the Dowsing Virtue for free, and allows the character to take two Virtue points for every Flaw point. This Virtue is incompatible with The Gift.
+
+#### Faerie Legacy
+
+*Minor, Supernatural*
+
+This Virtue can only be taken by characters with Faerie Blood or Strong Faerie Blood. Your Faerie Blood is particularly potent, and the usual benefit deriving from it is replaced with a more powerful version. See Varieties of Faerie Blood (earlier) for details on how the benefit is affected. Note that the legacy benefit from this Virtue is instead of the normal benefit, not in addition to it.
+
+#### Faerie Sympathy
+
+*Major or Minor, Supernatural*
+
+The character receives a positive Sympathy Trait. As a Major Virtue, this has an initial score of +3; as a Minor Virtue it is +1. This Trait may be increased with experience points, up to a maximum score of (the initial value + the character's Warping Score). For example, a character with Warping Score 1 and the Major Virtue could begin with a +4 Trait.
+
+Players with this Virtue may freely increase their character's Warping Score during character creation, though they should have some idea of what in the character's past caused this Warping to occur.
+
+This Virtue may be taken more than once. See Sympathy, earlier, for more information about Sympathy Traits.
+
+#### Familiarity with the Fae
+
+*Minor, Supernatural*
+
+You have a natural understanding of faerie ways, perhaps due to spending time among them. You get a +2 to all rolls involving social interaction with faeries. You also gain the effects of the Common Sense Virtue, but only when the situation pertains to faeries. You may purchase Faerie Lore at character generation, even if normally unable to take Arcane Abilities.
+
+#### Frightful Presence
+
+*Minor, Supernatural*
+
+You are capable of instilling great dread through your appearance. This can work in one of two ways: you are either able to contort your face into a vision of terror (common if Presence is less than zero); or else radiate an aura of awe and splendor that makes others weak at the knees (common if Presence is greater than zero).
+
+Everyone witnessing you displaying your Frightful Presence must make an immediate Brave Personality roll against an Ease Factor of 3. Add your Presence to the Ease Factor, ignoring any negative sign (for example, a Presence of +3 or –3 makes the Ease Factor 6). A failure means that they either attempt to flee your immediate vicinity, or else are cowed before your glory.
+
+If the targets remain within your presence (because they are awed or because they are trapped), they can reattempt the Brave roll every two minutes. Once a person has been affected by the Frightful Presence and recovered from its effects, he cannot be affected again; although you will acquire an appropriate Reputation (such as Fearsome or Awesome) at a score of 2 among those you have affected, which will color your dealings with them.
+
+This effect has a Penetration Total of 0.
+
+>## Example Greater Benedictions
+> 
+>### Flight
+> 
+> You are able to fly without the need of wings. Every time you take to the air, you lose a Long-Term Fatigue Level, and can remain airborne for a maximum of an hour, traveling up to fifty miles in this hour. Once you touch the ground, your current flight ends regardless of how much of your hour has elapsed. You require a prop to fly, such as a carpet or staff, but any prop of the appropriate type suffices.
+> 
+>### True Sight
+> 
+> You are rarely fooled by glamour or illusions that change the appearance of something (although a false image such as from a Creo Imaginem spells still fools you). Further, you can always detect the true form of a shapechanged creature (although not members of House Bjornaer, since both their human and animal forms are "true" forms). This power has a Penetration of 20.
+> 
+>### Universally Liked
+> 
+> Everyone who knows you is your friend. You receive a +3 bonus to all social rolls with people who have known you more than one month. Anyone who tries to act against you by swaying the emotions or opinions of others have +3 added to all Ease Factors. This effect has a Penetration of 0.
+
+#### Grant
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Grant with an initial score of 1.
+
+#### Greater Benediction
+
+*Major, Supernatural*
+
+You've been blessed by some supernatural power. The effects of the benediction should be comparable to other Major Virtues. (See insert for examples.)
+
+#### Lesser Benediction
+
+*Minor, Supernatural*
+
+You've been blessed by some supernatural power. The effects of the benediction should be comparable to other Minor General Virtues. (See insert on next page for examples.)
+
+#### Portage
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Portage with an initial score of 1.
+
+#### Strong Faerie Blood
+
+*Major, Supernatural*
+
+(See **ArM5**, page 49)
+
+In addition, this Virtue raises the maximum score to which the character may increase his Sympathy Traits by 3. A character with Strong Faerie Blood and a Warping Score of 2 could increase his Sympathy Traits to +5.
+
+#### Summoning
+
+*Major, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description. Choosing this Virtue gives the character Summoning with an initial score of 0.
+
+#### Ware
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Ware with an initial score of 1.
+
+>## Example Lesser Benedictions
+> 
+>### Gift of the Gab
+> 
+> You are a very convincing speaker; anyone attempting to detect untruth in your words receives a –3 penalty to their rolls.
+> 
+>### Green Fingers
+> 
+> Plants always prosper under your care. Your crops never suffer from natural diseases or pests so long as you personally tend to them, and you can therefore get half as much again in terms of yield as others.
+> 
+>### Pricking Thumbs
+> 
+> If you are in the presence of someone who bears you ill will, you feel a pricking sensation in your thumbs. You cannot distinguish one enemy from a crowd with this ability.
+> 
+>### Unusually Fecund
+> 
+> Every sexual encounter with a partner of the opposite sex results in conception.
+
+#### Weal
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Weal with an initial score of 1.
+
+#### Woe
+
+*Minor, Supernatural*
+
+See Chapter 6: Faerie Wizardry for a full description of this Faerie Power. Choosing this Virtue gives the character Woe with an initial score of 1.
+
+### New and Modified Flaws
+
+Faerie Characters may take these Flaws.
+
+#### Faerie Antipathy
+
+*Major or Minor, Supernatural*
+
+The character has a negative relationship with the Faerie realm, and receives a negative Sympathy Trait, with an initial value of –1 for a Minor Flaw and –3 for a Major Flaw. Subtract the character's Warping Score from this value at the end of character creation, so that a character with the Minor version of the Flaw and a Warping Score of 3 would begin with a –4 Trait.
+
+This Flaw may be taken more than once. See Sympathy, above, for more information about Sympathy Traits.
+
+#### Faerie Heritage
+
+*Major, Story*
+
+This Flaw can only be taken by characters with Faerie Blood or Strong Faerie Blood. Your birth was intentionally engineered by a highly cognizant faerie to fulfill some aspect of his or her glamour. You have a role to play in the story of your faerie stepfather or stepmother, although you may be initially unaware of the interest in your life. Before she involves you in her schemes, your "patron" is likely to test your suitability as her champion with a series of trials. You can expect to receive no assistance from your "patron."
+
+#### Faerie Metamorphosis
+
+*Minor, Supernatural or Hermetic*
+
+This Flaw can only be taken by characters with The Gift (as a Hermetic Flaw) or the faerie equivalent (as a Supernatural Flaw), such as a Mythic Companion Virtue. When the character's Warping score reaches 1, he develops a glamour as described under Faerie Warping. The Reputation granted by this glamour progresses just like a character suffering Faerie Warping, although he does not develop further Flaws or Virtues as a result of Warping. The character continues to experience Twilight (if a Hermetic magus) or Faerie Calling (if a faerie magician).
+
+#### Faerie Upbringing
+
+*Minor, General*
+
+(See ArM5, page 54)
+
+In addition, this Flaw raises the maximum score to which the character may increase Sympathy Traits by 1. Thus, a character with Faerie Upbringing and a Warping Score of 2 could increase a Sympathy Trait to +3.
+
+>## New and Modified Flaws
+> 
+>### Major, Hermetic
+> 
+> Homunculus Wizard
+> 
+>### Minor, Hermetic
+> 
+> Faerie Metamorphosis
+> 
+>##" Major, Story
+> 
+> Faerie Heritage Greater Charm Homunculus Wizard **Minor, Supernatural**
+> 
+> Faerie Antipathy Faerie Metamorphosis
+> 
+> Lesser Charm
+> 
+>### Major, Supernatural
+> 
+> Faerie Antipathy
+> 
+>### Minor, General
+> 
+> Faerie Upbringing
+
+#### Faerie Upbringing
+
+*Minor, General* (See **ArM5**, page 54)
+
+In addition, this Flaw raises the maximum score to which the character may increase Sympathy Traits by 1. Thus, a character with Faerie Upbringing and a Warping Score of 2 could increase a Sympathy Trait to +3.
+
+#### Greater Charm
+
+*Major, Story*
+
+One of the character's Virtues (usually a Supernatural Virtue) is ruled by a charm, which is required to activate it. This Flaw has all the effects of the Lesser Charm Flaw (see below) with one important difference — only one copy of the charm can exist, and the charmed Virtue is transferable to anyone who steals it (either the physical object or else by someone overhears a charm-poem or a ritual). To regain his Virtue, the character must either retrieve or destroy the original charm. In the case of a verbal charm such as a song or poem, or a performance charm such as a dance or a tune, the character forgets how to perform the charm when it is stolen, and therefore must witness the thief using the charm before he can steal it back by performing it himself. The charm may be transferred over and over again to many different people before the character manages to regain it. See Charms, earlier, for more details about using the Greater Charm Flaw.
+
+#### Homunculus Wizard
+
+*Major, Story or Hermetic*
+
+The character must have The Gift to take this Flaw. The character has a special Faerie version of The Gift, by virtue of its bond with a faerie homunculus. See later for more information. This is a Story Flaw, but may also count as a Hermetic Flaw if the character is a magus.
+
+#### Lesser Charm
+
+*Minor, Supernatural*
+
+One of the character's Virtues (usually a Supernatural Virtue) is ruled by a charm, which is required to activate it. There is always some minor ritual involved to use theaffected Virtue; this ritual need not be complex or obvious (taking less than a round), but is a necessary condition of the Virtue. Typical activation charms involve reciting a poem, applying a lotion, rubbing the head of a carved image, or kissing the pommel of a sword. The charm only works for the owner of the virtue; if it is stolen or its secrecy compromised, the charm stops working and must be made anew by the character before the Virtue may be used again. Remaking the charm takes the same time that it would to make a mundane object of the same type, typically less than a day. See Charms, earlier, for more details about using the Lesser Charm Flaw.
+
+## Faerie Abilities
+
+The following Abilities can be taken by faerie characters.
+
+#### Ceremony
+
+This Ability is used in conjunction with another Faerie Supernatural Ability to produce a greater effect. To use it, the character must gather a group together and determine what they are going to do. Since it increases the potency of faerie effects, at least one of the participants must possess the Ability (this character is called the **focus character**); if it is a Power, whatever Method the character would use to enact a rite must be performed by each member of the group. Because of this, all of the participants are considered to be the caster when evaluating the effect.
+
+Any number of people can participate in a ceremony. The group generates a **group modifier** by adding up all of their Ceremony scores and subtracting the total number of participants. This group modifier is applied to the focus character's total, and might be positive or negative depending on how many people have joined the ceremony and how skilled they are at performing it together.
+
+**Group Modifier: total Ceremony scores – number of participants**
+
+All participants also add their scores in the appropriate (Characteristic + Ability) or (Characteristic + Method) to the focus character's total. If a character does not have the relevant Ability or Method, only the Characteristic is added. After this bonus has been applied, the focus character rolls the die and resolves the effect as normal.
+
+(As there are several versions of this Ability associated with different realms, you should list this as Faerie Ceremony on the character sheet if it is necessary to distinguish them.)
+
+**Specialties:** With a certain Ability, in particular circumstances, with a specific person. (Supernatural)
+
+#### Curse-Throwing
+
+This Supernatural Ability is usually aligned to the Faerie Realm, but can be potentially aligned to any supernatural realm. It enables the character to heal diseases, remove curses, and dispel detrimental magical effects, but only by transferring (or "throwing") their effects to another person. Curse-Throwing cannot affect Flaws; specifically, someone with the Lesser or Greater Malediction Flaw is beyond the power of Curse-Throwing, unless it is a Flaw imposed by a faerie or magician with a limited duration. However, any other curse laid by a supernatural power is potentially within the remit of this Ability; note that curses laid directly by God (such as leprosy) are normally represented by permanent Flaws, and thus exempt. Only harmful effects can be transferred with this Ability, and the storyguide is the arbiter in cases where spells are not directly detrimental. Barrenness is a common affliction treated by this power; if transferred to a man or male animal then impotence is inflicted instead. Other curses transferred to inappropriate targets are changed in a similar manner.
+
+>## Example of Curse-Throwing
+> 
+> A young woman has failed to conceive despite four years of marriage, and she and her mother visit Aelfred, the local faerie doctor. He explains that her barrenness needs to be transferred to another, and the mother volunteers, since she has already had three children. The Ease Factor for this operation is 12, since barrenness is equivalent to a Minor Flaw. The ritual takes three hours, at the end of which, Aelfred generates a Casting Total: 2 (Presence) + 5 (Curse-Throwing) + 5 (stress die) + 2 (Faerie Aura of Aelfred's home), for a total of 14. However, unbeknown to the characters, the barrenness was caused by the curse of a local witch. Her Hex Ability score was 5, thus the Ease Factor was actually 17 (12 + Hex 5). Since Aelfred's player succeeds in an Intelligence + Faerie Lore roll, the storyguide informs him that Aelfred suspects that his Curse-Throwing should have worked if the barrenness was natural. Aelfred counsels the mother and daughter to investigate whether they have any enemies with supernatural powers.
+
+To throw a curse, the afflicted person must be physically present, and the recipient of the curse must be represented either in person or by an Arcane Connection. Afflictions can be passed from humans to animals or vice versa, but this is harder than transferring within the same species. Curse-Throwers sometimes transfer the curse to themselves, but such altruism is rare. To throw a curse, the character must perform an elaborate ritual that involves the crafting of a charm that transfers the curse. This charm is a combination of a physical object and a chant. The object is repeatedly touched to the target and the recipient (or the Arcane Connection), while the chant is repeated over and over. The ritual typically takes an hour for every 5 points (or fraction) of the Ease Factor (see below). At the end of this time, the character generates a Casting Total, which must equal or exceed the Ease Factor listed below. If either the sufferer or the intended recipient of the curse has Magic Resistance, the Penetration Total must exceed it, else the curse stays where it is. A botched Curse-Throwing roll swaps the recipient of the curse to the caster.
+
+> **Curse-Throwing Casting Total: Presence + Curse-Throwing + Aura + stress die**
+
+**Penetration Total: Casting Total – Ease Factor + Penetration Bonus (see ArM5, page 84)**
+
+**Ease Factor:** 9
+
+**Curse:** Minor Disease or Affliction\*
+
+**Ease Factor:** 12
+
+**Curse:** Serious Disease or Affliction\*
+
+**Ease Factor:** 15
+
+**Curse:** Major Disease or Affliction\*
+
+**Ease Factor:** 18
+
+**Curse:** Critical Disease \*
+
+**Ease Factor:** 12 + magnitude of spell
+
+**Curse:** Spell
+
+**Ease Factor:** 12 + Ability score **Curse:** Supernatural Ability
+
+**Ease Factor:** 12 + Might points spent
+
+**Curse:** Power
+
+\* A Minor disease inflicts a Light wound, a Serious disease inflicts a Medium wound, a Major disease inflicts a Heavy wound, and a Critical disease inflicts an Incapacitating wound. See Art & Academe, Chapter 4: Medicine for more details. Minor Afflictions include boils and warts. Serious Afflictions are equivalent to a Minor Flaw in magnitude, whereas Major Afflictions are as severe as a Major Flaw.
+
+| Casting Total Modifier | Example Situation |
+|------------------------|-------------------|
+| 0  | Recipient present in person |
+| –1 | Recipient represented by Arcane Connection lasting decades or more |
+| –3 | Recipient represented by Arcane Connection lasting months or years |
+| –6 | Recipient represented by Arcane Connection lasting weeks or less |
+| –3 | Recipient is different species to target |
+
+**Specialties**: Diseases, faerie curses, livestock. (Supernatural)
+
+## Learning Faerie Abilities
+
+Any characters who are strongly aligned to the Faerie realm can learn Faerie Supernatural Abilities. This works exactly like Gifted characters learning Magic Abilities (**ArM5**, page 166), in that the sum of the scores of all other Supernatural Abilities or Arts the character possesses must be subtracted from the character's Advancement Total for the season. However, because gaining new powers depends so strongly upon the character having a positive relationship with the Faerie realm, the maximum number of experience points the player can gain towards learning a new Faerie Ability or Art is also limited by the character's Faerie Rank, so that the sum of the character's strongest positive and negative Sympathy Traits must equal at least 5 at the start of the season for him to learn a new Ability in this way.
+
+Every tradition of faerie hedge wizardry typically has four Favored Abilities, which are easier for them to learn and teach to each other. Characters who have been initiated into the tradition can learn any of these Abilities or Arts without subtracting the value of the others from their Advancement Totals, and without limiting their Advancement Total by their Faerie Rank.
+
+## Faerie Doctors
+
+If humans are to dwell in regions haunted by the fae — such as the rural areas that provide the food of nations — then they must learn to come to an amicable relationship with their good neighbors. In lands historically connected to Saxon cultures (principally England, Frisia, and Saxony), a faerie doctor may act as an intermediary between the humans and the fae, leaving the region blessed indeed. Also called a *lybman* (who practiced *lyb-craeft* — magical healing and surgery), the faerie doctor is a human who speaks to the faeries on behalf of the peasants, explaining their concerns and wishes. Likewise, the local faeries know that the faerie doctor supports their flow of vitality by reinforcing the tales and lore of their kind within his region of influence. The faerie doctor takes it upon himself to keep the memory of the local fae alive through stories, and to ensure that their homes are not violated. Should a dispute between humans and faeries arise, the faerie doctor attempts to mediate, ensuring that there are no misunderstandings on either side; but he must try to remain a neutral party. In addition to his job as mediator and storyteller, the faerie doctor also administers directly to his human charges through use of faerie-granted supernatural powers, such as the removal of blights, banes, and diseases through his Curse-Throwing power (see above). Faerie doctors are also adept at locating water and lost things through dowsing.
+
+The faerie doctor is trained from birth by a relative, often an uncle, for the calling tends to run in families. Faerie doctors are almost exclusively male, although women can be taught the art if no other relative can be found. The apprentice is taught the lore of the faeries, and has direct and personal contact with all the Good Folk in the local region. As the boy enters puberty, he acquires a companion from among the fae, a friend who provides him with unique insights into faerie-kind and warns him if he is about to make a social *faux pas*. These faeries usually have a high cognizance, and this proves useful in explaining the actions of other fae. Apart from this, the faerie friend can take any form — it may be a willowy nymph, a talking animal, a wizened dwarf, or any number of other types of faerie. Upon acquiring his companion, the faerie doctor's apprenticeship is complete. He either takes over his mentor's practice, goes into partnership with him, or moves to a new area to strike out on his own.
+
+Faerie doctors often accompany their oath to not take sides in conflicts between humans and faeries with other oaths that reflect their status as having a foot in both realms. The most common oaths are to never cut one's hair, never grow a beard, wear women's clothes, and remain celibate. Such oaths represent the distance the faerie doctor must keep from the rest of humanity to maintain his close connection with the fae. Unsurprisingly, a faerie doctor may clash with the priesthood who see his "clients" as demons or evil spirits; however, the faerie doctor is rarely pagan himself. He simply realizes the true place of the fae in the daily lives of those who are under his care. 
+
+> # Story Seed: The Sorcerous Scapegoat
+> 
+> A Bjornaer magus comes to the characters for help. He was unwittingly part of the scapegoat rite when observing Jewish practices in his goat heartbeast, and now seeks a way to unburden himself from the community's sins.
+
+### Faerie Doctors as Mythic Companions
+
+Players wishing to play a magus-level faerie doctor should take the Faerie Doctor Special Virtue, which makes him into a Mythic Companion, as detailed in previous books for **Ars Magica Fifth Edition**. As a Mythic Companion, the Faerie Doctor receives one free Minor Virtue — Dowsing — and receives 2 points to spend on Virtues for every point he spends on Flaws, allowing him a maximum of 21 points of Virtues (including his free Dowsing Virtue) for 10 points of Flaws. However, there are some compulsory Virtues and Flaws he needs totake to fulfill his function as a Faerie Doctor, as given in the list below:
+
+- Wise One (Minor Social Virtue);
+- Curse-Throwing (Major Supernatural Virtue);
+- Faerie Friend (Minor Story Flaw);
+- Dutybound –– obey the oaths of a faerie doctor (Minor Personality Flaw).
+
+>## Sin-Eating
+> 
+> In some cultures, the supernatural power of Curse-Throwing is called Sin-Eating. A sin-eater uses this power to take on the sins of the dying or recently dead, often acquired by eating a ritual meal of bread, salt, and ale over the body of the sinner. It is believed that the sin-eater not only saves the deceased from Hell, but also prevents his spirit from wandering the world as a ghost. The magnitude of the unforgiven sin should be considered to be a Minor, Serious, or Major Affliction as appropriate. The effect of Sin-Eating on the soul of the practitioner or the fate of the mortal soul remains unknowable, but Sin-Eating does prevent the spirit of the deceased from becoming a ghost due to unrepented sins. A sin-eater can still use his Supernatural Ability in the standard fashion, and most commonly takes the curse onto himself. Sin-eaters are often outcast from society, shunned because of the sins they accumulate through their career. The Church regularly excommunicates sin-eaters, not only because of the burden of sin that they carry, but also because they encroach on the territory of the clergy to administer to the dead. A particularly evil sin-eater might transfer the sins of the dying onto an otherwise innocent child in return for pecuniary gain.
+> 
+> Sin-Eating stems from a similar tradition to Curse-Throwing, and thus is most common in cultures descended from Saxon people — those of England, Flanders, Frisia, and Saxony. Analogous traditions exist in other cultures, such as the Bavarians and the people of the Balkan Peninsula. An intriguing variant of Sin-Eating is part of the Jewish atonement rituals. Jewish practitioners of a version of Curse-Throwing aligned to the Divine Realm still conduct the rite of the scapegoat. A goat is loaded with the sins of a community on Yom Kippur, and driven into a place of desolation. Incorrectly identified as a propitiatory sacrifice to Satan, the scapegoat (and this is the origin of that phrase) is an act of obedience to God as detailed in Chapter 16 of Leviticus.
+
+The Faerie Doctor can choose up to 8 more points of Flaws, granting him up to 16 more Virtue Points. The Student of Faerie Virtue and the Faerie Upbringing Flaw are very common among Faerie Doctors; and a high number are Transvestites. Many of them possess enhanced abilities to resist many curses and diseases (such as a Greater or Lesser Immunity, or Rapid Convalescence Virtues). Other useful Virtues include Summoning (see New Virtues and Flaws), Control Fertility (see *Houses of Hermes: Societates*, pages 107–108), Free Expression, Herbalism (*Art & Academe*, Chapter 4: Medicine), Purifying Touch, and Second Sight. The Profession: Storyteller Ability is almost essential.
+
+A character can be a faerie doctor without being a Mythic Companion, but they are understandably less powerful. They must still take the compulsory Virtues and Flaws listed above, but must balance Virtues and Flaws in the normal manner (**ArM5**, page 28). Faerie doctors who have The Gift instead of being a Mythic Companion can choose one Supernatural Ability without needing the corresponding Virtue; for faerie doctors this is usually Curse-Throwing. Gifted characters can learn Supernatural Abilities as described on page 166 of **Ars Magica Fifth Edition**. Their favored Abilities are Curse-Throwing, Dowsing, Summoning, and Second Sight; the scores in these Favored Abilities do not penalize the Source Quality for learning other Favored Abilities. The scores in non-Favored Supernatural Abilities still penalize the Source Quality when learning Favored Abilities, and *vice versa*.
+
+# Homunculi Wizards
+
+Just as there are magi in Mythic Europe who are interested in faeries and who have adapted their magic to the Faerie realm, there are also hedge wizards aligned to Faerie who are interested in the Magic realm and have learned to adapt their faerie powers to seem magical. One sort does not have The Gift, but instead gets their power from their bond with a strange kind of faerie known as a homunculus.
+
+Homunculi might be described as faeries that live on the boundary between Magic and Faerie. They are said to be born from the dreams of magi, and typically look like tiny humans with exaggerated features. They come into the world as infants, and in this state they are highly impressionable, forming a powerful and lasting bond with the first person they see. If nurtured and cared for, they do not grow any larger, but their other extraordinary powers begin to emerge: by drawing vitality from their keeper, they can transform their glamour into the semblance of Magic.
+
+The person to whom a homunculus is bound effectively has a faerie version of The Gift. He can learn Supernatural Abilities, and even become opened to the Hermetic Arts, though he cannot have a talisman or a bind a familiar. All of his powers are associated with the Faerie realm, and he does not suffer Warping from living in Faerie auras, though he is vulnerable to Magic auras and Magical Warping. He does not go into Twilight, but instead experiences Faerie Calling (see later). People and animals are not disturbed by his presence, for he has a faerie equivalent of the Gentle Gift.
+
+The homunculus wizard's power is external rather than internal, and entirely dependent upon his faerie charge. Once a day he must secretly feed the homunculus some of his own blood, and the rest of the time he must keep it safe from harm and shielded from prying eyes. If the homunculus is ever harmed, or if any other human being ever sees it, it will shrivel up and die instantly. Until he can find and bind another homunculus to him, he will be unable to use or improve any of his powers that are not associated with Faerie or that require The Gift.
+
+There are said to be a few homunculus magi in the Order, though no one knows for sure since most of them are careful to keep their true natures hidden. What little that other magi know about them comes from the few hedge wizards living in Mythic Europe who have revealed their secrets to magi when questioned. Like other hedge wizards who live among magi, their power is generally considered too weak to threaten the dominance of the Order, and too minor to require them to "join or die."
+
+To play a Homunculus Wizard as a character, take The Gift and the Homunculus Wizard Flaw during character creation. If the character is a magus from House Ex Miscellanea, this may be taken as the character's inherent Flaw. Homunculi Wizards also benefit from House Merinita's outer mystery of Faerie Magic, as it attunes them with the Magic realm as well as Faerie.
+
+## Faerie Warping
+
+**Ars Magica Fifth Edition** does not distinguish between warping caused by faerie sources, and warping deriving from magical, divine, or infernal sources. For some characters, however, the principle source of warping can be identified to come from faerie sources. Such a character might live in a powerful aura, consort regularly with faeries, or else be a practitioner of faerie magic. These characters demonstrate a distinctive pattern of warping associated with their connection to the fae.
+
+Characters with supernatural powers aligned to the Faerie realm suffer Virtues or Flaws through Warping unless they belong to a magical tradition that provides another means of responding to Warping, such as the Order of Hermes. Characters with Sympathy Traits and Faerie Rank experience Faerie Calling instead, as described later. If a character experiences Warping through one of these other means, he cannot acquire a glamour as described here unless he possesses the Faerie Metamorphosis Flaw (see New and Modified Flaws, earlier).
+
+**Warping Score of 1**: In the place of the usual Flaw gained when the character's Warping Score reaches 1, a character may instead begin to develop a glamour of her own. The troupe should decide on a new Reputation for the character based on her actions in a prominent story. The Reputation, which begins at a score of 1, represents the stories told about her, and increases whenever the character's Warping Score increases. This Reputation is a Flaw, and so should be a hindrance to the character. For example, it might make her famous when she'd rather stay anonymous, or represent an unpleasant side of her character. Note that the Reputation need not be accurate, but it must be appropriate; a grog seen in the company of the walking dead could gain a Reputation as an Evil Necromancer, and a scholar who carries a sword could become known as a Soldier. This glamour has other effects that manifest as the character's Warping Score increases; see later for more details.
+
+**Warping Score of 3**: At this level of warping, the character suffers some supernatural penalty, which manifests as either Faerie Antipathy (Minor) or Lesser Malediction. If the character took on a glamour at a Warping Score of 1, he also develops the desire to derive vitality from his glamour. Since the character is still human ,this desire manifests as a need, and he suffers if he deprives himself of this need. The character must act in a manner concordant with his Reputation at least once a season, or else he suffers the effects of Deprivation (see **ArM5**, page 180). Thus, a character with the Soldier Reputation can stave off Deprivation by being involved in combat, and a character with a Reputation as an Evil Necromancer can prevent Deprivation by scaring some villagers with ghosts. When the character's Warping Score rises to 4, the interval between Deprivation rolls becomes a month; when it becomes 5 the interval is a week; and at a Warping Score of 6 or greater the interval is a day.
+
+**Warping Score of 5**: The character nearly always develops a Virtue that represents some minor faerie power at this level of warping, such as Faerie Sympathy (Minor), Lesser Benediction, Lesser Immunity, or Second Sight. A character who adopted a glamour is now so in touch with his personal story that he gains a Sympathy Trait of +1 in an area associated with his warping-derived Reputation (see Sympathy, above, for more details). Thus, a character with the Soldier Reputation might develop Fighting for a Cause +1, whereas the Evil Necromancer might acquire Dead Bodies +1.
+
+**Warping Score of 6+**: Supernatural Flaws usually manifest at each level of warping of 6 or greater, such as Greater Malediction or Magical Air. At a warping Score of 6, a character with a glamour also gains a new negative Sympathy Trait of –1. Once again, the affected Trait must be appropriate to the mantle of glamour that warping has given him. Thus, the Soldier might receive Cowardice –1, and the Evil Necromancer might suffer Compassion –1. When his Warping Score increases to 7 he gains another point of positive Sympathy, at 8 he gains another negative point, and so forth.
+
+### Sources of Faerie Warping
+
+There are several ways a character can receive Warping from a faerie source.
+
+#### The Faerie Realm
+
+Characters who adventure in the Faerie Realm may suffer Warping for the time spent there. This Warping partially or wholly offsets the effects of time dilation of the Faerie Realm. See Chapter 2: The Faerie Realm for more details.
+
+#### Faerie Auras
+
+Powerful Faerie auras and regiones grant Warping Points (**ArM5**, page 167) unless the character possesses a Faerie Might or Supernatural Abilities aligned to the Faerie realm.
+
+#### Faerie Powers
+
+The powers of faeries cause Warping to their target as powerful mystical effects (**ArM5**, page 168) if the faerie spends six or more Might points in activating the power. The powers of a faerie magician cause Warping if they create an effect of Level 30 or greater.
+
+#### Botches
+
+One Warping Point is gained for every botch die that comes up a zero when using faerie powers or supernatural effects aligned to the Faerie realm. The Warping caused by Divine, Infernal, or Magical botches that occur in a Faerie aura can also be assumed to induce Warping Points from a faerie source.
+
+## Faerie Calling
+
+When a character who is strongly aligned to the Faerie realm gains 2 or more Warping Points at once, he experiences the phenomenon known as Faerie Calling. This is when the attention of the Faerie realm is drawn to the character, and faerie spirits from outside the mortal world enter his being and attempt to coerce or force some of his vitality from him — the faeries come calling, so to speak, and do not leave until they are properly appeased. This experience is confusing and potentially frightening for the subject, like a daydream or a waking nightmare.
+
+Before proceeding, it is important to first resolve the scene in which the character suffered Warping. Until the Faerie Calling has been addressed, the character becomes dazed and delusional, and has great difficulty responding to his environment or communicating with others. It might be best to simply treat the character as if he were Incapacitated, though if the character is in mortal peril, the storyguide can allow him to stumble to safety or strike desperately at his opponent. More complicated actions should require a Perception + Awareness roll against an Ease Factor of (3 x (Warping Score + number of Warping Point gained)) to comprehend what is going on around him. For the most part, the character should be out of the action.
+
+**Act During Faerie Calling: stress die + Perception + Awareness vs. ((Warping Score + Warping Points gained) x 3)**
+
+Once the immediate scene has finished, the storyguide should ask the player to leave while she determines the circumstances of the Calling, and assigns parts to the other players, assuming they wish to play out the event. They will act as the faeries in the character's mind who drive the dream scenario forward, picking at his hopes and fears from inside. The targeted player should leave the room briefly while they discuss it. With the help of the other players, the storyguide must decide on the scene's **setting** and its **conflict**. The setting describes where the character believes himself to be, and the conflict describes what the character must do to leave the dream.
+
+The setting is usually a place of transition, literally or figuratively, and it can either be drawn from the subject's memories or located somewhere the character has never been. It might be an important event of his past, or what seems to be an ominous vision of the future. It could even be the same moment in the present. The character's Sympathy Traits typically figure prominently in the dream, and the mood of the setting depends upon the character's Faerie Rank — if negative, the setting is antagonistic and his Traits are against him; if positive, the dream is pleasant and his Traits will help him. The players will take on roles that are appropriate to this setting and mood.
+
+The conflict should describe what the character can do to leave the Calling and return to consciousness. This could center on a specific act, such as a child who needs to be rescued, a monster who must be defeated, or a carriage ripe for robbing. Often the conflict centers on resolving the transition depicted by the setting, perhaps by moving from one place to another, or by changing himself or someone else. Some example conflicts might include: leaving a forest, growing old, or marrying a prince. Different players might try to convince the character to do one thing or another in the dream.
+
+When the players have worked out how they want the scene to go, invite the player back and describe the setting. Through the course of the story, the character will still have all of his powers and possessions, and can do whatever he could do outside of the dream, though it might seem like he should not be able to do so. His appearance might change to be appropriate to the setting, so that he seems to be a child or an animal or perhaps a cloud of dust, but this does not alter his abilities or his faculties.
+
+Allow everyone to experience the scene and contribute something to the setting, but if the players have not resolved the conflict after a certain amount of time, say about fifteen minutes of play, have the player of the affected character make a stress roll + Perception + Concentration. If this total exceeds the character's ((Warping Score – Faerie Rank) x 3), the character has a positive experience. Otherwise, he has a negative experience.
+
+**Resolve the Faerie Calling: stress die + Perception + Concentration vs. (Warping Score – Faerie Rank) x 3**
+
+After a positive Faerie Calling, the character gains a new Sympathy Trait with a value of +1, or increases one of his Sympathy Traits that is particularly appropriate to the scene by 1. A negative experience gives the character a negative Sympathy Trait at –1, or reduces one of his appropriate Sympathy Traits by 1.
+
+When a character with Faerie Rank of 10 or more has a positive experience, or when a character with Faerie Rank of –10 or more has a negative experience, he does not return from the Faerie Calling once the scene is resolved. Masters of Faerie Lore imagine that this is because the person is so filled with the power of the Faerie realm that he is transformed into a faerie being, and so makes his way into Faerieland to remain forever. His body and his most treasured possessions slowly fade from the mortal realm, perhaps leaving behind a few material remains appropriate to his Sympathy Traits, such as a pile of leaves, a mound of ashes, or a puddle of water.
+
+Only characters with Faerie Rank are affected by the Calling, and only if they do not also belong to a magical tradition associated with another realm. The Divine, Infernal, and Magic realms all take precedence over the Faerie realm in this respect; upon gaining Warping Points, a magus experiences Wizard's Twilight, a holy character experiences Divine Ascent (see *Realms of Power: The Divine*, page 63), and an infernalist must undergo Vituperation (see *Realms of Power: The Infernal*, page 95).
+
+# Chapter Six: Faerie Wizardry
+
+Characters with Faerie Sympathy (represented by positive or negative Sympathy Traits) can learn to perform two different types of hedge wizardry: faerie rites and faerie bargaining. These characters are called faerie wizards, or sometimes faerie hedge wizards. They may join certain groups (called traditions) that teach their members the Supernatural Abilities and Arts they use to produce these effects; all of these traditions and the faerie powers they practice are described in more detail in this chapter.
+
+## Rites of Faerie
+
+Some faerie wizards are able to bring about supernatural effects with spontaneous spells that are similar to those used in Hermetic magic. Their sympathy with the faerie realm and knowledge of certain supernatural methods for drawing upon this sympathy allows them to focus their powers upon these spells, called rites.
+
+### Performing Faerie Rites
+
+Faerie rites require the character to possess three things: a Faerie Method, a Faerie Power, and faerie sympathy with the target, represented with an appropriate Sympathy Trait. The Method describes what the character must do to perform the rite, the Power describes the effect of the rite, and the Sympathy Trait describes the qualities the target must possess.
+
+If the character has an appropriate Sympathy Trait, and has met the activation conditions of the Faerie Method, he rolls a stress die and adds the result to the following formula: the Characteristic associated with the Faerie Method + the character's score in the Faerie Method Ability + the character's score in the Faerie Power Ability + the aura modifier for a Faerie effect. The result is the level of effect produced by the rite, though this cannot exceed the value of (the sum of the character's applicable Sympathy Traits x 5). For example, a character with two applicable Sympathy Traits — one at +2 and the other at +1 — has a Sympathy Trait total of +3, and cannot produce an effect greater than level 15.
+
+**Rite Casting Total: stress die + Characteristic + Method + Power + aura modifier**
+
+**Maximum Rite Level: (Sympathy Traits x 5)**
+
+It is possible to use negative Sympathy Traits to perform a rite, since they mean that the character has a powerful relationship with the faerie realm, albeit a negative one. When calculating the maximum level of a faerie rite, you should treat negative Sympathy Traits as if they were positive. Thus, a character with two applicable Sympathy Traits, at +1 and –4, could produce an effect of up to Level 25.
+
+When performing a faerie rite, a roll of 1 on the stress die gives the character an experience point in all of the applicable Sympathy Traits used in the ceremony, and a botch removes an experience point from each of them, just as when using Sympathy Traits as specializations. Negative Sympathy Traits also add additional botch dice, as usual.
+
+Characters have access to a wide variety of Ranges, Durations, and Targets associated with the Faerie realm when performing faerie rites. These are listed in the sidebar below. They can also use any of the standard Hermetic parameters, and players are also encouraged to invent others that seem appropriate to the effects produced by the rites, since there are many other limitations on these effects (especially the requirement for applicable Sympathy Traits).
+
+Ritual-level rites take fifteen minutes for each magnitude of the effect, just as in Hermetic magic, but do not require vis. However, it is impossible to produce a permanent effect with a faerie rite, the way it is done with Hermetic spells; rituals with Momentary duration simply end, and the targets immediately return to their natural and unaffected state. The only circumstances that have lasting effects are when the rite involves a natural (or supernatural) process, such as aging, healing, or Warping. For example, an effect that forces a character to age temporarily subjects that character to the same physical conditions that winter causes each year, and if the player fails the roll the character suffers the natural consequences.
+
+### Hermetic Rites
+
+A magus with a Faerie Method and Power can design rituals that use the guidelines for faerie rites, and may use any of the special Faerie Ranges, Durations, or Targets in these Hermetic versions. The storyguide should determine which Technique and Form are used for the ritual, but just as in faerie rites the effects are not natural changes, and will fade as soon as the duration expires. These rituals are cast like Hermetic rituals, including the vis cost, though the caster may use magic or faerie vis without penalty. Also, the caster may add his scores in the Method and Power instead of Artes Liberales and Philosophiae to his Casting Total, and the player may use either the Faerie column or the Magic column of the Realm Interaction Table to determine the aura modifier. The caster must still perform the actions prescribed by the applicable Method during the casting of the ritual, including any additional costs such as expended Fatigue levels or Confidence Points.
+
+>## Faerie Ranges, Durations, and Targets
+> 
+> A character casting a faerie rite may always use any of the following Ranges, Durations, and Targets, in addition to those associated with Hermetic magic (**ArM5**, pages 111-114) and the Faerie Magic of House Merinita (**ArM5**, pages 92-93).
+> 
+> **Crossroads (Range):** This range allows the character to affect a target that is on a road, from another road that intersects it, and is otherwise like Road (**ArM5**, page 92) save that any number of roads can cross each other with this Range. Note that the caster cannot affect targets on the same road as him. It is most effective when cast at an intersection, since there it can affect targets on either road, and is considered the same level as Voice.
+> 
+> **Presence (Range):** The character radiates a sort of faerie aura, which is not visible and has no effect on others except that it allows him to affect targets within this area through an extension of himself. The size of the aura depends upon the character's Presence, as shown below.
+> 
+> | Presence | Distance  |
+> |----------|-----------|
+> | +4/+5    | 100 paces |
+> | +2/+3    | 50 paces  |
+> | –1/0/+1  | 15 paces  |
+> | –2/–3    | 5 paces   |
+> | –4/–5    | 0 paces*  |
+> 
+> \* Caster only.
+> 
+> For the purposes of calculating spell levels, this range is the same as Voice.
+> 
+> **Prop (Range):** This is the same level as Touch. The caster touches the target with something that he is also touching. If the prop is too large for the caster to carry, the effect must include additional magnitudes for its size. For example, to affect a target through a wall upon which both target and caster stand would likely add two or three magnitudes to the rite.
+> 
+> **Symbol (Range):** You can affect a symbol of your target as if it were an Arcane Connection to it, essentially allowing you to create an Arcane Connection. This spell must be a ritual, but is otherwise equivalent to Arcane Connection range. To fashion a symbol, the character must have at least 3 points of Sympathy Traits that are applicable to the target. These are cumulative with the other Symbol parameters, so that a rite that includes Range, Duration, and Target: Symbol requires at least 9 points of Sympathy Traits. If the symbol does not uniquely describe the target, the spell will fail, since an Arcane Connection must be specific to a single target (unless cast with Target: Symbol).
+> 
+> **Held (Duration):** This duration is the same level as Concentration. The character may perform the rite as normal, but the effect is delayed for as long as he concentrates. When he releases it, treat it as if cast with Momentary duration.
+> 
+> **Focus (Duration):** The effect lasts until the caster performs another supernatural effect, including using Sympathy Traits as Ability specializations. During this time, the caster does not heal, recover fatigue or Might, or gain Confidence. It is equivalent to Concentration.
+> 
+> **While (Condition) (Duration):** The target must perform some activity such as a musical performance or reading a book, or fulfill some common and temporary physical condition like sleeping or being drunk. As long as that condition lasts, the effect remains. This is the same level as Concentration.
+> 
+> **Geas (Condition) (Duration):** Instead of causing an effect to take place immediately, the character can cast it as a conditional effect using this Duration. This ensures that the effect only manifests in response to an uncommon circumstance that is clearly outlined for the victim as part of the spell. For example, a geas might specify that a knight will lose all his courage if he ever commits adultery or refuses a challenge. The effect of the geas can also target something other than the person affected by the condition, as long as both targets are within range of the effect when it is cast. If either the target or the victim has Magic Resistance, the effect must penetrate at the time of casting to have any effect, and it may be dispelled through powers that undo other powers before the effect comes to pass. It is the same level of Duration as Sun, but adds a second Duration to describe the triggered effect; i.e. Geas/Moon would cost five magnitudes.
+> 
+> **Hour + 1 (Duration):** The effect lasts for an hour and a day; approximately 13 hours. It is equivalent to Sun.
+> 
+> **Midday/Midnight (Duration):** This duration is equivalent to Sun, but does not manifest until dawn, noon, dusk, or midnight. It then lasts until noon, dusk, midnight, or dawn. For example, a spell cast just after dawn would not manifest until noon, and would then last until dusk.
+> 
+> **Not (Condition) (Duration):** The spell lasts for as long as the target does *not* fulfill some common physical condition, such as sleeping or speaking. It is equivalent in level to Sun duration, but cannot last longer than a month.
+> 
+> **Season (Duration):** This duration is held until the start of the next equinox or solstice, and lasts only until the following equinox or solstice. It is the same level as Moon, but requires a ritual.
+> 
+> **Aura (Duration):** The spell lasts for as long as the target remains within a supernatural aura. If the target leaves the aura or the physical world entirely (dies or goes to Arcadia, for example) the spell ends. This does allow moving from one aura to another, so long as the two auras overlap — as long as the target never leaves a supernatural aura of some kind. It is equivalent to Year, and always requires a ritual effect.
+> 
+> **Faerie (Duration):** Either the target or the caster must have Faerie Might, and must be in Mythic Europe; the spell fails the instant this condition is not met, including dying or traveling to the Faerie Realm. This is the same level as Year, and thus requires a ritual to cast.
+> 
+> **Hidden (Duration):** The spell lasts as long as the caster or target (or a significant part of the caster or target) is hidden — buried in the earth, placed inside a box, covered with a curtain or disguised by a costume — by anything, even another spell, so long as the effect with the Hidden duration does not itself hide the target. If anyone other than the caster discovers it, the spell ends immediately. This is the same level as Year, and a ritual effect.
+> 
+> **If (Condition) (Duration):** This effect triggers if the target fulfills a specific condition, which can be common and even impossible to avoid such as eating or sleeping. It has an additional Duration that determines how long the triggered spell lasts after it takes effect. To determine the level, you should add four magnitudes to the level based on the Duration that the spell has when it takes effect, and it must be cast as a ritual. The spell expires without triggering if the caster dies, or if a year passes.
+> 
+> **Symbol (Duration):** The effect lasts as long as a symbol fashioned at the time of casting does (and the symbol must be a physical object, so that a poem or song, for example, must be written down). To fashion a symbol, the character must have at least 3 points of Sympathy Traits that are applicable to the target. These are cumulative with the other Symbol parameters, so that a rite that includes Range, Duration, and Target: Symbol requires at least nine points of Sympathy Traits. If the symbol is broken, erased, falls apart, dies, or is otherwise damaged, the spell ends. If the target changes so that any of the qualities of the symbol no longer apply, the spell is interrupted, but the effects will return once these qualities are true again — unlike the Until (Condition) Duration, this effect can outlive the caster. It is the same level as Year, and requires a ritual to cast.
+> 
+> **Medium (Target):** The effect is held by a medium for the duration of the effect and passed on to an applicable target as soon as it comes within range. When the target is removed from the medium, the effect is interrupted, but as long as the duration continues, the medium can affect another target that comes into range of the effect. For example, a R: Touch rite might target a person, but use an animal as a medium, so that the caster must touch the animal; Then when the animal touches another person, the spell is cast on that person. The caster must have an applicable Sympathy Trait for the medium as well as the target, and it must be within range of the caster when the rite is performed. This is the same level as Part.
+> 
+> **Passion (Target):** The effect targets a group of people through their passions, affecting only those inclined towards a particular emotion or desire, which is integrated into the spell. Each character within the targeted area must roll a simple die and add or subtract any appropriate Personality Traits. Anyone with a total of 6 or higher is affected. This is the same level of Target as Group, and is similarly modified by the size of the affected area.
+> 
+> **Symbol (Target):** The caster affects all targets represented by a symbol within range of the spell. To fashion a symbol, the character must have at least 3 points of Sympathy Traits that are applicable to the target. These are cumulative with the other Symbol parameters, so that a rite that includes Range, Duration, and Target: Symbol requires at least 9 points of Sympathy Traits. The effect is calculated at the same level as Boundary, though it is essentially a large Group, and modifiers according to the size of the target apply. It must be cast as a ritual.
+
+## Faerie Methods
+
+Methods describe what a faerie wizard must do to draw upon the power of the Faerie realm and perform a faerie rite. They are essentially Supernatural Abilities, in that they are gained from Virtues (see Chapter 5: Touches of Faerie, New and Modified Virtues) or study (see Chapter 5: Touches of Faerie, Learning Faerie Abilities), and increase on the same scale as Abilities. Like Arts, they may only be used in conjunction with a Faerie Power, however. Note that any Method may be used with any Power, so that the only difference between them is the means by which the character can bring about the effect.
+
+Players who develop new faerie hedge wizard traditions should feel free to design new Methods for them that work differently than the three given here. Each Method must specify a Characteristic that is used to perform the rite, and typically involves some sort of cost to the character. A Method also generally has an inherent advantage in unusual circumstances. The following examples demonstrate how to properly balance the relative cost and advantages of a particular Method.
+
+### Evocation
+
+**Rite Characteristic:** Communication
+
+Through Evocation, the character ritually calls upon one or more of the many gods associated with the Faerie realm, and through a short ceremony convinces them to lend their power to the rite. The character gains a Warping Point or spends a Confidence Point, and must call upon his patron faeries in a bold voice with firm gestures, much like a typical magus casting a spell. (Note that though this Method may call upon specific gods, it actually draws upon the power of the Faerie realm in general, and so specific faeries may or may not be involved in the rite.)
+
+As part of learning Evocation, the character learns to activate vis as magi do, with each pawn spent increasing his Rite Casting Total by 2. This vis can be used to improve any rite, even those that use another Method. The character is limited to a number of pawns equal to his score in Evocation + his score in the associated Faerie Power for any given rite, and note that unless the vis is associated with Faerie, each pawn of vis adds an additional botch die in case of a 0 on the Casting roll.
+
+### Enchantment
+
+**Rite Characteristic:** Presence
+
+Enchantment involves convincing a target to accept the effects of the rite through some sort of a performance, such as a song, dance, story, or another art form. This is represented through the use of an Ability, making a roll against an Ease Factor of (the magnitude of the intended effect x 3). If the character succeeds at this task, he may then perform the rite in the following round, but with the level of the effect fixed at the intended magnitude. Or, he may begin another performance, making another roll and increasing the magnitude of the effect he is trying to produce by one. The amount by which his previous total exceeds the target Ease Factor may be applied as a bonus to the character's next roll, whether this is another performance or the Casting total for the rite. Thus, it may be better for the caster to risk botching low-level effects for several rounds, and to slowly increase the magnitude of the rite as his advantage builds. If he fails to achieve the declared Ease Factor, he cannot produce the effect of the rite and must start over with no bonus to the roll.
+
+*For example, a knight attempts to enchant a lady of his acquaintance who is watching him at a tournament, using his skill at Single Weapon to hit a target. His player would like to produce a rite with an effect level of 25, which requires him to beat an Ease Factor of 15, but he does not think he will be able to do it without making several rolls. Thus he begins by declaring an effect of Level 15, which means the Ease Factor is 9. The knight makes a pass on the tourney field, and his player rolls a 6. This combined with his score of 5 and his Dexterity of +1 give him a total of 12. He has exceeded the necessary Ease Factor by 3, and if he released the spell he would gain a +3 bonus to his Casting total. Instead, he elects to increase the effect to Level 20 and an Ease Factor of 12, and the knight makes another pass. He rolls an 8, giving him a total of 17 and a bonus of +5. Increasing the ef-* *fect level to 25 and the Ease Factor to 15, he makes a final pass and rolls a 7. This gives him a total of 17; he decides his performance is finished, and makes his Casting roll for a Level 25 effect with a +2 bonus in the following round.*
+
+The character with this Method can perform all of his rites as part of his performance activity, even those that use another Method, and it is impossible for a bystander to recognize where his performance ends and the rite begins except by supernatural means (such as Magic Resistance or effects that detect Faerie powers). Enchantment also allows the player to choose to roll a simple die on the Casting roll for any rite, even those that use another Method, removing the risk of botching and losing sympathy on a roll of 0, but also forgoing the chance to gain sympathy on a roll of 1.
+
+### Empathy
+
+**Rite Characteristic**: Stamina
+
+Empathy is the ability to create the power of Faerie within the caster, by drawing forth the qualities of the realm through intense concentration. The caster must expend a Fatigue level while undergoing a mystic ritual, typically designed to lull the caster into a trance-like state. (If the character cannot spend Fatigue levels, or is so tired that the loss would knock him unconscious, the character suffers a Light Wound instead.) The ritual takes about an hour to perform, though if the character is already in this state (intoxicated, say, or having gone without sleep for an entire day and night), it takes no additional time. The disorientation caused by the ritual lasts for the duration of the effect, so that the lost Fatigue cannot be recovered until it has ended.
+
+As long as the character possesses the Empathy Ability, he may extend the length of a rite by expending another Fatigue level. This allows him to double up any bonuses he might receive to the Rite Casting Total, such as from expending Confidence (or vis, if he has access to Evocation). Each time the character exerts himself, the limit of Confidence Points or pawns of vis he can spend is reset. As part of this calculation, Empathy allows him to effectively double the value of the Sympathy Traits that determine his effect level, so that a character with a total of 3 in Traits could produce a maximum level 30 effect by spending two Fatigue levels, or 45 if he spent three.
+
+## Faerie Powers
+
+Faerie Powers are essentially Supernatural Abilities, in that they are gained from Virtues (see Chapter 5: Touches of Faerie, New and Modified Virtues) or study (see Chapter 5: Touches of Faerie, Learning Faerie Abilities), and increase on the same scale as Abilities. Like Arts, they may only be used in conjunction with a Faerie Method.
+
+Every Faerie Power is vulnerable to certain uncommon circumstances, such as when touching iron, running water, or salt, when in the Dominion, or when repeating the character's name three times. This condition dispels all effects associated with that Power whenever it is applied to the target, or all effects associated with that Power when applied to the caster. Whenever a new Power is gained, the character must choose its particular vulnerability.
+
+### Beguile
+
+Beguile is the power to command the target to do as you suggest, or to convince him that he has already done so. Note that this power does not typically give the target the ability to do anything it cannot already do, such as allow an inanimate object to move. However, those effects that change a target's memories can change the memories of inanimate objects and other things that do not have a mind — these changes will only come to light if the object is supernaturally questioned, of course.
+
+Normally, the caster must have a Sympathy Trait that is appropriate to the target. With Beguile, however, any Sympathy Trait may be applicable so long as it is appropriate to the memory, emotion, or perception brought about by the rite. For example, a caster with a Wind Sympathy Trait could change a person's memory of a wind, perception of the wind, or feelings about the wind.
+
+**Gown of Enfolding Colors**
+
+Evocation/Beguile 15
+
+R: Touch, D: Mid, T: Room
+
+The caster causes all the people in a room to perceive her or another as especially beautiful, and more alluring than anyone else. This impression is superficial only, and the targets may see through the effect by interacting with her in a more significant way.
+
+(Base 2, +1 Touch, +2 Mid, +2 Room)
+
+**The Irresistible Dance**
+
+Empathy/Beguile 25 R: Voice, D: Focus, T: Ind
+
+The target is filled with wild, hedonistic abandon, and feels compelled to dance. While under the effect of this rite, the target must make Stamina rolls to avoid losing Fatigue levels, and cannot fall unconscious — if he would pass out, he suffers a Light wound instead and keeps dancing. The effect lasts until the caster performs another rite, or uses any other supernatural power.
+
+(Base 10, +2 Voice, +1 Focus)
+
+**Seduce the Innocent Heart**
+
+Enchantment/Beguile 30 R: Prs, D: Sun, T: Ind
+
+The target experiences powerful curiosity and carnal desire, which affects everything he does until the sun rises. These inflamed passions may be easily manipulated by a skilled seducer, though of course the target is unlikely to do anything to which he is fundamentally opposed. The rite merely removes his inhibitions for the duration.
+
+(Base 10, +2 Prs, +2 Sun)
+
+> # Beguile Guidelines
+> 
+> **Level 1:** Make a minor change to the target's memory of an event.
+> 
+> **Level 2:** Make a major change to the target's memory of an event.
+> 
+> Make a minor change to the target's perceptions.
+> 
+> Plant a single suggestion in the mind of the target.
+> 
+> **Level 3:** Make a major change to the target's memory of a series of events. Make a major change to the target's
+> 
+> perceptions or emotions.
+> 
+> **Level 4:** Make major changes to the target's memory of a long period of time. Control the target's mental state (i.e. awake, asleep, confused, or lucid) Completely change the target's perceptions or emotions.
+> 
+> **Level 5:** Control the target's behavior based on a natural emotion.
+> 
+> Paralyze the target with emotion.
+> 
+> **Level 10:** Completely change the target's memories.
+> 
+> Control the target's behavior based on an unnatural emotion.
+> 
+> Imbue all of the target's responses with a particular emotion.
+> 
+> **Level 15:** Give a simple command to the target.
+> 
+> **Level 20:** Give a complex command to the target.
+> 
+> **Level 25:** Completely control the target, including its movement and communication.
+
+### Conjure
+
+Conjure rites produce solid images that conform to the same rules that faeries obey to create their identities — it makes faerie shapes appropriate to a particular faerie's role and made of the power of the realm. A faerie wizard can draw upon his Faerie sympathy to create or change an object in the same way that a faeries does when it adopts a new shape.
+
+Things conjured in this way are called **glamours** in the guidelines and effects given here, though most faerie wizards would probably not use this word. They are treated like animate illusions with substance, which last only for the duration of the effect, and often the consequences of the glamour are undone when the effect is ended. For example, a fire glamour burns down a house, but as soon as the effect goes away, the house might return exactly as it was. A person slain with a conjured sword is very likely to recover from the wound as soon as the weapon is dispelled.
+
+Many Conjure rites allow the caster to change a target into something else. In these cases, the caster must have an applicable Sympathy Trait for both states, before and after, though both Traits apply to the maximum effect level. For example, to change a monk into a lamb, the caster would need appropriate Sympathy Traits for both a monk and a lamb, but would factor both Traits into the total to decide how powerful an effect he can produce.
+
+Since glamours are based on images, it is possible to create very unnatural situations with them, such as a place that is larger on the inside than on the outside. For example, one could change the inside of a tent into the inside of a castle, or a bag into a deep well. This is simply creating the illusion of the castle on the inside of the tent, but because of the properties of glamours it is as if it were real. When the effect ends, the results are unpredictable and often surprising — the contents of the tent larger on the inside than outside might simply vanish, reappear outside the tent, or wind up transported into Faerie.
+
+**A Horse of a Different Color**
+
+Empathy/Conjure 20
+
+R: Voice, D: Sun, T: Ind
+
+The target animal grows brightly-colored wings for the duration, transforming into a chimerical beast that is a fanciful combination of two animals. This increases its Size category by 1, and it gains the temporary ability to fly and sing.
+
+(Base 3, +2 Voice, +2 Sun, +1 size)
+
+**The Old Guard**
+
+Evocation/Conjure 20
+
+R: Touch, D: Sun, T: Group
+
+The caster creates the glamour of ten men, properly equipped as grogs, who gather protectively about the caster to protect him from harm. These imaginary people have average Characteristics and no Abilities, and must act as an untrained group.
+
+(Base 3, +1 Touch, +2 Sun, +2 Group)
+
+>## Conjure Guidelines
+> 
+> Intricate glamours require an additional magnitude, such as those creations with moving parts or that mimic a specific target. A glamour that can act under the caster's direct mental command requires two additional magnitudes.
+> 
+> Changing an animate target (something that can move under its own power) into an inanimate object is also more difficult, and requires two additional magnitudes. Over time, however, the target will begin to regain its mobility unless the caster regularly concentrates on the effect. For example, a person may be changed into a tree, but if ignored for a few days that tree may begin to move and resemble a person, as its Essential Nature begins to reassert itself over the glamour.
+> 
+> The final form of a target changed into glamour will usually have recognizable properties in common with its true shape. For example, a person transformed into an animal might be extremely expressive and possibly retain other human qualities such as the ability to speak or walk upright.
+> 
+> **General:** Conjure a faerie with Faerie Might equal to the base level of this effect. (Ritual)
+> 
+> **Level 3:** Conjure a glamour.
+> 
+> Change the target into a glamour. The glamour must be approximately the same size as the target, though Size modifiers may be added to produce a larger effect.
+> 
+> **Level 4:** Change the target into a glamour up to two Size categories smaller than its normal size.
+> 
+> **Level 5:** Change the target into a glamour up to five Size categories smaller than its normal size.
+> 
+> **Level 10:** Change the target into a glamour up to 10 Size categories smaller than its normal size.
+> 
+> **Level 15:** Change the target into a glamour up to 15 Size categories smaller than its normal size.
+
+**Curse of the Faerie Forest**
+
+Enchantment/Conjure (Dream) 45
+
+R: Voice, D: Until, T: Group, Ritual
+
+The target group is changed into animals that are most appropriate to their surface thoughts. This effect lasts until they apologize to the enchanter and make amends for the insult that inspired this spell, or else until they or the caster die.
+
+(Base 5, +2 Voice, +4 Until, +2 Group)
+
+### Dream
+
+Dream is the power to see into the lands of Faerie beyond Mythic Europe, as an impartial observer from outside the stories in which faeries play their parts. Here, the dreamer can see the world around him from outside his body, and can comprehend the thoughts and words of others through the universal language of dreams. It is even possible to glimpse an idea of the future through dreams, though the information gained is based on how things generally go in faerie stories, and tends to be in the form of vague signs and portents — symbols of good or bad things to come. Faerie visions can be misleading, and some faerie wizards believe that they actually cause to happen what the dreamer imagines will happen, based on his conviction in his interpretation.
+
+To handle these visions in the game, the storyguide should allow the player to ask one question about the circumstances in the future, and answer it with a good feeling or bad feeling about the character's fate, perhaps with varying grades of severity. This should be associated with a symbol to give the player something to watch for. For example, a character might see an "old crow" as a very good sign within the next day, or a "green cloak" as a bad omen for the coming year. The troupe should consider this an opportunity for the dreaming character's player to request a story that he would like to see happen, by describing elements of a vision that the storyguide can bring to pass.
+
+> # Dream Guidelines
+> 
+> **General:** Treat the target as if it possessed the Premonitions Ability for the duration, with a score of (the base level of this effect / 5).
+> 
+> **Level 1:** Allow the target to use one sense at a distance.
+> 
+> **Level 2:** Allow the target to use two senses at a distance.
+> 
+> Allow the target to communicate mentally.
+> 
+> **Level 3:** Allow the target to use all senses at a distance.
+> 
+> Allow the target to understand the meaning of spoken sounds.
+> 
+> **Level 4:** Allow the caster to answer a question about the target's likely future in the next minute.
+> 
+> Allow the target to speak in the caster's native language.
+> 
+> **Level 5:** Allow the caster to answer a question about the target's likely future in the next hour.
+> 
+> Allow the caster to read the target's
+> 
+> surface thoughts.
+> 
+> **Level 10:** Allow the caster to answer a question about the target's likely future in the next day.
+> 
+> Allow the caster to read the target's memories of the past day.
+> 
+> **Level 15:** Allow the caster to answer a question about the target's likely future in the next month.
+> 
+> Allow the caster to read all of the target's memories.
+> 
+> **Level 20:** Allow the caster to answer a question about the target's likely future in the next season. (Ritual)
+> 
+> **Level 25:** Allow the caster to answer a question about the target's likely future in the next year. (Ritual)
+> 
+> **Level 30:** Allow the caster to answer a question about the target's likely future in the next decade. (Ritual)
+> 
+> **Level 35:** Allow the caster to answer a question about the target's likely future in the next century. (Ritual)
+
+**Words that Live in Song** Enchantment/Dream 20
+
+R: Touch, D: While, T: Group
+
+The caster of the rite clasps hands with one of the targets, and begins a song in his native language. For as long as the song lasts, everyone in the group can understand the lyrics to the song, and can contribute to it by singing their own words.
+
+(Base 4, +1 Touch, +1 While, +2 Group)
+
+Evocation/Dream 30
+
+R: Sympathy, D: Aura, T: Medium, Ritual After this rite has been performed, anyone can look into the pool and perceive events as they transpire at another location, described by the caster during the casting. It is often possible for the person looking into the pool to change this location, if he has strong faerie sympathy with another place.
+
+(Base 1, +4 Sympathy, +4 Aura, +1 Medium)
+
+#### Vision of the Oracles
+
+Empathy/Dream 30
+
+R: Prop, D: Mom, T: Ind, Ritual
+
+The caster places a coin against the target's forehead, and concentrates upon a question posed by the target. The caster then experiences a brief, fleeting faerie vision related to that question that concerns potential events in the next year.
+
+(Base 25, +1 Prop)
+
+### Grant
+
+Grant gives the caster the power to bless (or curse) a target with the supernatural power of Faerie. This most often manifests in the form of Warping Points or temporary Virtues and Flaws. Since most of these powers only last for the effect's duration, they are usually cast as rituals that remain until a particular condition is fulfilled. All Flaws gained from this power are either Supernatural (Faerie) or General, and all Virtues are Charmed Virtues; see Chapter 5: Touches of Faerie, Charms for details.
+
+Some Grant effects give the target faerie sympathy in the form of Sympathy Traits. Note that like Sympathy Traits gained through sympathetic influence, these Traits are temporary and cannot be increased, and do not affect the character's Faerie Rank (see Chapter 5: Touches of Faerie, Sympathetic Influence).
+
+### Red Sky at Dawn, Blue Sky at Dusk
+
+Empathy/Grant General
+
+R: Touch, D: Mid, T: Bound, Ritual
+
+The caster tints a Faerie aura with one of his Sympathy Traits for the duration, causing all those within the area to become sensitive to that Trait.
+
+(Base effect, +1 Touch, +2 Mid, +4 Bound)
+
+> # Grant Guidelines
+> 
+> **General:** The target faerie regains a number of Faerie Might Points equal to (the base level of this effect + 5) for the duration. (Ritual)
+> 
+> The target gains, as a faerie power, a non-ritual effect that the caster is capable of casting, the level of which must be less than or equal to half (the level of this effect + 15). This costs the target the granted effect's magnitude in Might Points to activate, and has an Initiative of (the target's Quickness – the magnitude of this effect). (Ritual)
+> 
+> **Level 3:** The target gains one of the caster's Sympathy Traits for the duration, with a maximum score of +1 or –1.
+> 
+> **Level 5:** Grant the target a Warping Point. Each additional magnitude grants an additional Warping Point.
+> 
+> The target gains one of the caster's Sympathy Traits for the duration, with a maximum score of +2 or –2.
+> 
+> **Level 10:** The target gains a Minor Flaw for the duration. (Ritual)
+> 
+> The target Boundary gains a temporary Faerie aura of 1 for the duration. Each additional magnitude increases the level of the aura by 1. Note that casting this with Duration: Aura does not work unless the entire boundary is already covered by another sort of aura, because that duration requires an aura to sustain the effect. (Ritual)
+> 
+> **Level 15:** The target gains a Minor Virtue for the duration. (Ritual)
+> 
+> The target gains one of the caster's Sympathy Traits for the duration, with a maximum score of +3 or –3.
+> 
+> **Level 25:** The target gains one of the caster's Sympathy Traits for the duration, with a maximum score of +4 or –4.
+> 
+> **Level 30:** The target gains a Major Flaw for the duration. (Ritual)
+> 
+> The target Boundary, which must include a Faerie aura, temporarily becomes a Faerie regio for the duration. Note that casting this with Duration: Aura does not work, because the rite creates the aura in the regio as part of the effect. (Ritual)
+> 
+> **Level 35:** The target gains one of the caster's Sympathy Traits for the duration, with a maximum score of +5 or –5.
+> 
+> **Level 45:** The target gains a Major Virtue for the duration. (Ritual)
+> 
+> The target gains one of the caster's Sympathy Traits for the duration, with a maximum score of +6 or –6.
+
+### Know Then the Calloused Touch of Faerie Hands
+
+Evocation/Grant 30
+
+R: Voice, D: Mom, T: Ind
+
+The target immediately gains 5 Warping Points — 4 from this effect and 1 from being exposed to a Level-30 rite. For a character who has never experienced Warping, unless the target has some connection to a supernatural realm, this typically increases his Warping Score to 1 and this gives him a Minor Flaw appropriate to his circumstances, such as Fear or Disfigured.
+
+Unlike the effects of other faerie rites this is a permanent effect, as Warping is a natural consequence of exposure to concentrated supernatural power.
+
+(Base 20, +2 Voice)
+
+### A Proper Blessing
+
+Enchantment/Grant 40
+
+R: Touch, D: Hidden, T: Ind, Ritual
+
+The target gains the Puissant Faerie Lore Virtue for as long as he keeps hidden a stone given to him by the caster, typically in his shoe or inside his hat. This is a Charmed Virtue; to make use of it, the target must perform a secret ceremonial charm that is taught to him by the caster during the rite. As with all Charmed Virtues, if the secrecy surrounding this charm is ever broken, the effect fails until the caster can fashion a new one for the target, by recasting the rite.
+
+(Base 15, +1 Touch, +4 Hidden)
+
+### Portage
+
+Portage is the power to travel across the sky in the blink of an eye, or put a girdle around the earth in forty minutes. It transports the target and anything attached to it from one place to another by means of the phenomenon known as faerie trods — a Hermetic term to describe areas of space that connect one place to another, like the paths between different levels of regiones. These short-cuts take no time at all to traverse, so that an outsider who watches such a traveler might see him disappear and immediately reappear several paces away. To the traveler himself, of course, this journey appears seamless.
+
+> # Portage Guidelines
+> 
+> **General:** Transport the target through a regio boundary to a regio with a level less than or equal to ((the base level of this effect + 15) / 5). For example, a base Level 20 effect would allow the target to pass through a regio boundary into a Level-7 regio.
+> 
+> Transport the target out of a regio through a boundary less than or equal to ((the base level of this effect + 15) / 5). For example, a base-Level-20 effect would allow the target to leave through a Level-7 regio boundary.
+> 
+> Transport the target into the Faerie Realm through a regio boundary with a level equal to (13 – ((the base level of this effect + 15) / 5)). For example, a base-Level-20 effect would allow the target to pass into Arcadia through a Level-6 regio boundary.
+> 
+> Transport the target out of the Faerie Realm into a regio with a level less than or equal to (13 – ((the base level of this effect + 15) / 5)). For example, a base-Level-20 effect would allow the target to return to a Level-6 regio.
+> 
+> **Level 5:** Instantly transport the target to anything within range associated with one of the caster's Sympathy Traits. Prevent the target from traveling out of the range of the effect, as determined when the rite is cast. For example, a Range: Touch effect would prevent the target from moving from the spot where the caster performed the rite, even if the caster leaves the area.
+> 
+> **Level 10:** Instantly transport the target anywhere within range of this effect. Cause the target to travel as faeries do; for the duration he becomes able to ignore Fatigue penalties, but unable to expend Fatigue levels.
+> 
+> **Level 15:** Double or halve the target's natural movement speed for the duration.
+
+**Leap of the Shadows**
+
+Evocation/Portage 20 R: Sight, D: Mom, T: Ind
+
+The caster causes any target he can see to move immediately to a place within the shadows. This requires a Sympathy Trait associated with darkness or shadow to enact.
+
+(Base 5, +3 Sight)
+
+### Hearth Prison
+
+Enchantment/Portage 40
+
+R: Touch, D: Aura, T: Room, Ritual
+
+All those within the room at the time of casting are prevented from leaving the room for the duration. If the rite is performed within a supernatural aura, this is essentially a permanent effect, though the targets may be able to escape through the Faerie Realm or otherwise departing the mortal realm without actually leaving the room's confines.
+
+(Base 5, +1 Touch, +4 Aura, +2 Room)
+
+**The Urgent Messenger**
+
+Empathy/Portage 25
+
+R: Touch, D: While, T: Ind
+
+For as long as the target is traveling, his movement rate is doubled.
+
+(Base 15, +1 Touch, +1 While)
+
+### Ware
+
+Ware allows the caster to take responsibility for the target and put it under his protection. This is designed to keep the target safe from harm, both natural and supernatural, often through the use of wards. Wards are effects that keep the specified thing from touching the target, or acting against it in any way. This includes using its powers on the target, and even sticking it with weapons or throwing things at it. The warded subject cannot harm the target, or through its actions cause it harm.
+
+While all rites require a Sympathy Trait that is applicable to the target, many of these effects require the caster to have two applicable Sympathy Traits — one to affect the target, and one to describe what the target is protected against. Use both of these Traits to determine the maximum level of the effect. These faerie wards are more effective in keeping away subjects with which the caster has positive sympathy than they are at warding away subjects with which the caster has negative sympathy. Like magical wards, the effect must penetrate to affect a subject with Magic Resistance.
+
+**Release the Spellbound Servant** Empathy/Ware General R: Touch, D: Hour+1, T: Ind, Ritual
+
+For the duration, the target is freed from a single supernatural effect, as if the duration of the effect had ended, so long as the level of this rite equals or exceeds the level of the effect. This protection lasts for an hour and a day, at which point the suppressed effect returns.
+
+(Base effect, +1 Touch, +2 Hour+1)
+
+**Sovereign Silence of Opposition** Evocation/Ware General
+
+R: Touch, D: Not, T: Ind
+
+For as long as the target does not speak, or until a month has passed, no creature with a Might Score less than or equal to the level of this effect may harm the target or cause the target to be harmed by its actions. This includes affecting the target with its powers, even if those powers seem to be beneficial.
+
+This requires that the caster possesses a Sympathy Trait appropriate to the subjects of the ward, as well as a Trait appropriate to the target. For example, Children would keep creatures associated with childhood at bay, and Stone would ward away beings tied to rock and solid earth.
+
+(Base effect, +1 Touch, +2 Not)
+
+**The Eternal Parry** Enchantment/Ware 25 R: Per, D: While, T: Ind
+
+The caster wields a blade while performing a dance, and from then on he receives a +3 bonus to his Defense for as long as he continues to brandish his weapon. The effect ends the moment he sheathes it, drops it, or stops fighting.
+
+(Base 20, +1 While)
+
+> # Ware Guidelines
+> 
+> **General:** Suppress a supernatural effect on the target for the duration, if the level of the effect is less than or equal to (the base level of this effect + 15). This may affect a Hermetic Longevity Ritual, though it must be suppressed for at least half the year or the target will still receive its benefits. (Ritual)
+> 
+> Ward the target against anything associated with one of the caster's positive Sympathy Traits, with Faerie Might no greater than (the base level of this effect + 20).
+> 
+> Ward the target against anything associated with one of the caster's positive Sympathy Traits with Divine, Faerie, Infernal, or Magic Might no greater than (the base level of this effect + 15).
+> 
+> Ward the target against anything opposed by one of the caster's negative Sympathy Traits, with Faerie Might no greater than (the base level of this effect + 5).
+> 
+> Ward the target against anything opposed by one of the caster's negative Sympathy Traits, with Divine, Faerie, Infernal, or Magic Might no greater than the base level of this effect.
+> 
+> Ward the target against anything associated with any of the caster's Sympathy Traits, with Faerie Might no greater than the base level of this effect.
+> 
+> Ward the target against anything associated with any of the caster's Sympathy Traits, with Divine, Faerie, Infernal, or Magic Might no greater than (the base level of this effect – 5).
+> 
+> Ward the target against anything that is not associated with any of the caster's Sympathy Traits, with Faerie Might no greater than (the base level of this effect – 10).
+> 
+> Ward the target against anything that is not associated with any of the caster's Sympathy Traits, with Divine, Faerie, Infernal, or Magic Might no greater than (the base level of this effect – 15).
+> 
+> **Level 1:** Ward the target against all mundane things associated with one of the caster's positive Sympathy Traits.
+> 
+> **Level 4:** Ward the target against all mundane things opposed by one of the caster's negative Sympathy Traits.
+> 
+> **Level 5:** Make the target more resistant to physical damage for the duration (+1 Soak). Each additional magnitude increases this bonus by one.
+> 
+> Ward the target against all mundane things associated with any of the caster's Sympathy Traits.
+> 
+> **Level 10:** Increase the target's natural defenses for the duration (+1 Dfn). Each additional magnitude increases this bonus by 1.
+> 
+> **Level 15:** Ward the target against all mundane things that are not associated with any of the caster's Sympathy Traits.
+
+### Weal
+
+This Power represents the faerie ability to shrug off damage relatively quickly, since injuries are rarely part of a faerie's persona. They tend to do this by changing how the target heals naturally, rather than actually healing, since most faerie powers do not have lasting effects beyond their durations. This can be seen most clearly in the Weal guidelines below.
+
+Weal also affects age, making living targets less likely to suffer the ravages of time, and can cause a target to regress in years for the duration. This effect cannot cause a character to revert to childhood, nor can it affect a character who has not yet reached physical maturity.
+
+> # Weal Guidelines
+> 
+> **General:** Give the target a bonus to Recovery rolls and a penalty to Aging rolls, or a bonus to Aging rolls and a penalty to Recovery rolls, equal to ((3 + magnitude) x 3) as long as this effect is active for at least half of the time period. This Recovery penalty does not cause wounds to worsen, though it does prevent them from healing normally.
+> 
+> **Level 1:** Give the target a +1 bonus to Recovery rolls and a +1 penalty to Aging rolls, or a –1 bonus to Aging rolls and a –1 penalty to Recovery rolls.
+> 
+> Reduce a physically mature target's apparent age by one year for the duration. Each additional magnitude removes another year. (Ritual)
+> 
+> **Level 2:** Give the target a +3 bonus to Recovery rolls and a +3 penalty to Aging rolls, or a –3 bonus to Aging rolls and a –3 penalty to Recovery rolls.
+> 
+> **Level 3:** Give the target a +6 bonus to Recovery rolls and a +6 penalty to Aging rolls, or a –6 bonus to Aging rolls and a –6 penalty to Recovery rolls.
+> 
+> **Level 4:** Give the target a +9 bonus to Recovery rolls and a +9 penalty to Aging rolls, or a –9 bonus to Aging rolls and a –9 penalty to Recovery rolls.
+> 
+> Prevent the target's wounds from worsening for the duration.
+> 
+> Delay all of the character's natural Aging and Recovery rolls until after the effect ends. (Ritual)
+> 
+> **Level 5:** Heal a Light wound for the duration.
+> 
+> **Level 10:** Heal a Medium wound for the duration.
+> 
+> **Level 15:** Heal a Heavy wound for the duration.
+> 
+> Reduce the interval in which a single wound heals naturally by one step for the duration. For example, a Heavy wound would heal as a Medium wound, and a Medium wound as a Light wound. For a Light or Incapacitating wound, the target can make an immediate recovery roll, with no worsening possible. (Ritual)
+> 
+> **Level 20:** Heal an Incapacitating wound for the duration.
+> 
+> Reduce the interval in which a single wound heals naturally by two steps.
+> 
+> **Level 25:** Heal all of the target's wounds for the duration.
+> 
+> Reduce the interval in which a single wound heals naturally by three steps. Restore the target to the semblance of life for the duration. (Ritual)
+> 
+> **Level 30:** Reduce the interval in which a single wound heals naturally by four steps. Reduce the interval in which all of the target's wounds heal naturally by one step. (Ritual)
+> 
+> **Level 35:** Reduce the interval in which all of the target's wounds heal naturally by two steps. (Ritual)
+> 
+> **Level 40:** Reduce the interval in which all of the target's wounds heal naturally by three steps. (Ritual)
+> 
+> **Level 45:** Reduce the interval in which all of the target's wounds heal naturally by four steps. (Ritual)
+> 
+
+**The Endless Summer** Empathy/Weal General R: Touch, D: Year+1, T: Ind, Ritual
+
+For the duration of the effect, the target receives a bonus to Aging rolls, equal to (3 x (the magnitude of this effect – 2)). For example, a Level-25 effect would subtract 9 from Aging rolls. This also negatively affects Recovery rolls made during the period by the same amount. This effect must remain active for at least half of the period before the roll is made, so the rite must be performed no later than summer to affect a character's Aging roll for that year.
+
+(Base level, +1 Touch, +4 Year+1)
+
+**Stir the Body** Evocation/Weal 20
+
+R: Touch, D: Mom, T: Ind, Ritual
+
+The target, who must be either incapacitated or must have suffered a Light wound, may make an immediate Recovery roll. If the results are negative, treat them as no change.
+
+(Base 15, +1 Touch)
+
+**The Faerie Shade** Enchantment/Weal 50 R: Touch, D: Aura, T: Ind, Ritual
+
+This rite brings the target back from the dead, restoring life to a corpse. The target remembers everything it knew up to the moment of its death, and can make new memories, but cannot learn anything or gain experience. Many believe that the body is animated by the spirit of a faerie, rather than the lost soul, and in support of this theory the person returned to life is often found to have a very different personality.
+
+(Base 25, +1 Touch, +4 Aura)
+
+### Woe
+
+Faerie rites allow faerie wizards to damage a target directly, like the faeries whose power they channel. Consequently, Woe can cause grave injuries with greater ease than Hermetic magic. However, because of the universal properties of faerie rites, this damage immediately goes away as soon as the effect wears off. Those who wield this power thus usually seek to harass and delude their quarry with their rites rather than simply destroying them. And of course, it is generally much easier to simply cut off their enemies' heads once they are disoriented.
+
+**Curse of the Festering Bruise**
+
+Evocation/Woe 20
+
+R: Touch, D: Moon, T: Medium
+
+This rite is cast on a weapon of some kind — typically an arrowhead or a knife — and targets the person struck by it. One of this target's wounds (probably the one caused by the weapon) heals as an Incapacitating wound for the duration of the effect. This means that the target must make a Recovery roll at sunrise and sunset, with the normal risk of death or a worsened condition, but is not actually incapacitated. Once the immediate danger has passed, the wound will remain a Heavy wound until the rite's duration ends, at which time it reverts to the level of wound it was previously.
+
+(Base 3, +1 Touch, +3 Moon, +1 Medium)
+
+**Touch of the Merciless Lover** Empathy/Woe 25
+
+R: Touch, D: Hour+1, T: Ind
+
+The caster brushes against the target, and the target immediately wastes away and dies. When the effect's duration ends, the target is restored to life, waking in exactly the same physical state as before the spell took effect, assuming no additional damage has been dealt to his body. However, if the corpse is buried or hanged, the target will likely suffocate upon reawakening. If it is destroyed during the interim, the target might still return but as a faerie ghost or spirit.
+
+While under the effects of this rite, the target may undergo something similar to the Faerie Calling, returning to life with a Faerie Sympathy Trait that is appropriate to the experience.
+
+(Base 10, +1 Touch, +2 Hour+1)
+
+**Gaze of Gray Years** Enchantment/Woe 30 R: Eye, D: Held, T: Ind
+
+The caster performs a work of grim and chilling significance, and then concentrates until he can look his target directly in the eye to release the effect. That person, who must be at least 35 years of age, must immediately make an Aging roll. As an additional effect, this rite includes a curse that gives the target a +15 penalty to this roll. This is generally powerful enough to cause the target to gain a Decrepitude Point and suffer an Aging crisis, and since this is a natural consequence of age, these effects are not undone when the duration ends.
+
+(Base 15, +1 Eye, +1 Held, +1 additional effect)
+
+> # Woe Guidelines
+> 
+> **General:** Give the target a penalty to Recovery or Aging rolls equal to ((3 + magnitude) x 3).
+> 
+> **Level 1:** Give the target a –1 penalty to Recovery rolls or a +1 penalty to Aging rolls.
+> 
+> Cause the target to lose a Fatigue level for the duration.
+> 
+> Increase the interval in which a single wound heals naturally by one step for the duration. For example, a Light wound heals as a Medium wound, a Medium wound as a Heavy wound, and a Heavy wound as an Incapacitating wound. Incapacitating wounds do not heal — if the effect lasts for more than half the recovery time, the target will simply die instead.
+> 
+> **Level 2:** Give the target a –3 penalty to Recovery rolls or a +3 penalty to Aging rolls.
+> 
+> Cause a Light wound to the target for the duration.
+> 
+> Increase the interval in which a single wound heals naturally by two steps for the duration.
+> 
+> **Level 3:** Give the target a –6 penalty to Recovery rolls or a +6 penalty to Aging rolls.
+> 
+> Cause a Medium wound to the target for the duration.
+> 
+> Increase the interval in which a single wound heals naturally by three steps for the duration.
+> 
+> Force the target to make a Recovery roll, with no improvement possible.
+> 
+> **Level 4:** Give the target a –9 penalty to Recovery rolls or a +9 penalty to Aging rolls.
+> 
+> Cause a Heavy wound to the target for the duration.
+> 
+> **Level 5:** Cause an Incapacitating wound to the target for the duration.
+> 
+> Increase the interval in which all of the target's wounds heal naturally by one step for the duration. (Ritual)
+> 
+> **Level 10:** Cause a deadly wound to the target for the duration.
+> 
+> Increase the interval in which all of the target's wounds heal naturally by two steps for the duration. (Ritual)
+> 
+> **Level 15:** Force the target to make an Aging roll.
+> 
+> Increase the interval in which all of the target's wounds heal naturally by three steps for the duration. (Ritual)
+> 
+> (Bonding, Captivating, and Dismissing) are exclusively Faerie powers.
+> 
+> When using any of these arts, a roll of 1 on the stress die gives the character an experience point in an applicable Sympathy Trait used to affect the faerie, and a botch removes an experience point, just as when using Sympathy Traits as specializations.
+
+## Faerie Bargaining
+
+There is a branch of faerie hedge wizardry that is concerned primarily with bargains made between mortals and fay. It has only begun to develop in the last century or so, originating in ancient and forbidden arts that allowed people to summon and command spirits such as angels and devils. In 1220 AD, it is likely to be found in the eastern parts of Mythic Europe, though it is not impossible that it has spread to other parts of the world with travelers who have more association with the Faerie realms than their homelands. The study of this fascinating and rare form of knowledge has not yet become known in academic circles, but if it were the scholars might be inclined to call it Ars Fabulosa, or "the fantastic art."
+
+### Ars Fabulosa
+
+The fantastic art facilitates communication between two parties — the summoner and a supernatural being. Like other forms of summoning, the art brings this being to the summoner, and if his skill exceeds its power then it also protects him against it. Unlike other forms of summoning, it does not force the being to comply or bind it to service unless it agrees to the bargain that the summoner proposes. For this reason, the art and its related powers are often called simply "bargaining."
+
+There are four powers associated with bargaining: Summoning, Bonding, Captivating, and Dismissing. Each of these powers may be learned as a Supernatural Ability (see Chapter 5: Touches of Faerie, Learning Faerie Abilities) or gained from a Virtue (see Chapter 5: Touches of Faerie, New and Modified Virtues). Once gained, these powers have an initial score of 0, and increase as Arts, though they can be practiced and studied as if they were Supernatural Abilities.
+
+There are several other summoning arts (see the Summoning Faeries sidebar), but this type of Summoning is almost always aligned with the Faerie realm. It is possible that there are other versions of this Summoning power aligned to the other realms, which similarly facilitate bargains with magic, infernal, or divine beings instead of faeries, but the other three bargaining arts
+
+### Summoning
+
+Summoning is the mystic art of calling out faeries from the surrounding area and holding them in attendance in order to bargain with them. To some it may appear as if this art actually creates a faerie, or transforms a mundane object into a faerie, but most summoners believe that the faerie comes from somewhere nearby and manifests in an appropriate shape. And since it is possible to summon faeries who have assumed a specific role, most summoners also believe that the other faeries that appear must exist before the summoning as well.
+
+To summon a faerie, a summoner must have an appropriate Sympathy Trait, positive or negative, to represent a connection to that type of faerie. If the summoner has several applicable Sympathy Traits, their scores are added together; if the values are negative, treat them as positive. The sum of these Traits, multiplied by 5, determines the maximum Might Score that the character can summon. The summoner's Faerie Rank also boosts or penalizes his Summoning Total.
+
+The summoner must then mentally prepare himself for a few minutes and expend a Fatigue level (if he cannot expend Fatigue, he cannot perform the summoning). The player decides the strength of the faerie he will attempt to summon, which cannot exceed the maximum Might Score determined by his applicable Sympathy Traits, and makes a roll: a stress die + Presence + Summoning + his Faerie Rank + the aura modifier.
+
+**Summoning Total: stress die + Presence + Summoning + Faerie Rank + aura Maximum Might** 
+
+**Score: (Sympathy Traits x 5)**
+
+>## Summoning Faeries
+> 
+> There are at least three other Supernatural Abilities in Mythic Europe that may be used to summon faeries, and since all of them originate from the same art practiced by sorcerers long before the birth of Christ, they use very similar concepts. The differences are mostly in how they target faeries and other supernatural beings, as summarized below. To help distinguish them, each version of Summoning might have a parenthetical in front of it, suggesting its focus. For example, faerie summoning from the Ars Fabulosa might be called (Faerie) Summoning, since it only affects beings of its particular realm.
+> 
+> **(Spirit) Summoning:** This Art calls an incorporeal spirit to the summoner, generally one associated with the realm of power that gives the summoner this power, though demons are also especially likely. If the summoning is successful, the spirit is bound in a circle until released by the summoner. Spirit Summoning is always tainted with the influence of the Infernal, and thus infernal versions are most common, but it may be associated with the Faerie or Magic realms instead. The related arts (Ablating, Binding, and Commanding) are all Infernal. (*Realms of Power: The Infernal*, pages 114-115.)
+> 
+> **(Elemental) Summoning:** Some applications of this type of hedge magic summon an elemental being associated with a specific element (Aquam, Auram, Ignem, or Terram). This being can come from any realm, including Faerie, and is typically held within a container where it remains under the summoner's control until released. The power is most commonly Magic, though versions associated with other realms are possible. The related Elementalist Arts (Controlling, Divining, and Refining) are always aligned with Magic. *(Hedge Magic*, Chapter 2: Elementalists, Summoning)
+> 
+> **Sihr:** This Art can summon and bind jinn, including faerie jinn, if the targets have been properly researched by a Hermetic Sihr. It is a Magic power, thought to be very similar to the Elemental version of Summoning, though perhaps Faerie, Infernal, or even Divine versions also exist. (*Houses of Hermes: Societates*, pages 135-136.)
+
+No matter what the Summoning Total, a faerie will appear, even on a botch. If there is a mundane object nearby that is associated with the Sympathy Traits used in the summoning, the faerie could appear by animating that object, or else it might simply emerge from somewhere in the surrounding environment, like from behind a tree or out of the ground. If the player does botch, the faerie will be hostile to the summoner, or perhaps unbound by the terms of any bargain they make. Or perhaps the summoner calls an angel or a demon by mistake, or a faerie that appears to be a different faerie, or is more or less powerful than the summoner intended.
+
+The summoner can try to summon a specific faerie based on its role, though unless he has an Arcane Connection to it there is no guarantee that the faerie he gets is the faerie that he wants. The effect will summon a faerie with Might Score no greater than the maximum value that has all of the qualities of the Sympathy Traits used in the summoning. And if this can apply to more than one faerie in the area, then it is left to the storyguide which one appears. If the summoner does have an Arcane Connection to a particular faerie, he must penetrate its Magic Resistance to be certain that it will appear, and note that the player may add his highest applicable Sympathy Trait to his Penetration score if he has it. Otherwise, the targeted faerie may receive the summons and simply ignore it.
+
+If the Summoning Total equals or exceeds to the summoned faerie's Might Score and the effect penetrates its Magic Resistance, the summoner takes hold of the faerie for the duration. When a faerie is held in this way, it is much easier to penetrate its Magic Resistance with his other bargaining arts. Also, until the summoning is over, it must attend to him and listen to what he has to say, and he is warded against any attacks or powers it tries to use against him. However, either the summoner or the faerie can end the summoning at any time, and this immediately returns the faerie to wherever it came from. A faerie might choose to stay and listen to what the summoner has to say, or it might simply leave immediately if it does not care for the circumstances. Most faeries will listen long enough to hear what the summoner has to offer.
+
+If the Summoning Total is less than the targeted faerie's Might Score, or the effect fails to penetrate its Magic Resistance, the faerie that appears is not in any way bound by the summoning. It is free to ignore the summoner, attack him, or affect him with its powers as it wishes. The faerie can return to where it came from at will, but the summoner cannot send it away.
+
+Once the summoning is over, if the two of them were able to come to an arrangement, the summoner gains an experience point in an appropriate Sympathy Trait. If they did not make a bargain, he subtracts an experience point from an appropriate Sympathy Trait. This means that it is generally bad for the character to harass faeries with disingenuous offers. Any bargain the two of them make is binding for the faerie, and it cannot through action or inaction break this agreement, even if the summoner does not fulfill his part of the arrangement. A summoner who breaks the terms of a bargain made during a summoning immediately gains a –3 Sympathy Trait appropriate to the faerie. This means that it is rarely worthwhile for a summoner to renege on a deal, since this will cause him to lose faerie sympathy and possibly Faerie Rank as well.
+
+### Bonding
+
+It is possible to establish enough supernatural rapport with a faerie that the summoner can create a mystic bond between him and it, through which he can channel its powers and use them as his own. It relies upon the summoner's Communication and Faerie Rank as well as his score in Bonding, and the maximum Might Score he can affect is again limited by his Sympathy Traits, just as in Summoning. It also requires him to spend a Fatigue level to activate the effect, and the affected faerie must be within range of his voice when the bond is first formed.
+
+**Bonding Total: stress die + Communication + Bonding + Faerie Rank + aura**
+
+**Maximum Might Score: (Sympathy Traits x 5)**
+
+The Bonding Total must exceed the faerie's Might to succeed, and must penetrate its Magic Resistance (though as usual the summoner can add his highest applicable Sympathy Trait to his Penetration score). If the faerie is held by a successful Summoning (one that penetrated its Magic Resistance), treat the effect level as 0 when calculating the Penetration Total, otherwise the effect level is the faerie's Might Score. For example, to bond with a faerie with Faerie Might 15, the summoner would need a Bonding Total + Penetration bonus of 30, or 15 if the faerie were held by a successful Summoning effect.
+
+If the Bonding succeeds, the summoner forges a special connection between himself and the faerie, or between the faerie and something he is touching. This bond acts as an Arcane Connection between the faerie and the bearer for as long as it endures. Through this bond, the bearer gains access to one of the following effects, chosen by the summoner at the time the bond is formed:
+
+- The bearer can use any of the faerie's Characteristics or Pretenses as if they were his own, and can take advantage of the faerie's supernatural senses, perceiving his surroundings as the faerie would see them in his place. This includes the use of Faerie Virtues like Faerie Sight and Faerie Speech. The faerie can do the same with the bearer's Characteristics, Abilities, and senses.
+- The bearer gains access to the faerie's powers, spending the faerie's Might Points to activate them. If the bond is with an object, the bearer or the faerie can treat the object as an extension of himself or itself, and can affect it with their powers at Personal range. The faerie can also draw upon the bearer's fatigue at will. If it wishes to exert itself in combat or for any other reason, the bearer immediately loses a Fatigue level.
+- The bond is opened for a temporary enchantment of a single faerie effect. Any spell or power the bearer can cast may be placed into the bond, so long as his casting total is at least equal to the effect level. The faerie and the bearer then gain the ability to cast that effect as a power. Both the faerie and the bearer must perform all the same actions as the caster each time the power is activated — including spending time, vis, Confidence, or Fatigue — but they do not need to roll the die, and the effect uses the faerie's (Might Score – the level of the effect) for Penetration.
+- The bearer is immune to Warping gained from living in a Faerie aura that season, does not suffer wounds caused by suffocation, lack of food or drink, exposure, or extreme fatigue, can ignore all Fatigue penalties, and may delay all Aging rolls until after the bonding is over (these rolls are made all at once as soon as the bond is broken).
+
+If the bond is tied to an object instead of a person, the object requires a charm (see Chapter 5: Touches of Faerie, Charms), which must be activated each day for the bearer to receive the effects. This charm is created at the time the bond is formed, and must be taught to the bearer by the summoner. If the secrecy of the charm is broken, the bond is undone and the bargain is ended. The bond also ends if the object is destroyed.
+
+A character may only benefit from a single bond at any given time, and activating a second bond destroys the first. Either the faerie or the bearer may also break the bond at will, though faeries rarely do this if it would go against the terms of a bargain. It is possible to bond with a faerie without its permission to do so, assuming the summoner can overcome its resistance, but there is nothing stopping the faerie from ending the effect immediately, if it does not believe the arrangement will be to its benefit.
+
+>## Faerie Bargains
+> 
+> Faeries have a special etiquette all of their own, as anyone with Faerie Lore might know, and a great deal of it has to do with how faeries make bargains. Faeries naturally value vitality, as discussed in Chapter 1: Nature of Faerie, but incognizant faeries may not realize that it is vitality they want. Accordingly, summoning a random faerie within range, even though it avoids the need to Penetrate Magic Resistance, is a risk, because the summoner does not know what this faerie thinks it wants. Intelligence + Faerie Lore rolls against an Ease Factor of 12 or higher may allow the character to work out exactly what a faerie wants after a short period of trial bargaining. It is safer to research a faerie, find an Arcane Connection, and then summon that faerie, but that is not always possible. On the other side, if the summoner does not know what a faerie can do, it is hard to make a reasonable request.
+> 
+> Players are encouraged to roleplay the bargaining session, and try to come to an agreement in character. If a player accidentally commits a breach of etiquette, such as saying "thank you" or acting above their station, the storyguide may allow the player to make an Intelligence + Faerie Lore roll versus an appropriate Ease Factor to see whether or not the character would have actually made that mistake. A particularly bad social gaffe might make it impossible for the characters to ever come to terms, and end the bargaining session immediately.
+> 
+> If after a certain period of time the players cannot come to an agreement, say after a few minutes, you can quickly resolve the bargaining session with a contested Communication + Bargain roll, modified by the character's Faerie Rank. Note that applicable Sympathy Traits may also apply as a specialization to this Ability.
+> 
+> Summoners generally bring beer, milk, gemstones, or other vitality-rich items with them when they travel, to offer in bargains; careful choice of Sympathy traits can make it likely that such items will be acceptable. Typical requests they might make of faeries include: service, such as fighting with the summoner against an enemy, using its powers to bless the summoner, or allowing the summoner to affect it with his other bargaining powers; permission to travel through lands owned by the faerie, or to harvest vis or other resources from it; a pact of non-aggression with the summoner and his community or his traveling companions; or the promise to owe the summoner a favor, to come and give aid when next called upon. Most faeries try to avoid long-term commitments, as they restrict their ability to gain vitality. Incognizant or narrowly cognizant faeries may, however, accept long-term commitments that suit them perfectly. They still expect substantial compensation from the summoner, however.
+
+### Captivating
+
+Captivating is the art of exchanging places with a faerie — giving it control over the summoner's body while the summoner becomes the faerie for the duration. The summoner can only affect a faerie that is within range of his voice and has Faerie Might no greater than the absolute total of his applicable Sympathy Traits multiplied by 5. Initiating the effect costs the summoner a Fatigue level.
+
+**Captivating Total: stress die + Perception + Captivating + Faerie Rank + aura**
+
+**Maximum Might Score: (Sympathy Traits x 5)**
+
+The Captivating Total must exceed the faerie's Might to succeed, and must penetrate its Magic Resistance (though as usual the summoner can add his highest applicable Sympathy Trait to his Penetration score). If the faerie is held by a successful Summoning (one that penetrated its Magic Resistance), treat the effect level as 0 when calculating the Penetration Total, otherwise the effect level is the faerie's Might Score. For example, to change places with a Faerie Might 20 faerie, the summoner would need a Captivating Total + Penetration bonus of 40, or 20 if the faerie were held by a successful Summoning.
+
+If the effect penetrates, the summoner and the faerie immediately switch places. Perhaps the easiest way to do this is to have the players trade character sheets. The summoner can do whatever it likes with the faerie, and the faerie has complete control over the summoner. They do not trade their memories, but they do effectively trade minds, so that either character can cast spells on itself to learn about that character's past actions. The only limitation is that the exchange does not affect either character's Personality Traits or Confidence Points (and Faith Points, if the summoner has True Faith), and the summoner also takes his Sympathy Traits with him.
+
+Either party can try to cancel the exchange at will, which faeries usually do when the terms of their bargain with the summoner expire. If the other does not wish to relinquish control, they have an emotional struggle for dominance. Both players should choose a Personality Trait that they agree is appropriate to the circumstances and what the character is currently doing — for example, if the summoner's body is sleeping, the faerie's Slothful Trait might best apply, while the summoner might use his Impatient Trait. If the character has no appropriate Personality Traits, treat this as a Trait with a score of 0. If the summoner character has Sympathy Traits appropriate to the faerie he is captivating, that player adds them to his total. Both players then add a stress die roll, and compare the results. If one of them has a higher total than the other, that player may decide whether or not to end the exchange.
+
+Captivating is a powerful, continuous effect that warps the summoner over time, giving his body 1 Warping Point every season, and another one every year. However, because the summoner's body is controlled by the faerie, and the faerie is controlled by the summoner, both of them are immune to Faerie Calling for as long as the exchange lasts. It is a risky but effective route to immortality, and a compelling way for a summoner to experience Faerie without giving up his essential humanity. It is said that if the faerie dies while its body is controlled by the summoner, the exchange becomes permanent. Whether or not this is so has yet to be proven, however; others fear that in fact the faerie returns to its body and it is the summoner who dies. Most summoners prefer to ensure that the faerie inhabiting their body remains safe and undamaged for the duration.
+
+### Dismissing
+
+Summoners who have studied the art of Dismissing have the power to undo supernatural effects made by beings with Might, and to free these beings from other effects that bind them. To do this, the summoner must expend a Fatigue level, and must speak with the being in question. As with the other Arts, he cannot affect a greater Might Score or effect Level than his Sympathy Traits allow.
+
+**Dismissing Total: stress die + Intelligence + Dismissing + Faerie Rank + aura**
+
+**Maximum Might Score or Effect Level: (Sympathy Traits x 5)**
+
+Dismissing has three uses:
+
+- The summoner can cancel any effect produced by the powers of a being with a Might Score, by exceeding the level of the effect on his Dismissing Total and penetrating the being's Magic Resistance. The summoner can also deflect the use of a being's power before it takes effect, if he beats the being's Initiative Total on a Quickness + Finesse stress roll. (If the summoner has Finesse, he can add his highest applicable Sympathy Trait to his score.) Just as magi can fast-cast spells, a summoner can try to dismiss multiple effects in one round, but he suffers a cumulative –6 penalty for each one. 
+- Dismissing can end the duration of any effects that target a being with a Might Score, if he penetrates that being's Magic Resistance and exceeds the level of the cancelled effect on his Dismissing Total.
+- The summoner can release a being with a Might Score from the terms of an agreement that has supernatural force, such as a bargain made between a summoner and a faerie. To do this, the summoner must exceed the creature's Might Score on his Dismissing Total, and must penetrate its Magic Resistance. Many believe that through this process the summoner takes the debt upon himself, freeing the being from its obligation.
+
+When checking for penetration, do not subtract the effect level from the Penetration Total if the being is held by a successful Summoning effect (as above, one that penetrated its Magic Resistance). Note that the summoner can add his highest applicable Sympathy Trait to his Penetration score if he has it.
+
+Dismissing is a good way for a summoner to make bargains with faeries that he has no intention of keeping, without suffering the loss of sympathy. While doing this does not affect the summoner's Faerie Rank, individual faeries are likely to resent this behavior. To avoid their enmity, a shrewd summoner will always offer a faerie something of comparable value to the terms of the original bargain in return for accepting the use of this power against it.
+
+## Pagan Traditions
+
+Many groups of pagans throughout Mythic Europe follow a particular tradition of faerie wizardry, which allows them to learn the tradition's Favored Abilities with greater ease (see Chapter 5: Touches of Faerie, Learning Supernatural Abilities). Faerie wizards may also initiate Virtues by undergoing Ordeals and following an Initiation Script, like other hedge wizards do (see *Hedge Magic* for details). However, faerie Initiation Scripts are rare, since most wizards learn their powers from a teacher instead. Here are three examples of these groups and the Methods and Powers at which they particularly excel.
+
+Note that in order to design a starting character with the power to perform Faerie rites, the player must devote at least four points of the character's starting Virtues to a Faerie Method and a Faerie Power, and to practice Faerie Bargaining the character must have one of the four Virtues associated with the fantastic art, usually Summoning. Either sort of character must also have Sympathy Traits, either from a Virtue or a Flaw, and since his power is limited by the number of these he possesses, he will probably need several — or else a high Warping Score, so that he can increase their values to higher levels with experience.
+
+### Borrowers
+
+**Favored Arts:** Summoning, Bonding, Captivating, Dismissing
+
+The Ars Fabulosa have only just begun to spread through Mythic Europe, and among the people who practice them is a strange sort that call themselves "faerie borrowers." These folk often seem especially foreign and exotic — like travelers from far-off lands with odd habits and unusual customs. They may present themselves as merchants or pilgrims, performers or messengers, or even soldiers or spies for distant lords. Their primary interest is in faeries, with whom they are especially skilled at dealing, and it is with faeries that they conduct their business. They essentially make their living selling goods to the faerie realm; their payment is the blessings of the fae. When asked what it is that they borrow, they might answer that they borrow the power of the faeries — though some of them "borrow" from humans as well, since not all of their wares are always obtained honestly.
+
+Borrowers usually trade in novelty; they pick up strange goods from distant places, including small animals, food and drink, fine art, and even magical artifacts (such as enchanted devices or other objects containing vis), and these wares often fetch a good price with faeries, since they usuallyaccept the claim that treasures from distant lands contain more vitality than items obtained locally. Through careful negotiation, Borrowers can sustain a burgeoning business on just a few faerie bargains a year, as long as their competition remains relatively scarce. To ensure this, they usually prefer to keep moving — which also keeps their stock fresh, they say.
+
+To help with the trade, Borrowers occasionally take promising children as their apprentices, usually by bargaining them away from faeries that have claimed or stolen them from their parents. While making use of prentice labor, they teach them to bargain and the intricacies of dealing with faeries, and eventually initiate them into the Ars Fabulosa. Eventually they become skilled enough to take over the trade from their master, or else to set off on their own.
+
+### Ollamhain
+
+**Favored Abilities:** Enchantment, Beguile, Dream, Portage
+
+The Ollamhain (pronounced "ah-luh-VAIN") are Irish poets, sages, and performers who have had many dealings with the Fair Folk, as they call the faeries, and who claim special kinship with them. Many of them have Faerie Blood. Their ancient songs and poems are said to contain magic when performed in the correct style — the power to see into hearts and minds, the future, and even the Faerie Realm itself. For these performances, many of them favor the Irish harp that is symbolically associated with them and their island, and pass from father to son special enchanted instruments that have been blessed to play especially well.
+
+### Volkhvy
+
+**Favored Abilities:** Evocation, Ceremony, Conjure, Grant
+
+Far beyond the reach of the eastern arm of the Christian Church are people who have never heard the Gospels and who still keep the old pagan ways — Russian faerie wizards known as the Volkhvy. Their great rites are legendary, where everyone in the community comes together to entreat their faerie gods for aid, usually through glamours and blessings that reflect the harsh wilderness in which they live. They typically possess great conviction because of these extreme conditions, becoming especially self-confident, though of course this Virtue could come from their faerie rites as easily as their personal fortitude.
+
+### Wise Folk
+
+**Favored Abilities:** Empathy, Ware, Weal, Woe
+
+There are many sorts of faerie-touched men and women who typically live on the fringes of society. Called "wise men" and "wise women" by villagers who turn to them when troubled, they are also forced to live apart from the community because of their strange ways and their intimidating powers. Their strengths are in keeping the supernatural at bay and protecting those in their charge, and through their exertions they can mend or injure those who they think worthy. It is folk like this that the magi of the Order of Hermes often imagine when they use the term "hedge wizard."
+
+# Chapter Seven: Telling Faerie Stories
+
+Faerie stories are rarely about faeries, and many do not even contain faeries. They are about people who go to unknown places, what they find there, and how they are transformed. This chapter offers advice to the storyguide who wishes to incorporate faerie stories into his saga, but retain the distinctive flavor of those stories so as to distinguish them from the legendary tales of heroes and wonder tales of saints. It is principally about stories with faerie tale elements, not necessarily stories for faerie characters.
+
+## Revel in Anachronism & Appropriation
+
+When telling faerie stories, most troupes should be less historically accurate than usual. Ars Magica games are usually set in the 13th century. But in the real 13th century, many of the faerie stories dearest to the hearts of players do not exist. The written versions of faerie stories that most players are familiar with are the result of nationalistic, literary movements that flowered in the middle and upper classes of Europe after the game period. The label "fairy tales" does not appear in the real 13th-century Europe, and the words "elf" and "faerie" are yet to be written in English. Storyguides should use the best faerie tales, from any culture or historical period, as inspiration for their stories.
+
+Faerie places touch, but do not much alter, Mythic Europe. That allows troupes to use faerie places as venues for stories that would damage the verisimilitude of the game world. For example, if the storyguide has a plot that requires the characters to travel by flying ship, but doesn't want a flying ship to make travel in Mythic European stories too easy, then the story could be set in a faerie place. Medieval storytellers often used the same device; they would set historical figures in the modern day, or give people powers that they could only use while they were in other lands. Faerie stories are an excuse to avoid, or temporarily suspend, whatever limitations of historical accuracy each troupe has decided for itself.
+
+### Anachronism
+
+Many medieval stories contain prominent historical figures, and yet have these characters using contemporary technology and language. Faerie is filled with historical stories. Some magi believe these stories are not mere fantasies conquered to catch the attention of magi: they are recitations of events long ago, and may contain information that is useful to modern people seeking ancient sites and lost lore. Stories being reenacted by faeries claiming to be the pagan dead are particularly likely to contain motifs that reflect historical fact.
+
+Settings include the conquests of Julius Caesar, the empire of Alexander, the fall of Troy, the ancient Nile, the court of Arthur, the palace of Charlemagne, the founding myths of each of the tribes of Europe, pivotal battles, and significant assassinations.
+
+Stories of what lies beyond Europe are also popular, and faeries hear and reproduce them. Magi have found many faerie courts that claim to be the kingdom of Prester John, or the land of the Silk People. It is not clear which elements of these courts are drawn from the expectations of the observers, and which are observations made by faeries who have traveled to distant places through Arcadia and returned. Many magi feel that these courts could be used to travel to the places they portray, but no-one has reported using a Faerie Court as a dependable transit point.
+
+With the agreement of the rest of the troupe, faeries can have roles that are suited to these fantastic pasts, distorted presents, or speculative futures.
+
+### Appropriation
+
+Appropriation is the theft of stories. Faerie is a setting that allows troupes to borrow stories from other media, or from the supplements of other game systems, and include them in a saga. By setting them in faerie, appropriated materials are separated from the saga's setting. This makes them particularly useful for games where only part of the troupe arrives for the session, and the storyguide wants to fill in a session from pregenerated materials rather than proceed with the saga's arc. Faerie is also a suitable setting for encounters with the many interesting creatures developed for other game systems that do not fit comfortably within Mythic Europe. Troupes that want their saga to cross over into the settings created by authors of popular fiction can also deem those worlds to be in Faerie, where they are accessible, but still distinct from Mythic Europe.
+
+#### Be Topical
+
+Medieval storytellers would use topical material to comment on the political situation of their day, hidden beneath a layer of stock characters and set in a distant land. Storyguides should steal ideas and characters from modern literature. Similarly, storyguides who take inspiration from modern social and political controversies are following an ancient tradition of folk storytelling.
+
+>## Mistakes To Avoid
+> 
+> Several traditional ways of telling faerie stories do not work well in roleplaying games. In brief these are:
+> 
+>### Catalog of the Fantastic
+> 
+> Some authors of faerie stories merely describe a cavalcade of marvelous things. Faerie is a good place to develop emotionally resonant settings, but unless the setting bears some relationship to the plot, and the plot is driven by the desires of the player characters, catalogs of the fantastic reduce the player characters to an audience.
+> 
+>### Cuteness
+> 
+> Diminutive faeries with lisps and names that sound like the simple sounds that babies make are an Edwardian reaction to the harshness of the Victorian world. They fail, in a roleplaying sense, because the plots of roleplaying games are about conflict, and baby faeries do not fit that milieu, except as victims.
+> 
+>### Genuineness
+> 
+> Authors who write about fairy tales can become very strident about which version of a story precedes the others, and about the division between genuine folk tales and literary retellings. Storyguides should not be too concerned about telling the "genuine" version of a faerie tale. Two stories that share the same motifs are not the same story: color, atmosphere, and detail matter and need to be tailored to the players. For game purposes, the versions of Red Riding Hood where she is saved by a woodcutter, eaten by the wolf, and seduces the wolf are all good material. Which version of a story is the best depends on the troupe, and the saga.
+> 
+>#### It Was All a Dream
+> 
+> Faerie stories are often allegorical, which makes them dream-like. It can be tempting for the story to have been a dream. This cheapens the accomplishments of the player characters, unless the dream has ongoing consequences in the saga. Faerie stories should be meaningful.
+
+## Use Other Stories
+
+Search the books in this book's bibliography for stories the troupe has not heard, because they are an endless well of *Ars Magica* adventures. Stories from the Middle East and Asia are particularly useful, because they are at once both strange and recognizable. These tales provide the surprise necessary for a successful story, while retaining many of the rhythms and structures with which players are familiar. Storyguides wanting original stories, but preferring not to have to change motifs to suit the European setting, might find collections of Italian fairy tales particularly useful. They have many of the features of the better-known French, German, and Danish tales, but their details differ enough to surprise players.
+
+### Dissecting Stories
+
+Faeries are very diverse, which helps to hide the fact that they play few roles in stories. The following lists include characters from popular, modern fairy tales, to demonstrate each role. Faeries often:
+
+### Create the problem that forces the player characters to act ...
+
+- The Witch in *Rapunzel* steals a child from a family with a magical pact that involves eating fairy food, and keeps her in a tower. Rapunzel develops magical powers, including tears that can permanently heal injuries and hair that grows at an alarming rate. She is likely a potent source of Corpus or Creo vis.
+- The insulted faerie in *Sleeping Beauty* curses her to prick her finger, suffering a wound, and then dying. This is commuted to just sending her entire community into a regio to sleep for a hundred years.
+- The magician in The Glass Coffin enchants the lands, turns the princes into animals, and seals the princess in a glass coffin when she refuses to marry him. 
+- The dwarf in *Snow White, Rose Red* curses a prince to take bear shape by stealing his money.
+- Eris, in *The Illiad*, pitches the entire world into war, because she thinks it amusing.
+
+### Are servants of player characters ...
+
+- The djinni from *Aladdin and the Wonderful Lamp* grants wishes.
+- Dick Whittington's Cat and Puss in Boots both help their masters become undeservedly rich.
+- Snow White's dwarfs make things for her.
+- Any brownie or house goblin does chores.
+- Dwarfs act as squires to great warriors in Arthurian tales.
+
+### Grant a useful item, or can teach a useful skill, after the characters are tested ...
+
+- Cinderella's helper (whether a godmother, ghost of her mother, or magical birds) provides her with, at least, one dress and set of shoes.
+- The elves in the *Shoemaker and the Elves* make shoes.
+- Dwarfs make the weapons of deserving heroes and gods in Norse mythology.
+- A Lady of the Lake is the guardian of Excalibur and gives it to Arthur, while another guards three magic shields, which she gives to Lancelot.
+
+### Allow the characters to travel to complete the story ...
+
+- Djinni from *Aladdin and the Wonderful Lamp* allow him to fly through the world.
+- Cinderella's helper (godmother, ghost of her mother, or magical birds) provides her with a coach.
+- The stag in *The Glass Coffin* carries the tailor to where he can break the curse.
+- The valkyries in Norse myth carry the dead to their conclusion.
+- Some pixies create dust that allows others to fly.
+
+### Embody a threat that must be overcome ...
+
+- Many faeries want to eat the heroes, like the giant in *Jack the Giant Killer,* the witch in *Hansel and Gretel*, the troll in the *Three Billy Goats Gruff*, the wolf in *Red Riding Hood* or the *Three Little Pigs*, or just about any other story.
+- Others want to capture the heroes. The Snow Queen steals Kay, and imprisons him. Calypso, in *The Odyssey*, wants to keep Odysseus from ever becoming famous or going home.
+
+### Are the thing that must be aided ...
+
+- Any number of cursed princes, like the Beast from *Beauty and the Beast*, the frog in *Frog Prince*, the prince in *The Hut in the Forest,* and the bear in *Snow White and Rose Red.*
+- Any number of princesses that must be saved from monsters or evil knights.
+- The animals in *The Hut in the Forest.*
+- The lion with the thorn in his paw in *Aesop's Fables.*
+
+### Are the givers of final rewards ...
+
+- The welcome fairies in *Sleeping Beauty.*
+- Any marriageable prince, or king with a daughter.
+- Any faerie that rewards the good daughter and punishes the evil one.
+- The cailleach that grants sovereignty of Ireland after testing the courage of a man.
+
+### Play several of these roles at various parts of the story ...
+
+- Rumplestiltzkin provides service, and the chance to marry a prince, but becomes a threat.
+- The Beast from *Beauty and the Beast* is initially a threat, then needs to be helped, and gives rewards.
+- The Frog Prince serves the princess (by getting back her lost ball), then becomes a moral test, needs to be helped, and grants rewards.
+
+### Are the heroes of stories (though this is more uncommon) ...
+
+- The Little Mermaid deliberately reverses traditional stories, with the mermaid losing her voice, then her life, in love for a mortal.
+- The Bremen Town Musicians.
+- The Gingerbread Man.
+
+Plundering stories by dissecting the roles of the faeries, however, misses much of their pilferable magic. Faerie tales are awash with small details that seem perfect when read, and can be reused in stories. When Charles Perrault changed Cinderella's slippers to glass, to represent the lightness of her step and the supernatural expensiveness of her shoes, he created a resonant image. Collections of fairy tales are filled with similarly perfect moments, items, and plot twists, all ready for a storyteller to take up and use.
+
+## Story Flow
+
+Every good story has a beginning, a middle, and an end; or, as Aristotle put it, a thesis, an antithesis, and a synthesis. The thesis is the initial position of the characters in the story, supported by appropriate premises which are generally acceptable to the listeners. In terms of a story, the thesis is represented by the **hook** and the **trigger**. The next stage of the story is to present the antithesis of the heroes — a sudden change in their circumstances that tests their character and presents the thesis in the best light. In story terms, the antithesis provides the **setting** of the story and the **twist**. The final task of the storyteller is to reconcile the thesis and antithesis into the synthesis, presenting the story as a coherent whole. This results in both **resolution** and **consequences**.
+
+A good tip when planning a story is to give each of the three basic stages of the plot a theme. Typically, these themes are emotions or personality traits, but they could be other symbols such as signs of the zodiac, planetary symbolism, moral fables, or any other system of archetypal themes. These are just simple drivers to the imagination, assisting the conception of the plot as a whole. For truly complex stories, the thesis, antithesis, and synthesis could be entire plots in their own right, perhaps each one deriving from one of the Thirty Six Dramatic Situations (see insert). However, this level of complexity is a daunting task and should be reserved for pivotal stories in the saga.
+
+*Example (based on emotions): The thesis is symbolized by Loyalty — a character hears that a faerie ally is in trouble, and pledges her support. The antithesis is Revenge — the faerie is not in trouble; he has faked his situation to avenge a former slight against the character. The synthesis is Courage — the character must weather the storm of the faerie's wrath to reveal that he has been misled by an evil-doer.*
+
+*Example (based on planetary symbolism): The thesis is Mercury — a message is received by a character from an old friend. The antithesis is Mars — old*  *rivalries have lead to open conflict, and the friend hopes that the characters can provide a level head. The synthesis is Venus — getting the opposing parties to remember their love for each other will resolve the story. Alternatively, the synthesis could be Saturn (only death of one of the parties will resolve the situation); or Jupiter (the characters must appeal to authority figures to achieve resolution).*
+
+Having decided on the overall themes of the thesis, antithesis, and synthesis, the next stage is to flesh out the six components of the story.
+
+##### The Hook
+
+The hook is the device that drags the characters into the action. Hooks often present themselves as being connected to a Story or Personality Flaw of a key character — a widow appeals to the charity of a Compassionate character, a Mentor asks that a character performs a small task for him, etc. However, not all stories derive from the characters themselves; they may result from prior escapades or the Flaws of storyguide characters who interfere with the players.
+
+#### The Trigger
+
+The trigger is the precipitating event of the plot. It may rely on the actions of the characters — for example, if the hook presents itself once the characters have acquired the Token of the Star — or it may be external to them entirely — the hook presents itself in the Spring of 1223.
+
+#### The Setting
+
+The setting of a plot is a description of the location in which most of the action takes place. The setting is usually determined by the hook, which allows intriguers to exert control over the situation by deciding on the battleground. If the characters need to travel to the setting, then this travel should not be belabored unduly, or else the momentum of the trigger will be lost.
+
+#### The Twist
+
+The twist is an element that is particularly important in intrigue stories. Its most common manifestation is that things are not what they first seemed. This might be because of willful deception by the hook, or it might be because the setting is more complex than either the hook or the characters realized at first.
+
+#### The Resolution
+
+The resolution is the most important part of the synthesis; how the situation could be brought to a conclusion. It is often best to describe a number of end-states that might result from the actions of the characters, rather than relying on railroading the players down a specific course of action towards a pre-determined conclusion.
+
+#### The Consequences
+
+The consequences of the story are those things that result from the actions of the characters. Defeating an enemy is a resolution, but the political ramifications of that defeat constitute the consequences of the story. If left alive, the foe might redouble his efforts against the players; however, his death may bring legal or punitive consequences from other sections of society. Finally, don't forget the rewards; quite apart from the prize that the characters thought that they were pursuing, there is always the potential to acquire new friends, information that might serve as hooks to further stories; and, in game terms, experience points, confidence points, and changes in Personality Traits and Reputations.
+
+## Dramatic Elements
+
+As well as the overall theme of a story (discussed in Story Flow, earlier), the story's structure can be broken down into dramatic elements. Some tellers of folktales believe that all tales have the same basic structure of elements. A story following the structure sometimes skips or repeats individual steps, but follows the general pattern. Most structural descriptions do not suit **Ars Magica** sagas because they assume that character begins as a normal person, and ends as a king. This provides little flexibility for characters to be used in many stories.
+
+A simplified version of the most popular structural description is:
+
+- Each story begins where the last one finished, perhaps after a period of time has passed.
+- Villainy is perpetrated, or the lack of some necessary thing becomes apparent.
+- The player characters become aware of the need to act.
+- They travel, and are tested by events.
+- The characters resolve the minor challenges that stand between them and the main challenge.
+- In doing so, they earn magical aid.
+- The characters travel to where the villain is located.
+- They fight the villain, who is defeated.
+- The villainy, or lack, is remedied
+- The characters head home, but have adventures on the way.
+- The characters are rewarded.
+
+Stories of this type — indeed, any stories — can be divided into constituent dramatic elements that consist of the major characters in a story (the actors, cast, or dramatis personae) and the things that those characters do (the parts, acts, and scenes of the play). Some general principles are discussed in this section, and methods of generating and interpreting dramatic elements can be found in Chapter 2: The Faerie Realm.
+
+### Dramatis Personae
+
+Within fairy tales, myths, and moral stories, there are a number of characters who play specific roles. These elements of the story need not be human-shaped, or even alive, and any one character can combine more than one of these roles.
+
+#### The Hero
+
+The hero is the one who sets off on adventure. The hero might be a seeker-hero (looking for a prize) or a victim-hero (forced into adventure by the actions of the villain). In many stories in the Faerie Realm, the characters collectively take on the role of the hero, although this is not always the case.
+
+Examples: Odysseus (in *The Odyssey*); Samson (in the *Book of Judges*); Es-Sindibad ("Sinbad").
+
+#### The Villain
+
+The villain opposes the hero several times during the story, cumulating with a fight or other form of struggle, and/or a pursuit. There is often more than one villain in a long story — one who tricks the hero, one who sets tasks for the hero, one who fights the hero, one who pursues the hero, and so forth.
+
+Examples: Thrym (in the *Theft of Thor's Hammer*); Hera (in the *Sorrows and Labors of Heracles*); Kostchei the Undying (in *Maria Morevna*).
+
+#### The Donor
+
+The donor grants the hero a magical gift or power that is vital to the execution of his task. However, the donor may not necessarily be kindly disposed towards the hero or acting out of altruism; the hero often has to force the donor to provide the magical aid by completing a task or defeating him in combat.
+
+Examples: Fafnir (in the *Saga of the Nibelungs*); Ceridwen (in the story of Gwion Bach, the witch whose cauldron gives him magical powers)
+
+>## The Thirty Six Dramatic Situations
+> There are a number of modern manuals on literary style that offer advice to aspiring authors, and a storyguide would do well to dip into such sources when planning a faerie story. One of the most useful is Thirty-Six Dramatic Situations by Georges Polti, which propounds that there are thirty six primal emotions that drive all dramatic plots in literature. 
+> 
+> Too many plots in roleplaying games devolve to one of two situations — in Polti’s scheme, numbers 9 (A Daring Enterprise) and 12 (Obtaining). By identifying new plots, excellent inspiration for faerie stories can be gained, particularly if the listed dynamic elements are interpreted metaphorically rather than literally. Adultery is about betrayal of a sacred oath, which encompasses more than just the wedding vows; “Kinsmen,” who feature in many of these situations, can be fellow members of one’s House, or the Order; and a “Conflict with a God” can represent any man’s battle against an undefeatable concept such as Love or Truth.
+> 
+> | Dramatic Situation | Dynamic Elements |
+> |--------------------|------------------|
+> | 1. Supplication | Persecutor, Supplicant, Power in Authority |
+> | 2. Deliverance | Victim, Threatener, Rescuer |
+> | 3. Crime Pursued by Vengeance | Avenger, Criminal |
+> | 4. Vengeance Taken for Kindred Upon Kindred | Avenging Kinsman, Guilty Kinsman, Remembrance of the Victim, Relative of Both |
+> | 5. Pursuit | Punishment, Fugitive |
+> | 6. Disaster | Vanquished Power, Victorious Enemy or Messenger |
+> | 7. Falling Prey to Cruelty or Misfortune | Victim, Master, or Misfortune |
+> | 8. Revolt | Tyrant, Conspirator |
+> | 9. Daring Enterprise | Bold Leader, Object of Quest, Adversary |
+> | 10. Abduction | Abductor, Abducted, Guardian |
+> | 11. The Enigma | Interrogator, Seeker, Problem |
+> | 12. Obtaining | Object Sought, and either Solicitor and Adversary or Arbitrator and Opposing Parties |
+> | 13. Enmity of Kinsmen | Malevolent Kinsman, Hated or Equally Malevolent Kinsman |
+> | 14. Rivalry of Kinsmen | Preferred Kinsman, Rejected Kinsman, Object of Rivalry |
+> | 15. Murderous Adultery | Two Adulterers, Betrayed Spouse |
+> | 16. Madness | Madman, Victim |
+> | 17. Fatal Imprudence | Careless Fool, Victim, or Object Lost |
+> | 18. Involuntary Crimes of Love | Lover, Beloved, Revealer |
+> | 19. Slaying of a Kinsman Unrecognized | Slayer, Unrecognized Victim |
+> | 20. Self-Sacrificing for an Ideal | Hero, Ideal, Creditor, or Person/Thing Sacrificed |
+> | 21. Self-Sacrifice for Kindred | Hero, Kinsman, Creditor, or Person/Thing Sacrificed |
+> | 22. All Sacrificed for a Passion | Lover, Object of Fatal Passion, Person or Thing Sacrificed |
+> | 23. Necessity of Sacrificing Loved Ones | Hero, Beloved Victim, Necessity for Sacrifice |
+> | 24. Rivalry of Superior and Inferior | Superior Rival, Inferior Rival, Object of Rivalry |
+> | 25. Adultery | Two Adulterers, Deceived Spouse |
+> | 26. Crimes of Love | Lover, Beloved |
+> | 27. Discovery of the Dishonor of a Loved One | Discovery, Guilty One |
+> | 28. Obstacles to Love | Two Lovers, Obstacle |
+> | 29. An Enemy Loved | Beloved Enemy, Lover, Hater |
+> | 30. Ambition | Ambitious Person, Thing Coveted, Adversary |
+> | 31. Conflict with a God | Mortal, Immortal |
+> | 32. Mistaken Jealousy | Jealous One, Object of Jealousy, Supposed Accomplice, Cause of Mistake |
+> | 33. Erroneous Judgment | Mistaken One, Victim of Mistake, Cause of Mistake, Guilty Person |
+> | 34. Remorse | Culprit, Victim or Sin, Interrogator |
+> | 35. Recovery of a Lost One | Seeker, One Found |
+> | 36. Loss of Loved Ones | Kinsman Lost, Kinsman Spectator, Executioner |
+
+#### The Helper
+
+The helper assists the hero; unlike the donor, the helper is always well inclined towards the hero, and his motives are pure. The help provided is always timely and perfectly suited to the story. The helper assists the hero in traveling between locations, reverses his ill fortune, rescues him from pursuit, or assists him in his difficult tasks.
+
+Examples: Hermes who shows Odysseus the moly plant; the Grey Wolf (in *Prince Ivan*)
+
+#### The Princess
+
+The Princess is either the object of the hero's quest or a prize acquired along the way. The role of Princess can be filled by any person or object, not just a young female royal.
+
+Examples: The magical apple that cures the illness of hero's grandmother.
+
+#### The Task-Setter
+
+The Task-Setter poses challenges for the hero to pass, and should he succeed, he will win the princess. The task-setter is distinct from the donor (whose tasks result in a magical gift or helper) and the villain (whose tasks are to oppose the hero, not keep the prize from him).
+
+Examples: The Sphinx faced by Oedipus; a king who demands the hero proves himself before winning his daughter's hand; the dragon who guards the Golden Fleece.
+
+#### The False Hero
+
+The false hero is an infrequent role occurring in a story. The false hero tries to claim credit for the hero's actions, and nearly claims the prize sought by him. However, the false hero's deception is always uncovered in the nick of time. Sometimes the false hero and the villain are the same character.
+
+Examples: A cowardly knight who finds a dead dragon and claims to have killed it.
+
+### Acts
+
+The dramatis personae of a fairy tale interact with one another in a series of linked scenes or Acts. Some archetypal acts are detailed in this section, but few stories have a large number of these elements; most combine only two or three. The acts below have been written in a general sense, because the traditional roles vary dramatically according to the nature of the roles. For example, the final act of Reconciliation can be a wedding (if the Princess is a literal princess) or a return to the comfort of home (if the Princess is a magical cure).
+
+The acts presented below are in the order in which they are normally encountered in a fairy story. Notably, the main struggle with the villain is not necessarily the final act, but is often followed by an escape, ordeal, and/ or acquiring the final prize. Most fairy tales start with a preparatory stage where the hero is introduced; in stories where the characters take the hero's role, this is not necessary.
+
+#### Interdiction
+
+Often the precipitating act of the story, the hero is issued a command by some authority figure, such as a king or parent. This command or interdiction is then intentionally or accidentally violated by the hero. It is because of this broken interdiction that the hero sets off on an adventure. Typical interdictions include:
+
+- "Do not leave the castle walls."
+- "Do not steal from the dragon's wealth."
+- "Do not speak to Baba Yaga."
+- "Look after your little sister."
+
+It is often the villain who manipulates the hero into breaking the interdiction by presenting a situation where he is sorely tempted, by greed or by conscience. Alternatively, the villain breaks the interdiction himself, by stealing away the hero's little sister, or hiding the dragon's gold in the hero's pockets.
+
+#### Reconnaissance
+
+The villain makes his first appearance in the story. He desires information about the hero who will oppose him, so gathers information about him. This act often takes place before the villain has revealed his maleficent nature, and the hero himself might naively offer the sought-after information. A quickwitted hero has the opportunity to learn about the villain as well.
+
+#### Trickery
+
+The villain deceives his intended victim in order to take possession of him or of his belongings. In fairy tales, such trickery is almost always fallen for. The villain may employ a number of means to gain control of the hero — persuasion, magic, or force. But there need not be any active trickery on behalf of the villain; for example, the hero may fall asleep and thereby put himself into the hands of the villain.
+
+#### Villainy
+
+This is where the action usually starts, with the villain causing direct harm or injury to someone close to the hero, or perhaps even the hero himself. The villain thus reveals himself to be such, and the hero pursues him for the rest of the story. Example forms of villainy are:
+
+- Abduction of a person;
+- Seizure or theft of a significant object;
+- Pillaging or spoilage of food or craft;
+- Infliction of disease or bodily injury, or murder;
+- Seduction of a loved one;
+- Substitution of a child or bride;
+- Inciting others to crime;
+- Expulsion or infliction of hardship;
+- Imprisonment;
+- Nocturnal tormenting;
+- Declarations of war.
+
+If the villain of the story is absent or a faceless force of nature, then villainy can take the form of a lack or insufficiency. The theft of a magic horse and the lack of a magic horse fulfill the same role in the story — the hero lacks a magic steed when he needs one.
+
+#### Receipt
+
+The hero gains the use of a magical agent or token from a donor. Note that a donor need not be willing or benevolent; a hag tricked out of her magic horse is an example of an unwilling donor. The initial encounter with the donor can take place in a number of ways:
+- *Realms of Power: Faerie*
+- The donor sets tests or obstacles before the hero;
+- The donor greets and interrogates the hero;
+- A dying (or deceased) donor requests a service;
+- A prisoner begs for his freedom;
+- The donor makes a request of the hero;
+- The donor tries to kill the hero;
+- The donor offers an exchange or deal.
+
+Once the hero has passed the test, made the deal, performed the service, or whatever the story demands, he acquires the token. This may be as simple as the donor handing him an object or animal, but this is not the only option. If the token is a magical power, then the hero is shown how to use it, or the token is eaten or drunk to gain the power. The token may be pointed out to the hero, or seized from the donor as part of the test.
+
+Another source of variation is the nature of the token. For it to appear in the story, it must have some relevance to a later act — random treasure is a concept alien to the fairy tale. The successful completion of the story by the hero is always dependent on the token, regardless of whether the hero realizes its significance. Example tokens are:
+
+- A magical steed that can fly;
+- The ability to transform into an animal;
+- An ointment that allows one to see the invisible;
+- The assistance of three magical animals;
+- A ship that folds up like a napkin;
+- The secret of how to kill the giant.
+
+#### Transference
+
+The hero is transported, delivered, or led to the whereabouts of the object of his quest. A remarkable number of fairy stories involve traveling over vast distances, often in a blink of the eye, effected by some magical token possessed or won by the hero.
+
+#### Struggle
+
+Separate to the fight with a hostile donor (see Receipt), this act is a direct conflict between the hero and the villain. The prize is not some magical agent to help him in his quest, but the very object of his quest. It is not uncommon for the hero to receive a wound or other mark during the struggle, or obtain an identifying object from his enemy. This element is important if there is a false hero in the story (see above). Of course, the struggle usually ends in victory for the hero. And by virtue of that defeat, the initial misfortune that sent him on the quest in the first place is liquidated.
+
+#### Pursuit
+
+The journey home is not always a simple one for the hero; sometimes he is pursued. The villain, if not killed during the struggle with the hero, is usually the pursuer. However, it might be some guardian or compatriot of the villain who takes the role of pursuer. The hero who is pursued never simply outruns his pursuer; rather, he is rescued from pursuit by employing the magical agent received from the donor, by the helper, or by the object of his quest.
+
+#### Ordeal
+
+One of the favorite elements of the fairy tale is the requirement that the hero perform some difficult task. The setter of the ordeal is not always the villain, though. For example, a hero might have to prove his worth to a king to obtain permission to marry his daughter. Some typical examples:
+
+- Riddle setting or guessing;
+- Choice (the hero must select his prize from among twelve identical objects);
+- Ordeal by food and drink (the hero must consume a vast amount of food or drink);
+- Hide and seek (the hero must hide himself from the task-setter);
+- Test of strength, adroitness, or fortitude;
+- Supply or manufacture (the hero must make a complex object in a single night, or obtain a mythical prize).
+
+#### Imposture
+
+The hero is sometimes not recognized for his deeds. Instead, a false hero (who may also be the villain) claims credit for the ordeals passed by the hero. However, in the predestined manner of the fairy tale, the hero always has some means to positively identify himself as the hero, and expose the false hero to receive the punishment he deserves. This identifying token may be the wound he suffered in his struggle against the villain, a token he took from the villain, or a token he received from his princess.
+
+#### Reconciliation
+
+The final act of the fairy tale is the hero finally acquiring the object he has sought after. A common resolution is a wedding followed by an ascension to the throne, but equally it could be the return home to his sick grandmother to give her the healing potion he has sought.
+
+# Appendix: Bibliography
+
+Anderson, Graham. *Fairytale in the Ancient World*. Routledge: New York, 2000.
+
+Bishop, Morris (Ed). *A Medieval Storybook*. Cornell University Press: Ithaca, 1970.
+
+Briggs, Katharine. *A Dictionary of Fairies*. Penguin: London, 1977.
+
+Briggs, Katharine. *Abbey Lubbers, Banshees & Boggarts: An Illustrated Encyclopedia of Fairies*. Pantheon Books: New York: 1979.
+
+Gerritsen, Willem and van Melle, Anthony
+
+(Eds). *A Dictionary of Medieval Heroes*. Boydell Press: Woodbridge, 1998.
+
+Palsson, Hermann and Edwards, Paul (Tr). *Seven Viking Romances*. Penguin: London, 1985.
+
+Polti, Georges. *Thirty-Six Dramatic Situations*. Lucille Ray trans. James Knapp Reeve: Franklin, Ohio, 1921.
+
+Propp, Vladimir. *The Morphology of the Folktale*. University of Texas Press: Austin, 1968.
+
+Purkiss, Diane. *Troublesome Things: A History of Fairies and Fairy Stories*. Penguin: London, 2000.
+
+Rose, Carol. *Giants, Monsters, and Dragons: an Encyclopedia of Folklore, Legend, and Myth*. ABC-CLIO: Santa Barbara, 2000.
+
+Synge, Ursula. *Kalevala*. Bodley Head: London, 1977.
+
+Wheeler, Post. *Russian Wonter Tales*. A&C Black: London, 1912.
+
+


### PR DESCRIPTION
I completed an initial cleanup pass on Realms of Power: Faerie.

Main changes include:

rebuilt the table of contents

rebuilt the list of inserts

cleaned up heading hierarchy

repaired many broken paragraphs caused by PDF extraction

reconstructed a number of damaged tables and inserts

corrected various layout and line-break artifacts

This PDF was significantly more chaotic than RoP: Magic, with many broken tables, mixed columns, and missing or displaced paragraph fragments, so I checked and corrected numerous places manually against the PDF.

I think it may now be ready for review, but of course, I’ll leave that judgment to others.