### PR TITLE
Substantially cleans up Lords of Men

### DIFF
--- a/wip/Ars Magica 5e - Lords of Men.md
+++ b/wip/Ars Magica 5e - Lords of Men.md
@@ -1,4 +1,16 @@
+# Lords of Men
 
+A sourcebook for Ars Magica 5th Edition.
+
+> *Open License Markdown version by applejuice1965 & OriginalMadman, https://github.com/OriginalMadman/Ars-Magica-Open-License*
+> 
+> *[Completion state: Text manually fixed, all official Errata included.]*
+> 
+> *Based on the material for Ars Magica, ©1993–2024, licensed by Trident, Inc. d/b/a Atlas Games®, under [Creative Commons Attribution-ShareAlike 4.0 International license 4.0](https://creativecommons.org/licenses/by-sa/4.0/) ("CC-BY-SA 4.0"). Order of Hermes, Tremere, Doissetep, and Grimgroth are trademarks of Paradox Interactive AB and are used with permission.*
+
+The undisputed rulers of Mythic Europe are the nobility — those high-born who are bound together by sacred vows of loyalty, are supported by the land, and provide support to the Church. Lesser nobles compete for the favor of those superior to them, while great nobles seek the loyalty of those beneath them. When not distracted by the politics of landholding and of war, they hunt the mundane and magical beasts of the forests and host extravagant feasts. For the nobles of Mythic Europe are first and foremost knights in shining armor.
+
+This book contains complete rules and background for the nobility of Mythic Europe, ranging from the details of their lands to their entertainments, political struggles, and dealings with the Order of Hermes. And, of course, it presents special rules for combat, whether at a tournament or during a desperate siege. It also describes the hard lives of the peasants, who make the rich existence of the nobility possible by providing the food at their feasts, the labor for their buildings, and the soldiers in their armies.
 
 # Credits
 
@@ -12,7 +24,9 @@
 
 **Cover Illustration:** Grey Thornberry
 
-**Interior Art:** Jason Cole, Keith DeCesare, Kelley Hensing, Bradley K. McDevitt, Jeff Menges, Robert Scott, Grey Thornberry **Ars Magica Fifth Edition Trade Dress:** J. Scott Reeves
+**Interior Art:** Jason Cole, Keith DeCesare, Kelley Hensing, Bradley K. McDevitt, Jeff Menges, Robert Scott, Grey Thornberry
+
+**Ars Magica Fifth Edition Trade Dress:** J. Scott Reeves
 
 **Publisher's Special Thanks**: Jerry Corrick & the gang at the Source.
 
@@ -39,417 +53,444 @@ Copyright 2011 Trident, Inc. d/b/a Atlas Games. All rights reserved. Reproductio
 
 DIGITAL VERSION 1.0
 
-
 # Contents
 
-| I. Introduction                   | 6 | Affinity 20                           |    | Herzog (Dux, Duke)34               |    |
-|-----------------------------------|---|---------------------------------------|----|------------------------------------|----|
-|                                   |   | Secular Allies20                      |    | König (Rex, King)34                |    |
-| Noble Characters for Many         |   | Church Allies20                       |    | Römischer Kaiser (Romanorum        |    |
-| Styles of Saga6                   |   | Affinity Leadership21                 |    | Imperator, Roman Emperor)34        |    |
-|                                   |   | Control Through Emotional             |    | Iberian Systems 35                 |    |
-| II. Politics                      | 7 | Bonds22                               |    | Infanzone35                        |    |
-|                                   |   | Agents22                              |    | Caballero35                        |    |
-| The Gratitude System 7            |   | Design of Agents22                    |    | Caballero Villano36                |    |
-| The Projection of Pow<br>er 7     |   | Acquiring Agents23                    |    | Caballero Hidalgo (or Fidalgo)36   |    |
-| Retinue 9                         |   | Using Agents24                        |    | Ricohombre36                       |    |
-| Family9                           |   | Maintaining Agents25                  |    | The Italian Model 36               |    |
-| Designing a Family9               |   | Reputation 25                         |    | Byzantine Models 36                |    |
-| Inheritance10                     |   | Noble Reputation25                    |    |                                    |    |
-| Marriage and Dowries10            |   | Prudhomme25                           |    |                                    |    |
-| Military11                        |   | Improving Noble Reputation25          |    | IV. Interference                   | 37 |
-| Clerical and Menial12             |   | The Advantages of Reputation26        |    | Methods of Interference 37         |    |
-| Criminals13                       |   | Reputation is Utterly Vital26         |    | Alternatives to Conspiracy37       |    |
-| Offices13                         |   | Public Pow<br>er for Women 27         |    | Making Riches37                    |    |
-| Admiral15                         |   |                                       |    |                                    |    |
-| Butler15                          |   | Dressing as a Man27                   |    | Magic Items38                      |    |
-| Chancellor15                      |   | Holding Land27                        |    | Involvement 39                     |    |
-| Chamberlain15                     |   | Absence27                             |    | Self-Defense39                     |    |
-| Constable15                       |   | Inheritance28                         |    | Defense of Sodales39               |    |
-| Counselor15                       |   | Political Success28                   |    | Defense of the Art40               |    |
-| Justiciar16                       |   | Conquest28                            |    | How<br>Much Do Nobles Know<br>? 40 |    |
-| Marshal16                         |   | Widow's Portion and Stewardship28     |    | Why Don't Magi Break Mythic        |    |
-| Sheriff / Bailie / Sénéchal16     |   | Nuns29                                |    | European Feuda<br>lism? 42         |    |
-| Steward16                         |   |                                       |    | Ignore It42                        |    |
-| Treasurer16                       |   | III. A Comparison of Titles           | 30 | The Code Works as Intended42       |    |
-| Offices Found Only Near England16 |   |                                       |    | Lucky Coincidence42                |    |
-| Coroner17                         |   | The French (and<br>English) System 30 |    | A Conspiracy of Realms42           |    |
-| Forest Warden17                   |   | Squire(Armiger, Écuyer)30             |    | God Has A Plan42                   |    |
-| Vassals 17                        |   | Knight (Miles, Chevalier)30           |    | Mythic Europe is Made for Sin42    |    |
-| Why Bother With Vassals?17        |   | Bacheler Knight30                     |    | Faeries Inadvertently Defend       |    |
-|                                   |   | Knight Banneret30                     |    | the Status Quo43                   |    |
-| Vassalage Allows Nobles to        |   | Baron (Baro, Baron)32                 |    | Magi Helped Design Feudalism43     |    |
-| Express a Common Interest17       |   | Earl or Count (Comes, Comte)32        |    |                                    |    |
-| Vassalage Allows for Huge         |   | Viscount (Vice-comes, Viscomte)32     |    | V. Leisure                         | 44 |
-| Transactions18                    |   | Count Palatine and Marcher Lord32     |    |                                    |    |
-| Vassalage is a Form of Truce18    |   | Duke (Dux, Duc)33                     |    | Pets44                             |    |
-| Vassalage Limits Genocidal        |   | King (Rex, Roi)33                     |    | Outdoor Pursuits44                 |    |
-| Warfare18                         |   | The German System 33                  |    | Board Games45                      |    |
-| Money18                           |   | Herr (Generosus, Lord)34              |    | Gambling45                         |    |
-| Warriors18                        |   | Freiherr34                            |    | Good Drink, Song, and Dance46      |    |
-| Scutage19                         |   | Ritter (Miles, Knight)34              |    | The Feast46                        |    |
-| Advice19                          |   | Ministeriales (Ministers)34           |    | Preparing the Feast46              |    |
-| Wardship of Heirs19               |   | Graf (Comes, Count/Earl)34            |    | The Noble Diet47                   |    |
-| Wardship of Widows20              |   | Markgraf (Marchio, Margrave)34        |    |                                    |    |
-|                                   |   |                                       |    |                                    |    |
+**Chapter One: Introduction**<br>
+&emsp;&emsp;&emsp;Noble Characters for Many Styles of Saga<br>
 
-| Seating the Guests, and             |
-|-------------------------------------|
-| Good Manners47                      |
-| Time to Eat48                       |
-| The Host48                          |
-| The Hunt 48                         |
-| Varieties of Hunting Hounds49       |
-| Hounds and Aging51                  |
-| Hunting with Hounds51               |
-|                                     |
-| The Quest51                         |
-| The Assembly52                      |
-| The Relay52                         |
-| The Finding52                       |
-| The Chase52                         |
-| The Kill52                          |
-| The Unmaking and Curee53            |
-| Bow and Stable Hunting53            |
-| Hunting Stories53                   |
-| The Prey54                          |
-|                                     |
-| Horses 55                           |
-| The Types of Horses55               |
-| The Care of Horses57                |
-| Horses and Aging57                  |
-| Haw<br>king 57                      |
-| Birds and Aging58                   |
-| Running an Establishment 58         |
-| The Kennels60                       |
-| The Mews60                          |
-| The Stables60                       |
-| Living Conditions and               |
-|                                     |
-| Specialists60                       |
-| Romance 61                          |
-| The Pursuit of Love61               |
-| The Rules of Love62                 |
-| Patronage 63                        |
-|                                     |
-| The Tournament 64                   |
-|                                     |
-| Staging a Tournament65              |
-| Patronage65                         |
-| Costs65                             |
-| Team Sponsors66                     |
-| The Tournament Site66               |
-| Lodgings66                          |
-| Tournament as Fair66                |
-| Rules of Melee66                    |
-| Ransom67                            |
-| Companies of Men67                  |
-| Tournament Combat67                 |
-| The Commencailles67                 |
-|                                     |
-| Jousting67                          |
-| Fencing68                           |
-| The Grand Charge68                  |
-| High Ambition68                     |
-| Gaining and Losing Reputation68     |
-| Company Reputations68               |
-| Patronage69                         |
-| Tournaments as Income69<br>Awards69 |
+**Chapter Two: Politics**<br>
+&emsp;The Gratitude System<br>
+&emsp;The Projection of Power<br>
+&emsp;Retinue<br>
+&emsp;&emsp;Family<br>
+&emsp;&emsp;&emsp;Designing a Family<br>
+&emsp;&emsp;&emsp;Inheritance<br>
+&emsp;&emsp;&emsp;Marriage and Dowries<br>
+&emsp;&emsp;Military<br>
+&emsp;&emsp;Clerical and Menial<br>
+&emsp;&emsp;Criminals<br>
+&emsp;&emsp;Offices<br>
+&emsp;&emsp;&emsp;Admiral<br>
+&emsp;&emsp;&emsp;Butler<br>
+&emsp;&emsp;&emsp;Chancellor<br>
+&emsp;&emsp;&emsp;Chamberlain<br>
+&emsp;&emsp;&emsp;Constable<br>
+&emsp;&emsp;&emsp;Counselor<br>
+&emsp;&emsp;&emsp;Justiciar<br>
+&emsp;&emsp;&emsp;Marshal<br>
+&emsp;&emsp;&emsp;Sheriff / Bailie / Sénéchal<br>
+&emsp;&emsp;&emsp;Steward<br>
+&emsp;&emsp;&emsp;Treasurer<br>
+&emsp;&emsp;Offices Found Only Near England<br>
+&emsp;&emsp;&emsp;Coroner<br>
+&emsp;&emsp;&emsp;Forest Warden<br>
+&emsp;Vassals<br>
+&emsp;&emsp;Why Bother With Vassals?<br>
+&emsp;&emsp;Vassalage Allows Nobles to Express a Common Interest<br>
+&emsp;&emsp;Vassalage Allows for Huge Transactions<br>
+&emsp;&emsp;Vassalage is a Form of Truce<br>
+&emsp;&emsp;Vassalage Limits Genocidal Warfare<br>
+&emsp;&emsp;Money<br>
+&emsp;&emsp;Warriors<br>
+&emsp;&emsp;Scutage<br>
+&emsp;&emsp;Advice<br>
+&emsp;&emsp;Wardship of Heirs<br>
+&emsp;&emsp;Wardship of Widows<br>
+&emsp;Affinity<br>
+&emsp;&emsp;Secular Allies<br>
+&emsp;&emsp;Church Allies<br>
+&emsp;&emsp;Affinity Leadership<br>
+&emsp;&emsp;Control Through Emotional Bonds<br>
+&emsp;Agents<br>
+&emsp;&emsp;Design of Agents<br>
+&emsp;&emsp;Acquiring Agents<br>
+&emsp;&emsp;Using Agents<br>
+&emsp;&emsp;Maintaining Agents<br>
+&emsp;Reputation<br>
+&emsp;&emsp;Noble Reputation<br>
+&emsp;&emsp;Prudhomme<br>
+&emsp;&emsp;Improving Noble Reputation<br>
+&emsp;&emsp;The Advantages of Reputation<br>
+&emsp;&emsp;Reputation is Utterly Vital<br>
+&emsp;Public Power for Women<br>
+&emsp;&emsp;Dressing as a Man<br>
+&emsp;&emsp;Holding Land<br>
+&emsp;&emsp;Absence<br>
+&emsp;&emsp;Inheritance<br>
+&emsp;&emsp;Political Success<br>
+&emsp;&emsp;Conquest<br>
+&emsp;&emsp;Widow’s Portion and Stewardship<br>
+&emsp;&emsp;Nuns<br>
 
-**Money in Ars Magica: A Recap ...... 70**
+**Chapter Three: A Comparison of Titles**<br>
+&emsp;The French (and English) System<br>
+&emsp;&emsp;Squire (Armiger, Écuyer)<br>
+&emsp;&emsp;Knight (Miles, Chevalier)<br>
+&emsp;&emsp;Bacheler Knight<br>
+&emsp;&emsp;Knight Banneret<br>
+&emsp;&emsp;Baron (Baro, Baron)<br>
+&emsp;&emsp;Earl or Count (Comes, Comte)<br>
+&emsp;&emsp;Viscount (Vice-comes, Viscomte)<br>
+&emsp;&emsp;Count Palatine and Marcher Lord<br>
+&emsp;&emsp;Duke (Dux, Duc)<br>
+&emsp;&emsp;King (Rex, Roi)<br>
+&emsp;The German System<br>
+&emsp;&emsp;Herr (Generosus, Lord)<br>
+&emsp;&emsp;Freiherr<br>
+&emsp;&emsp;Ritter (Miles, Knight)<br>
+&emsp;&emsp;Ministeriales (Ministers)<br>
+&emsp;&emsp;Graf (Comes, Count/Earl)<br>
+&emsp;&emsp;Markgraf (Marchio, Margrave)<br>
+&emsp;&emsp;Herzog (Dux, Duke)<br>
+&emsp;&emsp;König (Rex, King)<br>
+&emsp;&emsp;Römischer Kaiser (Romanorum Imperator, Roman Emperor)<br>
+&emsp;Iberian Systems<br>
+&emsp;&emsp;Infanzone<br>
+&emsp;&emsp;Caballero<br>
+&emsp;&emsp;Caballero Villano<br>
+&emsp;&emsp;Caballero Hidalgo (or Fidalgo)<br>
+&emsp;&emsp;Ricohombre<br>
+&emsp;The Italian Model<br>
+&emsp;Byzantine Models<br>
 
-| VI. Manorial Fiefs                             | 71 |
-|------------------------------------------------|----|
-| Subinfueda<br>tion 71                          |    |
-| The Manor: The Model Fief 71                   |    |
-| Alternatives to the Manor                      |    |
-| With Demesne71                                 |    |
-| Greater Fiefs73                                |    |
-| Capital Messuage73                             |    |
-| Hall73                                         |    |
-| Animal Sheds74                                 |    |
-| Barns74                                        |    |
-| Curtilage74                                    |    |
-| Fishponds75                                    |    |
-| Granary75<br>Kitchen75                         |    |
-| Stackyard75                                    |    |
-| Farmland75                                     |    |
-| Arable75                                       |    |
-| Meadow76                                       |    |
-| Pasture76                                      |    |
-| The Lord's Portion:                            |    |
-| The Demesne76                                  |    |
-| Market Fair77                                  |    |
-| Mills77                                        |    |
-| Baking77                                       |    |
-| Commons77                                      |    |
-| Waste78                                        |    |
-| Fisheries and Marshes78                        |    |
-| Woods78                                        |    |
-| Parks and Lodges79                             |    |
-| Warrens79                                      |    |
-| Mineral Rights79                               |    |
-| Legal Rights and the Manor                     |    |
-| Court79                                        |    |
-| Entering the Manor79                           |    |
-| Heriot, Mortuary, and                          |    |
-| Laity Objects79                                |    |
-| Tallage79                                      |    |
-| The Manor Court 80<br>Procedure of the Court80 |    |
-| Juries80                                       |    |
-| Disputes80                                     |    |
-| Disputes Based on Weights                      |    |
-| and Measures81                                 |    |
-| Fines81                                        |    |
-| Seizure81                                      |    |
-| Sex Taxes: Merchet, Leywrite,                  |    |
-| Childwrite, and Fines for Celibacy81           |    |
-| Fines for Being Fined82                        |    |
-| Church 82                                      |    |
-| Churchyard83                                   |    |
-| Glebe83                                        |    |
-| Church and Priest's House83                    |    |
-| Improvement 84                                 |    |
-| Assarting84                                    |    |
-| Conquest84                                     |    |
-| Land Management85                              |    |
-| Marriage85                                     |    |
-| Purchase85                                     |    |
+**Chapter Four: Interference**<br>
+&emsp;Methods of Interference<br>
+&emsp;Alternatives to Conspiracy<br>
+&emsp;Making Riches<br>
+&emsp;Magic Items<br>
+&emsp;Involvement<br>
+&emsp;&emsp;Self-Defense<br>
+&emsp;&emsp;Defense of Sodales<br>
+&emsp;&emsp;Defense of the Art<br>
+&emsp;How Much Do Nobles Know?<br>
+&emsp;Why Don’t Magi Break Mythic European Feudalism?<br>
+&emsp;&emsp;Ignore It<br>
+&emsp;&emsp;The Code Works as Intended<br>
+&emsp;&emsp;Lucky Coincidence<br>
+&emsp;&emsp;A Conspiracy of Realms<br>
+&emsp;&emsp;God Has A Plan<br>
+&emsp;&emsp;Mythic Europe is Made for Sin<br>
+&emsp;&emsp;Faeries Inadvertently Defend the Status Quo<br>
+&emsp;&emsp;Magi Helped Design Feudalism<br>
 
-| Fief-like Holdings 85                  |    |
-|----------------------------------------|----|
-| Allods85                               |    |
-| Alms and Charities85                   |    |
-| Alms Land85                            |    |
-| Charities85                            |    |
-| Towns With Royal Charters86            |    |
-| Discuss Poverty in Your Saga 87        |    |
-| VII. The Peasantry                     | 88 |
-|                                        |    |
-| Classes of Peasant 88                  |    |
-| The Unemployed and                     |    |
-| Day Workers88                          |    |
-| Famuli and Other Retained              |    |
-| Servants88                             |    |
-| Serf or Villein88                      |    |
-| Offices for Villeins89                 |    |
-| Half-free90                            |    |
-| Free Peasants90                        |    |
-| Officers91                             |    |
-| Standa<br>of Living 91<br>rd           |    |
-| Housing91                              |    |
-| Food and Drink92                       |    |
-| Improvement in Living Standa<br>rds 93 |    |
-| Paying Tithes Inadequately93           |    |
-| Paying the Lord Less Than              |    |
-| You Owe93                              |    |
-| Paying the Lord Only What              |    |
-| You Owe94                              |    |
-| Not Resting on Holy Days94             |    |
-| Perjury on Behalf of Lords94           |    |
-| Stealing from Neighbors94              |    |
-| Changing Priests Without               |    |
-| Permission, or Deducting               |    |
-| Tithe for his Flaws94                  |    |
-| Sexual Abstinence95                    |    |
-| Working in Old Age95                   |    |
-| Moving Manor96                         |    |
-|                                        |    |
-| Not Working Hard96                     |    |
-| Being Hard on Pilgrims                 |    |
-| and the Poor97                         |    |
-| The Gaining of Freedom 97              |    |
-| Manumission by Lay Lords97             |    |
-| Manumission by the Church97            |    |
-| Manumission by Membership              |    |
-| of a Town's Guild97                    |    |
-| Manumission by Force of                |    |
-| Crusading Sentiment97                  |    |
-| The Agricultural Year 98               |    |
-| Two- or Three-Field Rotation98         |    |
-| August and September98                 |    |
-| October99                              |    |
-| November99                             |    |
-| December99                             |    |
-| January99                              |    |
-| February99                             |    |
-| March100                               |    |
-| April100                               |    |
-| May100                                 |    |
+**Chapter Five: Leisure**<br>
+&emsp;Pets<br>
+&emsp;Outdoor Pursuits<br>
+&emsp;Board Games<br>
+&emsp;Gambling<br>
+&emsp;Good Drink, Song, and Dance<br>
+&emsp;The Feast<br>
+&emsp;&emsp;Preparing the Feast<br>
+&emsp;&emsp;The Noble Diet<br>
+&emsp;&emsp;Seating the Guests, and Good Manners<br>
+&emsp;&emsp;Time to Eat<br>
+&emsp;&emsp;The Host<br>
+&emsp;The Hunt<br>
+&emsp;&emsp;Varieties of Hunting Hounds<br>
+&emsp;&emsp;Hounds and Aging<br>
+&emsp;&emsp;Hunting with Hounds<br>
+&emsp;&emsp;&emsp;The Quest<br>
+&emsp;&emsp;&emsp;The Assembly<br>
+&emsp;&emsp;&emsp;The Relay<br>
+&emsp;&emsp;&emsp;The Finding<br>
+&emsp;&emsp;&emsp;The Chase<br>
+&emsp;&emsp;&emsp;The Kill<br>
+&emsp;&emsp;&emsp;The Unmaking and Curee<br>
+&emsp;&emsp;Bow and Stable Hunting<br>
+&emsp;&emsp;Hunting Stories<br>
+&emsp;&emsp;The Prey<br>
+&emsp;Horses<br>
+&emsp;&emsp;The Types of Horses<br>
+&emsp;&emsp;The Care of Horses<br>
+&emsp;&emsp;Horses and Aging<br>
+&emsp;Hawking<br>
+&emsp;&emsp;Birds and Aging<br>
+&emsp;Running an Establishment<br>
+&emsp;&emsp;The Kennels<br>
+&emsp;&emsp;The Mews<br>
+&emsp;&emsp;The Stables<br>
+&emsp;&emsp;Living Conditions and Specialists<br>
+&emsp;Romance<br>
+&emsp;&emsp;The Pursuit of Love<br>
+&emsp;&emsp;The Rules of Love<br>
+&emsp;Patronage<br>
+&emsp;The Tournament<br>
+&emsp;&emsp;Staging a Tournament<br>
+&emsp;&emsp;Patronage<br>
+&emsp;&emsp;Costs<br>
+&emsp;&emsp;Team Sponsors<br>
+&emsp;&emsp;The Tournament Site<br>
+&emsp;&emsp;Lodgings<br>
+&emsp;&emsp;Tournament as Fair<br>
+&emsp;&emsp;Rules of Melee<br>
+&emsp;&emsp;Ransom<br>
+&emsp;&emsp;Companies of Men<br>
+&emsp;&emsp;Tournament Combat<br>
+&emsp;&emsp;&emsp;The Commencailles<br>
+&emsp;&emsp;&emsp;Jousting<br>
+&emsp;&emsp;&emsp;Fencing<br>
+&emsp;&emsp;&emsp;The Grand Charge<br>
+&emsp;&emsp;&emsp;High Ambition<br>
+&emsp;&emsp;&emsp;Gaining and Losing Reputation<br>
+&emsp;&emsp;&emsp;Company Reputations<br>
+&emsp;&emsp;Patronage<br>
+&emsp;&emsp;Tournaments as Income<br>
+&emsp;&emsp;Awards<br>
+&emsp;Money in Ars Magica: A Recap<br>
 
+**Chapter Six: Manorial Fiefs**<br>
+&emsp;Subinfuedation<br>
+&emsp;The Manor: The Model Fief<br>
+&emsp;Alternatives to the Manor With Demesne<br>
+&emsp;Greater Fiefs<br>
+&emsp;&emsp;Capital Messuage<br>
+&emsp;&emsp;Hall<br>
+&emsp;&emsp;Animal Sheds<br>
+&emsp;&emsp;Barns<br>
+&emsp;&emsp;Curtilage<br>
+&emsp;&emsp;Fishponds<br>
+&emsp;&emsp;Granary<br>
+&emsp;&emsp;Kitchen<br>
+&emsp;&emsp;Stackyard<br>
+&emsp;&emsp;Farmland<br>
+&emsp;&emsp;&emsp;Arable<br>
+&emsp;&emsp;&emsp;Meadow<br>
+&emsp;&emsp;&emsp;Pasture<br>
+&emsp;&emsp;The Lord’s Portion: The Demesne<br>
+&emsp;&emsp;Market Fair<br>
+&emsp;&emsp;Mills<br>
+&emsp;&emsp;Baking<br>
+&emsp;&emsp;Commons<br>
+&emsp;&emsp;Waste<br>
+&emsp;&emsp;Fisheries and Marshes<br>
+&emsp;&emsp;Woods<br>
+&emsp;&emsp;Parks and Lodges<br>
+&emsp;&emsp;Warrens<br>
+&emsp;&emsp;Mineral Rights<br>
+&emsp;&emsp;Legal Rights and the Manor Court<br>
+&emsp;&emsp;&emsp;Entering the Manor<br>
+&emsp;&emsp;&emsp;Heriot, Mortuary, and Laity Objects<br>
+&emsp;&emsp;&emsp;Tallage<br>
+&emsp;&emsp;&emsp;The Manor Court<br>
+&emsp;&emsp;&emsp;&emsp;Procedure of the Court<br>
+&emsp;&emsp;&emsp;&emsp;Juries<br>
+&emsp;&emsp;&emsp;&emsp;Disputes<br>
+&emsp;&emsp;&emsp;&emsp;Disputes Based on Weights and Measures<br>
+&emsp;&emsp;&emsp;&emsp;Fines<br>
+&emsp;&emsp;&emsp;&emsp;Seizure<br>
+&emsp;&emsp;&emsp;&emsp;Sex Taxes: Merchet, Leywrite, Childwrite, and Fines for Celibacy<br>
+&emsp;&emsp;&emsp;&emsp;Fines for Being Fined<br>
+&emsp;&emsp;Church<br>
+&emsp;&emsp;&emsp;Churchyard<br>
+&emsp;&emsp;&emsp;Glebe<br>
+&emsp;&emsp;&emsp;Church and Priest’s House<br>
+&emsp;&emsp;Improvement<br>
+&emsp;&emsp;&emsp;Assarting<br>
+&emsp;&emsp;&emsp;Conquest<br>
+&emsp;&emsp;&emsp;Land Management<br>
+&emsp;&emsp;&emsp;Marriage<br>
+&emsp;&emsp;&emsp;Purchase<br>
+&emsp;Fief-like Holdings<br>
+&emsp;&emsp;Allods<br>
+&emsp;&emsp;Alms and Charities<br>
+&emsp;&emsp;&emsp;Alms Land<br>
+&emsp;&emsp;&emsp;Charities<br>
+&emsp;&emsp;Towns With Royal Charters<br>
+&emsp;&emsp;Discuss Poverty in Your Saga<br>
 
-| July101                           |     |
-|-----------------------------------|-----|
-|                                   |     |
-| VIII. Massed Combat               | 102 |
-| Medieval Armies 102               |     |
-| Raising an Army102                |     |
-| Vassals102                        |     |
-| Allies102                         |     |
-| Affinity102                       |     |
-| Mercenary Budget103               |     |
-| Heroic Endeavors 104              |     |
-| Territorial Advantage104          |     |
-| Using Magic to Seize Advantage105 |     |
-| Weight of Numbers105              |     |
-| Battlefield Events105             |     |
-| Maneuver106                       |     |
-| Size106                           |     |
-| Enemy106                          |     |
-| Wounds and Attrition106           |     |
-| Example Battlefield Events106     |     |
-| Skirmish 106                      |     |
-| Hold the Line 106                 |     |
-| Rescue 106                        |     |
-| Loose 107                         |     |
-| On All Sides 107                  |     |
-| Ransom 107                        |     |
-| Feint 107                         |     |
-| Seize the Colors 107              |     |
-| A "Heroic" Maneuver 107           |     |
-| Alone Against the Many 108        |     |
-| The Aftermath of Battle108        |     |
-| Siegecraft 109                    |     |
-| Castles109                        |     |
-| Every Castle Sends a Message110   |     |
-| Free Choices110                   |     |
-| Minor Castles110                  |     |
-| Shell Keep 110                    |     |
-| Tower Keep 110                    |     |
-| Curtain Walls and Mural Towers110 |     |
-| Keep Alternatives for Castles     |     |
-| with Curtain Walls111             |     |
-| Barbican and Moat 111             |     |
-| Describing Castles111             |     |
-| Garrison111                       |     |
-| Defenses111                       |     |
-| Supplies112                       |     |
-| Life Under Siege112               |     |
-| Stockade112                       |     |
-| Siege Engines112                  |     |
-| Laying Siege112                   |     |
-| Troop Deployment113               |     |
-| Undermining113                    |     |
-| Artillery114                      |     |
-| Escalade114                       |     |
-| Counterattack115                  |     |
-| Scale the Ladders 115             |     |
-| Open the Gates 115                |     |
-| Take the Marshal 115              |     |
-| Aftermath116                      |     |
+**Chapter Seven: The Peasantry**<br>
+&emsp;Classes of Peasant<br>
+&emsp;&emsp;The Unemployed and Day Workers<br>
+&emsp;&emsp;Famuli and Other Retained Servants<br>
+&emsp;&emsp;Serf or Villein<br>
+&emsp;&emsp;Offices for Villeins<br>
+&emsp;&emsp;Half-free<br>
+&emsp;&emsp;Free Peasants<br>
+&emsp;&emsp;Officers<br>
+&emsp;Standard of Living<br>
+&emsp;&emsp;Housing<br>
+&emsp;&emsp;Food and Drink<br>
+&emsp;&emsp;Improvement in Living Standards<br>
+&emsp;&emsp;&emsp;Paying Tithes Inadequately<br>
+&emsp;&emsp;&emsp;Paying the Lord Less Than You Owe<br>
+&emsp;&emsp;&emsp;Paying the Lord Only What You Owe<br>
+&emsp;&emsp;&emsp;Not Resting on Holy Days<br>
+&emsp;&emsp;&emsp;Perjury on Behalf of Lords<br>
+&emsp;&emsp;&emsp;Stealing from Neighbors<br>
+&emsp;&emsp;&emsp;Changing Priests Without Permission, or Deducting Tithe for his Flaws<br>
+&emsp;&emsp;&emsp;Sexual Abstinence<br>
+&emsp;&emsp;&emsp;Working in Old Age<br>
+&emsp;&emsp;&emsp;Moving Manor<br>
+&emsp;&emsp;&emsp;Not Working Hard<br>
+&emsp;&emsp;&emsp;Being Hard on Pilgrims and the Poor<br>
+&emsp;The Gaining of Freedom<br>
+&emsp;&emsp;Manumission by Lay Lords<br>
+&emsp;&emsp;Manumission by the Church<br>
+&emsp;&emsp;Manumission by Membership of a Town’s Guild<br>
+&emsp;&emsp;Manumission by Force of Crusading Sentiment<br>
+&emsp;The Agricultural Year<br>
+&emsp;&emsp;Two- or Three-Field Rotation<br>
+&emsp;&emsp;August and September<br>
+&emsp;&emsp;October<br>
+&emsp;&emsp;November<br>
+&emsp;&emsp;December<br>
+&emsp;&emsp;January<br>
+&emsp;&emsp;February<br>
+&emsp;&emsp;March<br>
+&emsp;&emsp;April<br>
+&emsp;&emsp;May<br>
+&emsp;&emsp;June<br>
+&emsp;&emsp;July<br>
 
-June.............................................101
+**Chapter Eight: Massed Combat**<br>
+&emsp;Medieval Armies<br>
+&emsp;&emsp;Raising an Army<br>
+&emsp;&emsp;&emsp;Vassals<br>
+&emsp;&emsp;&emsp;Allies<br>
+&emsp;&emsp;&emsp;Affinity<br>
+&emsp;&emsp;&emsp;Mercenary Budget<br>
+&emsp;Heroic Endeavors<br>
+&emsp;&emsp;Territorial Advantage<br>
+&emsp;&emsp;Using Magic to Seize Advantage<br>
+&emsp;&emsp;Weight of Numbers<br>
+&emsp;&emsp;Battlefield Events<br>
+&emsp;&emsp;&emsp;Maneuver<br>
+&emsp;&emsp;&emsp;Size<br>
+&emsp;&emsp;&emsp;Enemy<br>
+&emsp;&emsp;&emsp;Wounds and Attrition<br>
+&emsp;&emsp;Example Battlefield Events<br>
+&emsp;&emsp;&emsp;Skirmish<br>
+&emsp;&emsp;&emsp;Hold the Line<br>
+&emsp;&emsp;&emsp;Rescue<br>
+&emsp;&emsp;&emsp;Loose<br>
+&emsp;&emsp;&emsp;On All Sides<br>
+&emsp;&emsp;&emsp;Ransom<br>
+&emsp;&emsp;&emsp;Feint<br>
+&emsp;&emsp;&emsp;Seize the Colors<br>
+&emsp;&emsp;&emsp;A “Heroic” Maneuver<br>
+&emsp;&emsp;&emsp;Alone Against the Many<br>
+&emsp;The Aftermath of Battle<br>
+&emsp;Siegecraft<br>
+&emsp;&emsp;Castles<br>
+&emsp;&emsp;&emsp;Every Castle Sends a Message<br>
+&emsp;&emsp;&emsp;Free Choices<br>
+&emsp;&emsp;&emsp;Minor Castles<br>
+&emsp;&emsp;&emsp;&emsp;Shell Keep<br>
+&emsp;&emsp;&emsp;&emsp;Tower Keep<br>
+&emsp;&emsp;&emsp;Curtain Walls and Mural Towers<br>
+&emsp;&emsp;&emsp;Keep Alternatives for Castles with Curtain Walls<br>
+&emsp;&emsp;&emsp;Barbican and Moat<br>
+&emsp;&emsp;&emsp;Describing Castles<br>
+&emsp;&emsp;&emsp;Garrison<br>
+&emsp;&emsp;&emsp;Defenses<br>
+&emsp;&emsp;&emsp;Supplies<br>
+&emsp;&emsp;&emsp;Life Under Siege<br>
+&emsp;&emsp;&emsp;Stockade<br>
+&emsp;&emsp;&emsp;Siege Engines<br>
+&emsp;&emsp;&emsp;Laying Siege<br>
+&emsp;&emsp;&emsp;Troop Deployment<br>
+&emsp;&emsp;&emsp;Undermining<br>
+&emsp;&emsp;&emsp;Artillery<br>
+&emsp;&emsp;&emsp;Escalade<br>
+&emsp;&emsp;&emsp;Counterattack<br>
+&emsp;&emsp;&emsp;&emsp;Scale the Ladders<br>
+&emsp;&emsp;&emsp;&emsp;Open the Gates<br>
+&emsp;&emsp;&emsp;&emsp;Take the Marshal<br>
+&emsp;&emsp;&emsp;Aftermath<br>
 
-| 117<br>IX. Optional Combat Rules                      |  |
-|-------------------------------------------------------|--|
-| The Combat Round 117                                  |  |
-| When to Use Combat Rounds117                          |  |
-| Initiative117                                         |  |
-| When to Roll Initiative117                            |  |
-| Actions in Combat117                                  |  |
-| Not Everything is an Action117                        |  |
-| Examples of Actions117                                |  |
-| Reactions117                                          |  |
-| Extended Actions118                                   |  |
-| Option: Fast Actions118<br>Delaying Actions118        |  |
-| Option: Interrupting Actions119                       |  |
-| Option: Fast Casting as                               |  |
-| Interruption120                                       |  |
-| Tactical Movement 120                                 |  |
-| Moving in Combat120                                   |  |
-| Movement and Groups120                                |  |
-| Obstacles, Barriers, and                              |  |
-| Movement120                                           |  |
-| Engaging and Disengaging 121                          |  |
-| Engaging in Combat121                                 |  |
-| Effects of Being Engaged121                           |  |
-| Engagement and Defenders122                           |  |
-| Option: No Engagement for                             |  |
-| Missile Combat122                                     |  |
-| Option: No Missiles While<br>Engaged in Melee122      |  |
-| Option: Defenders as Interceptors122                  |  |
-| Disengaging122                                        |  |
-| Attempting to Disengage122                            |  |
-| Automatic Disengagement123                            |  |
-| Option: Reckless Disengagement123                     |  |
-| Attacking and Defending 123                           |  |
-| Attacking123                                          |  |
-| Charging on Foot123                                   |  |
-| Option: Interrupting a Charge123                      |  |
-| Option: Ready Missiles124                             |  |
-| Option: Constriction Attacks124                       |  |
-| Defending124                                          |  |
-| Defense when Unarmed124                               |  |
-| Helpless Characters124                                |  |
-| Option: Diceless Defense124<br>Option: No Defense for |  |
-| Missile Weapons125                                    |  |
-| Option: Evasion125                                    |  |
-| Option: Lasting Consequences                          |  |
-| of Serious Damage125                                  |  |
-| Option: Mitigating Deadly                             |  |
-| Wounds125                                             |  |
-| Mounted Combat 126                                    |  |
-| Untrained Mounts126                                   |  |
-| Mounted Movement126                                   |  |
-| Charging on Horseback126                              |  |
-| Option: Shock of the Charge127                        |  |
-| Shooting Missiles from                                |  |
-| Horseback127                                          |  |
-| Actions Taken by Horses127<br>Attacking Horses128     |  |
-|                                                       |  |
+**Chapter Nine: Optional Combat Rules**<br>
+&emsp;The Combat Round<br>
+&emsp;&emsp;When to Use Combat Rounds<br>
+&emsp;Initiative<br>
+&emsp;&emsp;When to Roll Initiative<br>
+&emsp;&emsp;Actions in Combat<br>
+&emsp;&emsp;&emsp;Not Everything is an Action<br>
+&emsp;&emsp;&emsp;Examples of Actions<br>
+&emsp;&emsp;&emsp;Reactions<br>
+&emsp;&emsp;&emsp;Extended Actions<br>
+&emsp;&emsp;&emsp;Option: Fast Actions<br>
+&emsp;&emsp;&emsp;Delaying Actions<br>
+&emsp;&emsp;&emsp;Option: Interrupting Actions<br>
+&emsp;&emsp;&emsp;Option: Fast Casting as Interruption<br>
+&emsp;Tactical Movement<br>
+&emsp;&emsp;Moving in Combat<br>
+&emsp;&emsp;Movement and Groups<br>
+&emsp;&emsp;Obstacles, Barriers, and Movement<br>
+&emsp;Engaging and Disengaging<br>
+&emsp;&emsp;Engaging in Combat<br>
+&emsp;&emsp;Effects of Being Engaged<br>
+&emsp;&emsp;Engagement and Defenders<br>
+&emsp;&emsp;Option: No Engagement for Missile Combat<br>
+&emsp;&emsp;Option: No Missiles While Engaged in Melee<br>
+&emsp;&emsp;Option: Defenders as Interceptors<br>
+&emsp;&emsp;Disengaging<br>
+&emsp;&emsp;&emsp;Attempting to Disengage<br>
+&emsp;&emsp;&emsp;Automatic Disengagement<br>
+&emsp;&emsp;&emsp;Option: Reckless Disengagement<br>
+&emsp;Attacking and Defending<br>
+&emsp;&emsp;Attacking<br>
+&emsp;&emsp;&emsp;Charging on Foot<br>
+&emsp;&emsp;&emsp;Option: Interrupting a Charge<br>
+&emsp;&emsp;&emsp;Option: Ready Missiles<br>
+&emsp;&emsp;&emsp;Option: Constriction Attacks<br>
+&emsp;&emsp;Defending<br>
+&emsp;&emsp;&emsp;Defense when Unarmed<br>
+&emsp;&emsp;&emsp;Helpless Characters<br>
+&emsp;&emsp;&emsp;Option: Diceless Defense<br>
+&emsp;&emsp;&emsp;Option: No Defense for Missile Weapons<br>
+&emsp;&emsp;&emsp;Option: Evasion<br>
+&emsp;&emsp;&emsp;Option: Lasting Consequences of Serious Damage<br>
+&emsp;&emsp;&emsp;Option: Mitigating Deadly Wounds<br>
+&emsp;Mounted Combat<br>
+&emsp;&emsp;Untrained Mounts<br>
+&emsp;&emsp;Mounted Movement<br>
+&emsp;&emsp;Charging on Horseback<br>
+&emsp;&emsp;&emsp;Option: Shock of the Charge<br>
+&emsp;&emsp;Shooting Missiles from Horseback<br>
+&emsp;&emsp;Actions Taken by Horses<br>
+&emsp;&emsp;Attacking Horses<br>
+&emsp;&emsp;Wounding Horses<br>
+&emsp;&emsp;Controlling a Panicked Horse<br>
+&emsp;&emsp;&emsp;Option: Defensive Bonus for Moving Horses<br>
+&emsp;&emsp;Mounting and Dismounting<br>
+&emsp;&emsp;&emsp;Leaping from the Saddle<br>
+&emsp;&emsp;&emsp;Option: Vaulting Into the Saddle<br>
+&emsp;&emsp;Falling from Horseback<br>
+&emsp;&emsp;&emsp;Being Pinned Under a Horse<br>
+&emsp;Battlefield Situations<br>
+&emsp;&emsp;General Situational Modifiers<br>
+&emsp;&emsp;Specific Situations<br>
+&emsp;&emsp;&emsp;Cover<br>
+&emsp;&emsp;&emsp;Concealment, Darkness, and Invisibility<br>
+&emsp;&emsp;&emsp;Higher Ground<br>
+&emsp;&emsp;&emsp;Fighting Indoors and in Narrow Spaces<br>
+&emsp;&emsp;&emsp;Option: Non-Lethal Combat<br>
+&emsp;&emsp;&emsp;Non-Lethal Damage: Bruises<br>
+&emsp;&emsp;&emsp;Recovering from Bruises<br>
+&emsp;&emsp;&emsp;Weapons and Bruises<br>
+&emsp;&emsp;&emsp;Special Effects<br>
+&emsp;Advanced Group Combat<br>
+&emsp;&emsp;Accelerated Group Training<br>
+&emsp;&emsp;The Leader’s Actions<br>
+&emsp;&emsp;Morale and Discipline<br>
+&emsp;&emsp;&emsp;Discipline<br>
+&emsp;&emsp;&emsp;Example Discipline Ease Factors<br>
+&emsp;&emsp;&emsp;Morale<br>
+&emsp;&emsp;&emsp;Example Morale Ease Factors<br>
+&emsp;&emsp;&emsp;Disordered Groups<br>
+&emsp;&emsp;&emsp;Routed Groups<br>
+&emsp;&emsp;&emsp;Rallying a Group<br>
+&emsp;&emsp;&emsp;Groups With No Leader<br>
 
-| Wounding Horses128               |
-|----------------------------------|
-| Controlling a Panicked Horse128  |
-| Option: Defensive Bonus for      |
-| Moving Horses128                 |
-| Mounting and Dismounting128      |
-| Leaping from the Saddle128       |
-| Option: Vaulting Into            |
-| the Saddle129                    |
-| Falling from Horseback129        |
-| Being Pinned Under a Horse129    |
-| Battlefield Situations 129       |
-| General Situational Modifiers129 |
-| Specific Situations130           |
-| Cover130                         |
-| Concealment, Darkness, and       |
-| Invisibility130                  |
-| Higher Ground130                 |
-| Fighting Indoors and in          |
-| Narrow Spaces131                 |
-| Option: Non-Lethal Combat 131    |
-| Non-Lethal Damage: Bruises131    |
-| Recovering from Bruises131       |
-| Weapons and Bruises132           |
-| Special Effects132               |
-| Advanced Group Combat 133        |
-| Accelerated Group Training133    |
-| The Leader's Actions133          |
-| Morale and Discipline134         |
-| Discipline134                    |
-| Example Discipline               |
-| Ease Factors134                  |
-| Morale134                        |
-| Example Morale                   |
-| Ease Factors134                  |
-| Disordered Groups134             |
-| Routed Groups135                 |
-| Rallying a Group135              |
-| Groups With No Leader135         |
+**Supplement: Arms & Armor**<br>
 
-*Supplement: Arms & Armor 136*
-
-
-## Chapter One
-
-# Rule by the Sword
+# Chapter One: Rule by the Sword
 
 Mythic Europe is governed by a warrior caste. To be noble is to expect the call to arms; to gain the esteem of other nobles, a lord must draw forces together and massacre his enemies. Nobles are wealthy, so they may live sumptuously and patronize the Church and the arts, but the thirteenth century is a time of strife. Those who kill, rule.
 
 Realms still need their armies, for virtually all have recently been burned by war, but many nobles feel their state is in decline. Kings and the Church chip away at the status of the warrior caste. Its great mission the liberation of the Holy Land — seems in disarray. The merchants of the cities are increasingly demanding, as well, and have the money to field armies of mercenaries. The nobility cannot conceive of a world in which it does not rule, but rule is harder to maintain than in earlier days.
 
-And at the edges of society, the nobles know, a mysterious Order of magicians lurks. The wizards are forbidden to meddle, it's said, but rumor states that little stops them. Are the wizards potential allies, or alreadyactive enemies? Is magic a threat, or an opportunity? The 13th century is a difficult time to be a nobleman, as challenges, as well as chances for glory, abound.
+And at the edges of society, the nobles know, a mysterious Order of magicians lurks. The wizards are forbidden to meddle, it's said, but rumor states that little stops them. Are the wizards potential allies, or already active enemies? Is magic a threat, or an opportunity? The 13th century is a difficult time to be a nobleman, as challenges, as well as chances for glory, abound.
 
 #### Noble Characters for Many Styles of Saga
 
@@ -464,9 +505,7 @@ Political sagas are also catered to. A skilled diplomat can lead his alliance to
 Sagas in which a nobleman acts as a servant and spokesman for a covenant are also supported. Nobles who reside primarily at covenants may be fleshed out using material on how members of the military class think and act. Land ownership and vassal maintenance are also detailed. A chapter describes the crude and unpleasant life of serfs, and contains many story seeds that can hook player characters from peasant backgrounds into sagas. The relationship between the Order and nobles is also described, with a comprehensive explanation of what most nobles know about the Order.
 
 
-## Chapter Two
-
-# Politics
+# Chapter Two: Politics
 
 Advancement in a political career depends on the whims of a powerful patron. Many lords wish to hire competent people, but it is difficult for a skilled character lacking social connections to demonstrate merit to potential patrons. A career normally begins with a fortunate birth, either as a noble or in the personal retinue of a great lord.
 
@@ -498,41 +537,35 @@ A story provides:
 
 ## The Projection of Power
 
-Great Nobles have a sphere of influence that can be divided into levels of proximity. The closest bond, which affects the fewest people, is between the lord and his retinue. These are the people he directly employs as part of his household for an extended period of time. This includes his officers, who are
+Great Nobles have a sphere of influence that can be divided into levels of proximity. The closest bond, which affects the fewest people, is between the lord and his retinue. These are the people he directly employs as part of his household for an extended period of time. This includes his officers, who are servants trusted with a portion of the lord's power in exchange for their loyal service. The next most significant bond is between the magnate and his tenants. These are the lords and knights who hold land from the magnate. They are more autonomous than his household, but cannot risk his displeasure save in times of crisis, when he lacks the power to punish their insolence.
 
-
-
-## Advancement Requirements Table
-
-See Chapter Three: A Comparison of Titles for more on those positions mentioned here.
-
-| Change                                        | Requires                                                                                                                                                                                                                         | Cost to Granter                                   |
-|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-| serf to freeman                               | 5 Gratitude                                                                                                                                                                                                                      | Cost of serf                                      |
-| warrior to knight                             | 5 Gratitude                                                                                                                                                                                                                      | Cost of gear (5 pounds mini<br>mum)               |
-| knight to bacheler                            | Must have the basic Abilities of a Knight, and the Abilities and Person<br>ality traits suited to this particular mesnie. Gratitude 5.                                                                                           | Ongoing support                                   |
-| bacheler to carissimus                        | Must be a bacheler, Gratitude 5, story event.                                                                                                                                                                                    | No cost                                           |
-| bacheler to lord of the<br>manor              | Gratitude 10, marriage to suitable heiress, or claiming land during war,<br>or being offered land that has returned to the lord.                                                                                                 | The revenues of the manor                         |
-| Added manors                                  | Gratitude 10, Reputation for loyalty to the lord, land must be available<br>due to the extinction of a line, or war, or assart, or appanage.                                                                                     | The revenues of the additional<br>manor or manors |
-| lord of the manor to<br>banneret              | Sufficient money to hire knights – usually from 5 manors.                                                                                                                                                                        | Nothing                                           |
-| banneret to baron of a<br>minor lord          | Gaining by any means at least 15 more manors. Reputation of loyalty<br>toward the lord, 10 Gratitude                                                                                                                             | Nothing, except if the manors<br>are the lord's.  |
-| minor baron to a lord<br>to baron of the king | Must be noticed by the king or his advisors, must be in the service of a<br>lord the king doesn't mind offending, like a rebel or an heir that owes<br>the king. Gratitude 20 and, usually, successful treason against the lord. | Nothing.                                          |
-| admiral                                       | Access to ships, Leadership 2                                                                                                                                                                                                    |                                                   |
-| butler                                        | Profession: Steward 2                                                                                                                                                                                                            |                                                   |
-| chancellor                                    | Must be highly literate in the local languages of business and diplo<br>macy, usually has Church Lore.                                                                                                                           |                                                   |
-| marshal                                       | Leadership 5, Reputation for skill at warfare.                                                                                                                                                                                   |                                                   |
-| steward                                       | Profession: Steward 2                                                                                                                                                                                                            |                                                   |
-| treasurer                                     | Profession: Steward 2                                                                                                                                                                                                            |                                                   |
-| appointment as baron                          | Gratitude 10, a suitable marriage, any officer role                                                                                                                                                                              |                                                   |
-| appointment as<br>justiciar                   | Story event, substantial baronial role, or church equivalent, plus Loyalty<br>to the dead person and a Reputation of 5 or more.                                                                                                  |                                                   |
-
-Appointment as an officer to Greater Baron or higher requires Gratitude 10, Landed Noble (at minimum), Reputation for loyalty to the lord, vacancy in the office, and office-specific traits. Abilities below 2 assume the noble has an oversight role and is aided by a skilled deputy in the practical functions of the office. A noble wishing to skillfully administer the daily business of the office should develop an appropriate Ability score of 5. Making a vassal an officer costs the granter nothing. It does, however, cost the previous holder of the office his status and income, which may lead to a story.
-
-In brief, to move from serf to freeman, or warrior to knight, or knight to bacheler, requires a single story in which the character provides heroic service to his lord, or the gradual accumulation of merit equivalent to this. To move through the middle ranks of knighthood requires two heroic services, five exceptional services, or ten stories with the magi that can be tied to the interest of the lord. These payments, again, require that the lord wishes to reward merit, that he has the desired reward available, and that there is no better claimant in his affinity.
-
-
-
-servants trusted with a portion of the lord's power in exchange for their loyal service. The next most significant bond is between the magnate and his tenants. These are the lords and knights who hold land from the magnate. They are more autonomous than his household, but cannot risk his displeasure save in times of crisis, when he lacks the power to punish their insolence.
+> ## Advancement Requirements Table
+> 
+> See Chapter Three: A Comparison of Titles for more on those positions mentioned here.
+> 
+> | Change                                 | Requires                                                                                                                                                                                                                         | Cost to Granter                          |
+> |----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|
+> | serf to freeman                        | 5 Gratitude                                                                                                                                                                                                                      | Cost of serf                             |
+> | warrior to knight                      | 5 Gratitude                                                                                                                                                                                                                      | Cost of gear (5 pounds minimum)          |
+> | knight to bacheler                     | Must have the basic Abilities of a Knight, and the Abilities and Personality traits suited to this particular mesnie. Gratitude 5.                                                                                             | Ongoing support                          |
+> | bacheler to carissimus                 | Must be a bacheler, Gratitude 5, story event.                                                                                                                                                                                    | No cost                                  |
+> | bacheler to Landed Noble          | Gratitude 10, marriage to suitable heiress, or claiming land during war, or being offered land that has returned to the lord.                                                                                                  | The revenues of the manor                |
+> | Added manors                           | Gratitude 10, Reputation for loyalty to the lord, land must be available due to the extinction of a line, or war, or assart, or appanage.                                                                                     | The revenues of the additional manor or manors |
+> | Landed Noble to banneret          | Sufficient money to hire knights – usually from 5 manors.                                                                                                                                                                        | Nothing                                  |
+> | banneret to baron of a minor lord      | Gaining by any means at least 15 more manors. Reputation of loyalty toward the lord, 10 Gratitude                                                                                                                               | Nothing, except if the manors are the lord's. |
+> | minor baron to a lord to baron of the king | Must be noticed by the king or his advisors, must be in the service of a lord the king doesn't mind offending, like a rebel or an heir that owes the king. Gratitude 20 and, usually, successful treason against the lord. | Nothing.                                 |
+> | admiral                                | Access to ships, Leadership 2                                                                                                                                                                                                    |                                          |
+> | butler                                 | Profession: Steward 2                                                                                                                                                                                                            |                                          |
+> | chancellor                             | Must be highly literate in the local languages of business and diplomacy, usually has Church Lore.                                                                                                                              |                                          |
+> | marshal                                | Leadership 5, Reputation for skill at warfare.                                                                                                                                                                                   |                                          |
+> | steward                                | Profession: Steward 2                                                                                                                                                                                                            |                                          |
+> | treasurer                              | Profession: Steward 2                                                                                                                                                                                                            |                                          |
+> | appointment as baron                   | Gratitude 10, a suitable marriage, any officer role                                                                                                                                                                              |                                          |
+> | appointment as justiciar               | Story event, substantial baronial role, or church equivalent, plus Loyalty to the dead person and a Reputation of 5 or more.                                                                                                   |                                          |             |
+> 
+> Appointment as an officer to Greater Baron or higher requires Gratitude 10, Landed Noble (at minimum), Reputation for loyalty to the lord, vacancy in the office, and office-specific traits. Abilities below 2 assume the noble has an oversight role and is aided by a skilled deputy in the practical functions of the office. A noble wishing to skillfully administer the daily business of the office should develop an appropriate Ability score of 5. Making a vassal an officer costs the granter nothing. It does, however, cost the previous holder of the office his status and income, which may lead to a story.
+> 
+> In brief, to move from serf to freeman, or warrior to knight, or knight to bacheler, requires a single story in which the character provides heroic service to his lord, or the gradual accumulation of merit equivalent to this. To move through the middle ranks of knighthood requires two heroic services, five exceptional services, or ten stories with the magi that can be tied to the interest of the lord. These payments, again, require that the lord wishes to reward merit, that he has the desired reward available, and that there is no better claimant in his affinity.
 
 The magnate also has influence over people who are not dependent on him for their livelihood. Powerful magnates usually create coalitions of allies around their demesne lands. This area of influence is called his country, and the people who participate in the alliance are called the magnate's affinity. Significant political figures are carefully watched by other members of the noble class, who do their best to avoid the anger of a magnate. A magnate's reputation can influence the actions of his neighbors without any effort on his part.
 
@@ -544,57 +577,53 @@ The retinue of most magnates can be split into four parts: family, military, cle
 
 Nobles are expected to favor their extended families when seeking vassals and household retainers. This is supposed to make a body of retainers more loyal than one composed of strangers. Male relatives are useful for a range of offices, and female relatives may be used to cement alliances through marriage.
 
-Bastards are particularly useful to medieval magnates, because they do not automatically inherit land in most areas. They have
+Bastards are particularly useful to medieval magnates, because they do not automatically inherit land in most areas. They have no incentive to overthrow their legitimate brother, and are dependent on his goodwill for advancement. Bastard sons, if trained as knights, are sometimes not fostered away, which allows them to grow more familiar with the estate than legitimate children. Bastard daughters are useful for making strong alliances with minor vassals or merchants, as marriage to a lesser noble or commoner does not dishonor them.
 
-## A Random Method of Death
+> ## A Random Method of Death
+> 
+> To simulate the randomness of age at death in Mythic Europe, which allows paths of inheritance to take unexpected turns, Storyguides may wish to secretly calculate the death age of non-player characters. Assume that any child has a 25% chance of dying of natural causes before adulthood is reached. For characters who are already adults, or children who survive, assume a death age of 6 simple dice + 20 years. In times of widespread war, flip a coin so that half of all adult men die by violence 10 years before the six dice indicate they should. For less-intense wars, instead use a die and grade the odds to suit the lethality of the conflict. Storyguides should note that these rules are harsher than the standard aging rules.
+> 
+> ### A Random Method of Life
+> 
+> If a character is waiting to inherit, check for the birth of new heirs. For each person between the character and inheritance, assess if they are likely to have a legitimate child in this year. Then roll a die for each, assuming that on average half of them do have a child. Check each child for random age of death.
 
-To simulate the randomness of age at death in Mythic Europe, which allows paths of inheritance to take unexpected turns, Storyguides may wish to secretly calculate the death age of non-player characters. Assume that any child has a 25% chance of dying of natural causes before adulthood is reached. For characters who are already adults, or children who survive, assume a death age of 6 simple dice + 20 years. In times of widespread war, flip a coin so that half of all adult men die by violence 10 years before the six dice indicate they should. For less-intense wars, instead use a die and grade the odds to suit the lethality of the conflict. Storyguides should note that these rules are harsher than the standard aging rules.
-
-#### A Random Method of Life
-
-If a character is waiting to inherit, check for the birth of new heirs. For each person between the character and inheritance, assess if they are likely to have a legitimate child in this year. Then roll a die for each, assuming that on average half of them do have a child. Check each child for random age of death.
-
-## Story Seed: Finding an Heir
-
-An elderly lord keeps falling ill. His sickness is not lethal, but it takes him longer to recover from each bout. He fears that he will die in the next few years as he weakens, so he dispatches the player characters to find his heir. The boy took the cross, but has not been heard from since he left.
-
-The lord has four daughters, and the lands will be divided among them if the heir is not produced. The husband of one of these daughters sends assassins and saboteurs to shadow the player characters. They strike at the group if they sense weakness, but prefer to let them find the heir, so that they can kill him without forewarning. Even if the heir is bought home, he still needs the protection of the player characters. After all, his brothersin-law can also claim his land if he dies in accident, or in war. And some may claim that he is not the son at all, but rather an impostor.
-
-The player characters also have a second lead to the identity of the heir's enemy. The illnesses suffered by his father are not natural: they are poisonings, given in a slow series so as not to arouse suspicion. If the characters can catch the servant who administers the poison, they may be able to trap her handler, who can provide the name of the lord responsible.
-
-no incentive to overthrow their legitimate brother, and are dependent on his goodwill for advancement. Bastard sons, if trained as knights, are sometimes not fostered away, which allows them to grow more familiar with the estate than legitimate children. Bastard daughters are useful for making strong alliances with minor vassals or merchants, as marriage to a lesser noble or commoner does not dishonor them.
+> ## Story Seed: Finding an Heir
+> 
+> An elderly lord keeps falling ill. His sickness is not lethal, but it takes him longer to recover from each bout. He fears that he will die in the next few years as he weakens, so he dispatches the player characters to find his heir. The boy took the cross, but has not been heard from since he left.
+> 
+> The lord has four daughters, and the lands will be divided among them if the heir is not produced. The husband of one of these daughters sends assassins and saboteurs to shadow the player characters. They strike at the group if they sense weakness, but prefer to let them find the heir, so that they can kill him without forewarning. Even if the heir is bought home, he still needs the protection of the player characters. After all, his brothers-in-law can also claim his land if he dies in accident, or in war. And some may claim that he is not the son at all, but rather an impostor.
+> 
+> The player characters also have a second lead to the identity of the heir's enemy. The illnesses suffered by his father are not natural: they are poisonings, given in a slow series so as not to arouse suspicion. If the characters can catch the servant who administers the poison, they may be able to trap her handler, who can provide the name of the lord responsible.
 
 #### Designing a Family
 
 Players wishing to generate a family for their characters may freely select any reasonable number of living siblings that they wish, and may select which are bastards. For a random number of legitimate siblings, roll two dice of different colors and halve each result. One die represents the number of male children surviving to adulthood, the other the number of female. Zeros represent no surviving children of that gender. For birth order, assign each child a number and roll randomly until all have a place. Distribute the births of all characters so that they lie within a 12-year span. Male characters older than 21 and female characters older than 18 are almost certainly married or committed to the religious life.
 
-For a random number of bastards, roll a die, halve it, and then add or subtract appropriate Personality traits of the father and mother. Roll birth order for each, comparing to the above siblings, and roll odd or even to determine gender. Bastards created by a straying husband and a woman of lower sta-
+For a random number of bastards, roll a die, halve it, and then add or subtract appropriate Personality traits of the father and mother. Roll birth order for each, comparing to the above siblings, and roll odd or even to determine gender. Bastards created by a straying husband and a woman of lower status are usually known; those from a noble woman who finds a lover are usually hidden among her legitimate children, which may be a source of the Dark Secret Flaw.
 
-
-## Story Seed: Not A Bastard
-
-A monk at a nearby abbey has made a final confession at unction that has alarming consequences. Before he entered the monastery, the monk was a village priest, and he performed a secret marriage for a young, smitten nobleman and his common lover. The young nobleman was later offered a rich marriage, and bigamously married the daughter of a neighboring landholder, acknowledging his children by his first marriage only as bastards. They have been the loyal servants of the "legitimate" line of the family for a generation, and fill many lesser positions in the court of the lord.
-
-Legally, the effect of this confession, which the dying man asked his confessor to make public after a little encouragement, is that the head of the "bastard" line should become the lord, dispossessing his younger half brother. Characters may earn gratitude by negotiating the continuing loyalty of the "bastard" line, by negotiating a smooth transition between the two lineages, or by taking the winning side if the parties seek justice in the courts or on the field of battle. Characters who hush up the confession cannot earn Gratitude points, but may be given other favors.
-
-This story seed may have several different twists, as well. The current lord may be murderously dedicated to keeping the land in his branch of the family for his sons, and try to eliminate the characters who have hushed the matter up, so that the secret remains buried. He might, alternatively, be almost too good, and be glad to give up his land to his wronged brother. The brother, however has a hatred for a neighboring community, and his ascension would pitch the land into war. His player-character vassals must choose between loyalty to their somewhat naive lord and loyalty to their community, which would be ravaged if the war was lost. Finally, the confession itself may be a lie, fostered by a demon or faeries to cause strife.
-
-tus are usually known; those from a noble woman who finds a lover are usually hidden among her legitimate children, which may be a source of the Dark Secret Flaw.
+> ## Story Seed: Not A Bastard
+> 
+> A monk at a nearby abbey has made a final confession at unction that has alarming consequences. Before he entered the monastery, the monk was a village priest, and he performed a secret marriage for a young, smitten nobleman and his common lover. The young nobleman was later offered a rich marriage, and bigamously married the daughter of a neighboring landholder, acknowledging his children by his first marriage only as bastards. They have been the loyal servants of the "legitimate" line of the family for a generation, and fill many lesser positions in the court of the lord.
+> 
+> Legally, the effect of this confession, which the dying man asked his confessor to make public after a little encouragement, is that the head of the "bastard" line should become the lord, dispossessing his younger half brother. Characters may earn gratitude by negotiating the continuing loyalty of the "bastard" line, by negotiating a smooth transition between the two lineages, or by taking the winning side if the parties seek justice in the courts or on the field of battle. Characters who hush up the confession cannot earn Gratitude points, but may be given other favors.
+> 
+> This story seed may have several different twists, as well. The current lord may be murderously dedicated to keeping the land in his branch of the family for his sons, and try to eliminate the characters who have hushed the matter up, so that the secret remains buried. He might, alternatively, be almost too good, and be glad to give up his land to his wronged brother. The brother, however has a hatred for a neighboring community, and his ascension would pitch the land into war. His player-character vassals must choose between loyalty to their somewhat naive lord and loyalty to their community, which would be ravaged if the war was lost. Finally, the confession itself may be a lie, fostered by a demon or faeries to cause strife.
 
 To see how loyal to the head of the family each sibling is, the player rolls a stress die and then, if the child is a legitimate son, subtracts the number of older sons of military inclination. The result is used to generate a number as per the Arts table on ArM5, page 31. The maximum score is 3 and negative scores are permitted. This score is the son's Loyal Personality Trait. A roll of zero indicates that the child is implacably disloyal to the head of the family.
 
 The subtraction of the birth number of the legitimate sons models the way that families in cultures that practice primogeniture ration economic support to favor the elder sons. It does not apply in those families that are so wealthy that they support all of their sons. Sons of "military inclination" do not include those who are dead, bastards, have joined the Church, have become magi, or are seriously disabled, as these sons do not inherit land. In powerful, wealthy families, the support required to prevent loss of loyalty may include land.
 
-Disloyal sons may remain in the service of their fathers for a long time, waiting for an opportunity to assert their independence. Sons who are not implacably disloyal may become loyal over time as their older brothers die, tying their interests closer to the head of the family's. On the other hand, many nobles feel that heirs are more likely to be disloyal than younger sons, since they have so much to gain by the deaths of their fathers; if this is the case in your campaign, troupes should shuffle these scores between sons to create interesting supporting characters for their stories. A family may be as detailed as the player and troupe prefer. Many troupes liketo keep extended families vague, so that new characters can be added as stories require.
+Disloyal sons may remain in the service of their fathers for a long time, waiting for an opportunity to assert their independence. Sons who are not implacably disloyal may become loyal over time as their older brothers die, tying their interests closer to the head of the family's. On the other hand, many nobles feel that heirs are more likely to be disloyal than younger sons, since they have so much to gain by the deaths of their fathers; if this is the case in your campaign, troupes should shuffle these scores between sons to create interesting supporting characters for their stories. A family may be as detailed as the player and troupe prefer. Many troupes like to keep extended families vague, so that new characters can be added as stories require.
 
 #### Inheritance
 
 In many areas of Mythic Europe, the lands of a father are divided between his sons at death. In those that are influenced by Norman culture, this is seen only as a way of dividing the family's estate into a patch of squabbling petty knights, and so all land goes to the nominated heir. If no heir is nominated, this is the eldest, or the strongest as selected by the dead father's liege. This method keeps the family estate together, but gives younger sons motive to oppose the head of their family in war.
 
-
 These non-heritable appanage lands are frowned upon by many. They assert that appanages are not usually resumed by the primary line of a family without warfare, and so they are a way of dividing the estate in slow stages. This does occur in some families, but in the majority, war and infant mortality prevent this from occurring. The French royal family has divided its lands somewhat through appanage. In contrast, the English crown has not, since the Conquest, been able to create a cadet branch that has held its land separate for more than two generations.
 
-time only.
+Four measures are taken to limit fratricide. First, younger brothers and nephews are given choice offices in the retinue of the family’s head. Second, the lands that a father inherited from his father are kept together as demesne, but land gained by conquest or marriage may be split away to endow younger sons. Third, if the lord gains wardship of an heiress, she will be married to a landless son to provide for him. And fourth, sections of the estate called appanages may be given to younger sons for the length of their lifetime only.
+
+These non-heritable appanage lands are frowned upon by many. They assert that appanages are not usually resumed by the primary line of a family without warfare, and so they are a way of dividing the estate in slow stages. This does occur in some families, but in the majority, war and infant mortality prevent this from occurring. The French royal family has divided its lands somewhat through appanage. In contrast, the English crown has not, since the Conquest, been able to create a cadet branch that has held its land separate for more than two generations. 
 
 If there is no male heir, the lands of families in many areas are divided between the daughters of the last lord. This prevents his sons-in-law from going to war, and provides lands to the Church through daughters who have taken the veil. This is one factor that prevents nobles having contiguous territories. The average noble family fails to provide a male heir every fourth generation, so this churning of lands is common.
 
@@ -604,11 +633,7 @@ A player may select the degree of affection in the character's marriage in consu
 
 In many areas, the father of the bride must consent to her marriage. This allows him to threaten his daughter, by saying he will approve no man other than his choice. A father does not, however, formally choose the husband of his daughters in any Christian part of Europe. The sacrament of marriage requires voluntary participation.
 
-Marriage may occur at very young ages
-
-
-
-for the heirs of greater nobles. The average groom of the lower noble class is, however, in his late twenties. This is lower if he has an opportunity to marry well and establish himself financially. Women marry slightly younger than men.
+Marriage may occur at very young ages for the heirs of greater nobles. The average groom of the lower noble class is, however, in his late twenties. This is lower if he has an opportunity to marry well and establish himself financially. Women marry slightly younger than men.
 
 Dowries are an important part of the marriage contract. A dowry is a sum of money or goods paid by the bride's family to the bride upon marriage. Dowries are the usual way for parents to pass wealth intergenerationally to daughters.
 
@@ -620,57 +645,50 @@ The military accompaniment of a nobleman varies with his wealth. Simple knights 
 
 Membership in a lord's mesnie has many advantages. The knights of a nobleman's household are fed, clothed, billeted, and their gear is replaced if it wears out or is lost occasionally in tournaments. As the personal guards of a lord, the mesnie knights profit from their lord's wars. If the lord is powerful, or becomes powerful, his mesnie is often rewarded with offices or lands. Many are rewarded with the lord's largesse.
 
-It is usual for lords to stuff their mesnie with young men from their extended family, or those of their neighbors. Younger sons raised as squires in a lord's court, for example, may lack the resources required to maintain their status. Placement in a mesnie is an excellent station for them. A mesnie filled with younger sons, who lack the prospect
+It is usual for lords to stuff their mesnie with young men from their extended family, or those of their neighbors. Younger sons raised as squires in a lord's court, for example, may lack the resources required to maintain their status. Placement in a mesnie is an excellent station for them. A mesnie filled with younger sons, who lack the prospect of independent inheritance, is preferred by some lords, while others prefer to befriend young heirs.
 
-## Size of Dowries
+> ## Size of Dowries
+> 
+> The size of a dowry varies by culture. In some areas it is equivalent to an equal portion of the land that the girl's parents own, when split between their children. In the French sphere, the oldest son and his patrimony are removed from this division, as they receive the inalienable section of land passed down through the family's primary line. This is adjusted downward if the daughter:
+> 
+> - Is marrying a groom from a less wealthy family. This is not unusual, because women outnumber men in Mythic Europe.
+> - Is one of few acceptable brides in her economic range.
+> - Is a virgin.
+> - Is more than ten years younger than the groom.
+> - Will receive other goods after marriage. It is illegal in some areas — like
+> 
+> Catalonia, southern France, and much of Italy — to leave bequests to daughters, so dowries in those regions are larger.
+> 
+> - Has more siblings than average, since her share of her parents' wealth is smaller.
+> - Has mostly female siblings, since this means her parents need to find more dowries.
+> - Is unlikely to have difficulty obtaining money from the male heir after her father dies.
+> - Will receive the dowry in land or money, rather than other rights.
+> 
+> Conversely, dowries are more generous if any of these statements are untrue. If the bride is exceptional, for example she is an heiress, her husband's family may pay her father or guardian a dower.
 
-The size of a dowry varies by culture. In some areas it is equivalent to an equal portion of the land that the girl's parents own, when split between their children. In the French sphere, the oldest son and his patrimony are removed from this division, as they receive the inalienable section of land passed down through the family's primary line. This is adjusted downward if the daughter:
-
-- Is marrying a groom from a lesswealthy family. This is not unusual, because women outnumber men in Mythic Europe.
-- Is one of few acceptable brides in her economic range.
-- Is a virgin.
-- Is more than ten years younger than the groom.
-- Will receive other goods after marriage. It is illegal in some areas — like
-
-Catalonia, southern France, and much of Italy — to leave bequests to daughters, so dowries in those regions are larger.
-
-- Has more siblings than average, since her share of her parents' wealth is smaller.
-- Has mostly female siblings, since this means her parents need to find more dowries.
-- Is unlikely to have difficulty obtaining money from the male heir after her father dies.
-- Will receive the dowry in land or money, rather than other rights.
-
-Conversely, dowries are more generous if any of these statements are untrue. If the bride is exceptional, for example she is an heiress, her husband's family may pay her father or guardian a dower.
-
-## A Tale Stolen From the Birth of Robert the Bruce
-
-There are two powerful territories in part of the lord's lands. He is on poor terms with the ruler of one, who feels he has some right to the lordship himself, due to a claim that one of current lord's ancestors couldn't inherit legally. The other territory currently has no lord, being administered by the widow of the previous holder. The greater lord has the right to select a husband for this woman, and is reserving her as a reward for service.
-
-News reaches the court that the son of the rival ruler was traveling through the country and was seduced by the widow. It has caused a great scandal. The bishop, who is a stern man of God and not given to laxity with regard to matters of fornication, is demanding that the two marry regardless of the objections of their overlord. A character who manages to prevent the lord's rival from consolidating this territory gains 5 Gratitude, and character who at least gets a fine out of the widow for not choosing who her lord wished earns 2. A character who pushes the marriage forward may gain Gratitude from the rival and the couple, however, and they have become a significant force in their territory.
-
-of independent inheritance, is preferred by some lords, while others prefer to befriend young heirs.
+> ## A Tale Stolen From the Birth of Robert the Bruce
+> 
+> There are two powerful territories in part of the lord's lands. He is on poor terms with the ruler of one, who feels he has some right to the lordship himself, due to a claim that one of the current lord's ancestors couldn't inherit legally. The other territory currently has no lord, being administered by the widow of the previous holder. The greater lord has the right to select a husband for this woman, and is reserving her as a reward for service.
+> 
+> News reaches the court that the son of the rival ruler was traveling through the country and was seduced by the widow. It has caused a great scandal. The bishop, who is a stern man of God and not given to laxity with regard to matters of fornication, is demanding that the two marry regardless of the objections of their overlord. A character who manages to prevent the lord's rival from consolidating this territory gains 5 Gratitude, and a character who at least gets a fine out of the widow for not choosing who her lord wished earns 2. A character who pushes the marriage forward may gain Gratitude from the rival and the couple, however, and they have become a significant force in their territory.
 
 Mesnie knights are expected to be loyal to their lord above all else, but in practice noblemen understand that knights have common sense. During the recent civil wars in England, the mesnie of the chief marshal showed extreme loyalty by being willing to lose all of their lands and be reduced to penury to follow their lord. This behavior is considered ideal. In practice, a mesnie is expected to desert a lord whose cause is failing. When Thomas Becket, the archbishop of Canterbury, was provoking the king, his mesnie knights deserted him and this was not considered a shameful thing for them to do, given that their lord was ensuring their annihilation.
 
 A member of the mesnie of a lord is sometimes called a bacheler, or "bachelor." This title is used to demonstrate that the knight has a patron. This means that if the knight is abused, the dishonor can be answered with more than the force of his arm. A knight becomes a bacheler by being offered a place in a mesnie.
 
-The mesnie knights of a lord tend to have
+> ## Story Seed: Choosing the Lord or Heir
+> 
+> The heirs to many major holdings are permitted to select their own mesnies, but are required to accept the priests foisted on them by their lord or the bishop. In some cases, this makes for a fiercely divided and partisan court. Each participant is required to either favor the current lord, or the heir to the lord. Generally, older characters favor the current lord, who can punish and reward them immediately. Younger courtiers tend to favor the heir, since they know that all they need to do is wait for their lord to die before reprisals against his supporters can begin.
+> 
+> Characters serving a covenant need to play a difficult game of supporting both sides sufficiently that they do not suffer reprisal now or later. One popular strategy, if the ill will between the lord and his son degenerates to war, is to send the head of the family to support the lord, and a younger son to support the heir. The hope is that if the heir wins and the lands of the lord are forfeit, they will be awarded to the younger son for his service. If the lord wins, then the family can just disclaim the younger son, and he can live in exile until the lord dies.
+> 
+> Covenants with tame nobles may need to employ similar stratagems. Covenants may also be asked to shelter younger sons who were sacrificed to lost causes. These characters may have a Dark Secret Flaw, because they are wanted by the current authorities, but they also have a variant of the Heir Virtue, because if they wait sufficiently long they will have a powerful Patron.
 
+The mesnie knights of a lord tend to have the personality traits that the lord admires. In the estates of powerful nobles, there is a select group of friends of the lord, called the mesnie privée, who strongly reflect his tastes. The average mesnie is much like a street gang. It is made up of violent and wealthy young men whose behavior is not effectively restricted by the law, and whose main business is the defense of their territory.
 
+Other flavors of mesnie are unusual, but common enough for a character to be able to seek one that suits his strengths. Mesnies filled with poets or knights interested in theology are common, particularly in the households of landholding women and priests. A character may make an Intelligence + Intrigue roll against an Ease Factor of 6 to recall if the mesnie members of a lord with whom he is interacting have a common feature. A character may make an Intelligence + Intrigue roll against an Ease Factor of 12 to recall or discover the name of a lord who favors a particular skill. Characters with high Intrigue scores will, for a small fee or owed favor, arrange introductions between player characters and either lords whose tastes they suit, or knights who suit their taste.
 
-
-A carissimus is the captain of a mesnie. A character becomes a carissimus by being the best friend of the lord, or by being so skilled that he is made leader of the mesnie regardless of personality. The carissimus of a powerful lord has great social cachet, and is treated as superior to the other members of the mesnie. Its common for the carissimus of a powerful nobleman to be landed, but to either still live within the household of his lord, or to live close by so that his advice can be easily sought.
-
-## Story Seed: Choosing the Lord or Heir
-
-The heirs to many major holdings are permitted to select their own mesnies, but are required to accept the priests foisted on them by their lord or the bishop. In some cases, this makes for a fiercely divided and partisan court. Each participant is required to either favor the current lord, or the heir to the lord. Generally, older characters favor the current lord, who can punish and reward them immediately. Younger courtiers tend to favor the heir, since they know that all they need to do is wait for their lord to die before reprisals against his supporters can begin.
-
-Characters serving a covenant need to play a difficult game of supporting both sides sufficiently that they do not suffer reprisal now or later. One popular strategy, if the ill will between the lord and his son degenerates to war, is to send the head of the family to support the lord, and a younger son to support the heir. The hope is that if the heir wins and the lands of the lord are forfeit, they will be awarded to the younger son for his service. If the lord wins, then the family can just disclaim the younger son, and he can live in exile until the lord dies.
-
-Covenants with tame nobles may need to employ similar stratagems. Covenants may also be asked to shelter younger sons who were sacrificed to lost causes. These characters may have a Dark Secret Flaw, because they are wanted by the current authorities, but they also have a variant of the Heir Virtue, because if they wait sufficiently long they will have a powerful Patron.
-
-the personality traits that the lord admires. In the estates of powerful nobles, there is a select group of friends of the lord, called the mesnie privée, who strongly reflect his tastes. The average mesnie is much like a street gang. It is made up of violent and wealthy young men whose behavior is not effectively restricted by the law, and whose main business is the defense of their territory.
-
-Other flavors of mesnie are unusual, but
+A carissimus is the captain of a mesnie. A character becomes a carissimus by being the best friend of the lord, or by being so skilled that he is made leader of the mesnie regardless of personality. The carissimus of a powerful lord has great social cachet, and is treated as superior to the other members of the mesnie. It's common for the carissimus of a powerful nobleman to be landed, but to either still live within the household of his lord, or to live close by so that his advice can be easily sought.
 
 ## Clerical and Menial
 
@@ -680,7 +698,7 @@ The clerical and militant sections of a household have different values, but usu
 
 Common menial workers will be discussed in greater length in Chapter Six: Manorial Fiefs and Chapter Seven: The Peasantry.
 
-
+## Criminals
 
 Many lords have contact with criminals, and use their services to harm the political interests of their rivals. Richer nobles often have criminals in their exclusive employ. Poorer nobles merely hire criminals for individual tasks. Criminals are particularly useful to female characters, who have little authority in Mythic Europe, but often have money. Players may design criminals using the rules for agents given in the Affinity section later. The rules in this section abstract the criminal, allowing the story to focus on the effect of their actions.
 
@@ -698,12 +716,12 @@ Characters use their Intrigue Ability to hire skilled professionals. If these in
 
 The type of sabotage attempted also adds to the sentry's roll: this reflects the time and difficulty required to inflict damage on the facility.
 
-| Type of<br>Sabotage | Sentry's<br>Awa<br>reness<br>Bonus | Examples                                                                                                                                                                      |
-|---------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Defacement          | +0                                 | Throwing a<br>bladder of ink at<br>a monument.                                                                                                                                |
-| Rendezvous          | +3                                 | Meeting a<br>spy inside the<br>enemy's area<br>of control for a<br>brief time. This<br>is also the modi<br>fier for seducing<br>an enemy's rela<br>tives in his own<br>house. |
-| Arson               | +6                                 | Lighting a large<br>fire within a<br>fortress or pri<br>vate residence.<br>Prompt atten<br>tion by sentries<br>can mitigate<br>damage caused<br>by fires.                     |
-| Burglary            | +9                                 | Removing<br>documents,<br>which the agent<br>must search a<br>room for.                                                                                                       |
+| Type of Sabotage | Sentry's Awareness Bonus | Examples |
+|------------------|--------------------------|----------|
+| Defacement       | +0                       | Throwing a bladder of ink at a monument. |
+| Rendezvous       | +3                       | Meeting a spy inside the enemy's area of control for a brief time. This is also the modifier for seducing an enemy's relatives in his own house. |
+| Arson            | +6                       | Lighting a large fire within a fortress or private residence. Prompt attention by sentries can mitigate damage caused by fires. |
+| Burglary         | +9                       | Removing documents, which the agent must search a room for. |                                                                                                       |
 
 **Spying:** All nobles have spies, and many of them are effectively free. Players are encouraged to design a few colorful informants. Spies within a rival nobleman's household require very large payments for their assistance, sometimes as much as they earn by their legitimate profession. If asked to sabotage operations with which they are legitimately involved, spies often charge far more: some as much as ten years' worth of income per attack. This is because their risk of discovery is very high, and the betrayed parties may not confine themselves to legal methods of redress.
 
@@ -717,61 +735,57 @@ A character who is ordered to fulfill a mundane task related to his or her emplo
 
 Women may be officers. It is traditional for women to be the treasurers or stewards of the husband's holdings in some areas. Senior nobles have female officers more rarely, but there is no bar on women fulfilling those offices that lack military command. In those rare cases where women hold land in their own right, it is even possible for them to lead armies themselves. This is unusual behavior, though, because even kings often leave the command of their forces to marshals schooled in war.
 
-The following offices are described as if they were part of the court of a king, but many great nobles have courts that, in a sim-
+The following offices are described as if they were part of the court of a king, but many great nobles have courts that, in a simplified way, have vassals fulfilling parallel roles. The exact title for a role varies widely. Characters designed as officers need the Temporal Influence Virtue.
 
-
-
-
-For Intrigue rolls to uncover information or allies, they must first exist. A character who has led a blameless life is armored against Intrigue. The following Ease Factors, for an Intelligence + Intrigue roll, demonstrate what a character might learn about potential allies, or the harm they may cause by spreading gossip. The noble to be harmed is referred to as the target.
-
-A character using the Intrigue ability in this way must entertain other gossips, hire spies, bribe servants, and threaten people. For Ease factors higher than 6, this takes (3 x Ease) days and costs at least (Ease / 3) pounds. Elaborate plans may cost far more, at the Troupe's discretion.
-
-#### Ease Factor 3
-
-- The stated reason for publicly declared enmity between the target and other nobles.
-- The target's well-known vices (Reputation 3 or more).
-
-#### Ease Factor 6
-
-- The reason behind public friction between the target and other nobles.
-- The target's lesser vices (Reputation 1 or more).
-- The intriguer spreads a rumor, to reduce one of the target's Reputations by 1, but the target knows the intriguer is responsible and can gain the Reputation back with appropriate public actions.
-
-#### Ease Factor 9
-
-- The reason behind private hostility between the target and other nobles.
-- Small, private vices known to the target's servants.
-
-- The lesser vices of a relative or friend of the target (Reputation 1 or more). The intriguer does not choose which relative or friend is vulnerable.
-- The intriguer spreads a rumor to create a negative Reputation of 1. The target, or the target's friends, may determine the identity of the perpetrator with an Intelligence + Intrigue roll higher than the intriguer's, and may combat the Reputation with appropriate public actions.
-
-#### Ease Factor 12
-
-- The reason behind minor disagreements between the target and other nobles.
-- What is required to push the private hostility of one of the target's enemies into public enmity.
-- A Story Flaw, if known by several other people.
-- Small, private vices of one of the target's friends. The intriguer does not choose which relative or friend is vulnerable.
-- The intriguer forges evidence of a tawdry nature that creates a negative Reputation of 2. The target, or the target's friends, may determine the identity of the perpetrator with an Intelligence + Intrigue roll higher than the intriguer's. The character may shed the Reputation with appropriate public actions and, if the target can find evidence, the intriguer may gain a poor Reputation instead.
-
-#### Ease Factor 15
-
-• The details of an old grudge, or an old enmity, that has lain forgotten for many years.
-
-- What is required to push one of the target's rivals from private friction into public enmity.
-- A Story Flaw, if known by only a few people but not all of them loyal to the target.
-- Information that will cause one of the target's friends or relatives to feel wronged by him.
-- The intriguer forges evidence of a crime, which will cause the character severe trouble. The target, or the target's friends, may determine the identity of the perpetrator with an Intelligence + Intrigue roll higher than the intriguer's. If they can find evidence, the intriguer will face legal reprisal. The target may demonstrate innocence through a story event.
-
-#### Ease Factor 18
-
-- Information about the crimes of the target's ancestors, which rile a descendant of their victim against the target.
-- What is required to push a defeated enemy of the target back into action.
-- One of the target's Story Flaws, if known only to a small number of people who are loyal to the target.
-- Information that will cause one of the target's friends to conspire toward his downfall.
-- The intriguer forges convincing evidence that makes the target appear to have a Dark Secret, like the Flaw. The target, or his friends, may determine the identity of the person who reveals the Flaw with an Intelligence + Intrigue roll of equal to the intriguer's and prove the secret false, but it is almost impossible to tie the intriguer to the revealer of the flaw, or the forgery (Intelligence + Intrigue roll of 21 or more).
-
-
-plified way, have vassals fulfilling parallel roles. The exact title for a role varies widely. Characters designed as officers need the Temporal Influence Virtue.
+> ## Intrigue and the Art of Indirect Action
+> 
+> For Intrigue rolls to uncover information or allies, they must first exist. A character who has led a blameless life is armored against Intrigue. The following Ease Factors, for an Intelligence + Intrigue roll, demonstrate what a character might learn about potential allies, or the harm they may cause by spreading gossip. The noble to be harmed is referred to as the target.
+> 
+> A character using the Intrigue ability in this way must entertain other gossips, hire spies, bribe servants, and threaten people. For Ease factors higher than 6, this takes (3 x Ease) days and costs at least (Ease / 3) pounds. Elaborate plans may cost far more, at the Troupe's discretion.
+> 
+> #### Ease Factor 3
+> 
+> - The stated reason for publicly declared enmity between the target and other nobles.
+> - The target's well-known vices (Reputation 3 or more).
+> 
+> #### Ease Factor 6
+> 
+> - The reason behind public friction between the target and other nobles.
+> - The target's lesser vices (Reputation 1 or more).
+> - The intriguer spreads a rumor, to reduce one of the target's Reputations by 1, but the target knows the intriguer is responsible and can gain the Reputation back with appropriate public actions.
+> 
+> #### Ease Factor 9
+> 
+> - The reason behind private hostility between the target and other nobles.
+> - Small, private vices known to the target's servants.
+> 
+> - The lesser vices of a relative or friend of the target (Reputation 1 or more). The intriguer does not choose which relative or friend is vulnerable.
+> - The intriguer spreads a rumor to create a negative Reputation of 1. The target, or the target's friends, may determine the identity of the perpetrator with an Intelligence + Intrigue roll higher than the intriguer's, and may combat the Reputation with appropriate public actions.
+> 
+> #### Ease Factor 12
+> 
+> - The reason behind minor disagreements between the target and other nobles.
+> - What is required to push the private hostility of one of the target's enemies into public enmity.
+> - A Story Flaw, if known by several other people.
+> - Small, private vices of one of the target's friends. The intriguer does not choose which relative or friend is vulnerable.
+> - The intriguer forges evidence of a tawdry nature that creates a negative Reputation of 2. The target, or the target's friends, may determine the identity of the perpetrator with an Intelligence + Intrigue roll higher than the intriguer's. The character may shed the Reputation with appropriate public actions and, if the target can find evidence, the intriguer may gain a poor Reputation instead.
+> 
+> #### Ease Factor 15
+> 
+> The details of an old grudge, or an old enmity, that has lain forgotten for many years.
+> 
+> - What is required to push one of the target's rivals from private friction into public enmity.
+> - A Story Flaw, if known by only a few people but not all of them loyal to the target.
+> - Information that will cause one of the target's friends or relatives to feel wronged by him.
+> - The intriguer forges evidence of a crime, which will cause the character severe trouble. The target, or the target's friends, may determine the identity of the perpetrator with an Intelligence + Intrigue roll higher than the intriguer's. If they can find evidence, the intriguer will face legal reprisal. The target may demonstrate innocence through a story event.
+> 
+> #### Ease Factor 18
+> 
+> - Information about the crimes of the target's ancestors, which rile a descendant of their victim against the target.
+> - What is required to push a defeated enemy of the target back into action.
+> - One of the target's Story Flaws, if known only to a small number of people who are loyal to the target.
+> - Information that will cause one of the target's friends to conspire toward his downfall.
+> - The intriguer forges convincing evidence that makes the target appear to have a Dark Secret, like the Flaw. The target, or his friends, may determine the identity of the person who reveals the Flaw with an Intelligence + Intrigue roll of equal to the intriguer's and prove the secret false, but it is almost impossible to tie the intriguer to the revealer of the flaw, or the forgery (Intelligence + Intrigue roll of 21 or more).
 
 #### Admiral
 
@@ -787,10 +801,7 @@ Nominally the king's wine steward, the butler is responsible for the feeding of 
 
 #### Chancellor
 
-The chancellor is, technically, the master of the king's correspondence. Effectively, this makes the chancellor the king's chief ad-
-
-
-visor on foreign relations and the state of the Church. It is a lucrative and powerful role, because it controls the vacant Church lands within the gift of the king. This role is almost always held by a priest, and in lesser courts it is sometimes combined with the role of personal confessor to the nobleman. It is an unusual chancellor who does not have private agents and criminals at his disposal.
+The chancellor is, technically, the master of the king's correspondence. Effectively, this makes the chancellor the king's chief advisor on foreign relations and the state of the Church. It is a lucrative and powerful role, because it controls the vacant Church lands within the gift of the king. This role is almost always held by a priest, and in lesser courts it is sometimes combined with the role of personal confessor to the nobleman. It is an unusual chancellor who does not have private agents and criminals at his disposal.
 
 #### Chamberlain
 
@@ -821,19 +832,17 @@ In Saxon England, the sheriffs were the king's loyal representatives in each shi
 
 The sheriff has many sources of money. He acts as magistrate for local matters, and keeps the king's fines, although he is required to pay a third of them to the earl of the shire. It is common for earls to purchase this role. The sheriff also commands the king's local forces, for example the garrisons of castles.
 
-In England, the term "bailiff" refers to all of the king's officers, and is used on a mano-
-
-## Amercements: Money From The Law
-
-Bribes, fines, and taxes provide much of the revenue gathered by the law officers of the kingdom, but a fourth, and lucrative, form of judicial remuneration exists. For many infractions, rather than a fine, the law provides a gruesome and disfiguring punishment. The hands of thieves, as a simple example, are cut off. Amercement occurs when, having found a person guilty, his judge allows that person to throw himself on the court's mercy. In exchange for a fine that is negotiated with the judge, the person is permitted to avoid physical punishment.
-
-Some of the punishments are deliberately horrific to encourage amercements. King Richard's forest law stated that anyone who killed one of his deer was to have his eyes and testicles extracted. Poachers were not, generally, blinded and castrated, since they far preferred to pay amercements.
-
-The most extreme case of amercement occurs when a felon — that is, someone who has performed a capital crime — has found sanctuary in a church and has asked to abjure the realm. In this case, the coroner takes a detailed confession from the felon, makes him take serious oaths on the Bible to not return, and then nominates a port he must walk to, to take ship from the realm. All of the felon's personal goods are forfeit to the crown, and his land falls under royal protection for a year.
-
-#### rial level to designate officers of the manorial lord. In Northern France, a bailie is much like a pre-corruption sheriff. They act as the keepers of the king's law in the domain royal. In southern France, the same role is fulfilled by sénéchaux. In some German speaking areas this role is filled by a vogt, although the parallel is inexact.
+In England, the term "bailiff" refers to all of the king's officers, and is used on a manorial level to designate officers of the manorial lord. In Northern France, a bailie is much like a pre-corruption sheriff. They act as the keepers of the king's law in the domain royal. In southern France, the same role is fulfilled by sénéchaux. In some German speaking areas this role is filled by a vogt, although the parallel is inexact.
 
 By whatever name, these roles are attractive to covenants. A proxy nobleman acting as sheriff provides an income for the covenant with effective legal impunity in temporal affairs. The Quaesitores consider it likely a breach of the Code to outbid other nobles for this role. However, through skilled diplomacy, overt bribery, and occasional threats, it has been possible for covenants to have a great deal of influence over the selection and activities of sheriffs.
+
+> ## Amercements: Money From The Law
+> 
+> Bribes, fines, and taxes provide much of the revenue gathered by the law officers of the kingdom, but a fourth, and lucrative, form of judicial remuneration exists. For many infractions, rather than a fine, the law provides a gruesome and disfiguring punishment. The hands of thieves, as a simple example, are cut off. Amercement occurs when, having found a person guilty, his judge allows that person to throw himself on the court's mercy. In exchange for a fine that is negotiated with the judge, the person is permitted to avoid physical punishment.
+> 
+> Some of the punishments are deliberately horrific to encourage amercements. King Richard's forest law stated that anyone who killed one of his deer was to have his eyes and testicles extracted. Poachers were not, generally, blinded and castrated, since they far preferred to pay amercements.
+> 
+> The most extreme case of amercement occurs when a felon — that is, someone who has performed a capital crime — has found sanctuary in a church and has asked to abjure the realm. In this case, the coroner takes a detailed confession from the felon, makes him take serious oaths on the Bible to not return, and then nominates a port he must walk to, to take ship from the realm. All of the felon's personal goods are forfeit to the crown, and his land falls under royal protection for a year.
 
 #### Steward
 
@@ -847,28 +856,15 @@ The treasurer of a king is the guardian of the lord's wealth. The exact role the
 
 The following offices are found only in England, Scotland, and the parts of Ireland and Wales dominated by the English. Britain is such a focus of play for **Ars Magica** groups, and the play potential of these offices so obvious, that they have been described here. Troupes with sagas in alternative countries can still use the ideas suggested below, because the kings of their own countries reserve the right to appoint vassals to perform any task.
 
-
-In towns where a body has been found, it is often considered best to circumvent the law of murdrum. If player characters find a body, he has the following choices:
-
-Investigate the murder, and see if the person is a Norman. This is difficult, because many Norman families are effectively English in the 13th century.
-
-Smuggle the body to a desolate place and bury it in secret. This is a crime, and characters must plan carefully to not be seen, or at least to only be seen by characters who also believe it best for the community to avoid the tax. A murder victim in an unhallowed grave may return to haunt his killer, though, and the characters if they were complicit in hiding the crime.
-
-Smuggle the body to another community, and make sure the coroner finds it before the people in the rival village can smuggle it back over the border. This strange sport is undignified, however, and is unlikely to end in a church burial. The ghosts of bodies that have been carted backward and forward over the countryside tend to range widely and be deeply distressed, particularly if pieces of the corpse have been lost in various places.
-
-Much as the office of coroner was created in response to the corruption of the sheriffs, so a series of offices has been created to deal with the corruption of the wardens. The verderers are unpaid landowners appointed to keep track of the fines taken by the wardens. Every third year, a separate group of four knights called regarders is appointed in each county containing forest to make a census of everything that might harm forest animals. Four more knights of each county, the agistors, guard the king's rights with regard to animals permitted to pasture in the forest.
-
-## Vassals
-
-A lord's vassals are theoretically his chief lieutenants. Flaws in the feudal system, however, force many lords to operate through officers, some of whom are traditional vassals, but many of whom are drawn from their mesnies. Lieges are in a state of constant negotiation with their senior vassals, able to utilize their resources fully only through a combination of friendship, charisma, and menace. The fundamental function of vassals is to provide resources to their liege during crises.
-
-## Why Bother With Vassals?
-
-Some kings try to minimize the role of their vassals in the politics of the kingdom. A land governed by royal officers, without a hereditary caste of landowners, would be more stable and provide greater revenue to its ruler, they assert. These attempts usually end badly. Regardless of its efficiency, the noble class exists, and when the king is weak, it has the financial and military power to crush the commoners raised as opponents by earlier, stronger kings.
-
-#### Vassalage Allows Nobles to Express a Common Interest
-
-Initially, in most kingdoms vassalage was voluntary. The great landholders of the kingdom came together and elected their kings. They did this so that a central figure of authority could lead them in war and settle their disputes. This method of select-
+> ## Story Seed: Avoiding the Murdrum
+> 
+> In towns where a body has been found, it is often considered best to circumvent the law of murdrum. If player characters find a body, he has the following choices:
+> 
+> Investigate the murder, and see if the person is a Norman. This is difficult, because many Norman families are effectively English in the 13th century.
+> 
+> Smuggle the body to a desolate place and bury it in secret. This is a crime, and characters must plan carefully to not be seen, or at least to only be seen by characters who also believe it best for the community to avoid the tax. A murder victim in an unhallowed grave may return to haunt his killer, though, and the characters if they were complicit in hiding the crime.
+> 
+> Smuggle the body to another community, and make sure the coroner finds it before the people in the rival village can smuggle it back over the border. This strange sport is undignified, however, and is unlikely to end in a church burial. The ghosts of bodies that have been carted backward and forward over the countryside tend to range widely and be deeply distressed, particularly if pieces of the corpse have been lost in various places.
 
 #### Coroner
 
@@ -888,7 +884,19 @@ All of the great royal forests contain hunting lodges. Some lodges are small cas
 
 The lands of the office are supposed to provide wages for the warden's retainers, but in many cases those persons pay him for their positions. Rangers extort money from peasants who make use of the wood, or accept bribes to look the other way when poaching and illegal wood collection occur. They also poach game and have all the wood they can use or surreptitiously sell.
 
-ing kings is failing, though. The current king of England was still a baby when loyalists defeated the army of the barons, who had offered the throne of England to the crown prince of France, forcing them to accept primogeniture on the English throne. Philip Augustus, the current king of France, has not forced the nobles of his kingdom to appoint his son co-king, as Phillip's father did just before dying. Again, primogeniture has been accepted as the proper way for the crown to pass to the next generation.
+Much as the office of coroner was created in response to the corruption of the sheriffs, so a series of offices has been created to deal with the corruption of the wardens. The verderers are unpaid landowners appointed to keep track of the fines taken by the wardens. Every third year, a separate group of four knights called regarders is appointed in each county containing forest to make a census of everything that might harm forest animals. Four more knights of each county, the agistors, guard the king's rights with regard to animals permitted to pasture in the forest.
+
+## Vassals
+
+A lord's vassals are theoretically his chief lieutenants. Flaws in the feudal system, however, force many lords to operate through officers, some of whom are traditional vassals, but many of whom are drawn from their mesnies. Lieges are in a state of constant negotiation with their senior vassals, able to utilize their resources fully only through a combination of friendship, charisma, and menace. The fundamental function of vassals is to provide resources to their liege during crises.
+
+### Why Bother With Vassals?
+
+Some kings try to minimize the role of their vassals in the politics of the kingdom. A land governed by royal officers, without a hereditary caste of landowners, would be more stable and provide greater revenue to its ruler, they assert. These attempts usually end badly. Regardless of its efficiency, the noble class exists, and when the king is weak, it has the financial and military power to crush the commoners raised as opponents by earlier, stronger kings.
+
+#### Vassalage Allows Nobles to Express a Common Interest
+
+Initially, in most kingdoms vassalage was voluntary. The great landholders of the kingdom came together and elected their kings. They did this so that a central figure of authority could lead them in war and settle their disputes. This method of selecting kings is failing, though. The current king of England was still a baby when loyalists defeated the army of the barons, who had offered the throne of England to the crown prince of France, forcing them to accept primogeniture on the English throne. Philip Augustus, the current king of France, has not forced the nobles of his kingdom to appoint his son co-king, as Phillip's father did just before dying. Again, primogeniture has been accepted as the proper way for the crown to pass to the next generation.
 
 #### Vassalage Allows for Huge Transactions
 
@@ -902,7 +910,7 @@ A feudal bond places two powerful men in a relationship to each other. It is con
 
 If a noble invades a neighboring lord, it is rarely possible to carry the war to the extinction of the neighbor's family. The nobility of Europe are too tightly connected by marriage. If an invader kills a sufficient number of heirs to most pieces of land, eventually one or more senior nobles will claim to be the closest relation still alive. This noble will then challenge for the land, particularly if this series of wars has weakened the aggressor. A way around this is to kill the neighbor and then select a claimant from his extended family from whom to accept vassalage. Most significant families have some disaffected cousins suitable for this purpose.
 
-## Money
+### Money
 
 Vassals owe a series of taxes to their lieges. Minor taxes taken as traditional gifts of produce have been commuted to cash in most areas. The largest tax is on inherited land, and is called relief. It varies by kingdom, and in some is not levied. In England, a lord owes approximately one year's income to his liege on the assumption of his title.
 
@@ -912,10 +920,9 @@ A lord is due a series of other taxes, called aids, which are to be used sparing
 
 Popular aids include payments when the lord is knighting his eldest son, or marrying his eldest daughter the first time, or ransoming his life. Ecclesiastical lords may make a similar demand when first ascending to office. A lord who knights his son before the boy is 15 years old or marries his daughter off before the age of seven is likely to anger his vassals. A payment of one pound per manor is likely, but may be as high as the lord feels he can get away with. Ransom aid may be demanded by a lord who has lost in tourney and owes money from it, but a lord who seeks to collect such money is certain to anger his vassals. Aid is also common when an heir owes relief to a lord.
 
-## Warriors
+### Warriors
 
-When called to muster for war, vassals are required to provide their lord with the service of one knight for per manor that
-
+When called to muster for war, vassals are required to provide their lord with the service of one knight for per manor that their fief contained at the time it was originally granted. In some families, which have retained properties for generations, this represents only a fraction of the wealth that the family has available. A character who is rich and well-disposed to his lord may provide additional forces. This is, in turn, rewarded with a greater share of the booty that becomes available if the war is successful.
 
 Assume that a powerful landowner must provide, at minimum, 20 knights when called to war. This may include the landowner himself, but need not unless he is personally instructed to attend. Even if the lord is instructed to come, it is possible for him to avoid this obligation through a series of ruses. Many of the nobles in Europe are subinfeudated to multiple lieges. When these lieges go to war with each other, it is useful to be able to avoid attending battle, while still fulfilling feudal obligations.
 
@@ -924,8 +931,6 @@ Knights are the commonest warriors detailed in feudal obligations, but many vass
 Infantry provide an advantage in terms of sheer numbers that is useful in pitched battle. Their formations provide a solid block that archers can shelter behind and cavalry can use when reforming after attacks. At the Battle of Grissors, the spears of the English even turned aside the cavalry charges of the French. Infantry serve as guards for stores and baggage on campaign. They are able to defend territory against those attempting to smuggle food to besieged castles. Infantry are able to hold captured castles, a role in which the mobility of the knight, and the expense of his maintenance, are wasted.
 
 A vassal is required to provide warriors for a number of days per year that varies by kingdom. In England this is 40 days, in Sicily 60. This is rarely long enough to complete a siege, so kings often need to pay their army additional money to extend this service. As an added incentive, once a castle falls after a lengthy siege, the besieging army is allowed to sack it with legal impunity. The same often holds true for towns.
-
-
 
 #### Scutage
 
@@ -937,15 +942,15 @@ The scutage in England is usually two pounds per knight in 1220. Under King John
 
 The right to ask advice is more significant than it initially appears. It allows a lord to control the movements of his vassals. It also allows the lord to force vassals to make public statements regarding their views on contentious matters.
 
-A vassal asked to attend his liege's court has a duty to attend. Failure to attend failure to render advice — is a breach of the character's feudal obligations and can be punished by a fine or even seizure of the recalcitrant's lands. A vassal who attends his lord is not permitted to leave without the lord's agreement. Nobles considered potentially rebellious can be forced to show their hand, by refusing summons or by flight from court.
+A vassal asked to attend his liege's court has a duty to attend. Failure to attend — failure to render advice — is a breach of the character's feudal obligations and can be punished by a fine or even seizure of the recalcitrant's lands. A vassal who attends his lord is not permitted to leave without the lord's agreement. Nobles considered potentially rebellious can be forced to show their hand, by refusing summons or by flight from court.
 
 The receipt of advice is a useful tool for building and demonstrating consensus among vassals. As an example, if the liege wishes to annex a neighboring territory, it is useful for him to gather together his vassals and ask their advice. This allows him to gauge the strength of their favor and see who opposes the plan. It also allows potentially tardy or rebellious vassals to see the level of support that the liege has, and measure the likelihood that they will suffer successful reprisal at the hands of more-enthusiastic vassals.
 
-## Story Seed: Scutage Raid
-
-The lord that a character is allied to lacks sufficient money to pay his scutage, but he has a plan to make good the shortage. He hates another, more-powerful lord. His plan is to place a group of bandits on the road that his enemy's troops will follow when they are carrying their scutage to the king. His men will then take a little silver for themselves, give the rest to him, and he will use his enemy's money to pay the scutage. This will leave the enemy embarrassed before the king, and will grant the king an excuse to chip a piece off the rival's land. The land won't come to the lord planning all of this, but he doesn't mind. A light blow against his enemy is still a blow. For this to work, the lord needs some men he can trust, like his mesnie, and somewhere for them to work.
-
-The player characters may become aware of this plot at any stage. They may hear rumors of it leaking out of the mesnie. They may find a group of bandits camped near a road who seem to have no intention of attacking passing merchants and wonder what is at the root of their strange behavior. They may intervene in the fight, or find the group switching clothes and carts on covenant land. Or they may be asked by the lord whose money was stolen to seek the thieves.
+> ## Story Seed: Scutage Raid
+> 
+> The lord that a character is allied to lacks sufficient money to pay his scutage, but he has a plan to make good the shortage. He hates another, more-powerful lord. His plan is to place a group of bandits on the road that his enemy's troops will follow when they are carrying their scutage to the king. His men will then take a little silver for themselves, give the rest to him, and he will use his enemy's money to pay the scutage. This will leave the enemy embarrassed before the king, and will grant the king an excuse to chip a piece off the rival's land. The land won't come to the lord planning all of this, but he doesn't mind. A light blow against his enemy is still a blow. For this to work, the lord needs some men he can trust, like his mesnie, and somewhere for them to work.
+> 
+> The player characters may become aware of this plot at any stage. They may hear rumors of it leaking out of the mesnie. They may find a group of bandits camped near a road who seem to have no intention of attacking passing merchants and wonder what is at the root of their strange behavior. They may intervene in the fight, or find the group switching clothes and carts on covenant land. Or they may be asked by the lord whose money was stolen to seek the thieves.
 
 Advice also allows a liege to weigh the interests of his lords against each other, and balance them according to the usefulness of the individual vassal. As an example, a lord who has an empty benefice may ask which churchman it should be awarded to. The bishop will certainly have an opinion, but so will many noble houses whose younger sons have interests in the Church. Asking advice allows the liege to measure these interests, and reward each noble in turn. It also allows the lord to play favorites.
 
@@ -961,41 +966,40 @@ The landed sons of lesser vassals are prized husbands for the daughters of rich 
 
 Heiresses are even more valuable than heirs. Marriage to an heiress is the fastest way to progress to a higher social status. Heiresses are given to supporters as rewards for their service. They are also the usual way for a lord to grant land to his younger sons, without splitting his patrimony or taking new territory through war. The right to select husbands or brides for the children of enemies is one of the concessions usually demanded after victory in war.
 
-Even a grown heir, returned to his parents, is still valuable to his father's lord. His friends and romantic interests are established
+Even a grown heir, returned to his parents, is still valuable to his father's lord. His friends and romantic interests are established in the court of the lord, to whom he may look with greater loyalty than to his own parents. If a vassal rebels, an adult heir loyal to the liege is a formidable weapon, as he is able to divide the loyalty of the vassal's supporters.
 
+> ## Story Seed: A Matter of Hermetic Honor
+> 
+> A lord has betrothed an heiress to the son of a Tytalus magus in exchange for undisclosed services. The Quaesitores are considering that matter, but seem satisfied that his support did not breach the Code. The matter of graver concern is that the heiress' family has made an appeal to the royal court, claiming that the marriage cannot proceed because this would be a disparagement.
+> 
+> House Tytalus wishes to run a case in a mortal court. If successful, this would mean that all children taken as apprentices, in the court's area, were automatically free, although a fine would be due their lords. It would also mean that no magus or apprentice could ever be treated as a villein, and that Hermetic courts would have complete legitimacy as an alternative to mundane or ecclesiastical courts. Magi are divided on whether this constitutes interference, or if it's a simple acknowledgement of the actual way that magi live.
 
-## Story Seed: A Matter of Hermetic Honor
-
-A lord has betrothed an heiress to the son of a Tytalus magus in exchange for undisclosed services. The Quaesitores are considering that matter, but seem satisfied that his support did not breach the Code. The matter of graver concern is that the heiress' family has made an appeal to the royal court, claiming that the marriage cannot proceed because this would be a disparagement.
-
-House Tytalus wishes to run a case in a mortal court. If successful, this would mean that all children taken as apprentices, in the court's area, were automatically free, although a fine would be due their lords. It would also mean that no magus or apprentice could ever be treated as a villein, and that Hermetic courts would have complete legitimacy as an alternative to mundane or ecclesiastical courts. Magi are divided on whether this constitutes interference, or if it's a simple acknowledgement of the actual way that magi live.
-
-in the court of the lord, to whom he may look with greater loyalty than to his own parents. If a vassal rebels, an adult heir loyal to the liege is a formidable weapon, as he is able to divide the loyalty of the vassal's supporters.
-
-## Wardship of Widows
+### Wardship of Widows
 
 Women, in most cases, are not permitted to rule by themselves in Mythic Europe. A woman not under the protection of her father is under the protection of her husband. A woman who loses the protection of her husband, through his death, often becomes the ward of his lord.
 
 The lord manages the finances of the widow. A widow is entitled to a portion of her husband's estate, fixed at the time of marriage, to maintain herself until her death. This portion, usually a third of his land plus whatever was her dowry, provides useful income for the liege who acts as its administrator. By tradition, it is wrong for a lord to sell the right of wardship over a child or woman.
 
-## Story Seed: Did You Keep The Receipt?
-
-A lord is attempting to claim back the lands of an heiress, because her husband has not paid the fee that was agreed upon for her hand. The local bishop really hates this kind of behavior, although the lord has a case in the royal court and may well succeed. The characters may earn Gratitude from the bishop and couple if they can get the lord to drop his suit, or from the lord by having the couple pay the money they owe. The story can be twisted in several ways: the lord might be lying about the fee, or the couple might have already paid by doing some shameful service to which they cannot admit. For example, the wife may not be the original widow, but instead a maidservant substituted before the wedding. The husband is unwilling to admit this, because he would then lose the widow's lands, but is unwilling to pay for a false widow.
-
 But this tradition is abused regularly.
 
 The Church takes a dim view of this chaffering about marriage: from its perspective, marriage is a divine mystery freely entered into by consenting individuals. The Church prefers people be married by priests, for the protection of women from exploitation, but it acknowledges that some people are married by custom, which the Church later sanctifies.
+
+> ## Story Seed: Did You Keep The Receipt?
+> 
+> A lord is attempting to claim back the lands of an heiress, because her husband has not paid the fee that was agreed upon for her hand. The local bishop really hates this kind of behavior, although the lord has a case in the royal court and may well succeed. The characters may earn Gratitude from the bishop and couple if they can get the lord to drop his suit, or from the lord by having the couple pay the money they owe. The story can be twisted in several ways: the lord might be lying about the fee, or the couple might have already paid by doing some shameful service to which they cannot admit. For example, the wife may not be the original widow, but instead a maidservant substituted before the wedding. The husband is unwilling to admit this, because he would then lose the widow's lands, but is unwilling to pay for a false widow.
+
 
 ## Affinity
 
 Powerful magnates prefer to have a bloc of territory that is friendly to their cause. The center of an affinity — the core lands of a nobleman — is called his caput in England and France. The lands of an affinity are called his country. A noble does not own all of the land in his country, but, in a perfect model of affinity, is allied to and is considered the de facto leader of all of the landholders in this area. In court, an affinity serves as a political faction. New landholders are often expected to join the affinity that surrounds their lands.
 
+Outside the perfect model, it is common for two rival affinities to vie for dominance in an area. This is dangerous, because it is these points, where affinities scrape against each other, that form the fault lines of the realm in times of national crisis. Areas whose affinities are firmly for one or the other side may be raided, but deep raiding, pitched battles, and sieges occur in those lands where affinities mingle. 
 
 Players may model the power their character has through affinity in two ways. First, the affinity may be treated as a bonus to the character's Leadership score. This is described in the Affinity Leadership section, later, and in the Raising an Army section of Chapter Eight: Massed Combat. Alternatively, key members of the affinity may be designed as agents, using the section on Control Through Emotional Bonds, also later. Characters within an affinity are usually either great nobles or ecclesiastical landholders. Some lords manage to have towns within their affinities, but this is unusual as most towns value their independence from local interference.
 
 #### Secular Allies
 
-An ally often has similar resources to the magnate. Alliances remain lucrative because the resources of allies cost little, and making neighbors allies allows characters focus their attention, money, and time elsewhere.
+An ally often has similar resources to the magnate. Alliances remain lucrative because the resources of allies cost little, and making neighbors allies allows characters to focus their attention, money, and time elsewhere.
 
 Public alliances prevent unnecessary wars by making it clear that, should a particular nobleman be attacked, wider conflict is inevitable. In many lands it is illegal for senior nobles to enter into treaties with foreign powers. It is seen as threatening treason. Informal public alliances are, however, common. In many places, alliances between senior noblemen in a realm and the kings of neighboring realms are inevitable, given the entanglement of marriages that bind the upper class of Europe together.
 
@@ -1003,11 +1007,7 @@ Alliances may be secret. This is common in those cases where a nobleman is being
 
 #### Church Allies
 
-A powerful churchman has all of the resources of a secular ally, coupled with his
-
-
-
-powers as a lord of the Church's land and a representative of the power of the vicar of Christ. Church allies are sought in a variety of ways. The land the Church uses may be held from a lord, or may have been granted by the lord's family. The churchman who uses that land is expected, socially, to demonstrate gratitude for it. Noblemen also seek positions in the Church for their younger sons, and maneuver to have them appointed to vacant offices within their country.
+A powerful churchman has all of the resources of a secular ally, coupled with his powers as a lord of the Church's land and a representative of the power of the vicar of Christ. Church allies are sought in a variety of ways. The land the Church uses may be held from a lord, or may have been granted by the lord's family. The churchman who uses that land is expected, socially, to demonstrate gratitude for it. Noblemen also seek positions in the Church for their younger sons, and maneuver to have them appointed to vacant offices within their country.
 
 The Church is a major landholder throughout Mythic Europe. Its lands are usually carved from the wild and improved over time, so they do not owe onerous duties to higher lords. The wealth of the Church is of great aid to a lord involved in war, and it is not unusual in major wars for both sides to field knights supported by Church manors, or mercenaries paid with Church aid. Some senior officers of the Church try to force their subordinates to only provide military aid to the side that is "right," but their prohibitions are often ineffective.
 
@@ -1015,23 +1015,17 @@ The most powerful weapon in the hands of the Church is excommunication. Christia
 
 Interdiction forbids the services of the Church in all of a nobleman's lands. In some cases this is relaxed in monasteries and nunneries, where services continue, although they are no longer heralded with bells. Interdiction is less effective than it initially appears, because saints ignore it and many of the services of the Church, like baptism and marriage, can be performed without a priest. It does prevent the forgiveness of sins and the proper burial of the dead. Churchmen who use interdiction trivially are held accountable by the representatives of the pope.
 
-A powerful churchman can lend his Reputation to a character's cause, so that disinterested or uninformed parties follow his guidance. Note that the support of the Church does not automatically sway even pious believers if the churchman in question is unexceptional. Many nobles are cynical about the Church's operation, if not its teaching. King John of England, for example, expressed the opinion that he was better off an excommu-
+A powerful churchman can lend his Reputation to a character's cause, so that disinterested or uninformed parties follow his guidance. Note that the support of the Church does not automatically sway even pious believers if the churchman in question is unexceptional. Many nobles are cynical about the Church's operation, if not its teaching. King John of England, for example, expressed the opinion that he was better off an excommunicant, because it allowed him to retain the funds of seven bishoprics and countless abbeys whose holders died and could not be replaced. Similarly, the Church's idea that work, including warfare as the work of the knightly class, should stop for about a third of the year to celebrate the feasts of obscure saints is considered a sign of the laziness of the holders of clerical office by some.
 
-## Story Seeds: Faulty Vassals
-
-The feudal system works on the assumption that if a vassal breaks his oath, he will be punished by God, his lord, or the lord's other vassals. This assumption rarely holds in times of crisis: precisely those times when a liege needs fidelity the most. The feudal system, of itself, contains no mechanism to prevent a vassal from defecting to an enemy of his liege.
-
-In many cases, vassalage is part of a negotiated settlement between two rivals. It allows the new vassal to take time to procure fresh forces before striking at his new liege again. During the build-up of forces, the vassal can pretend to adhere to the will of his lord, particularly if he is summoning mercenaries from outside the area. But the vassal can, with little difficulty, choose not to strike if it seems his lord has realized what may occur. Betraying an overlord after negotiated vassalage is a tactic that can only effectively be used once. It's considered dishonorable, but if it is effective, the survivors of the war will not dare question their new lord's honor.
-
-Most senior nobles have at least one vassal who could be convinced to rebel if circumstances seemed favorable for victory. These include younger brothers, the leaders of cadet branches of the lord's family, vassals forced to bend the knee in war, and opportunists who need no particular justification. These men cannot always be coaxed into taking the field against their lord, but can be used as spies and agents of influence.
-
-A servant of the player characters notices the build up of forces by a vassal. The vassal's lord can then muster his personal forces and look for suitable provocation to make attacking the man honorable, or he can arrange for saboteurs to obstruct the vassal's plans so that he can seek aid from other vassals.
-
-nicant, because it allowed him to retain the funds of seven bishoprics and countless abbeys whose holders died and could not be replaced. Similarly, the Church's idea that work, including warfare as the work of the knightly class, should stop for about a third of the year to celebrate the feasts of obscure saints is considered a sign of the laziness of the holders of clerical office by some.
-
-The bonus above is halved (round down) if the area is divided between two warring affinities.
-
-A character who neglects to support his affinity has his bonus reduced. A character supports an affinity by providing its members with offices and largesse. He must also exercise his power within that affinity, so that he is seen doing the things a regional
+> ## Story Seeds: Faulty Vassals
+> 
+> The feudal system works on the assumption that if a vassal breaks his oath, he will be punished by God, his lord, or the lord's other vassals. This assumption rarely holds in times of crisis: precisely those times when a liege needs fidelity the most. The feudal system, of itself, contains no mechanism to prevent a vassal from defecting to an enemy of his liege.
+> 
+> In many cases, vassalage is part of a negotiated settlement between two rivals. It allows the new vassal to take time to procure fresh forces before striking at his new liege again. During the build-up of forces, the vassal can pretend to adhere to the will of his lord, particularly if he is summoning mercenaries from outside the area. But the vassal can, with little difficulty, choose not to strike if it seems his lord has realized what may occur. Betraying an overlord after negotiated vassalage is a tactic that can only effectively be used once. It's considered dishonorable, but if it is effective, the survivors of the war will not dare question their new lord's honor.
+> 
+> Most senior nobles have at least one vassal who could be convinced to rebel if circumstances seemed favorable for victory. These include younger brothers, the leaders of cadet branches of the lord's family, vassals forced to bend the knee in war, and opportunists who need no particular justification. These men cannot always be coaxed into taking the field against their lord, but can be used as spies and agents of influence.
+> 
+> A servant of the player characters notices the build up of forces by a vassal. The vassal's lord can then muster his personal forces and look for suitable provocation to make attacking the man honorable, or he can arrange for saboteurs to obstruct the vassal's plans so that he can seek aid from other vassals.
 
 ### Affinity Leadership
 
@@ -1045,12 +1039,14 @@ A character has an Affinity bonus of:
 - +4 For being a greater baron.
 - +5 For being the senior noble beneath the king in the region (count, earl, duke).
 
-### Using Intrigue to Aggregate Class Opinion
+> ## Using Intrigue to Aggregate Class Opinion
+> 
+> A character may roll a stress die + Intelligence + Intrigue to feel the political mood of an organization, or the nobles of a region. This roll can only be made in a place where the character is familiar with the ruling class. It represents the character taking time to learn the superficial details of the concerns of the members of the surveyed group, sufficiently well to predict their attitude to an event. For example, a character who has a vacant benefice and wishes to give it to a certain priest can judge how other nobles will feel about it using this roll.
 
-A character may roll a stress die + Intelligence + Intrigue to feel the political mood of an organization, or the nobles of a region. This roll can only be made in a place where the character is familiar with the ruling class. It represents the character taking time to learn the superficial details of the concerns of the members of the surveyed group, sufficiently well to predict their attitude to an event. For example, a character who has a vacant benefice and wishes to give it to a certain priest can judge how other nobles will feel about it using this roll.
 
+The bonus above is halved (round down) if the area is divided between two warring affinities.
 
-leader must do, like resolving disputes and putting down brigands.
+A character who neglects to support his affinity has his bonus reduced. A character supports an affinity by providing its members with offices and largesse. He must also exercise his power within that affinity, so that he is seen doing the things a regional leader must do, like resolving disputes and putting down brigands.
 
 A typical lord spends about 20% of his income on minor offices that favor the members of his affinity. This expense is already calculated into the surplus figures found in Chapter Three: A Comparison of Titles. A character who diverts most of his usual spending to another cause, like a crusade or a covenant, may lose standing in his affinity.
 
@@ -1062,7 +1058,7 @@ Affinity leadership may be used, for example, in rolls that:
 - Encourage lesser lords to take a particular attitude to the Church, such as paying their tithes in full, or in part, or to demand the removal of a corrupt priest.
 - Referee a local tournament.
 
-## Control Through Emotional Bonds
+### Control Through Emotional Bonds
 
 **Ars Magica** provides a structure of rules in which characters can develop networks of personal influence. These rules have been used in other supplements to model merchant houses and the private agents of magi. Here they are adapted to model the bonds of loyalty between noble allies. In the rules given earlier, characters are assumed to do what is in their interest given the relative power of the two characters and the situation in which they are interacting. The rules in this section are used to model the unexpected interactions between people whose tight emotional bonds make them do things which, superficially, are not in their own interests.
 
@@ -1070,12 +1066,7 @@ Not all troupes find these rules convenient for the stories they wish to tell. E
 
 #### Agents
 
-Directly controlled subordinates are referred to as agents in these rules (though not
-
-#### Lords of Men
-
-
-by characters). A person may only control a limited number of subordinates through personal charisma. A character who attempts to control more subordinates than this gradually loses control of his network.
+Directly controlled subordinates are referred to as agents in these rules (though not by characters). A person may only control a limited number of subordinates through personal charisma. A character who attempts to control more subordinates than this gradually loses control of his network.
 
 A character may have a number of agents equal to:
 
@@ -1086,11 +1077,8 @@ This total excludes many other characters over whom the principal has influence.
 - Hermetic magi.
 - Characters with no political role these are free, providing color to the stories but rarely providing resources.
 - Indirect subordinates. The people who serve an agent are not, themselves, agents.
-- Characters who act not out of any personal ties to a character, but because of the economic demands of their lives and offices. A mercenary captain who is a hireling, for example, will change sides, flee, or surrender when faced with poor
-
-odds of victory. An agent may not, depending on a player's dice rolls. People granted fiefs are hirelings, but they are often designed as agents because they are most needed at the time when a hireling would choose self-preservation at the principal's expense.
-
-• The characters of other players, regardless of their social status.
+- Characters who act not out of any personal ties to a character, but because of the economic demands of their lives and offices. A mercenary captain who is a hireling, for example, will change sides, flee, or surrender when faced with poor odds of victory. An agent may not, depending on a player's dice rolls. People granted fiefs are hirelings, but they are often designed as agents because they are most needed at the time when a hireling would choose self-preservation at the principal's expense.
+- The characters of other players, regardless of their social status.
 
 A character with poor Presence or Leadership may control his entire network through a single agent who excels in these attributes. Hermetic magi call these primary agents factors.
 
@@ -1099,12 +1087,7 @@ A character with poor Presence or Leadership may control his entire network thro
 Each agent must have the following handful of statistics defined:
 
 - A name.
-- A Social Status Virtue or Flaw. A character may have an agent who feels the principal is his social inferior, but this is possible only through coercion. For the purpose of dealing with this agent, the character gains the Difficult Underlings
-
-
-
-Flaw. The agent has a Story Flaw, like Blackmail or Dark Secret, that represents his attempts to shed the control of the principal.
-
+- A Social Status Virtue or Flaw. A character may have an agent who feels the principal is his social inferior, but this is possible only through coercion. For the purpose of dealing with this agent, the character gains the Difficult Underlings Flaw. The agent has a Story Flaw, like Blackmail or Dark Secret, that represents his attempts to shed the control of the principal.
 - A Bond, which is a Personality Trait that expresses the reason for the agent's attachment to the principal, and its strength.
 - A list of the resources available to the principal through the agent. These may include Abilities, wealth, social influence, armed forces, or any other thing that makes the agent worth having.
 
@@ -1118,80 +1101,73 @@ Some characters have agents at character creation due to Virtues they have selec
 
 Most agents are gained as a result of interaction during stories. Some agents are offered freely by the Storyguide as a reward for players who complete a story. Others must be recruited. Recruitment is a process of wearing down the resistance of the potential agent. The scores on the Agent Recruitment Table represent how difficult it is to draw people under the principal's influence.
 
-The principal must first impress the potential agent, so that the potential agent knows that the offers and threats that the principal makes should be considered seriously. The principal does this by making a forceful and obvious intrusion into the po-
+The principal must first impress the potential agent, so that the potential agent knows that the offers and threats that the principal makes should be considered seriously. The principal does this by making a forceful and obvious intrusion into the potential agent's life. This can be done by assisting the potential agent, for example by aiding him in a story. It can also be completed through less-pleasant methods, for example a criminal may be beaten and left in an alley or hung by the ankles from a tower for an hour.
 
-## Agent Recruitment Table
+> ## Agent Recruitment Table
+> 
+> *A potential agent always has a minimum resistance score of 1.*
+> 
+> | Social Status | Resistance | Examples |
+> |---------------|:----------:|----------|
+> | Major Social Virtue | 3 | Landed Noble\*, Magister in Artibus, Redcap |
+> | Minor Social Virtue | 1 | Clerk, Custos, Failed Apprentice, Gentleman/woman, Knight, Mendicant Friar, Mercenary Captain\*, Priest, Wise One |
+> | Free Social Virtue (except Hermetic Magus) | 0 | Covenfolk, Craftsman, Merchant, Peasant, Wanderer |
+> | Minor Social Flaw | –1 | Branded Criminal, Outcast, Outlaw Leader\* |
+> | Major Social Flaw | –3 | Outlaw, Outsider |
+> 
+> \* Must take underlings, see below.
+> 
+> ### Modifiers
+> 
+> | Circumstance | Modifier | Examples |
+> |--------------|:--------:|----------|
+> | Major Flaws likely to inconvenience principal | –3 | Enemies, Feud, Lycanthrope, Plagued By Supernatural Entity |
+> | Minor Flaws likely to inconvenience principal | –1 | Black Sheep, Dark Secret, Dependant, Diabolic Past, Favors, Infamous |
+> | Minor Flaw used by player character to dominate agent | –6 | Hostage (Dependent or True Love), is Blackmailing using Dark Secret, Diabolic Past, or other leverage (Blackmail)\* |
+> 
+> \* Agent hates principal, which inflicts the Difficult Underlings Flaw for this agent only.
+> 
+> ### Resources
+> 
+> | Resource | Modifier | Examples |
+> |----------|:--------:|----------|
+> | Extraordinary Skill: Main Ability 6 or more | +1 | n/a |
+> | Exceptional Ability: Main Ability 8 or more | +3 | n/a |
+> | Minor General or Supernatural Virtue | +1 | Gossip, Magic Sensitivity, Protection, Skinchanger, Social Contacts, Temporal Influence |
+> | Major General or Supernatural Virtue | +3 | Entrancement, True Faith, Wealthy |
+> | Serves Rival | +9 | Covenant, nobleman of equal social standing |
+> | Underlings | +1 | Up to half a dozen people, including agents and hirelings |
+> | Many underlings | +3 | Up to two dozen people, including agents and hirelings |
+> | Useful Minor Flaw | +1 | Busybody, Faerie Friend, Magical Animal Companion, Mentor |
+> | Has more than three selections from this list | +6 | |
+> | Has more than six selections from this list | +9 | |
 
-*A potential agent always has a minimum resistance score of 1.*
 
-| Social Status                                 | Resistance | Examples                                                                                                                |
-|-----------------------------------------------|------------|-------------------------------------------------------------------------------------------------------------------------|
-| Major Social Virtue                           | 3          | Landed Noble*, Magister in Artibus,<br>Redcap                                                                           |
-| Minor Social Virtue                           | 1          | Clerk, Custos, Failed Apprentice, Gentle<br>man/woman, Knight, Mendicant Friar,<br>Mercenary Captain*, Priest, Wise One |
-| Free Social Virtue (except<br>Hermetic Magus) | 0          | Covenfolk, Craftsman, Merchant, Peasant,<br>Wanderer                                                                    |
-| Minor Social Flaw                             | –1         | Branded Criminal, Outcast, Outlaw<br>Leader*                                                                            |
-| Major Social Flaw                             | –3         | Outlaw, Outsider                                                                                                        |
-
-<sup>\*</sup> Must take underlings, see below.
-
-#### Modifiers
-
-| Circumstance                                             | Modifier | Examples                                                                                                                  |
-|----------------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------|
-| Major Flaws likely to<br>inconvenience principal         | –3       | Enemies, Feud, Lycanthrope, Plagued<br>By Supernatural Entity                                                             |
-| Minor Flaws likely to<br>inconvenience principal         | –1       | Black Sheep, Dark Secret, Dependant,<br>Diabolic Past, Favors, Infamous                                                   |
-| Minor Flaw used by player<br>character to dominate agent | –6       | Hostage (Dependent or True Love), is<br>Blackmailing using Dark Secret, Diabol<br>ic Past, or other leverage (Blackmail)* |
-
-<sup>\*</sup> Agent hates principal, which inflicts the Difficult Underlings Flaw for this agent only.
-
-#### Resources
-
-| Resource                                         | Modifier | Examples                                                                                    |
-|--------------------------------------------------|----------|---------------------------------------------------------------------------------------------|
-| Extraordinary Skill:<br>Main Ability 6 or more   | +1       | n/a                                                                                         |
-| Exceptional Ability:<br>Main Ability 8 or more   | +3       | n/a                                                                                         |
-| Minor General or<br>Supernatural Virtue          | +1       | Gossip, Magic Sensitivity, Protection, Sk<br>inchanger, Social Contacts, Temporal Influence |
-| Major General or<br>Supernatural Virtue          | +3       | Entrancement, True Faith, Wealthy                                                           |
-| Serves Rival                                     | +9       | Covenant, nobleman of equal social standing                                                 |
-| Underlings                                       | +1       | Up to half a dozen people, including agents<br>and hirelings                                |
-| Many underlings                                  | +3       | Up to two dozen people, including agents and<br>hirelings                                   |
-| Useful Minor Flaw                                | +1       | Busybody, Faerie Friend, Magical Animal Com<br>panion, Mentor                               |
-| Has more than three<br>selections from this list | +6       |                                                                                             |
-| Has more than six                                | +9       |                                                                                             |
-
-
-selections from this list
-
-## Tasks For Agents Table
-
-| Task                                                              | Persuasion Roll<br>Ease Factor | Example                                                                               |
-|-------------------------------------------------------------------|--------------------------------|---------------------------------------------------------------------------------------|
-| Provide common informa<br>tion that is easily obtained.           | 3                              | Relay the theories of gossips<br>concerning the unusual events in<br>the town square. |
-| Provide sensitive informa<br>tion that is difficult to<br>obtain. | 6                              | Discover the address of the<br>bishop's mistress.                                     |
-| Provide secret information<br>known to a select few.              | 9                              | Uncover which nobles are mem<br>bers of the Duke's diabolic cabal.                    |
-| Perform an Easy task (Ease<br>Factor 6 or less).                  | 3                              | Persuade a merchant to give pas<br>sage to a magus with the Blatant<br>Gift.          |
-| Perform a Hard task (Ease<br>Factor 12 or less).                  | 6                              | Steal a ring from a lady's finger,<br>unnoticed.                                      |
-| Perform an Impressive Task<br>(Ease Factor 18 or less).           | 9                              | Arrange a fatal accident for the<br>prince.                                           |
-
-#### Persuasion Roll Modifiers
-
-| Timeframe                                                         |          | Modifier                                |
-|-------------------------------------------------------------------|----------|-----------------------------------------|
-| Within a few weeks                                                |          | 0                                       |
-| Within a few days                                                 |          | +1                                      |
-| Within one day                                                    |          | +3                                      |
-|                                                                   |          |                                         |
-| Personal Risk                                                     | Modifier | Example                                 |
-| None at all (simple die).                                         | +0       | Deliver a package to a merchant.        |
-| Risk of embarrassment or reputation<br>(stress die, 1 botch die). | +1       | Deliver a prostitute to a<br>merchant.  |
-| Risk of injury or imprisonment<br>(stress die, 3 botch dice).     | +3       | Deliver a threat to a rich<br>merchant. |
-|                                                                   |          |                                         |
-
-tential agent's life. This can be done by assisting the potential agent, for example by aiding him in a story. It can also be completed through less-pleasant methods, for example a criminal may be beaten and left in an alley or hung by the ankles from a tower for an hour.
-
-Risk of death (stress die, 5 botch
-
-dice).
+> ## Tasks For Agents Table
+> 
+> | Task | Persuasion Roll Ease Factor | Example |
+> |------|:---------------------------:|---------|
+> | Provide common information that is easily obtained. | 3 | Relay the theories of gossips concerning the unusual events in the town square. |
+> | Provide sensitive information that is difficult to obtain. | 6 | Discover the address of the bishop's mistress. |
+> | Provide secret information known to a select few. | 9 | Uncover which nobles are members of the Duke's diabolic cabal. |
+> | Perform an Easy task (Ease Factor 6 or less). | 3 | Persuade a merchant to give passage to a magus with the Blatant Gift. |
+> | Perform a Hard task (Ease Factor 12 or less). | 6 | Steal a ring from a lady's finger, unnoticed. |
+> | Perform an Impressive Task (Ease Factor 18 or less). | 9 | Arrange a fatal accident for the prince. |                                         |
+> 
+> ### Persuasion Roll Modifiers
+> 
+> | Timeframe | Modifier |
+> |-----------|:--------:|
+> | Within a few weeks | 0 |
+> | Within a few days  | +1 |
+> | Within one day     | +3 |
+> 
+> | Personal Risk | Modifier | Example |
+> |---------------|:--------:|---------|
+> | None at all (simple die). | +0 | Deliver a package to a merchant. |
+> | Risk of embarrassment or reputation (stress die, 1 botch die). | +1 | Deliver a prostitute to a merchant. |
+> | Risk of injury or imprisonment (stress die, 3 botch dice). | +3 | Deliver a threat to a rich merchant. |
+> | Risk of death (stress die, 5 botch dice). | +6 | Deliver a threat to a count in his own palace. |
 
 A character seeking to impress a potential agent must roll:
 
@@ -1199,12 +1175,7 @@ A character seeking to impress a potential agent must roll:
 
 Failure indicates this character cannot be impressed until encountered in a different story, when a new roll may be made. A character using a recruiting agent may send him to impress the potential agent, and use the recruiter's scores for the dice roll.
 
-+6 Deliver a threat to a count in his
-
-own palace.
-
-An impressed agent-to-be must then be drawn into the principal's sphere of influence through story events that create a Bond. This is abstracted using experience points. Every time a character gains Adventure Experience, he gains an equal number of Agency Experience points. Agency Experience points are spent to weaken the resistance of potential
-
+An impressed agent-to-be must then be drawn into the principal's sphere of influence through story events that create a Bond. This is abstracted using experience points. Every time a character gains Adventure Experience, he gains an equal number of Agency Experience points. Agency Experience points are spent to weaken the resistance of potential agents, and to maintain the Bonds of active agents.
 
 The initial resistance of an agent is determined using the Agent Recruitment Table. When assessing the cost of an agent, select only those resources that the agent will use in play in the service of the principal. The Virtues and Flaws of agents do not need to balance each other. A character's resistance is reduced by 1 in exchange for a number of Agency experience points equal to their current resistance. The agent comes into the service of the principal when his or her resistance reaches 0. A new agent has a Bond score of 0.
 
@@ -1218,11 +1189,7 @@ If the agent attempts the task, the player makes a roll using the Characteristic
 
 The most common use for agents is as sources of information. Passive information gathering, which allows the principal to know, after a delay for communication, any specific fact, piece of gossip, or news that the agent knows or can casually ask people about, is not considered a task in these rules. It occurs at the discretion of the principal's player and requires no roll. Actively gathering private information counts as a form of assistance, as described later, and if required more than once per season may cause the agent to lose Bond strength. Troupes may decide that certain agents, such as the professional spies employed by the Church and some merchant houses, don't consider finding information in this way so onerous as to strain their Bond strength.
 
-Agents may also be asked for assistance: that is, they may be asked to expend their time and resources on behalf of the principal. Again, the agent must have Abilities suited
-
-
-
-to the task and have sufficient free time. A character with a Minor Flaw that consumes his time, or requires him to drop out of public sight, is unable to assist his principal in one quarter of those cases where his services are desirable. A character with a Major Flaw is unavailable half the time.
+Agents may also be asked for assistance: that is, they may be asked to expend their time and resources on behalf of the principal. Again, the agent must have Abilities suited to the task and have sufficient free time. A character with a Minor Flaw that consumes his time, or requires him to drop out of public sight, is unable to assist his principal in one quarter of those cases where his services are desirable. A character with a Major Flaw is unavailable half the time.
 
 #### Maintaining Agents
 
@@ -1248,21 +1215,17 @@ This section extends the Reputation Table on page 19 of ArM5, providing a fourth
 
 #### Prudhomme
 
-The prize reputation for a male noble in Mythic Europe is that of prudhomme. A prudhomme is a man considered to have been tested and found sound by other members of his class. A man is a prudhomme if he is noble of blood, handsome, demonstrates prowess, and is of suitable character. The prowess required and the character desired are those considered correct for the work of mounted medieval warriors. In some courts Christian ethics may appeal, but to be a
+The prize reputation for a male noble in Mythic Europe is that of prudhomme. A prudhomme is a man considered to have been tested and found sound by other members of his class. A man is a prudhomme if he is noble of blood, handsome, demonstrates prowess, and is of suitable character. The prowess required and the character desired are those considered correct for the work of mounted medieval warriors. In some courts Christian ethics may appeal, but to be a prudhomme to other knights, a man must be willing to do what is necessary to win war. A prudhomme makes war using means that the Church abhors as foul, and he does it well, and with delight.
 
-## Story Seed: Genetic Memory
-
-For the true knight, battle is more than a vocation: the need to fight is built into the knight before he is born. In folklore, this love of battle is said to pass in the blood. The sons of knights, raised away from court, are instinctively drawn to weapons or to make their own. In Mythic Europe, supernatural forces answer human desires. Demons and faeries place the tools of violence into the infant hands of knights kept from their birthright. Such children need no instruction in arms: it passes to them in the blood.
-
-Many covenants receive unwanted children, and raise them as custodes. One of the children in the covenant seems to have a mental illness. He is driven to kill small animals, and feels no shock at dreadful injuries suffered by other people. Instead, he is fascinated by the mechanics of their damaged bodies. Characters who interview the boy note that he seems utterly unable to feel sympathy for anyone else. His only strong desire is to kill people and animals. When he is alone and out of the covenant he keeps finding weapons. These are faerie-wrought and left for him by a dark faerie that knows his secret. The boy is a knight, and the lost heir of a noble house.
-
-prudhomme to other knights, a man must be willing to do what is necessary to win war. A prudhomme makes war using means that the Church abhors as foul, and he does it well, and with delight.
+> ## Story Seed: Genetic Memory
+> 
+> For the true knight, battle is more than a vocation: the need to fight is built into the knight before he is born. In folklore, this love of battle is said to pass in the blood. The sons of knights, raised away from court, are instinctively drawn to weapons or to make their own. In Mythic Europe, supernatural forces answer human desires. Demons and faeries place the tools of violence into the infant hands of knights kept from their birthright. Such children need no instruction in arms: it passes to them in the blood.
+> 
+> Many covenants receive unwanted children, and raise them as custodes. One of the children in the covenant seems to have a mental illness. He is driven to kill small animals, and feels no shock at dreadful injuries suffered by other people. Instead, he is fascinated by the mechanics of their damaged bodies. Characters who interview the boy note that he seems utterly unable to feel sympathy for anyone else. His only strong desire is to kill people and animals. When he is alone and out of the covenant he keeps finding weapons. These are faerie-wrought and left for him by a dark faerie that knows his secret. The boy is a knight, and the lost heir of a noble house.
 
 #### Improving Noble Reputation
 
-A character first develops a reputation by entering feudal life. The character does this by being born into a noble family, or by becoming the vassal of a landed person. This gives the character a Noble Reputation of 1, with boring content like "son of Lord Corvinius" or "vassal of the Count of Champagne." A character may gain a higher Reputation for doing anything so interesting that it is discussed widely by his or her peers. Being a Crusader touched by a miracle before an army of witnesses, or being caught lead-
-
-
+A character first develops a reputation by entering feudal life. The character does this by being born into a noble family, or by becoming the vassal of a landed person. This gives the character a Noble Reputation of 1, with boring content like "son of Lord Corvinius" or "vassal of the Count of Champagne." A character may gain a higher Reputation for doing anything so interesting that it is discussed widely by his or her peers. Being a Crusader touched by a miracle before an army of witnesses, or being caught leading a Black Mass, both add to the character’s Reputation. The flavor of the events alter the content of the Reputation.
 
 Every time a noble spends a season performing great deeds notable to other members of his class, he adds 1 Experience to his reputation. These points are spent using the Abilities table on page 31 of ArM5. Examples include:
 
@@ -1286,32 +1249,32 @@ There is very little a knight can do to decrease his Reputation. A knight who ru
 
 A character's Reputation allows the other members of the noble class to judge his interests and intentions. This lets them accommodate him in their plans. A character of strong Reputation need do nothing, but still affects the calculations of personal interest of his neighbors. A fierce Reputation is a potent envoy. Changes in the Reputation of significant characters can sway the fate of thrones, by making key nobles appear unwilling to fight, ill-prepared for war, or arrogant about their skill as a commander of troops.
 
-## Reputation Roll Adjustments
-
-| Ease Factor | Distance                          |
-|-------------|-----------------------------------|
-| 3           | Same shire, county, or equivalent |
-| 6           | Adjoining counties                |
-| 9           | Same kingdom                      |
-| 12          | Rival kingdom                     |
-|             |                                   |
-
-#### Status modifiers – select only one
-
-| Modifier | Circumstance                                                           |
-|----------|------------------------------------------------------------------------|
-| +6       | A commoner in the service of a noble.                                  |
-| +3       | A landholder of status lower than the character making the roll.       |
-| 0        | A landholder of status equivalent to the character making the<br>roll. |
-| –3       | A landholder of status superior to the character making the roll.      |
-| –6       | A vassal of the character making the roll.                             |
-
-#### Miscellaneous modifiers – select all appropriate
-
-| Modifier | Circumstance                                                          |
-|----------|-----------------------------------------------------------------------|
-| +3       | A widow who does not hold in her own right, or an heir of a<br>noble. |
-| +6       | An acknowledged lover or bastard.                                     |
+> ## Reputation Roll Adjustments
+> 
+> | Ease Factor | Distance                          |
+> |:-----------:|-----------------------------------|
+> | 3           | Same shire, county, or equivalent |
+> | 6           | Adjoining counties                |
+> | 9           | Same kingdom                      |
+> | 12          | Rival kingdom                     |
+> |             |                                   |
+> 
+> #### Status modifiers – select only one
+> 
+> | Modifier | Circumstance                                                           |
+> |:--------:|------------------------------------------------------------------------|
+> | +6       | A commoner in the service of a noble.                                  |
+> | +3       | A landholder of status lower than the character making the roll.       |
+> | 0        | A landholder of status equivalent to the character making the<br>roll. |
+> | –3       | A landholder of status superior to the character making the roll.      |
+> | –6       | A vassal of the character making the roll.                             |
+> 
+> #### Miscellaneous modifiers – select all appropriate
+> 
+> | Modifier | Circumstance                                                          |
+> |:--------:|-----------------------------------------------------------------------|
+> | +3       | A widow who does not hold in her own right, or an heir of a<br>noble. |
+> | +6       | An acknowledged lover or bastard.                                     |
 
 #### Reputation is Utterly Vital
 
@@ -1322,7 +1285,6 @@ Mythic Europeans, unlike the characters in most board games and computer games, 
 Comparing the Reputations of the major nobles on each side of a conflict doesn't just tell a character what each group wants. It allows the character to compare the resources of the two sides, and their determination to achieve particular objectives. Knowledge of these objectives often allows the character to have some idea of where battles are likely to be fought. This understanding that war is limited, and continues only until one side can claim some approximation of what it wants, allows a character to guess when each side will want to discuss peace.
 
 Single actions can seriously affect Reputations, and this can dramatically alter the way that characters are perceived. A king who flees a battle before defeat is certain to lose much more than a single army, because other armies will not follow him into battle.
-
 
 This does not reduce his Reputation score, but does alter its effect. A less decisive, but more instructive, example is found in the life of William Marshal.
 
@@ -1338,7 +1300,7 @@ Relatively few women hold public power in Mythic Europe. The elaboration of thei
 
 Players, who are likely most familiar with the English system, should be aware that women have fewer rights in England than in most other parts of Mythic Europe. This is, in part, an effect of the Conquest. The military character of the Norman nobility has not entirely given way to hereditary aristocracy. In areas where landholding is seen as a method of supporting warriors, women have fewer rights, while in those areas where landholding is seen as method of generating money to sustain an army, women have greater rights.
 
-## Dressing as a Man
+### Dressing as a Man
 
 This is the simplest way to ignore social conventions concerning women. There are many folkloric examples of women dressing as men and doing almost anything men do. War or pilgrimage, for example, are easier when pretending to be male. This may become a Dark Secret.
 
@@ -1350,20 +1312,17 @@ Women can gain control of land in six ways: during absence, through inheritance,
 
 #### Absence
 
-Landholding is intimately tied, in most of Mythic Europe, to providing military service. The male head of most families must be available to fight in campaigns, some of which last for months, or in civil wars, which can sputter along for years. Many nobles leave their wives as their deputies. The value of an educated wife to the military preparedness of her husband has overcome many of
+Landholding is intimately tied, in most of Mythic Europe, to providing military service. The male head of most families must be available to fight in campaigns, some of which last for months, or in civil wars, which can sputter along for years. Many nobles leave their wives as their deputies. The value of an educated wife to the military preparedness of her husband has overcome many of the objections concerning the education of women.
 
-
-Through much of this book, prohibitions against women are discussed. These provisions need to be enforced for them to be effective, and a woman with sufficient wealth can often buy an exclusion from enforcement, or even permission to do something that this book states elsewhere is forbidden. All a woman need do, if she wishes to be a baroness in her own right, is pay the king enough money that he allows it. All a woman need do if she wishes to hold a smaller fief in her own right, and not marry as directed, and not be in wardship, is pay a large enough fine to her guardian.
-
-This is of particular interest to player characters, because their Virtues and Flaws are balanced at the time they start play. This means that if a female character has paid a huge fine for a right before play begins, she does not necessarily have any Flaw representing that fine. She may choose a free Virtue, called Paid Rights, to note that she has paid for the right to do a certain thing that is generally forbidden for women. She may also take a Story Flaw that represents her family's displeasure at this use of her funds, the frustrations of suitors who would take her land by marriage, or other forms of social opprobrium, although this is not required.
-
-There are, however, a few prohibitions that a woman cannot pay a fine to ignore. She cannot pay a fine to do anything that only men are permitted to do in the administrative structure of the Church. It is also difficult for a woman to gain the rank of knight. There are some examples of female knights in folklore, so it is not impossible. But a female knight needs an unusual back story and her player should consider Story Flaws.
-
-the objections concerning the education of women.
+> ## Paid Rights: A Free Virtue
+> 
+> Through much of this book, prohibitions against women are discussed. These provisions need to be enforced for them to be effective, and a woman with sufficient wealth can often buy an exclusion from enforcement, or even permission to do something that this book states elsewhere is forbidden. All a woman need do, if she wishes to be a baroness in her own right, is pay the king enough money that he allows it. All a woman need do if she wishes to hold a smaller fief in her own right, and not marry as directed, and not be in wardship, is pay a large enough fine to her guardian.
+> 
+> This is of particular interest to player characters, because their Virtues and Flaws are balanced at the time they start play. This means that if a female character has paid a huge fine for a right before play begins, she does not necessarily have any Flaw representing that fine. She may choose a free Virtue, called Paid Rights, to note that she has paid for the right to do a certain thing that is generally forbidden for women. She may also take a Story Flaw that represents her family's displeasure at this use of her funds, the frustrations of suitors who would take her land by marriage, or other forms of social opprobrium, although this is not required.
+> 
+> There are, however, a few prohibitions that a woman cannot pay a fine to ignore. She cannot pay a fine to do anything that only men are permitted to do in the administrative structure of the Church. It is also difficult for a woman to gain the rank of knight. There are some examples of female knights in folklore, so it is not impossible. But a female knight needs an unusual back story and her player should consider Story Flaws.
 
 Women raised for this task always have Leadership and Profession: Steward scores. They also rapidly develop Ability scores that their husbands have due to the peculiarities of their holdings, allowing them to oversee work, or at least select competent overseers.
-
-
 
 In this role of deputy, the woman has the right to spend the income of the husband's territory, and may command his vassals in many matters, including war.
 
@@ -1375,11 +1334,7 @@ Many noblewomen maintain networks of agents completely separate from the househo
 
 Lands inherited by women are a recognized feature of feudal life. In most kingdoms land goes to sons before daughters, but daughters are given preference over more-distant male relations, like uncles and cousins. Some areas grant all of the land to the eldest son, and the daughter receives it intact if there are no sons. In others, when a paternal line extinguishes in this way, the land is divided between all of the remaining sisters, or their husbands. In a few areas women are permitted to inherit directly, either because the land of a family is divided between all of the siblings who are not already members of the Church, or because the lord is permitted to nominate his heirs and so may choose his daughters.
 
-A woman who rules a fief by inheritance usually retains legal authority in it during her marriage. With the exception of England, where the wife's rights become the husband's, there are many examples of women who married another noble, yet continued to hold her own court, issue charters, and command vassals. In Castile there is at least one example of an odd midpoint, where the bride continued to rule in her own land, with the exception of her dowry, which was transferred to her husband. At the death of an heiress, her lands may be kept by her eldest son if the area practices primogeniture. In areas where the lands of the parents are divided, the separate character of the wife's
-
-
-ous domain for one of her younger sons.
-
+A woman who rules a fief by inheritance usually retains legal authority in it during her marriage. With the exception of England, where the wife's rights become the husband's, there are many examples of women who married another noble, yet continued to hold her own court, issue charters, and command vassals. In Castile there is at least one example of an odd midpoint, where the bride continued to rule in her own land, with the exception of her dowry, which was transferred to her husband. At the death of an heiress, her lands may be kept by her eldest son if the area practices primogeniture. In areas where the lands of the parents are divided, the separate character of the wife's lands from her husband’s make them an obvious domain for one of her younger sons.
 Land that a girl's father has added to his ancestral territories may be made available as dowry. Dowries are used, in much of Europe, as a sort of inheritance before the death of the father. Rules for the design of dowries are given in the Family section, earlier.
 
 #### Political Success
@@ -1392,47 +1347,41 @@ Some women claim land through invasion, allowing their retinue of knights to set
 
 #### Widow's Portion and Stewardship
 
-In most areas a widow is permitted to retain the use of a portion of her husband's lands for her own use after his death. As a rule of thumb, assume a widow can keep
+In most areas a widow is permitted to retain the use of a portion of her husband's lands for her own use after his death. As a rule of thumb, assume a widow can keep the profit, not income, of a third of her husband's land until she remarries. If the woman was already landed at marriage, and has no adult sons, then she is likely to have complete ownership of her lands returned to her. Widows are extremely common in Mythic Europe.
 
-## A Note on Life Expectancy
+> ## A Note on Life Expectancy
+> 
+> A key to female landholding is the comparative longevity of women in wartime. Players in sagas designed for female nobles to play a significant role need to consciously cull male non-player characters. The rules for doing this are in the Random Method of Death insert, in the Family section earlier.
 
-A key to female landholding is the comparative longevity of women in wartime. Players in sagas designed for female nobles to play a significant role need to consciously cull male non-player characters. The rules for doing this are in the Random Method of Death insert, in the Family section earlier.
-
-
-
-## Women as Warriors
-
-In most areas there are folktales about particular women who, at some past time, acted in the role of knight. How characters react to contemporary women who attempt the same course varies by culture and by the status of the particular woman. In the Order of Hermes, the philosophy of Plato coupled with the scarcity of The Gift has led to a position of equity. Plato advocated the training of women for all the duties of the state including administration and warfare. Very few women seek military success, but sufficient do for the role to be accepted, to some degree, in most areas. The following examples may guide the generation of background for female nobles who seek military roles.
-
-## Dressing as a Man: Margaret of Beverley
-
-Margaret of Beverly was born in the Holy Land: her parents were English pilgrims who commenced their journey while her mother was pregnant. After reaching adulthood and seeing to the education of her younger brother, Margaret decided to revisit Jerusalem. Through terrible luck, she was present when Jerusalem fell to Saladin in 1187.
-
-She pretended to be a man, and took part in the defense of the wall, wearing improvised armor. Margaret was struck by a fragment thrown up by a stone fired from a siege engine, and carried scars for the rest of her life. She was captured, ransomed, and then after a difficult period involving slavery, theft, and rescue, by the grace of the Virgin she was able to arrive in Antioch, in time to participate in the siege there.
-
-After peace was concluded she sailed
-
-for England with the English army, departing from Acre. Her other travels, to Rome and Santiago, were almost as adventurous as this first trip. Historically, after her journeys she sought out her younger brother, who had become a monk, and he led her to the contemplative life. She joined a nunnery at Laon, in France, and may live there still in 1220.
-
-## Eleanor of Aquitaine: Inheritance
-
-Eleanor attended the Second Crusade with her husband, and was attended by a guard of female knights dressed as Amazons and mounted on white horses. Eleanor's right to lead her troops, as overlord of Aquitaine, was incontestable. The queens of several of the other leaders followed her example. Her behavior was considered scandalous, and led to the Papal Bull forbidding women from taking the cross in the Third Crusade.
-
-## Sikelgaita of Sicily: Conquest
-
-A princess of the Lombards, then the wife of the Duke of Apulia and Sicily, Sikelgaita is recorded as having participated in her husband's battles dressed as a knight, and as charging enemies with a spear. In her husband's wars against the Byzantine Empire, she rallied some troops that had fled a battle, sending them back into the fray at the Battle of Dyrrachium. The Norman conquests in Byzantium were lost after the war turned against her family.
-
-## Petronilla of Leicester: Absence
-
-Petronilla is recorded as having armed herself as a knight and fought in battles during the reign of Henry II, perhaps due to the absence of her husband. A namesake was active during the wars of John against his barons, and purchased the right to select her own husband. This Petronilla used John's desperation for money to haggle the relatively good price of 4000 marks. The latter Petronilla has only been dead eight years.
-
-## Matilda of Tuscany: Political Success
-
-Matilda's parents were allies of the pope, and open rebels against his rival the emperor. Matilda was trained in warfare from an early age. Her tutor was later the commander of her forces and stated he had trained her in lance, pike, axe, and sword. Matilda is widely believed to have ridden into battle from her teenage years.
-
-She was the primary proponent of the pope's cause during the Investiture Controversy, and through a series of marriages, alliances, and wars, she all but destroyed Imperial authority in Northern Italy. Matilda led her armies through a series of wars, crushing Imperial forces so that only a few cities remained under the emperor's banner. She spent her old age dispatching armies to besiege and capture many of these.
-
-the profit, not income, of a third of her husband's land until she remarries. If the woman was already landed at marriage, and has no adult sons, then she is likely to have complete ownership of her lands returned to her. Widows are extremely common in Mythic Europe.
+> ## Women as Warriors
+> 
+> In most areas there are folktales about particular women who, at some past time, acted in the role of knight. How characters react to contemporary women who attempt the same course varies by culture and by the status of the particular woman. In the Order of Hermes, the philosophy of Plato coupled with the scarcity of The Gift has led to a position of equity. Plato advocated the training of women for all the duties of the state including administration and warfare. Very few women seek military success, but sufficient do for the role to be accepted, to some degree, in most areas. The following examples may guide the generation of background for female nobles who seek military roles.
+> 
+> ### Dressing as a Man: Margaret of Beverley
+> 
+> Margaret of Beverly was born in the Holy Land: her parents were English pilgrims who commenced their journey while her mother was pregnant. After reaching adulthood and seeing to the education of her younger brother, Margaret decided to revisit Jerusalem. Through terrible luck, she was present when Jerusalem fell to Saladin in 1187.
+> 
+> She pretended to be a man, and took part in the defense of the wall, wearing improvised armor. Margaret was struck by a fragment thrown up by a stone fired from a siege engine, and carried scars for the rest of her life. She was captured, ransomed, and then after a difficult period involving slavery, theft, and rescue, by the grace of the Virgin she was able to arrive in Antioch, in time to participate in the siege there.
+> 
+> After peace was concluded she sailed for England with the English army, departing from Acre. Her other travels, to Rome and Santiago, were almost as adventurous as this first trip. Historically, after her journeys she sought out her younger brother, who had become a monk, and he led her to the contemplative life. She joined a nunnery at Laon, in France, and may live there still in 1220.
+> 
+> ### Eleanor of Aquitaine: Inheritance
+> 
+> Eleanor attended the Second Crusade with her husband, and was attended by a guard of female knights dressed as Amazons and mounted on white horses. Eleanor's right to lead her troops, as overlord of Aquitaine, was incontestable. The queens of several of the other leaders followed her example. Her behavior was considered scandalous, and led to the Papal Bull forbidding women from taking the cross in the Third Crusade.
+> 
+> ### Sikelgaita of Sicily: Conquest
+> 
+> A princess of the Lombards, then the wife of the Duke of Apulia and Sicily, Sikelgaita is recorded as having participated in her husband's battles dressed as a knight, and as charging enemies with a spear. In her husband's wars against the Byzantine Empire, she rallied some troops that had fled a battle, sending them back into the fray at the Battle of Dyrrachium. The Norman conquests in Byzantium were lost after the war turned against her family.
+> 
+> ### Petronilla of Leicester: Absence
+> 
+> Petronilla is recorded as having armed herself as a knight and fought in battles during the reign of Henry II, perhaps due to the absence of her husband. A namesake was active during the wars of John against his barons, and purchased the right to select her own husband. This Petronilla used John's desperation for money to haggle the relatively good price of 4000 marks. The latter Petronilla has only been dead eight years.
+> 
+> ### Matilda of Tuscany: Political Success
+> 
+> Matilda's parents were allies of the pope, and open rebels against his rival the emperor. Matilda was trained in warfare from an early age. Her tutor was later the commander of her forces and stated he had trained her in lance, pike, axe, and sword. Matilda is widely believed to have ridden into battle from her teenage years.
+> 
+> She was the primary proponent of the pope's cause during the Investiture Controversy, and through a series of marriages, alliances, and wars, she all but destroyed Imperial authority in Northern Italy. Matilda led her armies through a series of wars, crushing Imperial forces so that only a few cities remained under the emperor's banner. She spent her old age dispatching armies to besiege and capture many of these.
 
 In some areas, like France, Castile, and parts of the Holy Roman Empire, a widow may act as her son's guardian. This allows her to administer land on his behalf until he is an adult. Stewardship of lands may need to be purchased from the dead husband's overlord. In many areas the lord has the right to select the stewards for the heirs of vassals, and he may even arrange the marriage of the widow.
 
@@ -1442,10 +1391,7 @@ A third avenue for power, and one much enjoyed by the younger daughters of some 
 
 Young women may take temporary vows that allow them to retreat into the life of a nun while events unfold in the secular world. It is possible for a sufficiently influential nobleman to force a woman to leave the nunnery and marry, but this is rare. It is common for the female relatives of a man who has lost a war to retreat into the nunneries, so that they are not at the mercy of the victors.
 
-
-## Chapter Three
-
-# A Comparison of Titles
+# Chapter Three: A Comparison of Titles
 
 The level at which a character is considered noble varies by kingdom. A knight is part of the nobility in much of France, but in England a lord needs to have a great deal more influence than a knight to be considered noble. In parts of Iberia, nobility is more functional and its lower reaches can be grasped by anyone playing the role of knight for this moment, in the employ of the king, regardless of his birth. Churchmen claim to be noble by virtue of their station, a claim taken more or less seriously depending on the power of the Church in the affairs of a kingdom. Although there are a multitude of titles for landed nobility, few have practical meaning to players.
 
@@ -1453,9 +1399,9 @@ The level at which a character is considered noble varies by kingdom. A knight i
 
 This system is a remnant of the institutions that supported the Carolingian Empire, and is found in most areas once controlled by the Franks. It is also found in surrounding areas that have been invaded, like England, or are now ruled by people educated in a court that uses this system, like Scotland.
 
-In the lists below, a term in English is given first, as it assumed that most players will speak English in their games. This is followed by a Latin term, which magi might use for color. This is then followed by the French term, which is often similar to the English because the ruling class of England is comprised, in large part, of French-speaking Normans.
+In the lists below, a term in English is given first, as it is assumed that most players will speak English in their games. This is followed by a Latin term, which magi might use for color. This is then followed by the French term, which is often similar to the English because the ruling class of England is comprised, in large part, of French-speaking Normans.
 
-## Squire (Armiger, Écuyer)
+### Squire (Armiger, Écuyer)
 
 A squire is, strictly, a young person who attends upon a knight as part of his training, but it has evolved to have a second meaning. In many areas of Mythic Europe there are people who could be landed knights, and who do service like landed knights, but have chosen not to formally accept the higher status. The reason for this varies a little between kingdoms. In England it is because knights must pay a tax in exchange for their ascension. In Mythic Europe it is rare for these people to be called squires: each local version of this class has its own name, but for players this is the most convenient term.
 
@@ -1479,112 +1425,103 @@ Most knights who lead sergeants and infantry into battle use a small flag to ind
 
 In some areas, it is felt that the right to lead men in battle under your own banner is a reward that must be bestowed by a liege.
 
-
-
-## A Consideration of Virtues and Flaws
-
-## Oath of Fealty (Major Story Flaw)
-
-In many areas, a lord holds his land from a superior, in exchange for a mix of services and payments. This is represented by the Oath of Fealty Flaw (ArM5, page 56). This is a Major Story Flaw. For most non-player characters and many PCs this suffices, but troupes may wish to modify this slightly for several reasons.
-
-Some nobles hold land simply through descent from people who have held it since time immemorial. These lands are called allods. A holder of allodial land need not have an Oath of Fealty. These characters also tend to use titles that are grander than others of similar power and influence, although that is ignored for the purpose of Virtue selection.
-
-Troupes are encouraged to permit knights who have taken oaths to a lord, but whose oaths lack consequences in play. These insignificant oaths are not treated as Flaws, so they cannot be balanced against Virtues. Troupes may choose to allow insignificant oaths because otherwise knights cannot begin with many of the Story Flaws that suit the chivalric genre, like Black Sheep, Dark Secret, Enemies, Higher Purpose, Heir, True Love, or Vow. Player character knights are more interesting if they can have a range of Story Flaws.
-
-#### Knightly Demands (Major Story Flaw)
-
-As an alternative to all of this tinkering with detail, troupes may simply state that all knights have a Major Story Flaw, called Knightly Demands, that allows the Storyguide to drag them into any plot related to the kind of things knights do in medieval ballads. This flaw works best for high fantasy, highly mobile sagas, because it includes quests, military service, romances, feuds, rescuing damosels, aiding kinfolk, and chasing monsters. This flaw replaces Oath of Fealty entirely.
-
-#### Knight (Minor Virtue)
-
-Some few women serve as knights in Mythic Europe. These women are discussed in greater depth at the end of Chapter Two: Politics.
-
-#### Landed Noble (Major Virtue)
-
-A lord of the manor is the least senior style of landed noble. In England about half of the male manorial lords are knights. The rest are termed "gentry" or "squires" and could be knighted if they wished, but prefer to avoid it since there is a tax attached to the office. A lord of the manor has the Virtue Landed Noble. Knight and Protection are common Virtues, but are not required.
-
-In the Norman-influenced parts of Mythic Europe, Wealthy Landed Nobles are far more numerically common than either standard or Poor Landed Nobles. The average holding in England has five manors. In areas where the land of a father is divided equally between his sons, Poor Landed Nobles are far more common. The children of Wealthy Landed Nobles, or more-senior landowners, often have the Privileged Upbringing Virtue.
-
-A Poor Landed Noble usually has no surplus income. He has little free time, as he must continually administer his lands. This may be because he has debts, because his land has not recovered from a disaster, or because his manors were never fertile. He has one season of free time per year.
-
-A lord of the manor without Virtue or Flaw has a second manor, for which he owes knight service. This service is performed by a mercenary or waived for scutage (a fine discussed in Chapter Two: Politics). The lord may summon up to ten villeins to fight as infantry, which is doubled if the war is defensive. Each knight is also served by a squire who acts as a sergeant, a mounted combatant. This Virtue leaves the lord two seasons of free time per year, and ten pounds to spend on largesse, war, or other discretionary matters.
-
-A typical Wealthy Landed Noble holds, on average, five manors and lives at the richest, or the one to which he has the greatest sentimental attachment. These lands provide the lord with the service of four knights, other than himself, 5 serjants, and 50 villeins. If fighting in the same county, the lord may double the number of villeins who are required to assist him. The lord may spend money to swell the ranks of his personal army, and usually pays scutage for himself or sends a knight in his stead. He has three seasons of free time per year, and 20 pounds per year to spend as he wishes. His additional income comes from fertile land, active assarting in previous generations, or perhaps the lack of a knight-service on one of his manors.
-
-#### Great Noble (Two Major Virtues)
-
-This Virtue is used to represent the resources of a character of the rank of greater baron or higher. It should be treated as:
-
-Two Major Virtues for characters played in lieu of magi, as major protagonists in the plot.
-
-A Major Virtue for characters who, regardless of their rank, remain essentially supporting characters to the magi.
-
-Players should discuss their characters with their troupes before designing greater nobles. It requires extra effort and careful character design to integrate a player character that is a Great Noble into a saga. The interests of the Great Noble tend to draw the character away from stories focused on the covenant, unless he is the covenant's servant.
+> ## A Consideration of Virtues and Flaws
+> 
+> ### Oath of Fealty (Major Story Flaw)
+> 
+> In many areas, a lord holds his land from a superior, in exchange for a mix of services and payments. This is represented by the Oath of Fealty Flaw (ArM5, page 56). This is a Major Story Flaw. For most non-player characters and many PCs this suffices, but troupes may wish to modify this slightly for several reasons.
+> 
+> Some nobles hold land simply through descent from people who have held it since time immemorial. These lands are called allods. A holder of allodial land need not have an Oath of Fealty. These characters also tend to use titles that are grander than others of similar power and influence, although that is ignored for the purpose of Virtue selection.
+> 
+> Troupes are encouraged to permit knights who have taken oaths to a lord, but whose oaths lack consequences in play. These insignificant oaths are not treated as Flaws, so they cannot be balanced against Virtues. Troupes may choose to allow insignificant oaths because otherwise knights cannot begin with many of the Story Flaws that suit the chivalric genre, like Black Sheep, Dark Secret, Enemies, Higher Purpose, Heir, True Love, or Vow. Player character knights are more interesting if they can have a range of Story Flaws.
+> 
+> #### Knightly Demands (Major Story Flaw)
+> 
+> As an alternative to all of this tinkering with detail, troupes may simply state that all knights have a Major Story Flaw, called Knightly Demands, that allows the Storyguide to drag them into any plot related to the kind of things knights do in medieval ballads. This flaw works best for high fantasy, highly mobile sagas, because it includes quests, military service, romances, feuds, rescuing damosels, aiding kinfolk, and chasing monsters. This flaw replaces Oath of Fealty entirely.
+> 
+> #### Knight (Minor Virtue)
+> 
+> Some few women serve as knights in Mythic Europe. These women are discussed in greater depth at the end of Chapter Two: Politics.
+> 
+> #### Landed Noble (Major Virtue)
+> 
+> A lord of the manor is the least senior style of landed noble. In England about half of the male manorial lords are knights. The rest are termed "gentry" or "squires" and could be knighted if they wished, but prefer to avoid it since there is a tax attached to the office. A lord of the manor has the Virtue Landed Noble. Knight and Protection are common Virtues, but are not required.
+> 
+> In the Norman-influenced parts of Mythic Europe, Wealthy Landed Nobles are far more numerically common than either standard or Poor Landed Nobles. The average holding in England has five manors. In areas where the land of a father is divided equally between his sons, Poor Landed Nobles are far more common. The children of Wealthy Landed Nobles, or more-senior landowners, often have the Privileged Upbringing Virtue.
+> 
+> A Poor Landed Noble usually has no surplus income. He has little free time, as he must continually administer his lands. This may be because he has debts, because his land has not recovered from a disaster, or because his manors were never fertile. He has one season of free time per year.
+> 
+> A lord of the manor without Virtue or Flaw has a second manor, for which he owes knight service. This service is performed by a mercenary or waived for scutage (a fine discussed in Chapter Two: Politics). The lord may summon up to ten villeins to fight as infantry, which is doubled if the war is defensive. Each knight is also served by a squire who acts as a sergeant, a mounted combatant. This Virtue leaves the lord two seasons of free time per year, and ten pounds to spend on largesse, war, or other discretionary matters.
+> 
+> A typical Wealthy Landed Noble holds, on average, five manors and lives at the richest, or the one to which he has the greatest sentimental attachment. These lands provide the lord with the service of four knights, other than himself, 5 serjants, and 50 villeins. If fighting in the same county, the lord may double the number of villeins who are required to assist him. The lord may spend money to swell the ranks of his personal army, and usually pays scutage for himself or sends a knight in his stead. He has three seasons of free time per year, and 20 pounds per year to spend as he wishes. His additional income comes from fertile land, active assarting in previous generations, or perhaps the lack of a knight-service on one of his manors.
+> 
+> #### Great Noble (Two Major Virtues)
+> 
+> This Virtue is used to represent the resources of a character of the rank of greater baron or higher. It should be treated as:
+> 
+> Two Major Virtues for characters played in lieu of magi, as major protagonists in the plot.
+> 
+> A Major Virtue for characters who, regardless of their rank, remain essentially supporting characters to the magi.
+> 
+> Players should discuss their characters with their troupes before designing greater nobles. It requires extra effort and careful character design to integrate a player character that is a Great Noble into a saga. The interests of the Great Noble tend to draw the character away from stories focused on the covenant, unless he is the covenant's servant.
 
 After a battle in which a knight acts as a banneret, his lord may award him the office by presenting him a banner. This allows a little largesse.
 
-Lords are sometimes tempted to raise people with smaller followings to this style, to allow them to have precedence over other knights. To do this, they need to give their vassal sufficient land to maintain additional knights. This is usually requires five or more manors, or rights of equivalent value. There is, therefore, little economic difference between a banneret and a Wealthy Landed Noble, although their status and spending patterns differ. Bannerets are always Knights and are generally Landed Nobles. Most have an Oath of Fealty to a liege and are under his Protection.
+Lords are sometimes tempted to raise people with smaller followings to this style, to allow them to have precedence over other knights. To do this, they need to give their vassal sufficient land to maintain additional knights. This usually requires five or more manors, or rights of equivalent value. There is, therefore, little economic difference between a banneret and a Wealthy Landed Noble, although their status and spending patterns differ. Bannerets are always Knights and are generally Landed Nobles. Most have an Oath of Fealty to a liege and are under his Protection.
 
+### Baron (Baro, Baron)
 
-## Baron (Baro, Baron)
+This term initially referred to anyone holding land directly from the king, but by 1220 has degenerated so that many lesser lords refer to their own vassals as their barons. Although landed people are aware of their status as barons, they do not use this term as a title. Minor landholders have a variety of titles that are traditionally translated as “lord” in English. A character might be lord of the barony of Blackhill, but would not be called Baron of Blackhill. Technically, baron is not a title, so it is not inherited: the land of the barony is inherited and possession of the land makes its holders barons, even if they divide the territory up.
 
-This. term. initially. referred. to. anyone. holding.land.directly.from.the.king,.but.by. 1220. has. degenerated. so. that. many. lesser. lords.refer.to.their.own.vassals.as.their.barons.. Although. landed. people. are. aware. of. their. status. as. barons,. they. do. not. use. this. term.as.a.title..Minor.landholders.have.a.variety.of.titles.that.are.traditionally.translated. as."lord".in.English..A.character.might.be.lord. of.the.barony.of.Blackhill,.but.would.not.be. called.Baron.of.Blackhill..Technically,.baron. is.not.a.title,.so.it.is.not.inherited:.the.land.of. the.barony.is.inherited.and.possession.of.the. land.makes.its.holders.barons,.even.if.they. divide.the.territory.up.
+The barons of England informally differentiate themselves into greater and lesser barons. The greater barons are those who, in the opinion of other great landholders, matter in affairs of state. Lesser barons are designed as Landed Nobles, and are generally Wealthy.
 
-The. barons. of. England. informally. differentiate.themselves.into.greater.and.lesser. barons.. The. greater. barons. are. those. who,. in. the. opinion. of. other. great. landholders,. matter. in. affairs. of. state.. Lesser. barons. are. designed.as.Landed.Nobles,.and.are.generally.Wealthy.
+A man is considered greater baron if he has at least some land held directly from the king and expenses of at least 400 pounds per year. This is roughly equivalent to holding 20 manors. He owes service for at least 20 knights, 20 serjants, and 200 infantry, but this is a bare minimum often exceeded. All barons have the Great Noble Virtue. Baronesses who hold land in their own right take the Great Noble Virtue, while those who hold the title by marriage take Gentlewoman. Most barons have the Protection Virtue and the Oath of Fealty Flaw, but this is dependent on the political climate of their realm.
 
-A. man. is. considered. greater. baron. if. he. has.at.least.some.land.held.directly.from.the. king.and.expenses.of.at.least.400.pounds.per. year..This.is.roughly.equivalent.to.holding.20. manors..He.owes.service.for.at.least.20.knights,. 20.serjants,.and.200.infantry,.but.this.is.a.bare. minimum.often.exceeded..All.barons.have.the. Great.Noble.Virtue..Baronesses.who.hold.land. in.their.own.right.take.the.Great.Noble.Virtue,. while.those.who.hold.the.title.by.marriage.take. Gentlewoman..Most.barons.have.the.Protection.Virtue.and.the.Oath.of.Fealty.Flaw,.but. this. is. dependent. on. the. political. climate. of. their.realm.
-
-Barons. vary. in. wealth.. A. poor. baron. has. no. surplus. money. at. all:. he. is. likely. in. deep. debt.. An. average. baron. has. a. surplus. of.40.pounds.per.year.that.may.be.spent.as. he.wishes..A.Wealthy.baron.has.100.surplus. pounds.a.year.
+Barons vary in wealth. A poor baron has no surplus money at all: he is likely in deep debt. An average baron has a surplus of 40 pounds per year that may be spent as he wishes. A Wealthy baron has 100 surplus pounds a year. 
 
 ### Earl or Count (Comes, Comte)
 
-In.England,.earl.the.basic.title.for.a.major.landholder..The.term."earl".comes.from. a.Saxon.word.and.is.used.instead.of.the.title. of.count.in.England.and.Scotland..The.term. "earl". is. also. used. in. English. for. the. lesser. kings.of.the.Gaelic-speaking.areas.of.Scotland,.and.for.noblemen.in.Ireland.and.Wales,. although.they.have.legal.powers.far.different. from.those.of.the.earls.of.England.
+In England, earl is the basic title for a major landholder. The term “earl” comes from a Saxon word and is used instead of the title of count in England and Scotland. The term “earl” is also used in English for the lesser kings of the Gaelic-speaking areas of Scotland, and for noblemen in Ireland and Wales, although they have legal powers far different from those of the earls of England.
 
-A.count.or.earl.has.the.Great.Noble.Virtue,. while. a. countess. (which. is. the. correct. term.for.the.wife.of.an.earl,.or.a.female.earl). has.Gentlewoman.if.she.does.not.hold.the. land.in.her.own.right..A.count.has.a.yearly. expenditure.of.at.least.1000.pounds..The.average. count. might. be. required. to. bring. 50. knights.to.battle,.along.with.their.sergeants. and. 500. infantry.. Large. vassal. armies. are,. however,.worthless.for.sieges,.because.sieges. usually.last.longer.than.the.period.of.service. required.of.vassals.each.year..Their.muster.is. often.commuted.to.cash.payment,.to.allow. the. king. or. count. to. hire. mercenaries.. An. average.count.has.100.pounds.to.spend.on. trivialities.per.year,.and.a.wealthy.one.250. pounds.
+A count or earl has the Great Noble Virtue, while a countess (which is the correct term for the wife of an earl, or a female earl) has Gentlewoman if she does not hold the land in her own right. A count has a yearly expenditure of at least 1000 pounds. The average count might be required to bring 50 knights to battle, along with their sergeants and 500 infantry. Large vassal armies are, however, worthless for sieges, because sieges usually last longer than the period of service required of vassals each year. Their muster is often commuted to cash payment, to allow the king or count to hire mercenaries. An average count has 100 pounds to spend on trivialities per year, and a wealthy one 250 pounds.
 
-## viscount (vice-coMes, viscoMte)
+#### Viscount (vice-comes, viscomte)
 
-A. viscount. was,. initially,. a. deputy. to. a. count.. In. 1220,. the. term. viscomte. is. used. in.France.for.lesser.counts..Its.Latin.form.is. used.in.England.for.sheriffs,.who.are.officers. of.the.king.
+A viscount was, initially, a deputy to a count. In 1220, the term viscomte is used in France for lesser counts. Its Latin form is used in England for sheriffs, who are officers of the king.
 
-#### Count palatine and MarcHer Lord
+#### Count Palatine and Marcher Lord
 
-A.count.palatine.is.a.count.who.has.been. given.extra.powers.to.deal.with.a.difficult.border..In.England.there.are.several.counties.palatine:.Durham,.which.is.near.the.Scots.border,. and.Chester,.on.the.Welsh.border,.are.both.still. points.of.strength..Ely.and.Kent.were.points. of. resistance. after. the. Conquest,. where. local. churchmen. were. given. additional. powers. to. subdue.the.population..This.role.is.intertwined. with.the.role.of.marcher.lord.
+A count palatine is a count who has been given extra powers to deal with a difficult border. In England there are several counties palatine: Durham, which is near the Scots border, and Chester, on the Welsh border, are both still points of strength. Ely and Kent were points of resistance after the Conquest, where local churchmen were given additional powers to subdue the population. This role is intertwined with the role of marcher lord.
 
-The.original.marcher.lords.were.placed. as.a.buffer.between.England.and.Wales.after. the. Conquest.. They. had. greater. authority:. the. right. to. do. anything. a. king. might. do,. such. as. build. castles,. levy. taxes,. make. war,. and. found. towns.. Powerful. marcher. lordships.were.eventually.elevated.into.earldoms,. and.some.of.their.rights.curbed,.but.the.legal.inheritors.of.Marcher.lordships.still.have. unusual.rights.compared.with.other.counts.. This.title.appears.in.France.only.in.the.title. of. the. Count. of. Marche,. whose. ancestor. had.a.similar.role.before.the.pacification.of. southern.France.
+The original marcher lords were placed as a buffer between England and Wales after the Conquest. They had greater authority: the right to do anything a king might do, such as build castles, levy taxes, make war, and found towns. Powerful marcher lordships were eventually elevated into earldoms, and some of their rights curbed, but the legal inheritors of Marcher lordships still have unusual rights compared with other counts. This title appears in France only in the title of the Count of Marche, whose ancestor had a similar role before the pacification of southern France.
 
-Some. marcher. lords. are. effectively. Wealthy. counts.. Their. role. is. usually. de-
+Some marcher lords are effectively Wealthy counts. Their role is usually defensive so they have fewer knights in their retinue than other counts, but proportionally more infantry. This allows them to garrison impressive royal or private castles.
 
-
-
-fensive so they have fewer knights in their retinue than other counts, but proportionally more infantry. This allows them to garrison impressive royal or private castles.
-
-## Duke (Dux, Duc)
+### Duke (Dux, Duc)
 
 This title initially meant war leader. It is used in France for the highest class of vassal, particularly in those areas that are culturally distinct. It is not used in Britain. Dukes control vast estates and, in some cases, are more powerful than the kings to whom they are nominally subservient.
 
 All dukes have the Greater Noble Virtue, while duchesses are Greater Nobles if they have a right to rule their lands, or Gentlewomen if they have their rank by marriage. As a rough estimate, a duke has, at minimum, personal forces that include 75 knights, their sergeants, and 750 infantry. The duke is also likely to have vassals able to extend his forces. The most powerful earl in England (which has no dukes) spends 6,000 pounds a year and can muster armies of hundreds of mercenary and vassal knights.
 
-## King (Rex, Roi)
+### King (Rex, Roi)
 
 A king is defined in his role by the fact that he pays allegiance to no living man, except perhaps the pope or emperor. Kings were initially the war leaders elected to lead powerful tribal groups in wars against their neighbors. This process of electing the king led, in earlier times, to civil wars, as the group of possible claimants to the throne thinned each other out before the decision could be made. In the current generation, elective kingship will die out in most of Western Europe. The principle of hereditary kingship was forced on the English nobility in 1215, when William Marshal defeated the forces of Prince Louis of France, who had been offered the crown by the barons of England.
 
-In France it has been traditional, for several generations, to force the electors to vote and acclaim the heir while the incumbent still lives. The electors, in theory, freely choose that the eldest son of the king will be the next king. The current king, Phillip Augustus, is the first in the current dynasty not to bother with this. He is able to do this in part because he has crushed so many of his vassals and taken their land into demesne that his heir will be the most significant land-
+In France it has been traditional, for several generations, to force the electors to vote and acclaim the heir while the incumbent still lives. The electors, in theory, freely choose that the eldest son of the king will be the next king. The current king, Phillip Augustus, is the first in the current dynasty not to bother with this. He is able to do this in part because he has crushed so many of his vassals and taken their land into demesne that his heir will be the most significant landholder in his kingdom.
 
-## How Powerful is a King?
+> ## How Powerful is a King?
+> 
+> Strong kings are often the most significant secular landowners in their kingdoms. The King of England, for example, holds between 15 and 20% of the arable land in his realm as royal demesne. The king's officers do not, generally, hold their positions through hereditary right. The king's lands are, therefore, often better administered than those of his vassals. The king's average income from all sources, for the last five years, was 60,000 pounds a year, but the baronial rebellion caused a collapse of royal revenues for a brief period that affects this average. A king is technically a Great Noble and need not be a Knight, although virtually all are.
+> 
+> The household army of the King of England contains over 60 knights in a practical sense, and in a legal sense contains another 60 or so, plus their retainers. These additional knights serve the king's interest in areas remote from the court, by holding significant castles, commanding armies, and arranging the logistics of campaigns. The king's household army also contains sergeants, squires, crossbowmen, and infantry. This personal force is highly responsive to the king's whim, mustering when and where he commands, and not dispersing after 40 days of campaigning as his vassals do.
+> 
+> The king has 45 vassals who are greater barons. Each owes him at least 20 knights in service each year, most many more. For generations the kings of England have preferred to take a large portion of this service as scutage and hire mercenaries with it instead.
 
-Strong kings are often the most significant secular landowners in their kingdoms. The King of England, for example, holds between 15 and 20% of the arable land in his realm as royal demesne. The king's officers do not, generally, hold their positions through hereditary right. The king's lands are, therefore, often better administered than those of his vassals. The king's average income from all sources, for the last five years, was 60,000 pounds a year, but the baronial rebellion caused a collapse of royal revenues for a brief period that affects this average. A king is technically a Great Noble and need not be a Knight, although virtually all are.
-
-The household army of the King of England contains over 60 knights in a practical sense, and in a legal sense contains another 60 or so, plus their retainers. These additional knights serve the king's interest in areas remote from the court, by holding significant castles, commanding armies, and arranging the logistics of campaigns. The king's household army also contains sergeants, squires, crossbowmen, and infantry. This personal force is highly responsive to the king's whim, mustering when and where he commands, and not dispersing after 40 days of campaigning as his vassals do.
-
-The king has 45 vassals who are greater barons. Each owes him at least 20 knights in service each year, most many more. For generations the kings of England have preferred to take a large portion of this service as scutage and hire mercenaries with it instead.
-
-## How Small is the Ruling Class of a Kingdom?
-
-At the time of the signing of the Magna Carta, five years ago, there were only 197 lay baronies and 32 ecclesiastical baronies in England. Many barons hold more than one barony. Only 45 people were considered "greater barons," landholders significant enough that the king sent them personal invitations to attend court. This includes the earls, of whom there were no more than a dozen. These 45 men are all closely related to each other by blood and marriage.
-
-The chivalric class is somewhat larger. There are between 5,000 and 6,000 knight's fees in England, although only about 1,500 of these are actually held by warrior knights, and another 1,500 are held by men who could become landed knights but have chosen not to for tax purposes. These squires have the Gentleman Social Status and Wealthy Virtues. Many other knights are found in the retinues of the king and nobles, but these are outside the landed class.
-
-holder in his kingdom.
+> ## How Small is the Ruling Class of a Kingdom?
+> 
+> At the time of the signing of the Magna Carta, five years ago, there were only 197 lay baronies and 32 ecclesiastical baronies in England. Many barons hold more than one barony. Only 45 people were considered "greater barons," landholders significant enough that the king sent them personal invitations to attend court. This includes the earls, of whom there were no more than a dozen. These 45 men are all closely related to each other by blood and marriage.
+> 
+> The chivalric class is somewhat larger. There are between 5,000 and 6,000 knight's fees in England, although only about 1,500 of these are actually held by warrior knights, and another 1,500 are held by men who could become landed knights but have chosen not to for tax purposes. These squires have the Gentleman Social Status and Wealthy Virtues. Many other knights are found in the retinues of the king and nobles, but these are outside the landed class.
 
 It is possible for a lesser noble to claim the title of king, but he effectively only becomes so when recognized as a king by some other significant power. This is usually the pope or, in the East, the emperor. The usual way of demonstrating the acceptance of this new status is the sending of royal regalia. In the West, kings are also anointed with the oil used to create bishops, although priests performing this ritual are careful to not anoint the head of a king as they would a bishop's.
 
@@ -1592,10 +1529,7 @@ The anointing of kings at coronation gives them several advantages. It clearly i
 
 ## The German System
 
-The German system presented below is an abstraction. The empire is such an amalgam of local titles, historical peculiarities, and special cases that there is insufficient space to detail its complexity. At its core the German system, like the French system, is a descendant of the Frankish Empire. Its roles
-
-
-are similar in many cases, although the titles for various positions have been naturalized or replaced.
+The German system presented below is an abstraction. The empire is such an amalgam of local titles, historical peculiarities, and special cases that there is insufficient space to detail its complexity. At its core the German system, like the French system, is a descendant of the Frankish Empire. Its roles are similar in many cases, although the titles for various positions have been naturalized or replaced.
 
 In the lists below, ranks are given their title in German, then Latin, then English. Note that the English form is just what a person of that status would be called in English. These titles are not found natively in English-speaking areas.
 
@@ -1603,7 +1537,7 @@ In the German system, there are three parallel sources of titles. Some titles co
 
 Many of the senior German nobles are sometimes referred to with the title fürst. This means prince, in the sense of being the first member of a particular family. The senior English nobility are similarly sometimes referred to as the Princes of the Realm. Prince, in the sense of a person who is the child of a king, is the separate title prinz.
 
-## Herr (Generosus, Lord)
+### Herr (Generosus, Lord)
 
 This title is used for any member of the nobility lacking a superior title. As such, it is used in much the same way lord is for the English gentry.
 
@@ -1611,7 +1545,7 @@ This title is used for any member of the nobility lacking a superior title. As s
 
 A freiherr is a nobleman with an allodial holding. It is sometimes translated as baron in English, and most freiherren are approximately equivalent in power to a minor count. An allod in the Holy Roman Empire can, however, vary in scale from the equivalent of a single manor up to territory similar in scope to a county. The title freiherr is, therefore, not really indicative of the power of the holder.
 
-## Ritter (Miles, Knight)
+### Ritter (Miles, Knight)
 
 This is a general term for cavalry soldiers. The German ritter plays the same role as the French chevalier or the English knight.
 
@@ -1619,7 +1553,7 @@ This is a general term for cavalry soldiers. The German ritter plays the same ro
 
 Some German knights are not free men. These knights are called ministeriales, and initially served militarily in exchange for their upkeep. Over time the role of ministeriales has broadened, so that some provide other services to a lord. The reichsministeriales, for example, assist many of the legal and administrative functions within the empire. Over time, families of the ministeriales are being absorbed into the hereditary class of knights.
 
-## Graf (Comes, Count/Earl)
+### Graf (Comes, Count/Earl)
 
 The role of a graf is similar to the role of a count. The term is modified to create many related titles in the German system. These include examples like buggraf (burgrave), which means the keeper of a castle or fortified town, or landgraf, which is a graf with a larger area of administrative responsibility than usual. A burgrave ranks as a viscount, slightly below the graf. A landgraf ranks slightly above a count.
 
@@ -1629,27 +1563,23 @@ This relatively rare title is a remnant of imperial expansion. A margrave was, i
 
 This title is not found in England, although the role is very similar to that of the counts palatine and marcher lords. It is similarly absent in France, although the County of Marche was once a march. Iberian nobles often believe they are descended from the nobility of the Spanish March founded by Constantine the Great. The family that rules both Barcelona and Provence claims that they are heirs of this ancient margraviate.
 
-## Herzog (Dux, Duke)
+### Herzog (Dux, Duke)
 
 A herzog plays an almost identical role to a French duke. That is, at the time of foundation of his territory, the herzog's predecessor was the warlord responsible for an area that had some sort of separate ethnic identity from the people who conquered it. Outside the empire, many duchies have been broken into counties, or have risen to become small kingdoms. The title has persisted in parts of the Holy Roman Empire because herzogs have not been permitted to take the title of king.
 
-## König (Rex, King)
+### König (Rex, King)
 
 Within the Holy Roman Empire the kingdoms are usually monopolized by the emperor. The current emperor-elect has reworked this system a little to suit his political needs, so that at the end of 1220 his son is technically king of the Romans and the Germans, with himself as regent. He has also permitted the duke of Bohemia to take the title of king.
 
 The current emperor is also king of Sicily, but this is not part of the empire, merely his personal possession. When he took the crown he promised the pope to separate the two roles by making his son king of Sicily and appointing a regent. Eventually he decided against this, preferring to keep his base of power in his own hands.
 
-## Römischer Kaiser (Romanorum Imperator, Roman Emperor)
+### Römischer Kaiser (Romanorum Imperator, Roman Emperor)
 
 There are no emperors in the classical Roman sense in Mythic Europe. Various kings call themselves "emperor of the Scots" or "emperor of Castile" but these fancies never last. In the West the title of Roman emperor is granted by the electors of the Holy Roman Empire. This work, and other **Ars Magica** books, uses the term "Holy Roman Empire" for this area, although that precise name does not occur in historical Europe until 1254.
 
-The electors of the empire gather, and appoint a king of the Germans. The pope, in a highly technical sense, appoints this man the emperor, and might theoretically
+The electors of the empire gather, and appoint a king of the Germans. The pope, in a highly technical sense, appoints this man the emperor, and might theoretically veto their choice. The pope anoints the king of the Germans as emperor of the Romans. When this happens, the emperor automatically becomes king of Burgundy and king of Italy.
 
-
-
-veto their choice. The pope anoints the king of the Germans as emperor of the Romans. When this happens, the emperor automatically becomes king of Burgundy and king of Italy.
-
-The current Holy Roman Emperorelect is Frederick II. He has held the role in practice since 1215, but is anointed on 22 November 1220. His center of power is in Sicily, although he controls a great deal of territory and has many allies in Germanspeaking areas. His court is open to Muslim and Christian scholars alike, and is considered a marvel of the age. He is a cultured man, with some interest in magic, but spends much of his time feuding with fractious warlords or the pope.
+The current Holy Roman Emperor elect is Frederick II. He has held the role in practice since 1215, but is anointed on 22 November 1220. His center of power is in Sicily, although he controls a great deal of territory and has many allies in German-speaking areas. His court is open to Muslim and Christian scholars alike, and is considered a marvel of the age. He is a cultured man, with some interest in magic, but spends much of his time feuding with fractious warlords or the pope.
 
 ## Iberian Systems
 
@@ -1669,18 +1599,15 @@ The meaning of this term varies markedly over time and place, but should be cons
 
 A caballero is a mounted warrior. He keeps his rank by maintaining his gear, and by taking the field when required. The fueros of towns list what gear is required to uphold caballero status. This varies a little but essentially a horse, breastplate, jerkin, javelins, and melee weapons are required. Swords are found rarely in fueros, perhaps because of their expense compared to axes and other popular choices. A caballero has social status and useful exemptions from some royal taxes, so the rank is a prized one.
 
-The role of caballero is based on military function, so it is defended and encouraged by law. Suits of gear, for example, must be passed along intact. Dead horses and destroyed gear must be replaced within a certain time (varying between one month and three years). Men with a certain amount of property are required to buy and maintain horse, so that they can either become a ca-
+The role of caballero is based on military function, so it is defended and encouraged by law. Suits of gear, for example, must be passed along intact. Dead horses and destroyed gear must be replaced within a certain time (varying between one month and three years). Men with a certain amount of property are required to buy and maintain horse, so that they can either become a caballero or send a surrogate on campaign. The tax exemptions and the title of caballero are sometimes given for exceptional non-cavalry service. In Portugal, for example a number of archers have this status.
 
-
-## Catalonia
-
-The noble classes of all Christian Iberian states have some relationship to the Frankish rulers of the Spanish Marches. Despite the differences between their system and that of the Frankish or modern French, they see their knights as sharing the Carolingian heritage. This is most directly seen in the County of Barcelona. The rulers of Barcelona have such close historical links to southern France, particularly Provence, that Catalonian chivalry is better modeled by the French system.
-
-In Catalonia the condes are served by viscondes, who are served by valvasores. A valvasore is a noble with a retinue of five knights, similar to a banneret. These three classes are considered noble and called barones, collectively. The vassals of these, with subinfeudated holdings, are the vasallos or cavallers. Cavallers are rulers of single castles. Their vassals are called sotcastlàs, who hold fiefs sufficient to support a one knight.
-
-Despite this panoply of titles, the core of the Catalan army is the militias, which are similar to the levy in the English system. They differ in that they are usually based on the trade guilds of towns.
-
-ballero or send a surrogate on campaign. The tax exemptions and the title of caballero are sometimes given for exceptional non-cavalry service. In Portugal, for example a number of archers have this status.
+> ## Catalonia
+> 
+> The noble classes of all Christian Iberian states have some relationship to the Frankish rulers of the Spanish Marches. Despite the differences between their system and that of the Frankish or modern French, they see their knights as sharing the Carolingian heritage. This is most directly seen in the County of Barcelona. The rulers of Barcelona have such close historical links to southern France, particularly Provence, that Catalonian chivalry is better modeled by the French system.
+> 
+> In Catalonia the condes are served by viscondes, who are served by valvasores. A valvasore is a noble with a retinue of five knights, similar to a banneret. These three classes are considered noble and called barones, collectively. The vassals of these, with subinfeudated holdings, are the vasallos or cavallers. Cavallers are rulers of single castles. Their vassals are called sotcastlàs, who hold fiefs sufficient to support a one knight.
+> 
+> Despite this panoply of titles, the core of the Catalan army is the militias, which are similar to the levy in the English system. They differ in that they are usually based on the trade guilds of towns.
 
 Players designing caballeros can either take the Knight Minor Social Status Virtue, or just use gear that belongs to the covenant. Caballeros are required to fight as dictated by local customs or the fuero of their town (which may be used as a Major Story Flaw, or ignored with troupe approval).
 
@@ -1692,7 +1619,7 @@ Within the general body of mounted warriors are further distinctions. A caballer
 
 An hidalgo is an ancestral caballero, often defined as one whose grandfathers were hidalgos. That is, he is a caballero whose family will support him in matters of honor. Lack of money is a matter of honor in Iberia, because a poor caballero can lose his status. Hidalgos are a little like the lords of the manor in the English system, in that they are considered qualitatively superior to the average knight, but they are not necessarily required to have grants of land. In some fueros it is assumed that the hidalgos will provide heavy cavalry and the villanos light cavalry, but this is not universal. Hidalgos have the Knight Virtue and either Gentleman or Landed Noble.
 
-## Ricohombre
+### Ricohombre
 
 The ricohombres, or great men, are the aristocratic upper class. They often claim descent from the Frankish Mark, or from the Visigothic kings. These great lords initially received offices from kings, called honores. These honors were rents from towns, or tracts of land in the agricultural hinterland of towns, that permit the ricohombre to maintain a noble lifestyle, including a personal army. Over time these honors have become hereditary in many places.
 
@@ -1710,9 +1637,7 @@ The eastern Empire, before its division, had transformed from a centralized real
 
 Following the fall of Constantinople, the leaders of the various successor states took over the role of general in their controlled provinces. Such leaders are called despots by those who prefer a different candidate as emperor. The despot grants revenues from lands to particular supporters in exchange for military support. These rights are called pronia, but are modeled on western fiefs. The armies of the Byzantine successor states are highly dependent on mercenaries for their field effectiveness. In the Latin Empire the structure used is essentially the French one.
 
-## Chapter Four
-
-# Interference
+# Chapter Four: Interference
 
 The Code of Hermes strictly forbids interference with mundanes, lest it bring ruin on the Order. This portion of the Code is the most flagrantly abused, with the possible exception of the prohibition against molesting faeries. Hundreds of years ago, when the Code was first sworn, covenants could dwell in allods far outside the concern of any nobleman, but that golden age of Hermetic seclusion is over now. Younger covenants, founded on less perfect sites, must interact with a burgeoning mundane population ruled by a warrior caste that demands the subservience of all other people.
 
@@ -1722,52 +1647,49 @@ Hermetic justice is democratic, and over time the Code has been stretched to exp
 
 Interference, like many crimes, is lucrative for characters able to avoid detection and punishment. Mortal society is fragile, but simultaneously complex, so the actions that magi take may have unintended consequences. These make for interesting future stories. The story seeds that follow the forms of interference in this section give examples of the kinds of stories that mundane interference can generate. These usually relate to the idea that everyone in the Order agrees is wrong: bringing harm to your sodales because of your actions.
 
-## Alternatives to Conspiracy
+### Alternatives to Conspiracy
 
 In every Tribunal, magi are forbidden to ally with mundane lords, in the sense that they are not permitted to take sides in disputes. Importantly for magi, however, mortal society is fragile and relatively easy to disrupt. Mundane lords fight each other all the time, and so to destroy a rival, it's not actually necessary to ally openly with his enemies. That is, assisting the enemy of one's enemy isn't conspiracy if the assistance is given without the "ally's" knowledge.
 
 A magus, for example, is feuding with a local noble, Lord Cuthbert. Cuthbert has an enemy, Sir Dudley, whom he is preparing to battle. It's not conspiracy to aid Sir Dudley so long as Sir Dudley doesn't know that it is happening. Conspiracy requires conspirators working consciously at common cause. If a magus were to poison the oxen pulling Cuthbert's supply train so he was pinned to a particular location, that would be fine. If Cuthbert's army had a lot of archers, and Dudley had mostly spearmen, causing it to rain so the bowstrings of Cuthbert's army were less effective would not be conspiracy.
 
-## Making Riches
+### Making Riches
 
 Magi can simply produce money magically, but this has created trouble with the mundanes in previous centuries, so making valuable goods is forbidden in some Tribunals. In others it is permitted as long as the created items are used only in the covenant, or provided that they are not traceable to the Order. Members of House Mercere are willing to transport created trade goods to distant places, and sell them in small amounts, in exchange for a substantial cut.
 
 A side effect of magical wealth creation is that magi with agricultural holdings can reduce the taxes their peasants pay to nothing: indeed they can go further, and pay wages. Although Chapter Six: Manorial Fiefs points out that lowering taxes makes peasants more restive, once a covenant offers the peasants more than the king does, they then use that restiveness to defend their unique position. That is, magi can't make peasants personally loyal, but they can make it so that the interests of the peasants align with those of the covenant.
 
-### Interference Varies by Tribunal
+> ### Interference Varies by Tribunal
+> 
+> The democratic nature of the Order's Tribunal system has led to interference being more strictly defined in some Tribunals than others. The Alps has the strongest regulations. It's a simplification, but there is some truth to the perception that if you can't find an isolated mountain valley and hide the entrance before founding your covenant, then you are not trying hard enough. At the other end of the scale, covenants in Normandy are expected to retain a veneer of mundanity that shields other members of the Order from blame for any trouble they cause. In Normandy an action is interference if it demonstrably harms the interests of other magi, so actions which might be considered interference elsewhere — like magical mind control, bribery, and assassination — are perversely employed in Normandy as ways to prevent demonstrable interference.
 
-The democratic nature of the Order's Tribunal system has led to interference being more strictly defined in some Tribunals than others. The Alps has the strongest regulations. It's a simplification, but there is some truth to the perception that if you can't find an isolated mountain valley and hide the entrance before founding your covenant, then you are not trying hard enough. At the other end of the scale, covenants in Normandy are expected to retain a veneer of mundanity that shields other members of the Order from blame for any trouble they cause. In Normandy an action is interference if it demonstrably harms the interests of other magi, so actions which might be considered interference elsewhere — like magical mind control, bribery, and assassination — are perversely employed in Normandy as ways to prevent demonstrable interference.
+### Magic Items
 
+Many members of the Order wish to trade magical items to nobles. The typical case involves the tame noble of a covenant being granted a longevity potion in exchange for his service, and this is easily accommodated by the Order. More difficult is the trade of magic items for land, money, or political support. Technically, no magus has been permitted to sell magic items to a nobleman since 1061, but an obvious loophole was designed that allows magi to sell magic items to mundane servants, who then may sell the items to outsiders. This means that the sale of magic items is easy, and that regulation occurs on the Tribunal level, rather than on an Order-wide basis.
 
+> ## Story Seeds: Items
+> 
+> A nobleman purchases a magic item that allows a single man to harvest a field in a day. This is such a popular idea that the next year, several more are purchased, and the noblemen begins hiring his magical harvesters to other nobles. This causes widespread poverty and prompts the formation of an angry peasant militia seeking to smash the items. Do the characters waylay the militia, or egg them on, knowing that if the devices are destroyed, the nobles will need to buy new ones? If it seems the militia are about to stray onto Hermetic lands, how do the magi divert them?
+> 
+> Some mundane nobles have used potent magic items against others of their class during war. This has led to interest in the Order's military potential, either because they are enduring a civil war, or because they are at peace allowing their rulers to contemplate crusading using magical weapons. Magi are threatened, and the characters are given the task of finding who is to blame. The items, when examined, are centuries old, so there is no magus to punish for their inappropriate use. The characters come to suspect that while the items are ancient, they were purchased recently. How can they find evidence to prove this?
+> 
+> A character seeks out the magi and purchases a single-use item that will strike a bloodline sterile. He does this in the hope of inheriting a portion of the family's land. He delivers the cursed item to a family banquet and it is activated. The player characters would prefer that the lands of the family do not become the battleground of rival claimants, as they have interests nearby. Knowing that they have decades before the heir is required and that the family is unlikely to understand the threat, how can the player characters position a tame nobleman now, to inherit it all? What do they do when the wife of one of their victims becomes pregnant after an affair? How do they deal with the original purchaser? If another covenant finds out, do they cut them in, or feud through proxies?
 
-Many members of the Order wish to trade magical items to nobles. The typical case involves the tame noble of a covenant being granted a longevity potion in exchange for his service, and this is easily accommodated by the Order. More difficult is the trade of magic items for land, money, or political support. Technically, no magus has been permitted to sell magic items to a nobleman since 1061, but an obvious loophole was designed that allows magi to sell magic items to mundane servants, who then may sell the items to outsiders. This means that the sale of magic items is easy, and that regulation occurs on the Tribunal level, rather
+> ## Story Seeds: Conspiracy's Consequences
+> 
+> The characters, or rival magi, have used magic to artificially boost the harvest of a nobleman who hates one of their enemies, and this nobleman they helped used this extra wealth to successfully defeat the hated foe. In this time, the population of the "friendly" nobleman's holding has tripled. If the magi withdraw their support it might lead to famine, and there will certainly be economic refugees. How can the magi reduce the population without causing widespread suffering and feeding Infernal auras?
+> 
+> The characters, or rival magi, have used weather magic or some other effect to help a nobleman win a series of battles. He takes this as a sign of divine favor and agitates for greater control of the surrounding lands. Driven on, perhaps by a demon of pride, he begins to convince others of his destiny. How can the players prevent needless warfare?
+> 
+> The characters, or rival magi, use illusions to replace a nobleman with a double shortly before a peace conference or other diplomatic event. Do they switch the characters back afterward? If they do, how do they hold the true nobleman to the promises made by his replacement? If they do not swap the characters back, how do they extract their minion? Do they imprison the noble, or kill him?
 
-## Story Seeds: Items
-
-A nobleman purchases a magic item that allows a single man to harvest a field in a day. This is such a popular idea that the next year, several more are purchased, and the noblemen begins hiring his magical harvesters to other nobles. This causes widespread poverty and prompts the formation of an angry peasant militia seeking to smash the items. Do the characters waylay the militia, or egg them on, knowing that if the devices are destroyed, the nobles will need to buy new ones? If it seems the militia are about to stray onto Hermetic lands, how do the magi divert them?
-
-Some mundane nobles have used potent magic items against others of their class during war. This has led to interest in the Order's military potential, either because they are enduring a civil war, or because they are at peace allowing their rulers to contemplate crusading using magical weapons. Magi are threatened, and the characters are given the task of finding who is to blame. The items, when examined, are centuries old, so there is no magus to punish for their inappropriate use. The characters come to suspect that while the items are ancient, they were purchased recently. How can they find evidence to prove this?
-
-A character seeks out the magi and purchases a single-use item that will strike a bloodline sterile. He does this in the hope of inheriting a portion of the family's land. He delivers the cursed item to a family banquet and it is activated. The player characters would prefer that the lands of the family do not become the battleground of rival claimants, as they have interests nearby. Knowing that they have decades before the heir is required and that the family is unlikely to understand the threat, how can the player characters position a tame nobleman now, to inherit it all? What do they do when the wife of one of their victims becomes pregnant after an affair? How do they deal with the original purchaser? If another covenant finds out, do they cut them in, or feud through proxies?
-
-## Story Seeds: Conspiracy's Consequences
-
-The characters, or rival magi, have used magic to artificially boost the harvest of a nobleman who hates one of their enemies, and this nobleman they helped used this extra wealth to successfully defeat the hated foe. In this time, the population of the "friendly" nobleman's holding has tripled. If the magi withdraw their support it might lead to famine, and there will certainly be economic refugees. How can the magi reduce the population without causing widespread suffering and feeding Infernal auras?
-
-The characters, or rival magi, have used weather magic or some other effect to help a nobleman win a series of battles. He takes this as a sign of divine favor and agitates for greater control of the surrounding lands. Driven on, perhaps by a demon of pride, he begins to convince others of his destiny. How can the players prevent needless warfare?
-
-The characters, or rival magi, use illusions to replace a nobleman with a double shortly before a peace conference or other diplomatic event. Do they switch the characters back afterward? If they do, how do they hold the true nobleman to the promises made by his replacement? If they do not swap the characters back, how do they extract their minion? Do they imprison the noble, or kill him?
-
-## Story Seeds: Making Riches
-
-Rich peasants naturally become politically active. In areas where they have traditional rights, they exercise them to defend their new privileges. Historically, this has often meant controls on immigration, regulation of off-manor marriage, or the creation of castes of "old families" (who get most of the benefits) and "new families" (who do not). How does the petty aristocracy form around the covenant? Is it divided by profession, or location in the village? How does it enforce its role in town affairs? If it decides, wisely, to do this by being useful to the magi, how does this express itself?
-
-Noblemen can't ignore magi who "steal" their serfs by offering them better living conditions. The Order allows magi to defend their properties if they are attacked, but a wise noble, perhaps goaded on by the covenant's enemies, declares that unless the characters accede to his demands, he will attack an entirely different covenant. This would make what the characters are doing a high crime, because it brings ruin on other magi, but are the rest of the Tribunal's magi willing to allow this tactic to succeed, and for this idea to germinate in the minds of the nobility?
-
-A nobleman has a pressing need for money for some worthy cause, like a crusade, and he prefers to take that money from people who are not good, like sorcerers. The covenant is fantastically rich, and so can afford to buy the noble off handsomely, but how far away does his crusade have to go to not bring ruin on the characters' sodales? Initially, the nobleman intends to crusade in Egypt. There are no members of the Order known to reside in that area, so that's probably fine. When magi learn he has changed his mind and will instead campaign in Iberia, can they use magical travel to steal back their resources? Can they find spells that will destroy the materials given to him from a distance? Can they get a message to Iberia and give resources of equal value to the other side, so that they aren't favoring a noble?
-
-
-than on an Order-wide basis.
+> ## Story Seeds: Making Riches
+> 
+> Rich peasants naturally become politically active. In areas where they have traditional rights, they exercise them to defend their new privileges. Historically, this has often meant controls on immigration, regulation of off-manor marriage, or the creation of castes of "old families" (who get most of the benefits) and "new families" (who do not). How does the petty aristocracy form around the covenant? Is it divided by profession, or location in the village? How does it enforce its role in town affairs? If it decides, wisely, to do this by being useful to the magi, how does this express itself?
+> 
+> Noblemen can't ignore magi who "steal" their serfs by offering them better living conditions. The Order allows magi to defend their properties if they are attacked, but a wise noble, perhaps goaded on by the covenant's enemies, declares that unless the characters accede to his demands, he will attack an entirely different covenant. This would make what the characters are doing a high crime, because it brings ruin on other magi, but are the rest of the Tribunal's magi willing to allow this tactic to succeed, and for this idea to germinate in the minds of the nobility?
+> 
+> A nobleman has a pressing need for money for some worthy cause, like a crusade, and he prefers to take that money from people who are not good, like sorcerers. The covenant is fantastically rich, and so can afford to buy the noble off handsomely, but how far away does his crusade have to go to not bring ruin on the characters' sodales? Initially, the nobleman intends to crusade in Egypt. There are no members of the Order known to reside in that area, so that's probably fine. When magi learn he has changed his mind and will instead campaign in Iberia, can they use magical travel to steal back their resources? Can they find spells that will destroy the materials given to him from a distance? Can they get a message to Iberia and give resources of equal value to the other side, so that they aren't favoring a noble?
 
 In most Tribunals there is some sort of limitation on how many magic items a magus may sell to mortal rulers. The commonest is that a magus may sell at most one magic item to a mortal per year, provided the system of mundane intermediaries is maintained. In some Tribunals the regulations are far looser.
 
@@ -1779,46 +1701,39 @@ This lack of regulation causes frequent problems for individual magi, and someti
 
 Note that to be acceptable, a magus's actions must usually be proportionate to the threat he faces. If a nobleman steals a keg of beer from a wagon belonging to the covenant, it is probably fair to steal something of equal value in retaliation, or soundly thrash his tax collectors, or burn the words "You owe me a keg of beer" through his door. It is not, according to a Tribunal ruling from Iberia, appropriate to burn down his castle and spell the same message with its smoking ashes.
 
-## Self-Defense
+### Self-Defense
 
 Members of the Order are permitted to defend themselves from harm. Harm is defined very broadly, but the finer level of detail varies by Tribunal. In the Rhine most covenants claim to be allodial and refuse to pay taxes. Trying to take them by force is considered harm to the magus's ability to fund his study, and can be met with force. Similarly, nobles who accidentally try to clear land which contains a vis source may be met with lethal magical force if required. In England, by comparison, there are no allods, and covenants pay a traditional fee, as if they were rented royal demenses, to officers of the king. Sheriffs trying to increase this fee may be met with force along the same general line of reasoning as in the Rhine.
 
-## Defense of Sodales
+### Defense of Sodales
 
-Members of the Order are permitted to do such things for a sodalis such that as any sensible sodalis would request that
+Members of the Order are permitted to do such things for a sodalis such that as any sensible sodalis would request that they do, in that sodalis's defense. If a magus is held prisoner, for example, it's not a Hermetic crime to break him out. If a Redcap is harmed, it is a duty to teach humility to his enemies. It is not a Hermetic crime to take children with The Gift, even though they are technically not sodales and are often the serfs of lords.
 
-## Story Seeds: Self-Defense?
+> ## Story Seeds: Self-Defense?
+> 
+> An elderly magus has refused to attend a county court to give evidence in a boundary dispute between two noblemen. He claims that it would be a waste of potential laboratory time, and that the noble he gave evidence against would consider him to be choosing sides in a dispute. His covenant has been fined by mundane authorities, but they refuse to pay, on the grounds of self-defense. Can other magi see a way forward in this dispute?
+> 
+> A Tribunal has been asked to rule on whether baiting of noblemen is allowed. A group of magi set up a profitable business in a town and made sure that a rival noble knew of it, but not of their ownership. When war began, the noble's troops raided the town. As the noble broke into the business to steal its wares he was killed by a *Waiting Spell* triggered by his specific presence. Is this reasonable self-defense? Some magi believe that a magus has the right to leave a pile of gold in the middle of the road and incinerate anyone who tries to take some, while others believe that frank disclosure of ownership is required before magical self-defense becomes appropriate.
 
-An elderly magus has refused to attend a county court to give evidence in a boundary dispute between two noblemen. He claims that it would be a waste of potential laboratory time, and that the noble he gave evidence against would consider him to be choosing sides in a dispute. His covenant has been fined by mundane authorities, but they refuse to pay, on the grounds of self-defense. Can other magi see a way forward in this dispute?
+### Defense of the Art
 
-A Tribunal has been asked to rule on whether baiting of noblemen is allowed. A group of magi set up a profitable business in a town and made sure that a rival noble knew of it, but not of their ownership. When war began, the noble's troops raided the town. As the noble broke into the business to steal its wares he was killed by a *Waiting Spell* triggered by his specific presence. Is this reasonable self-defense? Some magi believe that a magus has the right to leave a pile of gold in the middle of the road and incinerate anyone who tries to take some, while others believe that frank disclosure of ownership is required before magical self-defense becomes appropriate.
+Members of the Order are permitted to treat as an enemy anyone who publicly declares his intent to purge wizards from an area. These declarations were relatively common during the Schism War. It is the opinion of the Order that when someone declares all magi his enemy, he may be taken at his word.
 
-
-
-they do, in that sodalis's defense. If a magus is held prisoner, for example, it's not a Hermetic crime to break him out. If a Redcap is harmed, it is a duty to teach humility to his enemies. It is not a Hermetic crime to take children with The Gift, even though they are technically not sodales and are often the serfs of lords.
-
-## Defense of the Art
-
-Members of the Order are permitted to treat as an enemy anyone who publicly declares his intent to purge wizards from an area. These declarations were relatively common during the Schism War. It is the
-
-## Story Seeds: Defense of Sodales
-
-The characters, or NPC allies, steal a child with The Gift from a monastery. The child's father placed him there certain that the pope would release the child from his vows if his older brothers died on crusade, allowing him to become an heir to the father's lands once more. The child has been taken as an apprentice, but has only a smattering of Magic Theory. Should he be returned when his older brothers do, in fact, die, or is a Gifted child taken from a life of mere nobility being given a matchless opportunity, regardless of the wishes of his parents? In some Tribunals, a magus's children may inherit land, skipping over the magus as if he had entered the Church after fathering the child, or been struck down by a disabling malady. Could a rule such as this allow a compromise?
-
-A Redcap has an affair with a married, female serf, who runs away with him and becomes his apprentice. When her lord comes to collect her, the Redcap stabs him, although not fatally, claiming that his apprentice has as much right to protection as any Gifted member of the Order. If the noble attacks the Redcap, what should the player characters do? If the woman demonstrates some magical talent, like Direction Sense or Dowsing, does this change the attitude of the characters? What if she has a personal vis source?
-
-opinion of the Order that when someone declares all magi his enemy, he may be taken at his word.
+> ## Story Seeds: Defense of Sodales
+> 
+> The characters, or NPC allies, steal a child with The Gift from a monastery. The child's father placed him there certain that the pope would release the child from his vows if his older brothers died on crusade, allowing him to become an heir to the father's lands once more. The child has been taken as an apprentice, but has only a smattering of Magic Theory. Should he be returned when his older brothers do, in fact, die, or is a Gifted child taken from a life of mere nobility being given a matchless opportunity, regardless of the wishes of his parents? In some Tribunals, a magus's children may inherit land, skipping over the magus as if he had entered the Church after fathering the child, or been struck down by a disabling malady. Could a rule such as this allow a compromise?
+> 
+> A Redcap has an affair with a married, female serf, who runs away with him and becomes his apprentice. When her lord comes to collect her, the Redcap stabs him, although not fatally, claiming that his apprentice has as much right to protection as any Gifted member of the Order. If the noble attacks the Redcap, what should the player characters do? If the woman demonstrates some magical talent, like Direction Sense or Dowsing, does this change the attitude of the characters? What if she has a personal vis source?
 
 ## How Much Do Nobles Know?
 
-Most nobles know of magi, although the information they have is usually a mixture of folktale, fabrication, and fact. This is due to a jumble of Hermetic reputation-making,
+Most nobles know of magi, although the information they have is usually a mixture of folktale, fabrication, and fact. This is due to a jumble of Hermetic reputation-making, deliberate lies, demonic deception, faerie games, and the exaggerations of troubadours. Educated nobles may have low Order of Hermes Lore scores, and those who have family members — either current or ancestral — associated with House Jerbiton may know far more. Many nobles who know little about the Order know someone they can ask for greater detail, either a scholarly relative, an advisor from the church, or a hedge wizard.
 
-## Story Seed: Defense of the Art
-
-A group of hedge witches have angered a baron and he has declared they are to be purged from the area. Hermetic interests are likely to be disrupted in the short term, although once the wise women have been cleared away the magi may be able to collect vis from sites the witches once claimed. Do the magi simply wait out the purge, or do they want to nip the idea of crushing magicians as quickly as possible? Is this sufficient for the magi to convince a Tribunal that they acted to defend the Art?
-
-A group of invaders believes the best way to pacify the land is to pay off or kill all of its magicians. Does this sort of offer — which may be paraphrased as "Take our gold and shut up, or die!" allow player character magi to defend the Art? How do the magi deal with more distant covenants who feel that this is a very reasonable way of behaving? Do the magi change their minds when the invading nobleman complains to the Tribunal that the magi are gathering an annual payment from him, but not his enemy? (The basis of his complaint is that the current situation allows his enemy to hire more mercenaries, and so the magi have effectively given preferential treatment to his enemy.) Do the magi give the invader his money back, or opt instead to destroy some of the rival's resources?
-
+> ## Story Seed: Defense of the Art
+> 
+> A group of hedge witches have angered a baron and he has declared they are to be purged from the area. Hermetic interests are likely to be disrupted in the short term, although once the wise women have been cleared away the magi may be able to collect vis from sites the witches once claimed. Do the magi simply wait out the purge, or do they want to nip the idea of crushing magicians as quickly as possible? Is this sufficient for the magi to convince a Tribunal that they acted to defend the Art?
+> 
+> A group of invaders believes the best way to pacify the land is to pay off or kill all of its magicians. Does this sort of offer — which may be paraphrased as "Take our gold and shut up, or die!" allow player character magi to defend the Art? How do the magi deal with more distant covenants who feel that this is a very reasonable way of behaving? Do the magi change their minds when the invading nobleman complains to the Tribunal that the magi are gathering an annual payment from him, but not his enemy? (The basis of his complaint is that the current situation allows his enemy to hire more mercenaries, and so the magi have effectively given preferential treatment to his enemy.) Do the magi give the invader his money back, or opt instead to destroy some of the rival's resources?
 
 The factual information nobles have varies, but almost all of them know that magi…
 
@@ -1826,33 +1741,7 @@ The factual information nobles have varies, but almost all of them know that mag
 - are part of a larger group that forbids them from ruling lands distant from where they live
 - are divided into families by the type of magic they do
 - cannot teach their own children, or each other's children, but instead take misfits as apprentices from the rest of society
-- are forbidden to take sides in wars, but
-
-### The Nature of the Plea
-
-Most Tribunals have some way for noblemen to make known that they have a legal issue with the Order. The precise method varies from Tribunal to Tribunal, from a magic item that whisks glass bottles to a covenant's safehouse, to an inn where retired redcaps live, to a formalized schedule of audiences with local nobles. These facilities were almost always initially designed by some covenant but over time fell to the administration of the redcaps, House Guernicus, or House Jerbiton. The degree of investigation that actually occurs into the matters noblemen bring to the Order's attention varies among Tribunals.
-
-Note that pleas entered to the Order by noblemen are not considered "real" by most nobles or churchmen, because the Order is not seen as a legitimate font of justice. The plea is, instead, treated rather like a complaint to a guildhall that a member has been using false weights. Sometimes it works, and it is worth a try, but there's no one to complain to if it doesn't work and there is no way to check whether the investigation was carried out properly.
-
-
-## Magic Resistance For Church Officers and Sovereigns
-
-The religious and secular leaders listed below receive a Magic Resistance score as listed here, and a Soak bonus equal to Resistance / 5. Excommunication cancels these benefits (but only if the excommunication is God's will). Those listed here also have a Penetration 0 *Aura of Rightful Authority* extending to Voice Range.
-
-| Pope                | 25 |
-|---------------------|----|
-| Cardinal            | 20 |
-| Archbishop          | 10 |
-| King (once crowned) | 10 |
-
-- Wives gain Magic Resistance equal to their husbands.
-- Magic Resistance from relics is added to the above, but does not affect Soak.
-
-## Demonstrating Harm
-
-An important part of the process of a plea is the demonstration of harm. Many Jerbiton magi, and some covenants from House Mercere, deliberately intertwine their financial affairs with those of a major city. Damage to its economy, caused by other magi, is therefore a Hermetic crime. This role is not legally recognized by the Order, but is informally recognized by its members, particularly those interested in the enforcement of the Code.
-
-may fight in self-defense
+- are forbidden to take sides in wars, but may fight in self-defense
 
 - are served by a caste of messengers who wear red caps.
 - teach cruel lessons to those who harm their messengers
@@ -1860,14 +1749,34 @@ may fight in self-defense
 - have animal companions with human intelligence
 - grow strange trees they harvest for power
 - hunt magical animals and faeries
-- leave places in response to complaints,
-
-
-and act on just pleas
-
+- leave places in response to complaints, and act on just pleas
 - live longer than normal people
 - sell magical items, including weapons and methods of extending one's lifespan
 - had a terrible war that destroyed much of the countryside centuries ago, when some of their number turned to Satan
+
+> ## The Nature of the Plea
+> 
+> Most Tribunals have some way for noblemen to make known that they have a legal issue with the Order. The precise method varies from Tribunal to Tribunal, from a magic item that whisks glass bottles to a covenant's safehouse, to an inn where retired redcaps live, to a formalized schedule of audiences with local nobles. These facilities were almost always initially designed by some covenant but over time fell to the administration of the redcaps, House Guernicus, or House Jerbiton. The degree of investigation that actually occurs into the matters noblemen bring to the Order's attention varies among Tribunals.
+> 
+> Note that pleas entered to the Order by noblemen are not considered "real" by most nobles or churchmen, because the Order is not seen as a legitimate font of justice. The plea is, instead, treated rather like a complaint to a guildhall that a member has been using false weights. Sometimes it works, and it is worth a try, but there's no one to complain to if it doesn't work and there is no way to check whether the investigation was carried out properly.
+
+> ## Magic Resistance For Church Officers and Sovereigns
+> 
+> The religious and secular leaders listed below receive a Magic Resistance score as listed here, and a Soak bonus equal to Resistance / 5. Excommunication cancels these benefits (but only if the excommunication is God's will). Those listed here also have a Penetration 0 *Aura of Rightful Authority* extending to Voice Range.
+> 
+> |  |  |
+> |--|--:|
+> | Pope | 25 |
+> | Cardinal | 20 |
+> | Archbishop | 10 |
+> | King (once crowned) | 10 |
+> 
+> - Wives gain Magic Resistance equal to their husbands.
+> - Magic Resistance from relics is added to the above, but does not affect Soak.
+
+> ## Demonstrating Harm
+> 
+> An important part of the process of a plea is the demonstration of harm. Many Jerbiton magi, and some covenants from House Mercere, deliberately intertwine their financial affairs with those of a major city. Damage to its economy, caused by other magi, is therefore a Hermetic crime. This role is not legally recognized by the Order, but is informally recognized by its members, particularly those interested in the enforcement of the Code.
 
 Senior nobles of scholarly inclination know more:
 
@@ -1877,10 +1786,7 @@ Senior nobles of scholarly inclination know more:
 - The name and approximate boundary of the local Tribunal in which the noble lives.
 - The Order is democratic.
 - The Order has laws that are enforced by its members.
-- Magi usually live in places that feel
-
-strange and vivid.
-
+- Magi usually live in places that feel strange and vivid.
 - Kings and senior churchmen have some mystical protection from magical influence.
 - Carrying relics provides some resistance to magical influence.
 
@@ -1896,39 +1802,37 @@ Many common misconceptions about members of the Order are spread by House Jerbit
 
 Nobles who interact with magi, particularly those from Houses other than Jerbiton, are more likely to realize that these are misconceptions.
 
-
 ## Why Don't Magi Break Mythic European Feudalism?
 
 Mythic Europe's political and economic systems are fragile when they interact with magicians. Despite obvious ways for magi to revolutionize Europe, the Order is largely peripheral to Mythic European society, to the extent that Mythic Europe appears virtually identical to historical Europe. One of your tasks, as a player or storyguide in an **Ars Magica** saga, is to explain or ignore this feature of the setting. Troupes should discuss their approach to the impact of magi on society when designing their sagas, selecting an approach that suits the stories they wish to tell. Different options are discussed and explored in the sections that follow.
 
-## Ignore It
+### Ignore It
 
 Ignoring the elements of the setting that don't seamlessly cohere between Mythic and historical Europe is the simplest solution, and the one suggested for most troupes. Suspension of disbelief is required for the enjoyment of virtually every other roleplaying game or piece of genre fiction. In most sagas, there are knights and castles and magi all thrown together because the players enjoy mixing them, and even if it doesn't make a lot of sense as a simulation of a functioning world, that's not what matters.
 
-## The Code Works as Intended
+### The Code Works as Intended
 
 Players may not be clear why, exactly, but in some sagas the magi who wrote the Code simply understood Mythic Europe better than they do. The Code works. If this seems implausible, it's because players don't understand the underlying structure of the Mythic European world. The Code is a perfectly tailored instrument for the preservation of that underlying order.
 
-## Lucky Coincidence
+### Lucky Coincidence
 
 In some sagas, the similarity of Mythic Europe to historical Europe is simply coincidence. These sagas assume that the course of history has been roughly as described by real historians up until 1220. During the saga, the player characters may accidentally or deliberately instigate a clash between the Order and one of the other estates. Alternatively, they may need to react when other characters engineer a confrontation.
 
-## A Conspiracy of Realms
+### A Conspiracy of Realms
 
 In a campaign with hidden forces, the similarities between historical and Mythic Europe are superficial. Mythic Europe's economy and kingdoms have their structure because an underlying force, or series of contesting forces, have shaped them. These forces defend the status quo, either by coaxing events gently toward a perpetuation of current structures, or by making examples of those who transgress.
 
-## Story Seed: Judgment
+> ## Story Seed: Judgment
+> 
+> Over the centuries, a few covenants have been destroyed by overt acts of God. The Quaesitores examine these sites, hoping to determine what provoked the Divine. Generally they conclude that the destroyed magi were diabolists. Many magi scoff at this conclusion, because God did not directly intervene during the Corruption of House Tytalus. They suggest that there must be some other connecting thread, some other forbidden secret that these magi dared to explore. If a covenant in the characters’ Tribunal is destroyed in a way that is clearly a Divine judgement, do they investigate? How does this affect the political factions of the Tribunal? Can a vast, destructive miracle be faked? Who would do such a thing? How many covenants have fallen, over the centuries, to such malefactors?
 
-Over the centuries, a few covenants have been destroyed by overt acts of God. The Quaesitores examine these sites, hoping to determine what provoked the Divine. Generally they conclude that the destroyed magi were diabolists. Many magi scoff at this conclusion, because God did not directly intervene during the Corruption of House Tytalus. They suggest that there must be some other connecting thread, some other forbidden secret that these magi dared to explore. If a covenant in the characters' Tribunal is destroyed in a way that is clearly a Divine judgement, do they investigate? How does this affect the political factions of the Tribunal? Can a vast, destructive miracle be faked? Who would do such a thing? How many covenants have fallen, over the centuries, to such malefactors?
-
-
-of the forces that could have shaped Mythic Europe for these reasons, and troupes may mix these influences as suits the stories they wish to tell.
+Each of the following sections details one of the forces that could have shaped Mythic Europe for these reasons, and troupes may mix these influences as suits the stories they wish to tell.
 
 #### God Has A Plan
 
 The will of God is difficult to successfully describe for Mythic Europeans. Some saints, supported by miracles, believe that the poor should be succored at the expense of the rich and that peace is desirable in all circumstances. These gentle souls may be contrasted with the many churchmen who suggest that good kings are instruments of the Divine will, and even wicked kings deserve their due by customary law, because they are the scourges of God.
 
-Many Hermetic magi have personal beliefs concerning the will of God that oppose meddling in mundane affairs. It is clear to them, from simple observation, that God does not favor the casting of magic in large cities, or at the sites of certain holy events, because the Dominion suppresses magic in these places. Similarly, the relics of saints provide Magic Resistance. But at the same time, God does not regularly strike down magi with angelic visitations, overt miracles, or crowds of the Divinely inspired. These manifestation of Divine will are more frequently deployed against diabolists and the worshipers of the pagan gods.
+Many Hermetic magi have personal beliefs concerning the will of God that oppose meddling in mundane affairs. It is clear to them, from simple observation, that God does not favor the casting of magic in large cities, or at the sites of certain holy events, because the Dominion suppresses magic in these places. Similarly, the relics of saints provide Magic Resistance. But at the same time, God does not regularly strike down magi with angelic visitations, overt miracles, or crowds of the Divinely inspired. These manifestations of Divine will are more frequently deployed against diabolists and the worshipers of the pagan gods.
 
 Such magi note that the Divine seems to prefer the Order to do much as it does. But even so, the parameters of the Divine's plan for the Order are unclear. Thus, many magi are cautious when their affairs cross those of agents of the highest Realm, because they are unsure what God will allow.
 
@@ -1936,10 +1840,9 @@ Such magi note that the Divine seems to prefer the Order to do much as it does. 
 
 The current social structure of Mythic Europe tempts the powerful. Europe's military caste engages in indecisive wars, causing great suffering. Noblemen believe, falsely, that they can reduce this suffering by having larger armies so they can conduct shorter and more successful wars. This tempts them further, to levy unjust taxes and commit atrocities, to speed the conduct of the war. Powerful demons would oppose any character who tried to reform the social system of Europe, if in doing so these reformers alleviated the suffering of the poor, or removed the militant ruling caste.
 
-
-
-
-Many magi think that an easy way to create wealth is to manipulate the harvests of the towns under their control. This strategy is simple and can be pursued inconspicuously if spells with long Ranges or broad Targets are used. In this story seed, a covenant that creates bountiful crops angers famine demons, who flock from across the country to assault the covenant's servants and supplies. The characters are aided by a mysterious figure, which they later discover to be a demon of avarice. He is hoping that the small town, made wealthy, will develop a strong merchant class where he can more easily claim souls that suit his personal preference.
+> ## Story Seed: Rival Demon Factions
+> 
+> Many magi think that an easy way to create wealth is to manipulate the harvests of the towns under their control. This strategy is simple and can be pursued inconspicuously if spells with long Ranges or broad Targets are used. In this story seed, a covenant that creates bountiful crops angers famine demons, who flock from across the country to assault the covenant's servants and supplies. The characters are aided by a mysterious figure, which they later discover to be a demon of avarice. He is hoping that the small town, made wealthy, will develop a strong merchant class where he can more easily claim souls that suit his personal preference.
 
 #### Faeries Inadvertently Defend the Status Quo
 
@@ -1951,194 +1854,169 @@ Some magi conjecture that in the depths of Arcadia, beyond even the deep realms 
 
 Feudalism may exist in part because magi find it a convenient way to hobble the power of the nobility. Feudalism distributes power, diluting it into antagonistic blocs. This makes it easy for magi to inconspicuously favor one side in mundane affairs. For example, a series of bountiful harvests that allow a particular warlord to hire mercenaries and attack his rival may allow magi to assassinate one of their enemies without any crime, sin, or evidence. Perpetually impoverished and dedicated to petty feuds of honor, the nobility of Mythic Europe are easy prey and willing dupes for clever magi.
 
-## Story Seed: The Counterfeit Lordling
+> ## Story Seed: The Counterfeit Lordling
+> 
+> A powerful faerie is the ancestor spirit to the family of noblemen with rights over a nearby village. When the family dies out, it kidnaps a child and, dressing it in the clothes of an infant of the family killed by bandits, deposits in on the doorstep of the town's church. The characters may be able to prove the child is false. This would please the group of merchants hoping that the end of the line will allow the land to revert to the king, who can be paid for charter rights. This would make the village a proper town, with independence from local nobles, and the right to elect a council for a government. The young lord's interests will, however, be defended by the faerie lord and his servants, who take the shapes of ancestral ghosts.
 
-A powerful faerie is the ancestor spirit to the family of noblemen with rights over a nearby village. When the family dies out, it kidnaps a child and, dressing it in the clothes of an infant of the family killed by bandits, deposits in on the doorstep of the town's church. The characters may be able to prove the child is false. This would please the group of merchants hoping that the end of the line will allow the land to revert to the king, who can be paid for charter rights. This would make the village a proper town, with independence from local nobles, and the right to elect a council for a government. The young lord's interests will, however, be defended by the faerie lord and his servants, who take the shapes of ancestral ghosts.
-
-
-## Chapter Five
-
-# Leisure
+# Chapter Five: Leisure
 
 The lives of the nobility are busy and their obligations many, yet like everybody else they pursue leisure activities. Having the wealth and opportunity to pursue expensive hobbies and interests, they do so, becoming dedicated to lavish entertainments and sports suitable to their standing. While many noble leisure activities are shared with all orders of society, hunting, hawking, and tournaments are all primarily noble sports and are therefore given more a detailed description in this chapter, as are the feasts that provide entertainment in noble households.
 
 Children play as children always play, exploring their locality, fighting and brawling, and playing with wooden toys or a ball. Noble boys are, of course, expected to show leadership, to play with wooden swords and the ever-popular hobby horse, and to emulate their elders' martial prowess. Some children die and are injured in such games, and while infant mortality is high parents are still distraught and horrified by such tragedies, and fret over their infants' safety. Noble children play with the other household children indiscriminately. Popular children's games often involve imitating adult pursuits, playing at celebrating Mass, or holding mock scholarly debates. Some games, like hoodman's bluff (blind man's bluff), skipping, whipping tops, seesaws, chase, and walking on stilts, are almost entirely children's activities.
 
-## Pets
+### Pets
 
-From childhood onwards the keeping of animals as pets is common. People love animals, and while most beasts kept are for food or as working animals, all classes of society, even monks and nuns, keep pets. These range from the ubiquitous dogs to animals such as caged songbirds, monkeys, squirrels, and magpies. The latter can mimic human voices and are often trained
+From childhood onwards the keeping of animals as pets is common. People love animals, and while most beasts kept are for food or as working animals, all classes of society, even monks and nuns, keep pets. These range from the ubiquitous dogs to animals such as caged songbirds, monkeys, squirrels, and magpies. The latter can mimic human voices and are often trained to speak parrot-fashion. Noble ladies favor tiny lap dogs, which clearly are not working animals, hence demonstrating their ability to spend on frivolities and thus their high status. As with all noble life, conspicuous consumption rather than frugality is to be admired.
 
-
-to speak parrot-fashion. Noble ladies favor tiny lap dogs, which clearly are not working animals, hence demonstrating their ability to spend on frivolities and thus their high status. As with all noble life, conspicuous consumption rather than frugality is to be admired.
+> ## Some Unusual Pets
+> 
+> Some medieval pets seem unusual to a modern reader, but were widely kept even by monks and nuns. Game statistics are given for some of these animals here. These animals may be trained by their owners. The animals' Qualities are described here in terms of the rules given in *Houses of Hermes: Mystery Cults*, page 40 but necessary skill modifiers are summarized here for ease of reference. These statistics are for mundane versions of these animals, but may be used as templates for Magical Animal Companions.
+> 
+> ### Magpie
+> 
+> **Characteristics:** Cun 0, Per +2, Pre –2, Com +1, Str –8, Sta 0, Dex +3, Qik +5
+> 
+> **Size:** –4
+> 
+> **Qualities:** Crafty, Mimicry, Timid, Vocal **Personality Traits:** Mischievous +2
+> 
+> **Combat:**
+> 
+> Bite: Init +4, Attack +9, Defense +9, Damage –7
+> 
+> Dodge: Init +4, Attack n/a, Defense +9, Damage n/a
+> 
+> **Soak:** 0
+> 
+> **Fatigue Levels:** OK, 0, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+)
+> 
+> **Abilities:** Athletics 3 (flying), Awareness 4 (predators), Brawl 4 (dodge), Music 3 (mimicry), Stealth 4 (hiding), Survival 3 (foraging)
+> 
+> ### Monkey
+> 
+> **Characteristics:** Cun +2, Per 0, Pre –3, Com –3, Str –6, Sta 0, Dex +2, Qik +3
+> 
+> **Size:** –3
+> 
+> **Qualities:** Crafty, Defensive Fighter, Skilled Climber, Timid +3 to all climb rolls.
+> 
+> **Personality Traits:** Mischievous +2 **Combat:**
+> 
+> *Bite:* Init +3, Attack +9, Defense +8, Damage –5
+> 
+> *Dodge:* Init +3, Attack n/a, Defense +8, Damage n/a
+> 
+> **Soak:** 0
+> 
+> **Fatigue Levels:** OK, 0, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–2), –3 (3–4), –5 (5–6), Incapacitated (7–8), Dead (9+)
+> 
+> **Abilities:** Athletics 3 (climbing), Awareness 4 (food), Brawl 4 (dodge), Stealth 4 (hiding), Survival 3 (foraging)
+> 
+> ### Squirrel
+> 
+> **Characteristics:** Cun +1, Per 0, Pre –3, Com –5, Str –12, Sta +1, Dex +3, Qik +5
+> 
+> **Size:** –7
+> 
+> **Qualities:** Crafty, Defensive Fighter, Skilled Climber, Timid +3 to all climb rolls.
+> 
+> **Virtues & Flaws**: Lightning Reflexes **Personality Traits:** Timid +3, Acquisitive +2, Inquisitive +1
+> 
+> **Combat:**
+> 
+> *Dodge:* Init +5, Attack n/a, Defense +10, Damage n/a
+> 
+> **Soak:** +1
+> 
+> **Fatigue Levels:** OK, 0, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+)
+> 
+> **Abilities:** Athletics 3 (climbing), Awareness 4 (food), Brawl 4 (dodge), Stealth 4 (hiding), Survival 3 (foraging)
 
 ### Outdoor Pursuits
 
 Many adults pass leisure time in a variety of sports. Ball games featuring a leather ball are popular, and some use bats or heavy gloves. Handball is played against any stone wall, with players taking turns to strike the ball so it ricochets back, and bittle-battle involves a stick with a head being used to strike a ball, sometimes to try to knock it in to a hole. There is also stoolball, in which ladies sitting on milking stools try to avoid being struck by a ball bowled or kicked by men. Shuttlecocks are used in racket games, which are very popular.
 
-Throwing stones for distance or accuracy forms the basis of many games, and weightlifting and contests of strength are common. Mob football or camp-ball is played between entire villages. In the wintertime ice skating on bone skates is very popular in northern
+Throwing stones for distance or accuracy forms the basis of many games, and weightlifting and contests of strength are common. Mob football or camp-ball is played between entire villages. In the wintertime ice skating on bone skates is very popular in northern climes, though tragedies often occur when the ice breaks. Skaters propel themselves with two wooden poles, and "jousting" with these skate poles on a frozen river is a popular pursuit. Every so often — as with ice skating — the ice breaks and some poor unfortunate drowns, but this seems to do little to deter the practice. Just as common are ball games played on the ice, and the ever popular snowball fight.
 
-
-
-climes, though tragedies often occur when the ice breaks. Skaters propel themselves with two wooden poles, and "jousting" with these skate poles on a frozen river is a popular pursuit. Every so often — as with ice skating — the ice breaks and some poor unfortunate drowns, but this seems to do little to deter the practice. Just as common are ball games played on the ice, and the ever popular snowball fight.
-
-## Board Games
+### Board Games
 
 More cerebral games are also played. Chess is a common game, prized for its supposed ability to teach military tactics and strategy. There are many variants of the rules of chess, and a large number of players employ dice either to decide what pieces can be moved, or to decide how far certain pieces are moved. Merels, or nine man's morris, is widely played, as is fox and geese, a board game that also has links to one of the most popular board games of all, tafl. Tafl exists in many variants, and involves two unequally matched sets of pieces, with one as defender and one as attacker, played on a cross-shaped board of squares. The defender attempts, as in chess, to protect his king, and the attacker to take it. Only in the last hundred years has chess begun to supplant tafl as the favored noble strategy game, but both are still played extensively. Related is the Celtic fidchell or wood-sense, another game of protect-theking, in this case played on a seven-by-seven grid of squares. Vying with these games for popularity are the many variants of tables, which resemble backgammon. The academically inclined play rithmomachia, the philosopher's game, another popular board game of the period.
 
 Board games are played by all classes, but skill at them is most important to a noble who thereby demonstrates his understanding of the arts of war, and may gain respect for his ability. Playing well is a social grace, and while the Carouse Ability may allow a win, Etiquette is needed as well to impress one's opponent in what is, after all, a pursuit of polite company.
 
-## Gambling
+> ## Story Seed: Chess Partners
+> 
+> A great noble has two great passions: chess, and war, in that order. As a dynastic struggle threatens the kingdom, the noble's decision whether to rebel against the king or to remain loyal may well determine the future of the realm. This noble is well-known to spend much time playing chess against a scholar, one Octavian of Tremere. Is Octavian breaking the Code of Hermes by simply playing board games and teaching chess to the noble? Can anyone find an answer to the Coeris Gambit, the move he prides himself on, and break his influence over the noble before it is too late?
 
-Gambling is common in Mythic Europe. Though playing cards are as yet unknown, many dice games are popular. The rules for
+### Gambling
 
-## Some Unusual Pets
-
-Some medieval pets seem unusual to a modern reader, but were widely kept even by monks and nuns. Game statistics are given for some of these animals here. These animals may be trained by their owners. The animals' Qualities are described here in terms of the rules given in *Houses of Hermes: Mystery Cults*, page 40 but necessary skill modifiers are summarized here for ease of reference. These statistics are for mundane versions of these animals, but may be used as templates for Magical Animal Companions.
-
-#### Magpie
-
-**Characteristics:** Cun 0, Per +2, Pre –2, Com +1, Str –8, Sta 0, Dex +3, Qik +5
-
-**Size:** –4
-
-**Qualities:** Crafty, Mimicry, Timid, Vocal **Personality Traits:** Mischievous +2
-
-**Combat:**
-
-Bite: Init +4, Attack +9, Defense +9, Damage –7
-
-Dodge: Init +4, Attack n/a, Defense +9, Damage n/a
-
-**Soak:** 0
-
-**Fatigue Levels:** OK, 0, –1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+)
-
-**Abilities:** Athletics 3 (flying), Awareness 4 (predators), Brawl 4 (dodge), Music 3 (mimicry), Stealth 4 (hiding), Survival 3 (foraging)
-
-#### Monkey
-
-**Characteristics:** Cun +2, Per 0, Pre –3, Com –3, Str –6, Sta 0, Dex +2, Qik +3
-
-**Size:** –3
-
-**Qualities:** Crafty, Defensive Fighter, Skilled Climber, Timid +3 to all climb rolls.
-
-**Personality Traits:** Mischievous +2 **Combat:**
-
-*Bite:* Init +3, Attack +9, Defense +8, Damage –5
-
-*Dodge:* Init +3, Attack n/a, Defense +8, Damage n/a
-
-**Soak:** 0
-
-**Fatigue Levels:** OK, 0, –1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–2), –3 (3–4), –5 (5–6), Incapacitated (7–8), Dead (9+)
-
-**Abilities:** Athletics 3 (climbing), Awareness 4 (food), Brawl 4 (dodge), Stealth 4 (hiding), Survival 3 (foraging)
-
-#### Squirrel
-
-**Characteristics:** Cun +1, Per 0, Pre –3, Com –5, Str –12, Sta +1, Dex +3, Qik +5
-
-**Size:** –7
-
-**Qualities:** Crafty, Defensive Fighter, Skilled Climber, Timid +3 to all climb rolls.
-
-**Virtues & Flaws**: Lightning Reflexes **Personality Traits:** Timid +3, Acquisitive +2, Inquisitive +1
-
-**Combat:**
-
-*Dodge:* Init +5, Attack n/a, Defense +10, Damage n/a
-
-**Soak:** +1
-
-**Fatigue Levels:** OK, 0, –1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1), –3 (2), –5 (3), Incapacitated (4), Dead (5+)
-
-**Abilities:** Athletics 3 (climbing), Awareness 4 (food), Brawl 4 (dodge), Stealth 4 (hiding), Survival 3 (foraging)
-
-hazard can be found in *Tales of Mythic Europe*, The Ship of Desire. Raffle is even simpler, as three dice are thrown and the highest total, or the highest matching numbers on two or three dice, wins. In "pair with an ace," three dice are thrown in turn by each player, and the first to roll a matching pair and a one wins. These are the simplest dice games, with dozens more known, many with much more complex rules. It is simple — if six-sided dice are available — for **Ars Magica** players to play several authentic medieval games, and allow those with successful Legerdemain
+Gambling is common in Mythic Europe. Though playing cards are as yet unknown, many dice games are popular. The rules for hazard can be found in *Tales of Mythic Europe*, The Ship of Desire. Raffle is even simpler, as three dice are thrown and the highest total, or the highest matching numbers on two or three dice, wins. In "pair with an ace," three dice are thrown in turn by each player, and the first to roll a matching pair and a one wins. These are the simplest dice games, with dozens more known, many with much more complex rules. It is simple — if six-sided dice are available — for **Ars Magica** players to play several authentic medieval games, and allow those with successful Legerdemain
 
 tests or the Virtue Luck to change one die to the desired result! Even without dice at hand, Mythic Europeans played "heads or tails" (or, rather, "cross or piles," for the designs on the coins).
 
 People gamble on almost anything to relieve boredom, from races between people or animals, to the weather, to the outcome of contests of skill. Games of chance are based upon the Ability Carouse, games of skill upon the Ability Concentration.
 
-
-## Story Seed: Chess Partners
-
-A great noble has two great passions: chess, and war, in that order. As a dynastic struggle threatens the kingdom, the noble's decision whether to rebel against the king or to remain loyal may well determine the future of the realm. This noble is well-known to spend much time playing chess against a scholar, one Octavian of Tremere. Is Octavian breaking the Code of Hermes by simply playing board games and teaching chess to the noble? Can anyone find an answer to the Coeris Gambit, the move he prides himself on, and break his influence over the noble before it is too late?
+> ## A Game of Chance?
+> 
+> Dice are commonly made from bones or wood, or even fired clay, and are by their manufacture not perfectly even. As a result, any given die may be subtly weighted so that even an honest player can observe the pattern and use Perception + Carouse Ability to gain an advantage over an unskilled player. The Virtue Luck also directly provides a bonus to die rolls, and the skill Legerdemain allows for the manipulation of the dice, and cheating. Many a brawl has broken out when someone, especially a stranger, seems to be winning rather more than his share, and allegations of cheating follow. Problems with dice manufacture are well understood, and crooked dice are warned against in many of the books on gaming of the period.
 
 ### Good Drink, Song, and Dance
 
 Where there is gambling there is drinking, and vice versa. A gallon of ale is purchased by a group of men in the village from one of the many ale-wives, and the men drink themselves inebriated while gambling, telling stories, and sharing their news. The noble has rather better alcohol in the form of wine and mead, but is excluded by his status from the rough company of the ale-wife's house. Instead, he expects to be entertained by his household staff playing music, singing, or telling stories. Alternately, a traveling jongleur might be hired to play. Many castle halls have a gallery where minstrels and players stand to perform for the assembled guests and host. Performance is covered in detail in *Art & Academe*, Chapter Eight.
 
-With music and singing comes dancing. The most popular form of dance is the carol, a joyful form of energetic dance performed in a circle with linked hands, as a line dance, or in a processional of couples with linked hands. The leader, usually the musician, stands in the center and calls out actions that the dancers perform. Carols were occasionally condemned by the Church for inappropriate bodily contact, but are extremely popular, and dance remains a common occurrence at religious festivities and even in church services. Some carols had names, the ductia and rondeau being particular forms of carol common in France. Another joyous and noisy dance is the estampie, performed
+With music and singing comes dancing. The most popular form of dance is the carol, a joyful form of energetic dance performed in a circle with linked hands, as a line dance, or in a processional of couples with linked hands. The leader, usually the musician, stands in the center and calls out actions that the dancers perform. Carols were occasionally condemned by the Church for inappropriate bodily contact, but are extremely popular, and dance remains a common occurrence at religious festivities and even in church services. Some carols had names, the ductia and rondeau being particular forms of carol common in France. Another joyous and noisy dance is the estampie, performed with hopping and stamping, to a genre of music of the same name performed by jongleurs in France. Another innovative dance originates from Naples: the salterello, a new dance that involves great leaping steps and jumps, and which is very much — like estampie — a courtly fashion. The estampie is the first-known purely instrumental dance, whereas with carols it is normal for the dancers and musicians to all sing along. Prowess in dancing is a source of considerable pride and favorable Reputations. While knowledge of the steps of any given court dance is based upon Etiquette (local folk dances fall under Area Lore), a successful performance depends upon the Ability Athletics.
 
-## A Game of Chance?
+> ## Story Seed: The New Dance
+> 
+> A visiting noble lady introduces a new dance to the court, and causes a sensation. The dance involves leaping, pirouetting, and performing spirals in a chain of dancers, and is very hard to get right, but when it is finally achieved everyone present is consumed with mirth and great excitement. But later that night, a number of the dancers slip off to adulterous liaisons, while others act lewdly and inappropriately in polite company. The chaplain is horrified, and entertains the whispered claims of the guilty that the dance bewitched them. What is the secret of the dance, and is the lady involved in some intrigue against the household?
 
-Dice are commonly made from bones or wood, or even fired clay, and are by their manufacture not perfectly even. As a result, any given die may be subtly weighted so that even an honest player can observe the pattern and use Perception + Carouse Ability to gain an advantage over an unskilled player. The Virtue Luck also directly provides a bonus to die rolls, and the skill Legerdemain allows for the manipulation of the dice, and cheating. Many a brawl has broken out when someone, especially a stranger, seems to be winning rather more than his share, and allegations of cheating follow. Problems with dice manufacture are well understood, and crooked dice are warned against in many of the books on gaming of the period.
-
-with hopping and stamping, to a genre of music of the same name performed by jongleurs in France. Another innovative dance originates from Naples: the salterello, a new dance that involves great leaping steps and jumps, and which is very much — like estampie — a courtly fashion. The estampie is the first-known purely instrumental dance, whereas with carols it is normal for the dancers and musicians to all sing along. Prowess in dancing is a source of considerable pride and favorable Reputations. While knowledge of the steps of any given court dance is based upon Etiquette (local folk dances fall under Area Lore), a successful performance depends upon the Ability Athletics.
-
-## The Feast
+### The Feast
 
 Good food is always appreciated, and with many who can lay claim to a lord's hospitality, the feast was a frequent feature of noble life. Although peasants often hold communal feasts like picnics in the village to mark holidays and important occasions like marriages, with much drinking, dancing, and lewd behavior, the noble feast stands apart as a particularly special event.
 
-While all meals in noble households are taken communally in the hall, feasts are special occasions when a celebration is put on to entertain guests or mark a holiday. But while they are special events, feasts are also very
-
-## Story Seed: The New Dance
-
-A visiting noble lady introduces a new dance to the court, and causes a sensation. The dance involves leaping, pirouetting, and performing spirals in a chain of dancers, and is very hard to get right, but when it is finally achieved everyone present is consumed with mirth and great excitement. But later that night, a number of the dancers slip off to adulterous liaisons, while others act lewdly and inappropriately in polite company. The chaplain is horrified, and entertains the whispered claims of the guilty that the dance bewitched them. What is the secret of the dance, and is the lady involved in some intrigue against the household?
-
-common, and a host who does not put on a feast for a guest will soon gain a Reputation for being inhospitable. It is also customary in many manors for the lord to provide a public feast on certain holidays or special occasions.
+While all meals in noble households are taken communally in the hall, feasts are special occasions when a celebration is put on to entertain guests or mark a holiday. But while they are special events, feasts are also very common, and a host who does not put on a feast for a guest will soon gain a Reputation for being inhospitable. It is also customary in many manors for the lord to provide a public feast on certain holidays or special occasions.
 
 #### Preparing the Feast
 
-The noble feast is prepared as any other meal is, in the kitchen and bakehouse, which are usually detached structures built outside the hall to lessen the ever-present risk of fire. The kitchen often possesses cellars for the purpose of storing hanging meat. Cooking is performed on spits over an open fire, the spit turned by a small boy shielded from the heat by a screen of wet rushes. A metal dripping tray is placed below the meat to catch the fats and juices, and it is not uncommon for several large fires to be kept each with its own spit laden with cooking game and poultry. Stone ovens are heated by fires lit within within them, and then, when the flames have burned down to embers, the ovens are swept clean and are used for baking, with bread, pies, and pastries placed inside and allowed to cook as the oven cools. Adjustable cranes (a curved pole or metal rod) support cauldrons dangling over fires, in which sauces, stews, and boiled foods are prepared, the temperature being adjusted by raising or lowering the cauldron. The kitchen staff carries wood-handled metal ripping forks called
+The noble feast is prepared as any other meal is, in the kitchen and bakehouse, which are usually detached structures built outside the hall to lessen the ever-present risk of fire. The kitchen often possesses cellars for the purpose of storing hanging meat. Cooking is performed on spits over an open fire, the spit turned by a small boy shielded from the heat by a screen of wet rushes. A metal dripping tray is placed below the meat to catch the fats and juices, and it is not uncommon for several large fires to be kept each with its own spit laden with cooking game and poultry. Stone ovens are heated by fires lit within within them, and then, when the flames have burned down to embers, the ovens are swept clean and are used for baking, with bread, pies, and pastries placed inside and allowed to cook as the oven cools. Adjustable cranes (a curved pole or metal rod) support cauldrons dangling over fires, in which sauces, stews, and boiled foods are prepared, the temperature being adjusted by raising or lowering the cauldron. The kitchen staff carries wood-handled metal ripping forks called flesh hooks for tasting the stew and checking if the meat is properly cooked. Work in a kitchen is extremely hot. Smoke and fumes exit through a louver of latticed boards set into the roof. Once ready, the food is placed in bowls of red or gray earthenware that is finished with a greenish lead glaze and sometimes decorated with simple patterns and carried to the hall to be served. With some castles having a staff of up to three hundred servants, officials, and others with the customary right to take certain meals in the lord's hall, the kitchens are continuously busy and the cooks are extremely important members of the household.
 
-
-## Story Seed: Rats in the Kitchens
-
-One fine morning, on the Feast of St. John, the whole household is in great excitement. The noble's liege has accepted an invitation to stay, and a huge feast of exquisite finery has been promised to impress the lord, as a very delicate situation has arisen and his full support is required. But soon after breakfast a shout goes up — every member of the kitchen staff has vanished, and a plague of rats has mysteriously appeared in the manor. Can the vermin be dealt with, and untrained characters manage to somehow cook such a huge meal in time? Plenty of womenfolk from the manor know how to cook, but none has the skills to produce a noble feast. Why has disaster fallen today, and where are the kitchen folk?
-
-flesh hooks for tasting the stew and checking if the meat is properly cooked. Work in a kitchen is extremely hot. Smoke and fumes exit through a louver of latticed boards set into the roof. Once ready, the food is placed in bowls of red or gray earthenware that is finished with a greenish lead glaze and sometimes decorated with simple patterns and carried to the hall to be served. With some castles having a staff of up to three hundred servants, officials, and others with the customary right to take certain meals in the lord's hall, the kitchens are continuously busy and the cooks are extremely important members of the household.
+> ## Story Seed: Rats in the Kitchens
+> 
+> One fine morning, on the Feast of St. John, the whole household is in great excitement. The noble's liege has accepted an invitation to stay, and a huge feast of exquisite finery has been promised to impress the lord, as a very delicate situation has arisen and his full support is required. But soon after breakfast a shout goes up — every member of the kitchen staff has vanished, and a plague of rats has mysteriously appeared in the manor. Can the vermin be dealt with, and untrained characters manage to somehow cook such a huge meal in time? Plenty of womenfolk from the manor know how to cook, but none has the skills to produce a noble feast. Why has disaster fallen today, and where are the kitchen folk?
 
 #### The Noble Diet
 
-Meat and fish served at feasts has usually been preserved by smoking, pickling, or salting, though par-boiling removes much of the salt before cooking in the case of roasts. Spices can be extremely expensive, especially if imported over long distances, but are used for their flavoring. However, because of the great price, they are used in small quantities and so much of the food tastes quite bland. No root vegetables are eaten, and it is considered unhealthy to eat fruit raw. (Fruit is, however, often served stewed or in preserves.) Even so, the noble household can draw upon a varied range of foodstuffs, all prepared with seasonal berries, vegetables,
-
-## Story Seed: Damsel's Tresses
-
-A particularly rare and exotic spice is damsel's tresses, a golden plant of unknown origin. With an important feast due soon a knight has stumbled upon the source of the plant, growing like mistletoe on an ancient oak on the manor. Delighted, the noble has ordered it be harvested and brought back to adorn the main dish, honey-glazed pig, to render a delicious dish truly succulent. Who are the strange scholars who seem so upset by the harvesting, and why do they seem to believe eating the spice may have unfortunate effects?
-
-and large quantities of bread, eggs, and dairy produce.
+Meat and fish served at feasts has usually been preserved by smoking, pickling, or salting, though par-boiling removes much of the salt before cooking in the case of roasts. Spices can be extremely expensive, especially if imported over long distances, but are used for their flavoring. However, because of the great price, they are used in small quantities and so much of the food tastes quite bland. No root vegetables are eaten, and it is considered unhealthy to eat fruit raw. (Fruit is, however, often served stewed or in preserves.) Even so, the noble household can draw upon a varied range of foodstuffs, all prepared with seasonal berries, vegetables, and large quantities of bread, eggs, and dairy produce.
 
 While cooks frequently mix sweet and savory flavors in the same dish, the general pattern of food service places sweet dishes last, as dessert. A simple meal as served in the hall might open with pork brawn, served with bread and butter, before proceeding to salt bacon served with peas pottage, and then stewed mutton, boiled chickens, and roast pork, all served with seasonal produce. The next course would consist of mortrewes, which is a thick-ground meat or fish soup, served alongside a meat pie of birds or rabbit, and perhaps some roast pork. Finally, sweet dessert dishes would be served, with baked apples and pears in pies, and cheese and spiced cakes washed down with mead.
 
 Plainer food was served to the staff and less-important guests, but was still offered in large quantities. Other foods one might expect to grace a noble's table include game, be it boar or venison; doves from the cote; figs, olives, and oranges where available; small songbirds and larger fowl such as goose, duck, and peacock; and dishes of pickles or preserves served with bread. The finest, nearwhite wheat bread was served at the lord's table, with those lower down the social order eating inferior bread made from barley or rye.
 
-## Seating the Guests, and Good Manners
+> ## Story Seed: Damsel's Tresses
+> 
+> A particularly rare and exotic spice is damsel's tresses, a golden plant of unknown origin. With an important feast due soon a knight has stumbled upon the source of the plant, growing like mistletoe on an ancient oak on the manor. Delighted, the noble has ordered it be harvested and brought back to adorn the main dish, honey-glazed pig, to render a delicious dish truly succulent. Who are the strange scholars who seem so upset by the harvesting, and why do they seem to believe eating the spice may have unfortunate effects?
+
+> ## Story Seed: The Silent Damsel
+> 
+> On a dark winter's night a mysterious lady arrives at the court with a very small escort and claims hospitality. Young, noble in demeanor, and beautiful, she refuses to speak. Her escort explains she is vowed to silence by a solemn oath until what troubles her is resolved, but will not say, or do not know, what troubles her. None will speak of her rank or dignity, and with several important guests present, the household is troubled by the question of where she should be seated given that her birth is unknown. And why does the elderly nurse, a woman with a deep knowledge of the family history that reaches back generations, seem so worried by the visitor?
+
+#### Seating the Guests, and Good Manners
 
 Within the hall itself, benches against either wall have trestles set up in front of them, so the staff sit with their backs to the walls.
 
-## Story Seed: The Silent Damsel
-
-On a dark winter's night a mysterious lady arrives at the court with a very small escort and claims hospitality. Young, noble in demeanor, and beautiful, she refuses to speak. Her escort explains she is vowed to silence by a solemn oath until what troubles her is resolved, but will not say, or do not know, what troubles her. None will speak of her rank or dignity, and with several important guests present, the household is troubled by the question of where she should be seated given that her birth is unknown. And why does the elderly nurse, a woman with a deep knowledge of the family history that reaches back generations, seem so worried by the visitor?
-
 Dancing and other entertainments take place in the central area, while at the top end of the hall a table is placed for the lord, his family, and important guests. The top table is headed by a chair where the lord himself sits, with guests sitting closer to or further from him in order of precedence. Most are seated on benches, but important guests are sometimes seated on wooden stools. Placing someone in too low a position can be seen as an insult, so Etiquette is used to decide the correct seating. The ladies eat with the men, and everyone on a table shares similar dishes, with the top table having the very best food. The top table is laid with a white tablecloth, with guests bringing their own eating knives and napkins. The food is served from bowls onto trenchers of flat, stale bread, which serve as plates, often with two guests to one trencher. Spoons may be used, and forks, though the latter are used mainly for serving rather than eating. A servant moves around with bowls of warm water and cloths for washing and drying hands throughout the meal, with fresh warm water brought for each course. Each table has its own dish of salt, with the finest salt on the top table, and coarser salt lower down. Salt degrades as guests dip their food in it, even though proper etiquette suggests they should avoid this practice and instead sprinkle salt onto their plates to season their food.
 
-Etiquette is gaining in popularity, with good table manners being a mark of noble birth. Polite conversation, gracious remarks
+Etiquette is gaining in popularity, with good table manners being a mark of noble birth. Polite conversation, gracious remarks about the host, and restraint in eating are always appreciated, and gluttons and the crass are noted for their base behavior. At the lower tables, less emphasis is placed on manners, and good cheer and companionship as reflected in the Ability Carouse are more important than gracious manners governed by the Ability Etiquette.
 
-
-## Story Seed: Village Politics
-
-Each Christmas time it is traditional for six leading tenants and six of the poorest tenants, plus the freemen of the manor, to gather in the lord's hall for a lavish feast, with as much good ale as they can drink. This year, however, resentment and village politics threaten to boil over. Several squabbles break out, becoming more and more heated as calls are made for justice and a brawl seems about to break out. Normally the lord would quickly deal with such foolishness, but earlier in the day, news arrived that a gang of outlaws had ransacked the church and made off with the altar plate, and most of the fighting men have set off with the lord in pursuit. Can the ladies of the court manage to achieve peace, when so many of the servants are related to the disputants, or will the feast end in a fight?
-
-about the host, and restraint in eating are always appreciated, and gluttons and the crass are noted for their base behavior. At the lower tables, less emphasis is placed on manners, and good cheer and companionship as reflected in the Ability Carouse are more important than gracious manners governed by the Ability Etiquette.
+> ## Story Seed: Village Politics
+> 
+> Each Christmas time it is traditional for six leading tenants and six of the poorest tenants, plus the freemen of the manor, to gather in the lord's hall for a lavish feast, with as much good ale as they can drink. This year, however, resentment and village politics threaten to boil over. Several squabbles break out, becoming more and more heated as calls are made for justice and a brawl seems about to break out. Normally the lord would quickly deal with such foolishness, but earlier in the day, news arrived that a gang of outlaws had ransacked the church and made off with the altar plate, and most of the fighting men have set off with the lord in pursuit. Can the ladies of the court manage to achieve peace, when so many of the servants are related to the disputants, or will the feast end in a fight?
 
 #### Time to Eat
 
@@ -2156,11 +2034,7 @@ To keep a well-stocked larder and ensure a well-provisioned pantry requires cons
 
 Hunting is an activity common to nobles across Mythic Europe. Whereas the Church is often opposed to tournaments, hunting is seen as a vigorous and manly exercise befitting a knight, and it is an expected leisure pursuit of all males of noble birth, also participated in by many ladies. It serves three purposes. First, it is considered a thrilling and enjoyable pursuit in its own right, occupying energies that might otherwise be spent on more sinful pursuits. Second, it is a martial pursuit, and those well trained in the tactics and skills needed for hunting can employ those skills in time of war, so it is a form of training for the knight's primary role. Finally, there is a purely pragmatic benefit, in that the prey is taken home for the larder, and hunting therefore serves an important role in the noble diet and in providing for the household.
 
-The lower orders also engage in hunting, albeit outside of the chases, warrens, and forests where hunting rights are reserved. Game elsewhere may be freely taken by anyone with the ability to do so. (A chase or warren is a Minor Surroundings Boon; see *Covenants*, page 23.) In any area where hunting rights are not protected (as they will be increasingly in a century if your saga follows mundane history) peasants hunt and trap game with impunity. In some areas, like the Pyrenees or the forests of Germany, villages have specialist huntsmen who use bows, nets, and snares to catch prey and sell the game on the open market. However, within the Angevin domains and France it is customary for feudal grants of exclusive hunting rights to be made, and large parts of the countryside are designated as warrens or chases, places where hunting is forbidden to all but the noble (or clergyman) who holds the right. Given the economic importance of hunting, this is a minor source of income, and given the extremely high status attached to noble hunting, especially hunting with hounds, a grant of lands as a warren or chase is extremely prestigious, and fiercely protected with vicious gamekeepers and, against noble trespassers, lawsuits. Most protected of all were the forests, areas where hunting rights were held by the king. The designation of forests in England (where a third of the nation was designated as forest during the reign of King John) have become a major political issue. It is worth noting that a "forest" is not necessarily a wooded area, but rather a term designating a hunting reserve. The Royal
-
-
-
-Forest of Dartmoor in England, for example, is comprised of moorland.
+The lower orders also engage in hunting, albeit outside of the chases, warrens, and forests where hunting rights are reserved. Game elsewhere may be freely taken by anyone with the ability to do so. (A chase or warren is a Minor Surroundings Boon; see *Covenants*, page 23.) In any area where hunting rights are not protected (as they will be increasingly in a century if your saga follows mundane history) peasants hunt and trap game with impunity. In some areas, like the Pyrenees or the forests of Germany, villages have specialist huntsmen who use bows, nets, and snares to catch prey and sell the game on the open market. However, within the Angevin domains and France it is customary for feudal grants of exclusive hunting rights to be made, and large parts of the countryside are designated as warrens or chases, places where hunting is forbidden to all but the noble (or clergyman) who holds the right. Given the economic importance of hunting, this is a minor source of income, and given the extremely high status attached to noble hunting, especially hunting with hounds, a grant of lands as a warren or chase is extremely prestigious, and fiercely protected with vicious gamekeepers and, against noble trespassers, lawsuits. Most protected of all were the forests, areas where hunting rights were held by the king. The designation of forests in England (where a third of the nation was designated as forest during the reign of King John) have become a major political issue. It is worth noting that a "forest" is not necessarily a wooded area, but rather a term designating a hunting reserve. The Royal Forest of Dartmoor in England, for example, is comprised of moorland.
 
 Wherever there are forests there are also usually poachers. Just as noble hunting is a high-status occupation, the poacher who apes and deprives his betters of their rights — is a high-status criminal, and armed gangs of even clerical and noble poachers participate in this lucrative and illegal pastime, a significant insult to the landholder's prerogatives, and therefore fiercely punished whenever practical. Holding hunting rights is therefore not only a privilege and sign of status, it can also require expenditure and effort to protect the right and to maintain it.
 
@@ -2168,7 +2042,7 @@ The association of snares, nets, and traps with poaching and with commoners' hun
 
 Noble hunting falls into two main types, which are similar across Mythic Europe: hunting with hounds, and bow and stable hunting.
 
-## Varieties of Hunting Hounds
+### Varieties of Hunting Hounds
 
 Hunting is a prestige sport that requires the upkeep of specialist kennels, trained dog handlers, and considerable expenditure. The breeding, care, and acquisition of hounds are a noble preoccupation and source of conversation, even if much of the work is conducted by paid professionals attached to the household of the noble.
 
@@ -2176,194 +2050,184 @@ The types of dogs found in noble households show considerable variation in breed
 
 Before considering how a hunt proceeds, one must be familiar with the role and characteristics of the hounds themselves. All hunting dogs are highly trained, requiring many seasons of work to teach them their specialist duties. This is the work of a commoner called a master of kennels, a skilled professional who holds a high-status position within the noble household, but there is no shame — and indeed there is some respect and status (represented by Reputation)—for the noble who participates directly in training his own pack of hounds.
 
-Lymers, heavy-jowled beasts related to the modern bloodhound, are dogs bred for their sense of scent and ability to move quietly while tracking prey. From an early age they are taught to remain silent, and to suppress yaps or barks while following an almost imperceptible trail. Running dogs are the animals that actually pursue the prey, and work in pairs, trained to move together and fight as a team with other pairs when the prey is finally cornered, exhausted. Like lymers they require a good sense of smell to follow the trail of the prey, but they lack the lymers' stealth and restraint. Many running dogs resemble modern foxhounds and come in many colors. By far the best breed is the St. Hubert, from the Swiss monastery of that name where the abbot breeds these superb hounds, which, while slow, have unrivaled noses for prey. Greyhounds, the best examples of which hail from Scotland, are used to catch and bring down the prey, but are expensive and
+Lymers, heavy-jowled beasts related to the modern bloodhound, are dogs bred for their sense of scent and ability to move quietly while tracking prey. From an early age they are taught to remain silent, and to suppress yaps or barks while following an almost imperceptible trail. Running dogs are the animals that actually pursue the prey, and work in pairs, trained to move together and fight as a team with other pairs when the prey is finally cornered, exhausted. Like lymers they require a good sense of smell to follow the trail of the prey, but they lack the lymers' stealth and restraint. Many running dogs resemble modern foxhounds and come in many colors. By far the best breed is the St. Hubert, from the Swiss monastery of that name where the abbot breeds these superb hounds, which, while slow, have unrivaled noses for prey. Greyhounds, the best examples of which hail from Scotland, are used to catch and bring down the prey, but are expensive and limited to Northern Europe. The Irish provide the shaggy-coated wolfhound, which performs a similar role. The greyhound has unparalleled speed, but a poor sense of scent, and must be unleashed within sight of the prey or it will soon lose its quarry. Alaunts (Great Danes) are powerful animals that are generally brought forward for the final kill, held on leashes till the last stages of the chase. They are fighting animals, fresh and ready for the dangerous task of holding the quarry until the huntsmen can administer the killing blow. The best are white with black patches, and because of their vicious temperaments they are frequently kept muzzled. Where greyhounds or wolfhounds are not available, the lower-status alaunt performs the same role. Mastiffs are shaggy, powerful dogs, slower than a greyhound but bred for viciousness and strength, used when facing dangerous prey such as boar or bear. Mastiffs can be formidable opponents even to a man. They are kept as guard dogs or to protect flocks, are common throughout society, and are sometimes employed in the hunt instead of more expensive greyhounds. Harriers are small dogs used to chase hares, and employed in bow and stable hunting. Finally, bird dogs are trained for hawking. The best come from Iberia, and they are sometimes called espagnols or spaniels. Exceptional kennels may also use pairs of leashed leopards, but this is very rare even in Mythic Europe and only the very wealthiest can afford this extravagance. There are, of course, many other breeds of medieval dogs, from the lady's lap dog to exotic animals from Scandinavia or the East, and a considerable trade exists, with animals being bred and imported from afar by ship. Any noble could be interested in acquiring a high-status or unusual hound for his kennels, and many regional varieties exist of each of these hounds.
+
+> ## Hunting Dogs
+> 
+> The hunting dog statistics presented here are based upon the rules in *Houses of Hermes: Mystery Cults*, page 38, but can be used fully without that book.
+> 
+> #### Lymer
+> 
+> **Characteristics:** Cun 0, Per +3, Pre –3, Com 0, Str -4, Sta +1, Dex +2, Qik +2
+> 
+> **Size:** –2
+> 
+> **Qualities:** Domesticated, Keen Sense of Smell, Pursuit Predator, Timid, Vocal (silent)
+> 
+> +2 to all Hunt rolls.
+> 
+> **Personality Traits:** Obedient +3, Placid +1
+> 
+> #### Combat:
+> 
+> *Bite:* Init +2, Attack +9, Defense +7, Damage –3
+> 
+> *Dodge:* Init +2, Attack n/a, Defense +5, Damage n/a
+> 
+> **Soak:** +1
+> 
+> **Fatigue Levels:** OK, 0,–1, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+)
+> 
+> **Abilities:** Athletics 3 (running), Awareness 4 (deer), Brawl 3 (bite), Hunt 4 (deer), Stealth 4 (stalking)
+> 
+> #### Alaunt
+> 
+> **Characteristics:** Cun +1, Per +1, Pre –2, Com –4, Str +2, Sta +1, Dex 0, Qik 0
+> 
+> **Size:** –1
+> 
+> **Confidence:** 1 (3)
+> 
+> **Virtues & Flaws**: Ferocity (Boar)
+> 
+> **Qualities:** Aggressive, Domesticated, Grapple, Keen Sense of Smell, Pursuit Predator
+> 
+> +2 to all Hunt rolls.
+> 
+> **Personality Traits:** Aggressive +3
+> 
+> **Combat:**
+> 
+> *Bite:* Init +0, Attack +9, Defense +7, Damage +3
+> 
+> *Dodge:* Init +0, Attack n/a, Defense 0, Damage n/a
+> 
+> *Grapple:* Init +0, Attack +5, Defense +5, Damage special (see ArM5, page 174)
+> 
+> **Soak:** +1
+> 
+> **Fatigue Levels:** OK, 0,–1, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–4), –3 (5–8), –5 (9–12), Incapacitated (13–16), Dead (17+)
+> 
+> **Abilities:** Athletics 3 (running), Awareness 3 (deer), Brawl 5 (bite), Hunt 4 (boar)
+> 
+> #### Greyhound
+> 
+> **Characteristics:** Cun 0, Per +1, Pre –2, Com –4, Str –4, Sta 0, Dex +1, Qik +5
+> 
+> **Size:** –2
+> 
+> **Qualities:** Domesticated, Fast Runner, Grappler, Keen Eyesight, Pursuit Predator
+> 
+> +3 to all running rolls, +3 to all sight rolls. **Personality Traits:** Persistent +3
+> 
+> **Combat:**
+> 
+> *Bite:* Init +5, Attack +8, Defense +10, Damage –3
+> 
+> *Dodge:* Init +5, Attack n/a, Defense +8, Damage n/a
+> 
+> *Grapple:* Init +5, Attack +4, Defense +8, Damage special (see ArM5**,** page 174) **Soak:** 0
+> 
+> **Fatigue Levels:** OK, 0,–1, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+)
+> 
+> **Abilities:** Athletics 3 (running), Awareness 3 (deer), Brawl 3 (bite), Hunt 4 (deer)
+> 
+> #### Running Dog
+> 
+> **Characteristics:** Cun 0, Per +3, Pre –2, Com –4, Str –4, Sta +1, Dex 0, Qik +4
+> 
+> **Size:** –2
+> 
+> **Qualities:** Domesticated, Fast Runner, Keen Sense of Smell, Pack Animal, Pursuit Predator, Tireless
+> 
+> +3 to all running rolls, +2 to all Hunt rolls.
+> 
+> The Pack leader has Com –3, Leadership 5.
+> 
+> **Personality Traits:** Cooperative +3, Loyal +3
+> 
+> #### Combat:
+> 
+> *Bite:* Init +4, Attack +7, Defense +9, Damage –3
+> 
+> *Dodge:* Init +4, Attack n/a, Defense +7, Damage n/a
+> 
+> **Soak:** +1
+> 
+> **Fatigue Levels:** OK, 0,–1, –1, –1, –3, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+)
+> 
+> **Abilities:** Athletics 3 (running), Awareness 3 (deer), Brawl 3 (bite), Hunt 4 (deer)
+> 
+> #### Mastiff
+> 
+> **Characteristics:** Cun +1, Per +1, Pre –4, Com –4, Str +1, Sta +2, Dex +1, Qik +1
+> 
+> **Size:** –1
+> 
+> **Confidence:** 1 (3)
+> 
+> **Virtues & Flaws**: Ferocity (defending owner)
+> 
+> **Qualities: Aggressive,** Domesticated, Keen Sense of Smell, Large Teeth
+> 
+> +3 to all rolls using scent, +2 to all Hunt rolls.
+> 
+> **Personality Traits:** Loyal +3, Vicious +1 **Combat:**
+> 
+> *Bite:* Init +1, Attack +11, Defense +8, Damage +4
+> 
+> *Dodge:* Init +1, Attack n/a, Defense +6, Damage n/a
+> 
+> **Soak:** +1
+> 
+> **Fatigue Levels:** OK, 0,–1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–4), –3 (5–8), –5 (9–12), Incapacitated (13–16), Dead (17+)
+> 
+> **Abilities:** Athletics 3 (running), Awareness 3 (intruders), Brawl 5 (bite)
 
-
-
-## Hunting Dogs
-
-The hunting dog statistics presented here are based upon the rules in *Houses of Hermes: Mystery Cults*, page 38, but can be used fully without that book.
-
-#### Lymer
-
-**Characteristics:** Cun 0, Per +3, Pre –3, Com 0, Str -4, Sta +1, Dex +2, Qik +2
-
-**Size:** –2
-
-**Qualities:** Domesticated, Keen Sense of Smell, Pursuit Predator, Timid, Vocal (silent)
-
-+2 to all Hunt rolls.
-
-**Personality Traits:** Obedient +3, Placid +1
-
-#### Combat:
-
-*Bite:* Init +2, Attack +9, Defense +7, Damage –3
-
-*Dodge:* Init +2, Attack n/a, Defense +5, Damage n/a
-
-**Soak:** +1
-
-**Fatigue Levels:** OK, 0,–1, –1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+)
-
-**Abilities:** Athletics 3 (running), Awareness 4 (deer), Brawl 3 (bite), Hunt 4 (deer), Stealth 4 (stalking)
-
-#### Alaunt
-
-**Characteristics:** Cun +1, Per +1, Pre –2, Com –4, Str +2, Sta +1, Dex 0, Qik 0
-
-**Size:** –1
-
-**Confidence:** 1 (3)
-
-**Virtues & Flaws**: Ferocity (Boar)
-
-**Qualities:** Aggressive, Domesticated, Grapple, Keen Sense of Smell, Pursuit Predator
-
-+2 to all Hunt rolls.
-
-**Personality Traits:** Aggressive +3
-
-**Combat:**
-
-*Bite:* Init +0, Attack +9, Defense +7, Damage +3
-
-*Dodge:* Init +0, Attack n/a, Defense 0, Damage n/a
-
-*Grapple:* Init +0, Attack +5, Defense +5, Damage special (see ArM5, page 174)
-
-**Soak:** +1
-
-**Fatigue Levels:** OK, 0,–1, –1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–4), –3 (5–8), –5 (9–12), Incapacitated (13–16), Dead (17+)
-
-**Abilities:** Athletics 3 (running), Awareness 3 (deer), Brawl 5 (bite), Hunt 4 (boar)
-
-#### Greyhound
-
-**Characteristics:** Cun 0, Per +1, Pre –2, Com –4, Str –4, Sta 0, Dex +1, Qik +5
-
-**Size:** –2
-
-**Qualities:** Domesticated, Fast Runner, Grappler, Keen Eyesight, Pursuit Predator
-
-+3 to all running rolls, +3 to all sight rolls. **Personality Traits:** Persistent +3
-
-**Combat:**
-
-*Bite:* Init +5, Attack +8, Defense +10, Damage –3
-
-*Dodge:* Init +5, Attack n/a, Defense +8, Damage n/a
-
-*Grapple:* Init +5, Attack +4, Defense +8, Damage special (see ArM5**,** page 174) **Soak:** 0
-
-**Fatigue Levels:** OK, 0,–1, –1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+)
-
-**Abilities:** Athletics 3 (running), Awareness 3 (deer), Brawl 3 (bite), Hunt 4 (deer)
-
-#### Running Dog
-
-**Characteristics:** Cun 0, Per +3, Pre –2, Com –4, Str –4, Sta +1, Dex 0, Qik +4
-
-**Size:** –2
-
-**Qualities:** Domesticated, Fast Runner, Keen Sense of Smell, Pack Animal, Pursuit Predator, Tireless
-
-+3 to all running rolls, +2 to all Hunt rolls.
-
-The Pack leader has Com –3, Leadership 5.
-
-**Personality Traits:** Cooperative +3, Loyal +3
-
-#### Combat:
-
-*Bite:* Init +4, Attack +7, Defense +9, Damage –3
-
-*Dodge:* Init +4, Attack n/a, Defense +7, Damage n/a
-
-**Soak:** +1
-
-**Fatigue Levels:** OK, 0,–1, –1, –1, –3, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12), Dead (13+)
-
-**Abilities:** Athletics 3 (running), Awareness 3 (deer), Brawl 3 (bite), Hunt 4 (deer)
-
-#### Mastiff
-
-**Characteristics:** Cun +1, Per +1, Pre –4, Com –4, Str +1, Sta +2, Dex +1, Qik +1
-
-**Size:** –1
-
-**Confidence:** 1 (3)
-
-**Virtues & Flaws**: Ferocity (defending owner)
-
-**Qualities: Aggressive,** Domesticated, Keen Sense of Smell, Large Teeth
-
-+3 to all rolls using scent, +2 to all Hunt rolls.
-
-**Personality Traits:** Loyal +3, Vicious +1 **Combat:**
-
-*Bite:* Init +1, Attack +11, Defense +8, Damage +4
-
-*Dodge:* Init +1, Attack n/a, Defense +6, Damage n/a
-
-**Soak:** +1
-
-**Fatigue Levels:** OK, 0,–1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–4), –3 (5–8), –5 (9–12), Incapacitated (13–16), Dead (17+)
-
-**Abilities:** Athletics 3 (running), Awareness 3 (intruders), Brawl 5 (bite)
-
-
-
-limited to Northern Europe. The Irish provide the shaggy-coated wolfhound, which performs a similar role. The greyhound has unparalleled speed, but a poor sense of scent, and must be unleashed within sight of the prey or it will soon lose its quarry. Alaunts (Great Danes) are powerful animals that are generally brought forward for the final kill, held on leashes till the last stages of the chase. They are fighting animals, fresh and ready for the dangerous task of holding the quarry until the huntsmen can administer the killing blow. The best are white with black patches, and because of their vicious temperaments they are frequently kept muzzled. Where greyhounds or wolfhounds are not available, the lower-status alaunt performs the same role. Mastiffs are shaggy, powerful dogs, slower than a greyhound but bred for viciousness and strength, used when facing dangerous prey such as boar or bear. Mastiffs can be formidable opponents even to a man. They are kept as guard dogs or to protect flocks, are common throughout society, and are sometimes employed in the hunt instead of more expensive greyhounds. Harriers are small dogs used to chase hares, and employed in bow and stable hunting. Finally, bird dogs are trained for hawking. The best come from Iberia, and they are sometimes called espagnols or spaniels. Exceptional kennels may also use pairs of leashed leopards, but this is very rare even in Mythic Europe and only the very wealthiest can afford this extravagance. There are, of course, many other breeds of medieval dogs, from the lady's lap dog to exotic animals from Scandinavia or the East, and a considerable trade exists, with animals being bred and imported from afar by ship. Any noble could be interested in acquiring a high-status or unusual hound for his kennels, and many regional varieties exist of each of these hounds.
 
 #### Hounds and Aging
 
 There is generally no need to keep track of the births and deaths of individual hounds. However, in the case of favorite dogs, trained animals, and other hounds important to the saga it may be desirable to keep track of their individual age and health. Medieval hounds can expect to live up to fourteen years, but some exceptional animals may live longer.
 
-A dog begins to age at ten years, and must make an Aging roll every season thereafter except in the spring, rather than every
+A dog begins to age at ten years, and must make an Aging roll every season thereafter except in the spring, rather than every year as with a human. Every four years the aging modifier increases by one. Kennels provide a positive Living Conditions modifier, representing appropriate care, veterinary medicine, and good food and exercise. This, however, requires a score in the Ability Profession Master of Kennels.
 
-## Taming Creatures
+> ## Taming Creatures
+> 
+> Taming creatures is a seasonal activity. A character undertaking it accumulates a number of points each season towards taming a given animal equal to Intelligence + Animal Handling (no die). The taming is complete when the accumulated total of points exceeds a total equal to 1 + (2 x the creature's Confidence Score). Points only accumulate between consecutive seasons, so if the character does something else for a season, accumulated point are lost. Points for taming animals cannot be transferred between trainers. The tamer must be able to interact daily with the creature throughout the season.
+> 
+> If the tamer can generate enough points to tame a creature in a single season he may split his point total among the taming of several creatures of the same species, but he cannot tame a number of additional creatures in excess of his Animal Handling Ability Score.
+> 
+> Once an animal is tamed characters with an Intelligence characteristic may command it. The animal can be commanded by any such character with the Animal Handling Ability, or by a character to whom the animal is loyal (as described in the next paragraph).
+> 
+> Once a creature is tamed it acquires the Personality Trait (Loyal +0), directed towards the character who tamed it. If the creature already had a Loyal Personality Trait before it was tamed, it does not gain a new Trait, but rather, the old Trait becomes focused towards the trainer and its level does not change. Sometimes, commanding an animal calls for a Loyalty test, and as this is a "social interaction," penalties for The Gift apply.
+> 
+> If he wishes, any character with the Animal Handling Ability may spend additional seasons with an already-tamed creature to improve or transfer the loyalty of that creature. Each additional season of training increases the Loyal Personality Trait by +1, to a maximum of +3. A character can only improve the loyalty of an animal that is loyal to him. Instead of increasing a creature's Loyal Personality Trait with a season of extra training, the trainer can choose to instead transfer the animal's loyalty to another character, who must also be present for the season. The trainer may even transfer the loyalty of the animal to himself if he was not the character who originally tamed the animal.
+> 
+> Any character with the Animal Handling Ability may train and therefore improve a tamed animal's Abilities using the standard training rules (see ArM5, page 164). As normal, the master must have a greater score in the Ability than the animal does.
+> 
+> Usually, an animal may only be trained in Abilities that it already has a score in, as other Abilities are beyond its capacity, but the troupe may relax this restriction on a case-by-case basis, for example, to allow a horse to be taught to swim. At the end of any season spent training an Ability that the animal does not already have a score in, make a Loyalty test for the animal against an Ease Factor of 6. If this Loyalty test fails, then the animal does not gain any training experience and the season is wasted. Loyalty tests are not required to improve existing Abilities.
 
-Taming creatures is a seasonal activity. A character undertaking it accumulates a number of points each season towards taming a given animal equal to Intelligence + Animal Handling (no die). The taming is complete when the accumulated total of points exceeds a total equal to 1 + (2 x the creature's Confidence Score). Points only accumulate between consecutive seasons, so if the character does something else for a season, accumulated point are lost. Points for taming animals cannot be transferred between trainers. The tamer must be able to interact daily with the creature throughout the season.
-
-If the tamer can generate enough points to tame a creature in a single season he may split his point total among the taming of several creatures of the same species, but he cannot tame a number of additional creatures in excess of his Animal Handling Ability Score.
-
-Once an animal is tamed characters with an Intelligence characteristic may command it. The animal can be commanded by any such character with the Animal Handling Ability, or by a character to whom the animal is loyal (as described in the next paragraph).
-
-Once a creature is tamed it acquires the Personality Trait (Loyal +0), directed towards the character who tamed it. If the creature already had a Loyal Personality Trait before it was tamed, it does not gain a new Trait, but rather, the old Trait becomes focused towards the trainer and its level does not change. Sometimes, commanding an animal calls for a Loyalty test, and as this is a "social interaction," penalties for The Gift apply.
-
-If he wishes, any character with the Animal Handling Ability may spend additional seasons with an already-tamed creature to improve or transfer the loyalty of that creature. Each additional season of training increases the Loyal Personality Trait by +1, to a maximum of +3. A character can only improve the loyalty of an animal that is loyal to him. Instead of increasing a creature's Loyal Personality Trait with a season of extra training, the trainer can choose to instead transfer the animal's loyalty to another character, who must also be present for the season. The trainer may even transfer the loyalty of the animal to himself if he was not the character who originally tamed the animal.
-
-Any character with the Animal Handling Ability may train and therefore improve a tamed animal's Abilities using the standard training rules (see ArM5, page 164). As normal, the master must have a greater score in the Ability than the animal does.
-
-Usually, an animal may only be trained in Abilities that it already has a score in, as other Abilities are beyond its capacity, but the troupe may relax this restriction on a case-by-case basis, for example, to allow a horse to be taught to swim. At the end of any season spent training an Ability that the animal does not already have a score in, make a Loyalty test for the animal against an Ease Factor of 6. If this Loyalty test fails, then the animal does not gain any training experience and the season is wasted. Loyalty tests are not required to improve existing Abilities.
-
-year as with a human. Every four years the aging modifier increases by one. Kennels provide a positive Living Conditions modifier, representing appropriate care, veterinary medicine, and good food and exercise. This, however, requires a score in the Ability Profession Master of Kennels.
-
-## Hunting with Hounds
+### Hunting with Hounds
 
 Hunting with hounds is by far the most prestigious version of the sport, and is widely engaged in all across Mythic Europe, being from Iberia to Novgorod part of noble culture. While minor regional variations exist, the general format is known and accepted by anyone with a score in the Ability Etiquette.
 
 #### The Quest
 
-A formal hunt begins an hour or so before dawn when the first glimmer of light shows. The huntsmen set out in different directions on foot with leashed lymers to seek out suitable prey, in a process known as the quest. The huntsmen will have gathered the night before for a feast to discuss
+A formal hunt begins an hour or so before dawn when the first glimmer of light shows. The huntsmen set out in different directions on foot with leashed lymers to seek out suitable prey, in a process known as the quest. The huntsmen will have gathered the night before for a feast to discuss and determine the nature of the hunt's prey, and then stayed overnight as guests of the host. The huntsmens' job is to locate a suitable example of the chosen beast, in perfect condition, that will give good sport. Huntsmen each make Perception + (the lymer's or huntsman's Hunt Ability, whichever is lower) rolls against Ease Factor 9, to track an appropriate beast to its lair. After locating potentially suitable prey the huntsman does not approach, but instead tests Presence + Animal Handling against Ease Factor 9 to keep the lymer quiet. He then circles the prey collecting droppings and examining marks. The huntsman makes an Intelligence + Hunt roll against Ease Factor 9 to establish the quarry's age and condition, and whether the beast is suitable, and then returns swiftly to be back in time for the hunt breakfast.
 
-
-## Story Seed: Poachers
-
-Recently, game has been diminishing in a noble's forest. Last night two gamekeepers were found dead, one apparently slain by a sword, the other's skull crushed by a club or mace. Clearly, this is not the work of peasant poachers, and a person of some wealth was involved. Frightened villagers claim to have heard the sound of hooves and armor, as if several men rode through the woods at night, and whispers have began to circulate of devils in the forest. Who is responsible, and can they be brought to justice?
-
-and determine the nature of the hunt's prey, and then stayed overnight as guests of the host. The huntsmens' job is to locate a suitable example of the chosen beast, in perfect condition, that will give good sport. Huntsmen each make Perception + (the lymer's or huntsman's Hunt Ability, whichever is lower) rolls against Ease Factor 9, to track an appropriate beast to its lair. After locating potentially suitable prey the huntsman does not approach, but instead tests Presence + Animal Handling against Ease Factor 9 to keep the lymer quiet. He then circles the prey collecting droppings and examining marks. The huntsman makes an Intelligence + Hunt roll against Ease Factor 9 to establish the quarry's age and condition, and whether the beast is suitable, and then returns swiftly to be back in time for the hunt breakfast.
+> ## Story Seed: Poachers
+> 
+> Recently, game has been diminishing in a noble's forest. Last night two gamekeepers were found dead, one apparently slain by a sword, the other's skull crushed by a club or mace. Clearly, this is not the work of peasant poachers, and a person of some wealth was involved. Frightened villagers claim to have heard the sound of hooves and armor, as if several men rode through the woods at night, and whispers have began to circulate of devils in the forest. Who is responsible, and can they be brought to justice?
 
 #### The Assembly
 
@@ -2381,7 +2245,6 @@ Now the main pack of hounds and the noble hunters move off, riding to the quarry
 
 As the animal hears the hunters approach it flees, the hounds give cry, and the chase begins. The chase is a severe test of the hunters' Ride Ability, with good horsemanship vital. Some are thrown by obstacles, some simply fail to keep up and become lost, while others choose to fall back and accompany the ladies. The hounds are subject to the hunters' commands, and tests of the Animal Handling Ability are required to keep them on the trail, rather than pursuing other prey or becoming distracted. (An animal that leads the hunt astray from its desired prey is called a "rascal.") Unexpected hazards may befall the hunters, and the chase may lead them into adventure as they charge across the countryside in single-minded pursuit.
 
-
 Each round of the chase represents one hour of pursuit, and requires a Dexterity + Ride stress roll against Ease Factor 6 to keep in sight of the hounds. Many hunters fall behind, sometimes intentionally. The hounds lose one level of fatigue per round unless they can succeed in a simple roll of Stamina + Athletics against Ease Factor 12, as does the prey. For every three rounds of hunting hunters must succeed in a simple Stamina + Ride roll against Ease Factor 9, or lose one long term fatigue level.
 
 As well as accumulating long term fatigue, the hunters test to see whether they can catch the prey. Use the hounds' Perception + Hunt Ability + stress die (using the best total of any individual dog, if they differ) to generate their Pursuit Total. Match this against the prey's Dexterity +Athletics + Terrain Bonus + stress die, representing its Evasion Total. Remember to include all fatigue modifiers. Storyguides should also add events, encounters, and other challenges to each round to represent the terrain that the chase is occurring through.
@@ -2394,11 +2257,7 @@ If the Evasion Total is higher, the prey has won that round; if the Pursuit Tota
 
 #### The Kill
 
-The hunters dismount now, and close in on foot to kill the prey. The host normally makes the kill with a sword, though he may
-
-
-
-grant this honor to one of his guests if he wishes, and with dangerous creatures like bear or boar the hunters may all approach, or even call upon the huntsmen to assist with spears if the situation is severe enough. This is best resolved as a melee combat, but as the prey is typically fatigued it is normally over swiftly.
+The hunters dismount now, and close in on foot to kill the prey. The host normally makes the kill with a sword, though he may grant this honor to one of his guests if he wishes, and with dangerous creatures like bear or boar the hunters may all approach, or even call upon the huntsmen to assist with spears if the situation is severe enough. This is best resolved as a melee combat, but as the prey is typically fatigued it is normally over swiftly.
 
 #### The Unmaking and Curee
 
@@ -2406,45 +2265,39 @@ Once the animal is slain it is butchered, which is known as the unmaking, and th
 
 Of course not all hunts are this formal. Knights and lesser nobles often participate in quite informal hunts. Nonetheless, whenever possible, formal hunting in preferred.
 
-## Bow and Stable Hunting
+### Bow and Stable Hunting
 
 Bow and stable hunting is very different from hunting with hounds. In bow and stable hunting the noble hunters divide in to two groups, the archers, who dress in green hunting clothing for camouflage purposes, and the mounted huntsmen. An area of woodland is selected, preferably with either a natural boundary such as a river or cliff on either side, or with local villagers guarding the flanks with sticks and stones, to drive any animal that tries to flee past them back in to the woods. The archers on foot take up positions in a line across the bottom of the area, spaced several yards apart, and the hunters on horses — with a small group of beaters whose job is to run alongside them, making noise — do likewise at the top of the area, a mile or so away, completing the rectangle.
 
-The hunters now ride slowly forward, flushing out the game. Every animal in the area runs for cover, and, finding no escape left or right, runs forward towards where the archers wait. As the game comes in sight the
-
-## The Terrain Bonus
-
-Assuming the hunted animal is native to the environment through which it is being pursued, it stands a good chance of escape. This is reflected in a Terrain Bonus of +6 added to the prey's Evasion Total. This can be reduced in two ways: through the relay, and through the actions of the hunters. These actions can turn the Terrain Bonus into a penalty in a sufficiently long hunt.
-
-#### The Relay
-
-Every round, any character who participated in establishing the relay must make a stress roll of Intelligence + Hunt + 6 against an Ease Factor equal to the Evasion Total. If at least one roll succeeds, that character chose to station fresh dogs in an appropriate place, and new hounds join the pack in the next round, reducing the hounds' Fatigue penalty to zero.
-
-On a successful roll, the same character may make a stress roll of Intelligence + Area Lore against an Ease Factor equal to the Evasion Total. If this also succeeds, the prey's Terrain Bonus is reduced by 1 for the rest of the hunt. The planning of the relay can only reduce the Terrain Bonus by 1 point per round.
-
-#### The Hunters
-
-Every round, any hunter who is still with the pack may make a Perception + Area Lore stress roll against an Ease Factor equal to the prey's Evasion Total in the current round. If any of these rolls succeed, the Terrain Bonus is reduced by 1 for the rest of the hunt.
-
-## Story Seed: Errant Arrow
-
-While out hunting in the forest, an arrow glances off a stag and kills a prominent noble. The knight who fired the arrow is a vassal of another noble with a long-time enmity for the dead man. Was it an accident, or a deliberate assassination? The knight has been captured attempting to flee the country, but protests his innocence before God. The only witnesses are the wounded stag and the silent trees. Magi can question either easily enough, but who will believe their testimony?
-
-This story idea is taken directly from a historical incident, the death of William Rufus, King of England, in August 1100 after William Tyrell accidentally shot him.
-
-archers take careful aim and shoot. If they fire too quickly, their arrows have the potential to strike oncoming hunters, so they normally wait until the beasts are almost upon them, but if they wait too long and shoot as the animal passes through their line, they may well shoot their fellow archers (as, in fact, happens quite frequently).
+The hunters now ride slowly forward, flushing out the game. Every animal in the area runs for cover, and, finding no escape left or right, runs forward towards where the archers wait. As the game comes in sight the archers take careful aim and shoot. If they fire too quickly, their arrows have the potential to strike oncoming hunters, so they normally wait until the beasts are almost upon them, but if they wait too long and shoot as the animal passes through their line, they may well shoot their fellow archers (as, in fact, happens quite frequently).
 
 Large amounts of game can be taken in this manner, but bow and stable hunting lacks the status of hunting with hounds, and is regarded as rather archaic and boorish in many areas. In parts of the Loch Leglean, Hibernian, Stonehenge, Iberian, Rhine, and Novgorod Tribunals it is, however, a perfectly socially acceptable form of hunting for nobles, as acceptable as hunting with hounds.
 
-## Hunting Stories
+> ## The Terrain Bonus
+> 
+> Assuming the hunted animal is native to the environment through which it is being pursued, it stands a good chance of escape. This is reflected in a Terrain Bonus of +6 added to the prey's Evasion Total. This can be reduced in two ways: through the relay, and through the actions of the hunters. These actions can turn the Terrain Bonus into a penalty in a sufficiently long hunt.
+> 
+> #### The Relay
+> 
+> Every round, any character who participated in establishing the relay must make a stress roll of Intelligence + Hunt + 6 against an Ease Factor equal to the Evasion Total. If at least one roll succeeds, that character chose to station fresh dogs in an appropriate place, and new hounds join the pack in the next round, reducing the hounds' Fatigue penalty to zero.
+> 
+> On a successful roll, the same character may make a stress roll of Intelligence + Area Lore against an Ease Factor equal to the Evasion Total. If this also succeeds, the prey's Terrain Bonus is reduced by 1 for the rest of the hunt. The planning of the relay can only reduce the Terrain Bonus by 1 point per round.
+> 
+> #### The Hunters
+> 
+> Every round, any hunter who is still with the pack may make a Perception + Area Lore stress roll against an Ease Factor equal to the prey's Evasion Total in the current round. If any of these rolls succeed, the Terrain Bonus is reduced by 1 for the rest of the hunt.
+
+> ## Story Seed: Errant Arrow
+> 
+> While out hunting in the forest, an arrow glances off a stag and kills a prominent noble. The knight who fired the arrow is a vassal of another noble with a long-time enmity for the dead man. Was it an accident, or a deliberate assassination? The knight has been captured attempting to flee the country, but protests his innocence before God. The only witnesses are the wounded stag and the silent trees. Magi can question either easily enough, but who will believe their testimony?
+> 
+> This story idea is taken directly from a historical incident, the death of William Rufus, King of England, in August 1100 after William Tyrell accidentally shot him.
+
+### Hunting Stories
 
 While the process of playing out a hunt might not seem attractive, it has great dramatic potential, as the many medieval hunting tales show. A hunt ranges over large areas of wilderness filled with animals magical and mundane, and many hazards not found in the manor, village, or road. It involves characters from all levels of society who wander in small groups, often guided only by the distant cries of the hounds.
 
-Any hunting story should involve many encounters and mysteries stumbled upon in the depths of the woods. The wilderness of Mythic Europe is a strange and dangerous place, and no hunt should ever feel safe or mundane, just as in medieval stories no hunt was ever prosaic. It is quite possible for the hunters to become the hunted if they stum-
-
-
-
-ble upon predators or enemies, and in one of the most common medieval folklore motifs this happens quite literally, when a magician or fairy transforms one of the hunters into a beast of prey by some enchantment. Hermetic magi who make their homes in the wilderness may be troubled by hunts that come to the covenant, especially if the quarry takes refuge therein, and given that Beasts of Virtue and magical animals are the highest aspirations of any hunter as quarry, there are many possibilities for stories arising from hunting.
+Any hunting story should involve many encounters and mysteries stumbled upon in the depths of the woods. The wilderness of Mythic Europe is a strange and dangerous place, and no hunt should ever feel safe or mundane, just as in medieval stories no hunt was ever prosaic. It is quite possible for the hunters to become the hunted if they stumble upon predators or enemies, and in one of the most common medieval folklore motifs this happens quite literally, when a magician or fairy transforms one of the hunters into a beast of prey by some enchantment. Hermetic magi who make their homes in the wilderness may be troubled by hunts that come to the covenant, especially if the quarry takes refuge therein, and given that Beasts of Virtue and magical animals are the highest aspirations of any hunter as quarry, there are many possibilities for stories arising from hunting.
 
 ### The Prey
 
@@ -2464,6 +2317,7 @@ Wolves are diffi cult prey, as they must somehow be separated from the pack. Kil
 
 The fox is known for its cunning. While less a threat than the wolf, the fox gives good sport, often outwitting the dogs by its guile and deceitful tricks. Hunting foxes is perfectly acceptable, but lacks the prestige of hunting the hart or boar. Otters are regarded with similar disdain — they are seen as the riverine equivalent of foxes, predators that need to be killed. The best time to hunt them is summer or autumn when the water levels are low.
 
+## Horses
 
 A huntsman requires excellent hounds, but fine horses are essential to all aspects of noble life. The use of horses goes far beyond hunting and leisure; travel, war, and even some farm work is also often best served by a fine horse. Medieval horses are not differentiated from one another by breed, but rather by their suitability for certain roles. (A war horse is not suited for lengthy journeys, for example, and a farm horse is unsuitable for war or travel.) Horses are distinguished by pedigree (usually given orally but sometimes recorded in writing), by coloration, and by country of origin, but at the most basic level a horse is described by a name designating its role.
 
@@ -2471,169 +2325,152 @@ Horses, even farm horses, are expensive to possess, and give the owner status. T
 
 While some commoners can afford to employ the more-efficient horse to replace the traditional yoked oxen, the ox remains the primary agricultural working animal in most parts of Mythic Europe. The horse collar allows a horse to outperform an ox, and teams of working horses known as draught horses are an increasingly common sight on the land. Working horses are invariably mares, as are those employed for travel and to pull carts and wagons, while many warhorses are stallions prized for their aggression and temperament. The exception is in Muslim lands, particularly Iberia and the Levant, where mares are employed commonly as warhorses for their ability to be trained. Either gender of horse can be, if properly trained, adapted to any given role, but training a horse is a specialist and highly valued skill.
 
-## The Types of Horses
-
-Horses are, as noted, distinguished by their role rather than their breed. Horse templates typical of each type are provided that the storyguide can modify to individualize horses available at market or presented
-
-## Horses
-
-The following templates describe the types of horse most commonly found in Mythic Europe.
-
-#### Noble Warhorse (Destrier)
-
-**Characteristics:** Cun –2, Per +1, Pre +1, Com –4, Str +6, Sta +3, Dex +1, Qik 0
-
-**Size:** +3
-
-**Confidence Score:** 1 (3)
-
-**Virtues & Flaws:** Ferocity (when ridden in battle), Improved Characteristics x 2, Long-Winded, Proud (minor)
-
-**Qualities:** Domesticated, Fast Runner, Herd Animal, Imposing Appearance, Tireless
-
-**Personality Traits:** Proud +3, Loyal +2, Brave +1
-
-**Soak:** +3
-
-**Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–8), –3 (9–16), –5 (17–24), Incapacitated (25–32), Dead (33+)
-
-**Abilities:** Athletics 5 (in battle), Awareness 2 (bad footing), Brawl 3 (hooves)
-
-**Combat:** 
-
-*Hooves:* Init +2, Attack +7, Defense +7, Damage +7
-
-Destriers are the highest-status horses in Mythic Europe. Often from Spain, these fine animals may stand fifteen hands (sixty inches) high, and are superb warhorses. Extremely rare, they can command prices from 50 to 140 pounds, and for an exceptional horse far more. A disproportionate number are aligned with the Magic, Faerie, Divine, or Infernal realm in some way, and these often possess Might and powers appropriate to that realm. The best tournament horses are destriers. Only major nobility and the extremely wealthy are ever likely to possess such a fine animal, unless found through a story, granted as a gift, or won as a prize in a tournament. Owning such a beast is worth at least a single experience point in Reputation: Prudhomme.
-
-## Warhorse (Courser or Rouncey)
-
-**Characteristics:** Cun –2, Per 0, Pre 0, Com –4, Str +4, Sta +3, Dex +1, Qik 0
-
-**Size:** +2
-
-**Confidence Score** 1 (3)
-
-**Virtues & Flaws:** Ferocity (when ridden in battle), Improved Characteristics, Long-Winded, Proud (minor)
-
-**Qualities:** Domesticated, Fast Runner, Herd Animal, Imposing Appearance, Tireless
-
-**Personality Traits:** Proud +3, Loyal +2, Brave +1
-
-**Soak:** +3
-
-**Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+)
-
-**Abilities:** Athletics 5 (in battle), Awareness 2 (bad footing), Brawl 3 (hooves)
-
-**Combat:** 
-
-*Hooves:* Init +2, Attack +7, Defense +7, Damage +5
-
-Coursers are the most common combat-trained warhorses of the era. Like most horses in Mythic Europe, they are between fourteen and fifteen hands in height. A courser usually costs around 10 to 20 pounds, varying based on the horse's quality, with 16 pounds being the average price for most sagas (see *Covenants,* page 71). Coursers are completed unsuited as pack animals and workhorses, and are temperamentally unsuited as general riding horses for travel. A rouncey, often favored by squires, can be used as a general utility horse, but retains the combat training of the courser; such horses lack Ferocity and Confidence, and gain the Flaw Proud. A rouncey costs between five and ten pounds, though some fine specimens cost many times that sum. A commoner or squire who rides a particularly fine rouncey may attract a Reputation as having ideas above his station, and the scorn of his betters.
-
-*(continued on the next page)*
-
-
-
-
-## Riding Horse (Palfrey or Jennet)
-
-**Characteristics:** Cun –2, Per –1, Pre 0, Com –4, Str +4, Sta +3, Dex +1, Qik +1
-
-**Size:** +2
-
-**Virtues & Flaws**: Improved Characteristics, Long-Winded
-
-**Qualities:** Domesticated, Fast Runner, Herd Animal, Imposing Appearance, Tireless
-
-**Personality Traits:** Skittish +3, Brave –2 (Jennet: Docile +1, Brave –3)
-
-**Soak:** +3
-
-**Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+)
-
-**Abilities:** Athletics 5 (distance riding), Awareness 2 (escape routes), Brawl 1 (hooves)
-
-**Combat:** 
-
-*Hooves:* Init +3, Attack +5, Defense +6, Damage +5
-
-Palfreys are the standard riding horse favored for general usage, capable of being ridden in a hunt, being controlled in combat by anyone with a Ride Ability of 3 or more, and suitable for long-distance travel, being able to make thirty miles a day or more on good roads if ridden hard. Most palfreys are mares rather than stallions. They lack the aggression of coursers. The palfrey, if ridden by a lady, is often referred to as a jennet, which is always a mare. It is extremely uncommon for ladies to ride side-saddle in Mythic Europe, though a few might if their gowns are particularly unsuited to riding and the need is urgent. (Riding
-
-## Horses (continued)
-
-side-saddle is not a feature of etiquette in this period, simply something forced upon ladies in some circumstances. Riding astride a horse is entirely normal and provokes no unfavorable comment.) A palfrey or jennet stands a little over fourteen hands, and can be purchased for around two pounds.
-
-#### Draught Horse (Hackney)
-
-**Characteristics:** Cun –3, Per –1, Pre 0, Com –4, Str +6, Sta +4, Dex +1, Qik –2
-
-**Size:** +3
-
-**Virtues & Flaws:** Long-Winded, Noncombatant
-
-**Qualities:** Domesticated, Herd Animal, Imposing Appearance, Tireless
-
-**Personality Traits:** Placid +2, Stubborn +1, Brave –2
-
-**Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–8), –3 (9–16), –5 (17–24), Incapacitated (25–32), Dead (33+)
-
-**Abilities:** Athletics 3 (stamina), Awareness 2 (commands), Brawl 1 (hooves)
-
-The hackney is a large horse of up to sixteen hands used for general riding, and as a workhorse. With the new horse collar, and teamed either one in front of the other or in parallel pairs, they are half again as efficient as a similar number of oxen. Hackneys are slow and ponderous beasts not suited for combat or hunting, but they can be ridden for long journeys, or by those not bothered about appearances or speed. Primarily they are used for farm work. A pair of hackneys can be bought for as little as a pound, but no noble would ever be seen riding such a beast. A hackney with a horse collar can easily pull a heavily laden cart, which might otherwise require two oxen.
-
-## Working Pony (Fell or Icelandic)
-
-**Characteristics:** Cun –2, Per +1, Pre 0, Com –4, Str +2, Sta +3, Dex +2, Qik 0
-
-**Size:** +1
-
-**Virtues & Flaws:** Improved Characteristics, Long-Winded, Perfect Balance, Noncombatant
-
-**Qualities:** Domesticated, Herd Animal, Imposing Appearance, Tireless
-
-**Personality Traits:** Brave+2, Resilient +1 **Soak:** +3
-
-**Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
-
-**Wound Penalties**: –1 (1–6), –3 (7–12), –5 (13–18), Incapacitated (19–24), Dead (25+)
-
-**Abilities:** Awareness 2 (footing)
-
-This sturdy pony is suited for use on the roughest terrain. These statistics may be used to represent animals from the north of England and Scotland, or Iceland, and such beasts are greatly prized for their ability to cross mountain trails and treacherous moors. A working pony costs about one pound in Northern Europe, but far more in southern regions. Superb pack animals, sure footed and sturdy, they are used to carry supplies over long distances where no cart can go, and across country. The Perfect Balance Virtue represents their abilities on treacherous mountain paths.
-
-as gifts. Individualizing a horse can be as simple as adding a new Personality trait, adding a new Quality (see *Houses of Hermes: Mystery Cults*, page 40), altering the characteristics to reflect unusual speed or intelligence, or — for faerie or magical horses (though Divine horses and Infernal horses are also known) — adding Might and Magical Qualities using the process described in *Realms of Power: Magic* or *Realms of Power: Faerie*. No two horses should ever be identical, and each should have a distinct personality and quirks, whether a proclivity to eat hedges or
-
-being frightened of rabbits.
+### The Types of Horses
+
+Horses are, as noted, distinguished by their role rather than their breed. Horse templates typical of each type are provided that the storyguide can modify to individualize horses available at market or presented as gifts. Individualizing a horse can be as simple as adding a new Personality trait, adding a new Quality (see *Houses of Hermes: Mystery Cults*, page 40), altering the characteristics to reflect unusual speed or intelligence, or — for faerie or magical horses (though Divine horses and Infernal horses are also known) — adding Might and Magical Qualities using the process described in *Realms of Power: Magic* or *Realms of Power: Faerie*. No two horses should ever be identical, and each should have a distinct personality and quirks, whether a proclivity to eat hedges or being frightened of rabbits.
+
+> ## Horses
+> 
+> The following templates describe the types of horse most commonly found in Mythic Europe.
+> 
+> #### Noble Warhorse (Destrier)
+> 
+> **Characteristics:** Cun –2, Per +1, Pre +1, Com –4, Str +6, Sta +3, Dex +1, Qik 0
+> 
+> **Size:** +3
+> 
+> **Confidence Score:** 1 (3)
+> 
+> **Virtues & Flaws:** Ferocity (when ridden in battle), Improved Characteristics x 2, Long-Winded, Proud (minor)
+> 
+> **Qualities:** Domesticated, Fast Runner, Herd Animal, Imposing Appearance, Tireless
+> 
+> **Personality Traits:** Proud +3, Loyal +2, Brave +1
+> 
+> **Soak:** +3
+> 
+> **Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–8), –3 (9–16), –5 (17–24), Incapacitated (25–32), Dead (33+)
+> 
+> **Abilities:** Athletics 5 (in battle), Awareness 2 (bad footing), Brawl 3 (hooves)
+> 
+> **Combat:** 
+> 
+> *Hooves:* Init +2, Attack +7, Defense +7, Damage +7
+> 
+> Destriers are the highest-status horses in Mythic Europe. Often from Spain, these fine animals may stand fifteen hands (sixty inches) high, and are superb warhorses. Extremely rare, they can command prices from 50 to 140 pounds, and for an exceptional horse far more. A disproportionate number are aligned with the Magic, Faerie, Divine, or Infernal realm in some way, and these often possess Might and powers appropriate to that realm. The best tournament horses are destriers. Only major nobility and the extremely wealthy are ever likely to possess such a fine animal, unless found through a story, granted as a gift, or won as a prize in a tournament. Owning such a beast is worth at least a single experience point in Reputation: Prudhomme.
+> 
+> ### Warhorse (Courser or Rouncey)
+> 
+> **Characteristics:** Cun –2, Per 0, Pre 0, Com –4, Str +4, Sta +3, Dex +1, Qik 0
+> 
+> **Size:** +2
+> 
+> **Confidence Score** 1 (3)
+> 
+> **Virtues & Flaws:** Ferocity (when ridden in battle), Improved Characteristics, Long-Winded, Proud (minor)
+> 
+> **Qualities:** Domesticated, Fast Runner, Herd Animal, Imposing Appearance, Tireless
+> 
+> **Personality Traits:** Proud +3, Loyal +2, Brave +1
+> 
+> **Soak:** +3
+> 
+> **Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+)
+> 
+> **Abilities:** Athletics 5 (in battle), Awareness 2 (bad footing), Brawl 3 (hooves)
+> 
+> **Combat:** 
+> 
+> *Hooves:* Init +2, Attack +7, Defense +7, Damage +5
+> 
+> Coursers are the most common combat-trained warhorses of the era. Like most horses in Mythic Europe, they are between fourteen and fifteen hands in height. A courser usually costs around 10 to 20 pounds, varying based on the horse's quality, with 16 pounds being the average price for most sagas (see *Covenants,* page 71). Coursers are completed unsuited as pack animals and workhorses, and are temperamentally unsuited as general riding horses for travel. A rouncey, often favored by squires, can be used as a general utility horse, but retains the combat training of the courser; such horses lack Ferocity and Confidence, and gain the Flaw Proud. A rouncey costs between five and ten pounds, though some fine specimens cost many times that sum. A commoner or squire who rides a particularly fine rouncey may attract a Reputation as having ideas above his station, and the scorn of his betters.
+> 
+> ### Riding Horse (Palfrey or Jennet)
+> 
+> **Characteristics:** Cun –2, Per –1, Pre 0, Com –4, Str +4, Sta +3, Dex +1, Qik +1
+> 
+> **Size:** +2
+> 
+> **Virtues & Flaws**: Improved Characteristics, Long-Winded
+> 
+> **Qualities:** Domesticated, Fast Runner, Herd Animal, Imposing Appearance, Tireless
+> 
+> **Personality Traits:** Skittish +3, Brave –2 (Jennet: Docile +1, Brave –3)
+> 
+> **Soak:** +3
+> 
+> **Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+)
+> 
+> **Abilities:** Athletics 5 (distance riding), Awareness 2 (escape routes), Brawl 1 (hooves)
+> 
+> **Combat:** 
+> 
+> *Hooves:* Init +3, Attack +5, Defense +6, Damage +5
+> 
+> Palfreys are the standard riding horse favored for general usage, capable of being ridden in a hunt, being controlled in combat by anyone with a Ride Ability of 3 or more, and suitable for long-distance travel, being able to make thirty miles a day or more on good roads if ridden hard. Most palfreys are mares rather than stallions. They lack the aggression of coursers. The palfrey, if ridden by a lady, is often referred to as a jennet, which is always a mare. It is extremely uncommon for ladies to ride side-saddle in Mythic Europe, though a few might if their gowns are particularly unsuited to riding and the need is urgent. (Riding side-saddle is not a feature of etiquette in this period, simply something forced upon ladies in some circumstances. Riding astride a horse is entirely normal and provokes no unfavorable comment.) A palfrey or jennet stands a little over fourteen hands, and can be purchased for around two pounds.
+> 
+> ### Draught Horse (Hackney)
+> 
+> **Characteristics:** Cun –3, Per –1, Pre 0, Com –4, Str +6, Sta +4, Dex +1, Qik –2
+> 
+> **Size:** +3
+> 
+> **Virtues & Flaws:** Long-Winded, Noncombatant
+> 
+> **Qualities:** Domesticated, Herd Animal, Imposing Appearance, Tireless
+> 
+> **Personality Traits:** Placid +2, Stubborn +1, Brave –2
+> 
+> **Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–8), –3 (9–16), –5 (17–24), Incapacitated (25–32), Dead (33+)
+> 
+> **Abilities:** Athletics 3 (stamina), Awareness 2 (commands), Brawl 1 (hooves)
+> 
+> The hackney is a large horse of up to sixteen hands used for general riding, and as a workhorse. With the new horse collar, and teamed either one in front of the other or in parallel pairs, they are half again as efficient as a similar number of oxen. Hackneys are slow and ponderous beasts not suited for combat or hunting, but they can be ridden for long journeys, or by those not bothered about appearances or speed. Primarily they are used for farm work. A pair of hackneys can be bought for as little as a pound, but no noble would ever be seen riding such a beast. A hackney with a horse collar can easily pull a heavily laden cart, which might otherwise require two oxen.
+> 
+> ### Working Pony (Fell or Icelandic)
+> 
+> **Characteristics:** Cun –2, Per +1, Pre 0, Com –4, Str +2, Sta +3, Dex +2, Qik 0
+> 
+> **Size:** +1
+> 
+> **Virtues & Flaws:** Improved Characteristics, Long-Winded, Perfect Balance, Noncombatant
+> 
+> **Qualities:** Domesticated, Herd Animal, Imposing Appearance, Tireless
+> 
+> **Personality Traits:** Brave+2, Resilient +1 **Soak:** +3
+> 
+> **Fatigue Levels:** OK, 0/0, –1/–1, –3, –5, Unconscious
+> 
+> **Wound Penalties**: –1 (1–6), –3 (7–12), –5 (13–18), Incapacitated (19–24), Dead (25+)
+> 
+> **Abilities:** Awareness 2 (footing)
+> 
+> This sturdy pony is suited for use on the roughest terrain. These statistics may be used to represent animals from the north of England and Scotland, or Iceland, and such beasts are greatly prized for their ability to cross mountain trails and treacherous moors. A working pony costs about one pound in Northern Europe, but far more in southern regions. Superb pack animals, sure footed and sturdy, they are used to carry supplies over long distances where no cart can go, and across country. The Perfect Balance Virtue represents their abilities on treacherous mountain paths.
 
 Even more than with other horses, there is no such thing as a standard destrier. The term denotes not so much a type of horse as a horse of exceptional quality far beyond the norm. Many destriers are Horses of Virtue, and others have powers aligned with one of the realms and possess appropriate Might, but no two destriers are the same.
 
 As well as being differentiated by type, horses are differentiated by country of origin. Barbs from North Africa, the Muslim regions of Iberia, or the Levant, make fine coursers and destriers, as do Spanish horses, with perhaps the majority of destriers being stallions from Iberia, and in particular Andalusia. Northern Britain produces particularly fine fell ponies, with Iceland being the source of the very best beasts of this type. Hungary is known for the quality of its riding horses, such as palfreys and jennets, with fine rounceys being available in England, Ireland, France, and Scandinavia. The Low Countries and the Novgorod Tribunal produce good draught horses, with English and German breeds also being notable.
 
 
-## The Care of Horses
+### The Care of Horses
 
 Horses are extremely important and valuable, so their care can be come an important consideration in the saga.
 
 #### Horses and Aging
 
-If the stables rules are being used (see Running an Establishment, later) there is no need to keep track of the births and deaths of individual horses, though a shoddy stable
+If the stables rules are being used (see Running an Establishment, later) there is no need to keep track of the births and deaths of individual horses, though a shoddy stable loses one horse every three years to bad conditions, requiring replacement.. However, in the case of destriers, favorite warhorses, trained animals, and other horses important to the saga it may be desirable to keep track of individual animals' ages and health. Medieval horses can expect to live up to twenty years, but some exceptional animals may live into their fifties. A horse begins to age at 14 years, and must make an aging roll every season thereafter, rather than every year as humans do. Every five years a horse's aging modifier increases by one.
 
-## A Note on Size and Capacity
-
-Horses are measured in hands, abbreviated "hh." A hand is four inches, or approximately ten centimeters, and the horse is measured from the ground to the top of the withers, which is the highest point on a horse's back. In modern terms a horse up to 14.2 hands is classified as a pony, but medieval horses are smaller. A modern thoroughbred averages about sixteen hands in comparison, so is eight inches higher than the horses of Mythic Europe. A horse can carry unencumbered about 30% of its weight in pounds, so a 14 hh horse weighing perhaps 1,200 pounds can carry 400 pounds of goods or riders without being encumbered.
-
-#### Lords of Men
-
-loses one horse every three years to bad conditions, requiring replacement.. However, in the case of destriers, favorite warhorses, trained animals, and other horses important to the saga it may be desirable to keep track of individual animals' ages and health. Medieval horses can expect to live up to twenty years, but some exceptional animals may live into their fifties. A horse begins to age at 14 years, and must make an aging roll every season thereafter, rather than every year as humans do. Every five years a horse's aging modifier increases by one.
+> ## A Note on Size and Capacity
+> 
+> Horses are measured in hands, abbreviated "hh." A hand is four inches, or approximately ten centimeters, and the horse is measured from the ground to the top of the withers, which is the highest point on a horse's back. In modern terms a horse up to 14.2 hands is classified as a pony, but medieval horses are smaller. A modern thoroughbred averages about sixteen hands in comparison, so is eight inches higher than the horses of Mythic Europe. A horse can carry unencumbered about 30% of its weight in pounds, so a 14 hh horse weighing perhaps 1,200 pounds can carry 400 pounds of goods or riders without being encumbered.
 
 Stables provide a positive Living Conditions modifier, representing appropriate care, veterinary medicine, and good food and exercise. This, however, requires a score in the Ability Profession Marshal, as described in Running an Establishment.
 
@@ -2645,46 +2482,39 @@ The birds employed are divided into two classes, hawks and falcons, though the t
 
 Hawking birds often live within a chamber in the falconer's house, where they are secured to their perches by leather or silk cords called jesses. The far end is placed on a ring called a terret, which is slipped over the perch, or can be worn over the finger on the creep, the great leather gloves worn by the hawker to protect his hands from the birds' talons when they are taken out to hunt. A new fashion originating at the court of Sicily but becoming increasingly widespread involves the hawk being kept calm with a hood, often elaborately embroidered or bejeweled.
 
-Hunting birds are first trained by professional falconers, and then afterward trained
-
-
-to be loyal to their owners (see the rules for animal training earlier for information about how this transfer of loyalty is effected).
+Hunting birds are first trained by professional falconers, and then afterward trained to be loyal to their owners (see the rules for animal training earlier for information about how this transfer of loyalty is effected).
 
 When hunting, the hawker rides out with a party, and beaters or sometimes bird dogs are used to flush the game out. Prey varies from rabbit and hare on the ground to birds in flight, with experienced hawkers able to get two birds to work together to bring down such large birds as ducks and cranes, though pigeons are more normal prey.
 
 The mechanics of hunting require a Presence + Animal Handling roll from the hawker, as he releases the hawk and issues commands. The result is determined on the table below. Penalties for The Gift apply as normal.
 
-| Roll      | Result                                                                                                                        |
-|-----------|-------------------------------------------------------------------------------------------------------------------------------|
-| 0 or less | Make a Loyalty check for<br>the animal. On a failure, the<br>animal leaves, never to be seen<br>again.                        |
-| 1–3       | The hawk flies off to a nearby<br>tree and looks at the hawker<br>quizzically.                                                |
-| 4–6       | The hawk disregards its<br>intended target and merely<br>circles before returning.                                            |
-| 7–9       | The hawk conducts a single<br>attack against its prey, which<br>may result in a kill.                                         |
-| 10–12     | The hawk attacks with a +1<br>bonus to its attack roll.                                                                       |
-| 13–15     | The hawk attacks with a +2<br>bonus to its attack roll.                                                                       |
-| 16–20     | The hawk attacks with a +3<br>bonus to its attack roll.                                                                       |
-| 21+       | The hawk attacks with a +5<br>bonus to both its attack and<br>initiative rolls, and continues<br>launching additional attacks |
+| Roll | Result |
+|------|--------|
+| 0 or less | Make a Loyalty check for the animal. On a failure, the animal leaves, never to be seen again. |
+| 1–3 | The hawk flies off to a nearby tree and looks at the hawker quizzically. |
+| 4–6 | The hawk disregards its intended target and merely circles before returning. |
+| 7–9 | The hawk conducts a single attack against its prey, which may result in a kill. |
+| 10–12 | The hawk attacks with a +1 bonus to its attack roll. |
+| 13–15 | The hawk attacks with a +2 bonus to its attack roll. |
+| 16–20 | The hawk attacks with a +3 bonus to its attack roll. |
+| 21+ | The hawk attacks with a +5 bonus to both its attack and initiative rolls, and continues launching additional attacks after the first. |
 
 While certain birds are ascribed by tradition and etiquette to certain social classes, in practice birds are employed as available and as required for specific roles, irrespective of social rank. Hawking is largely the preserve of the noble classes (irrespective of gender), though some clergymen do engage in it.
 
-after the first.
-
 #### Birds and Aging
 
-If the mews rules (see Running an Establishment, later) are being used it is not
+If the mews rules (see Running an Establishment, later) are being used it is not necessary to keep track of the births and deaths of individual hawks, though a shoddy mews will kill all of its birds quickly, losing twenty percent of them every season. However, in the case of trained birds and other hawks important to the saga it may be desirable to keep track of particular birds' ages and health. Medieval hawks and falcons can expect to live up to 15 years, but some exceptional animals may live in to their twenties. A hawk or falcon begins to age at ten years, and must make an Aging roll every season thereafter, rather than every year as with a human, with an additional Aging roll in the winter during the molt when the bird's plumage changes. Sparrowhawks must make an Aging roll every winter from their very first year owing to these birds' extreme fragility. Every four years after age ten the aging modifier increases by 1.
 
-|           |      | Some Typical Prey Animals |     |     |     |      |     |     |     |      |
-|-----------|------|---------------------------|-----|-----|-----|------|-----|-----|-----|------|
-| Type      | Size | Str                       | Sta | Dex | Qik | Init | Atk | Def | Dam | Soak |
-| Partridge | –5   | –10                       | 0   | +3  | +6  | +6   | +5  | +9  | –9  | 0    |
-| Hare      | –6   | –6                        | +1  | +3  | +4  | +4   | n/a | +4  | n/a | +1   |
-| Duck      | –3   | -6                        | 0   | +3  | +4  | +4   | +5  | +7  | –5  | 0    |
-| Goose     | –2   | -4                        | +1  | +3  | +3  | +3   | +5  | +6  | –3  | +1   |
-| Pheasant  | –2   | –4                        | 0   | +3  | +4  | +4   | n/a | +7  | n/a | 0    |
-| Heron     | –2   | –4                        | –1  | +4  | +4  | +2   | +3  | +7  | –5  | –1   |
-| Crane     | –1   | –2                        | 0   | +3  | +3  | +2   | +5  | +5  | –1  | 0    |
-
-necessary to keep track of the births and deaths of individual hawks, though a shoddy mews will kill all of its birds quickly, losing twenty percent of them every season. However, in the case of trained birds and other hawks important to the saga it may be desirable to keep track of particular birds' ages and health. Medieval hawks and falcons can expect to live up to 15 years, but some exceptional animals may live in to their twenties. A hawk or falcon begins to age at ten years, and must make an Aging roll every season thereafter, rather than every year as with a human, with an additional Aging roll in the winter during the molt when the bird's plumage changes. Sparrowhawks must make an Aging roll every winter from their very first year owing to these birds' extreme fragility. Every four years after age ten the aging modifier increases by 1.
+> ## Some Typical Prey Animals
+> | Type      | Size | Str | Sta | Dex | Qik | Init | Atk | Def | Dam | Soak |
+> |-----------|:----:|:---:|:---:|:---:|:---:|:----:|:---:|:---:|:---:|:----:|
+> | Partridge | –5   | –10 | 0   | +3  | +6  | +6   | +5  | +9  | –9  | 0    |
+> | Hare      | –6   | –6  | +1  | +3  | +4  | +4   | n/a | +4  | n/a | +1   |
+> | Duck      | –3   | –6  | 0   | +3  | +4  | +4   | +5  | +7  | –5  | 0    |
+> | Goose     | –2   | –4  | +1  | +3  | +3  | +3   | +5  | +6  | –3  | +1   |
+> | Pheasant  | –2   | –4  | 0   | +3  | +4  | +4   | n/a | +7  | n/a | 0    |
+> | Heron     | –2   | –4  | –1  | +4  | +4  | +2   | +3  | +7  | –5  | –1   |
+> | Crane     | –1   | –2  | 0   | +3  | +3  | +2   | +5  | +5  | –1  | 0    |
 
 Mews provide a positive Living Conditions modifier, representing appropriate care, veterinary medicine, and good food and exercise. This, however, requires a score in the Ability Profession Falconer, as described in Running an Establishment.
 
@@ -2692,72 +2522,65 @@ Mews provide a positive Living Conditions modifier, representing appropriate car
 
 Nobles often wish to ensure they have available the finest hounds, horses, and hawks for their pleasure. The following rules provide a simple system for maintaining kennels, stables, and mews, which are interchangeably referred to as "establishments" here.
 
-The quality of kennels, stables, or mews
+> ## Story Seed: The Vanishing Hawk
+> 
+> A contest of falconry has been declared, with a great prize to be awarded by the king. One lady who wishes to enter has recently lost her prize hawk, which simply vanished in mid-air over a sunny meadow while in plain sight of the hawking party. She is distraught, and offers a great prize to any who can solve the mystery and return the magnificent bird to her in time for the contest.
 
-## Story Seed: The Vanishing Hawk
-
-A contest of falconry has been declared, with a great prize to be awarded by the king. One lady who wishes to enter has recently lost her prize hawk, which simply vanished in mid-air over a sunny meadow while in plain sight of the hawking party. She is distraught, and offers a great prize to any who can solve the mystery and return the magnificent bird to her in time for the contest.
-
-describe their capacity, bonus to the housed animals' Living Conditions modifier, and the prestige they confer upon their owner. All nobles are assumed to own standard stables at no cost, as part of their estate. Mews and kennels must be built if desired. Note that a noble's (and his visitors') horses, hackneys, ponies, mules, and farm horses generally do not require more than minimal stabling — a paddock and a stable for wintering — so do not apply these rules, which are intended for more valuable and delicate war and riding horses, to such common beasts.
+The quality of kennels, stables, or mews describe their capacity, bonus to the housed animals' Living Conditions modifier, and the prestige they confer upon their owner. All nobles are assumed to own standard stables at no cost, as part of their estate. Mews and kennels must be built if desired. Note that a noble's (and his visitors') horses, hackneys, ponies, mules, and farm horses generally do not require more than minimal stabling — a paddock and a stable for wintering — so do not apply these rules, which are intended for more valuable and delicate war and riding horses, to such common beasts.
 
 Establishments are defined by a quality, such as "shoddy" or "superior." Each quality corresponds to a rank of noble to which its ownership is typically appropriate.
 
 A given establishment's quality corresponds to a capacity of active animals it may support. The actual number of animals present may include up to one-third again the capacity in immature beasts and breeding stock.
 
-Each establishment has a maintenance cost for a year listed, but a stable of appropriate level to its owner's rank can be main-
+Each establishment has a maintenance cost for a year listed, but a stable of appropriate level to its owner's rank can be maintained at no cost. (Thus, a knight running a standard stable does not incur a maintenance cost, nor an earl who keeps an excellent stable. However, if a covenant of Hermetic magi wished to own anything better than a standard stable, or a knight wished to maintain a superior stable, the cost would be incurred as given.) Kennels and mews always require the maintenance cost to be paid.
 
-
-
-Rather than provide characteristics for each type of hawk and falcon, the gyrfalcon template can be modified to represent better quality birds and different breeds as appropriate and as described below. The Size characteristic reflects a female bird, the gender primarily used in hawking. Many male birds are a Size smaller, usually weighing one-half to two-thirds the body weight of a female.
-
-+2. The statistics for its beak are Init 0, Attack +3, Defense +1, Damage +1.
-
-less specifically trained to hunt that particular type of prey. An untrained goshawk can be purchased for a pound. **Merlin:** A small but very fast falcon.
-
-do not attack prey larger than Size –2 un-
-
-#### Gyrfalcon (Falco)
-
-**Gyrfalcon:** These statistics are for a gyrfalcon, the largest and most prized of falcons. Its wingspan can exceed four feet. It has a short, hooked beak and dark eyes. Its plumage may be white, grey, or dark brown and has a banded pattern. The gyrfalcon is among the swiftest of birds and hunts on the wing, overtaking its prey in
-
-flight. Nobles use falcons to hunt game
-
-Modify the gyrfalcon statistics to Size –5, Str –10, Qik +8, and Beak Init +11\*, Attack +6, Defense +11, Damage –9. Merlins are useful for hunting small prey up to partridge size (–6). Four untrained birds can
-
-0, Str –6, Sta –2, Dex +1, Qik +6
-
-be purchased for a pound.
-
-**Size:** –3
-
-**Characteristics:** Cun –1, Per +3, Pre –1, Com **Qualities:** Accomplished Flier, Fast Flier, Keen Eyesight, Pursuit Predator, Extra birds such as partridge. In the wild, the gyrfalcon can kill prey as large as a goose, and usually hunts birds and small rodents. It lives in cold northern lands including Scandinavia, Iceland, and Russia. An untrained bird costs about three to four pounds, and
-
-**Lanner:** Found mainly in North Africa and Mediterranean climes, the lanner is often used to teach falconry. A Size –4 falcon, it lacks the Ferocity virtue and Confidence Score and is therefore easy to train. Lanners are, uniquely, usually taught to hunt in pairs. The lanner has Str –8, Qik+7, and Talons with Init +7, Attack +6, Defense +14, Damage –6, but a pair can be taught to fight as a trained group, and a lanner has Leadership 1. A trained pair therefore attacks with Str –8, Qik +7, and Talons with Init +7, Attack +12, Defense +14, Damage
-
-Natural Weapons **Confidence Score:** 1 (3)
-
-**Virtues and Flaws:** Ferocity (swooping attack), Keen Vision, Fragile Constitution **Personality Traits:** Fierce +3
-
-–6. A pair of untrained birds can be pur-
-
-**Combat:**
-
-*Talons:* Init +8\*, Attack +6, Defense +12, Damage –4
-
-*Beak:* Init +9\*, Attack +6, Defense +9, Damage –5
-
-\* Includes +3 bonus for Fast Flyer Quality. **Soak:** –2
-
-**Fatigue levels:** OK, 0/0, –1, –3, –5, Unc. **Wound Penalties**: –1 (1–2), –3 (3–4), –5 (5–6), Incapacitated (7–8), Dead (9+)
-
-**Abilities:** Athletics 5 (swift flight), Awareness 4 (spotting prey), Brawl 2 (talons), Hunt 4 (game birds), Survival 3 (cold climates)
-
-**Natural Weapons:** The unmodified weapon statistics for a falcon's talons are Init –1, Attack +2, Defense +3, Damage they are greatly prized. **Peregrine Falcon:** Smaller than the gyrfalcon, with Size –4, the peregrine attacks from flight, hovering overhead and then falling like a stone to grab its prey in outstretched talons in a swooping attack. The peregrine is an Ambush Predator, not a Pursuit Predator, and has Str –8, Qik +7, and Talons with Init +7, Attack +6, Defense +14, Damage –6. It has Stealth 3 (ambush prey) but only Athletics 3 (climbing flight). If it makes a stealthy attack on unsuspecting prey it automatically gains +3 to its attack total and wins initiative. A peregrine falcon costs around one pound untrained.
-
-**Goshawk:** The female goshawk is the same size as a gyrfalcon, but the goshawk is flown from the fist, with a distinctive graceful flight style. Remove the Quality Fast Flyer and add Aggressive for a +3 bonus to Attack. Despite this aggression, goshawks chased for a pound. **Sparrowhawk:** The most commonly found hawk in Mythic Europe, and hence the most widely flown, sparrowhawks are often captured in the wild. If purchased, six untrained bird can be bought for a pound. Remove the Quality Fast Flyer, reduce Size to –4, and add Beak Init +8, Attack +6, Defense +13, Damage –7. Sparrowhawks are notoriously difficult to raise, with an Aging rolls modifier of –3 and a Stamina of –3, giving them Soak –3 to reflect their extreme fragility. They are naturally perverse, sometimes dying just to spite their owners.
-
-tained at no cost. (Thus, a knight running a standard stable does not incur a maintenance cost, nor an earl who keeps an excellent stable. However, if a covenant of Hermetic magi wished to own anything better than a standard stable, or a knight wished to maintain a superior stable, the cost would be incurred as given.) Kennels and mews always require the maintenance cost to be paid.
-
+> ## Hawks and Falcons
+> 
+> Rather than provide characteristics for each type of hawk and falcon, the gyrfalcon template can be modified to represent better quality birds and different breeds as appropriate and as described below. The Size characteristic reflects a female bird, the gender primarily used in hawking. Many male birds are a Size smaller, usually weighing one-half to two-thirds the body weight of a female.
+> 
+> #### Gyrfalcon (Falco)
+> 
+> **Characteristics:** Cun –1, Per +3, Pre –1, Com -2, Str –6, Sta –2, Dex +1, Qik +6
+> 
+> **Size:** –3
+> 
+> **Qualities:** Accomplished Flier, Fast Flier, Keen Eyesight, Pursuit Predator, Extra Natural Weapons
+> 
+> **Confidence Score:** 1 (3)
+> 
+> **Virtues and Flaws:** Ferocity (swooping attack), Keen Vision, Fragile Constitution
+> 
+> **Personality Traits:** Fierce +3
+> 
+> **Combat:**
+> 
+> *Talons:* Init +8\*, Attack +6, Defense +12, Damage –4
+> 
+> *Beak:* Init +9\*, Attack +6, Defense +9, Damage –5
+> 
+> \* Includes +3 bonus for Fast Flyer Quality.
+> 
+> **Soak:** –2
+> 
+> **Fatigue levels:** OK, 0/0, –1, –3, –5, Unc.
+> 
+> **Wound Penalties:** –1 (1–2), –3 (3–4), –5 (5–6), Incapacitated (7–8), Dead (9+)
+> 
+> **Abilities:** Athletics 5 (swift flight), Awareness 4 (spotting prey), Brawl 2 (talons), Hunt 4 (game birds), Survival 3 (cold climates)
+> 
+> **Natural Weapons:** The unmodified weapon statistics for a falcon’s talons are Init –1, Attack +2, Defense +3, Damage +2. The statistics for its beak are Init 0, Attack +3, Defense +1, Damage +1.
+> 
+> **Gyrfalcon:** These statistics are for a gyrfalcon, the largest and most prized of falcons. Its wingspan can exceed four feet. It has a short, hooked beak and dark eyes. Its plumage may be white, grey, or dark brown and has a banded pattern. The gyrfalcon is among the swiftest of birds and hunts on the wing, overtaking its prey in flight. Nobles use falcons to hunt game birds such as partridge. In the wild, the gyrfalcon can kill prey as large as a goose, and usually hunts birds and small rodents. It lives in cold northern lands including Scandinavia, Iceland, and Russia. An untrained bird costs about three to four pounds, and they are greatly prized.
+> 
+> **Peregrine Falcon:** Smaller than the gyrfalcon, with Size –4, the peregrine attacks from flight, hovering overhead and then falling like a stone to grab its prey in outstretched talons in a swooping attack. The peregrine is an Ambush Predator, not a Pursuit Predator, and has Str –8, Qik +7, and Talons with Init +7, Attack +6, Defense +14, Damage –6. It has Stealth 3 (ambush prey) but only Athletics 3 (climbing flight). If it makes a stealthy attack on unsuspecting prey it automatically gains +3 to its attack total and wins initiative. A peregrine falcon costs around one pound untrained.
+> 
+> **Goshawk:** The female goshawk is the same size as a gyrfalcon, but the goshawk is flown from the fist, with a distinctive graceful flight style. Remove the Quality Fast Flyer and add Aggressive for a +3 bonus to Attack. Despite this aggression, goshawks do not attack prey larger than Size –2 unless specifically trained to hunt that particular type of prey. An untrained goshawk can be purchased for a pound.
+> 
+> **Merlin:** A small but very fast falcon. Modify the gyrfalcon statistics to Size –5, Str –10, Qik +8, and Beak Init +11\*, Attack +6, Defense +11, Damage –9. Merlins are useful for hunting small prey up to partridge size (–6). Four untrained birds can be purchased for a pound.
+> 
+> **Lanner:** Found mainly in North Africa and Mediterranean climes, the lanner is often used to teach falconry. A Size –4 falcon, it lacks the Ferocity virtue and Confidence Score and is therefore easy to train. Lanners are, uniquely, usually taught to hunt in pairs. The lanner has Str –8, Qik +7, and Talons with Init +7, Attack +6, Defense +14, Damage –6, but a pair can be taught to fight as a trained group, and a lanner has Leadership 1. A trained pair therefore attacks with Str –8, Qik +7, and Talons with Init +7, Attack +12, Defense +14, Damage –6. A pair of untrained birds can be purchased for a pound.
+> 
+> **Sparrowhawk:** The most commonly found hawk in Mythic Europe, and hence the most widely flown, sparrowhawks are often captured in the wild. If purchased, six untrained birds can be bought for a pound. Remove the Quality Fast Flyer, reduce Size to –4, and add Beak Init +8, Attack +6, Defense +13, Damage –7. Sparrowhawks are notoriously difficult to raise, with an Aging rolls modifier of –3 and a Stamina of –3, giving them Soak –3 to reflect their extreme fragility. They are naturally perverse, sometimes dying just to spite their owners.
 Staff are any folk who are dedicated to the care and maintenance of the stables as their primary occupation, spending at least three seasons a year in this role and typically possessing the Abilities Animal Handling, Ride, and Hunt.
 
 The Living Conditions modifier applies to the animals, not the staff, but if it is higher than the prevailing Living Condition of the residences, then the staff also benefit from it. The Living Conditions modifier assumes that a suitable specialist is available (see Living Conditions and Specialists, later.)
@@ -2766,11 +2589,7 @@ Paying the annual maintenance cost keeps the number of animals constant, through
 
 While the maintenance cost covers replacing normal losses, players may wish to keep track of the aging of superior and particular animals separately, as described in the various sections describing horses, hounds, and hawks earlier in this chapter.
 
-A superior stables or better requires at least one specialist (a marshal, head falconer,
-
-
-
-or master of kennels) with the appropriate Profession Ability. Royal quality establishments require additional specialists.
+A superior stables or better requires at least one specialist (a marshal, head falconer, or master of kennels) with the appropriate Profession Ability. Royal quality establishments require additional specialists.
 
 ### The Kennels
 
@@ -2782,75 +2601,75 @@ A kennel usually houses a certain ratio of types of hounds, so that for every 12
 
 Falcons and hawks are kept in a mews, a house set aside for this purpose, where the falconer and his assistant live with the birds. They may have their own caged courtyard and fountain as well, and a low, stable-like building if the mews is large enough.
 
-## The Stables
+### The Stables
 
 Horses are kept in stables. See the Stables table for more information.
 
-## Kennels, Mews, and Stables Tables
+> ## Kennels, Mews, and Stables Tables
+> 
+> ### Kennels
+> 
+> | Quality | Capacity (hounds) | Maintenance (pounds/year) | Staff | Living Conditions Modifier |
+> |---------|:-----------------:|:-------------------------:|:-----:|:--------------------------:|
+> | Shoddy (Inn/Farm) | 8 | 0 | 0 | –1 |
+> | Standard (Knight) | 16 | 1 | 2 | 0 |
+> | Superior (Noble) | 48 | 5 | 6 | +1 |
+> | Excellent (Great Noble) | 80 | 20 | 12 | +2 |
+> | Royal | 150+ | 100 | 36 | +3 |
+> 
+> ### Mews
+> 
+> | Quality | Capacity (birds) | Maintenance (pounds/year) | Staff | Living Conditions Modifier |
+> |---------|:----------------:|:-------------------------:|:-----:|:--------------------------:|
+> | Shoddy (Loft) | 3 | 0 | 0 | –1 |
+> | Standard (Knight) | 6 | 0 | 1 | 0 |
+> | Superior (Noble) | 15 | 5 | 3 | +1 |
+> | Excellent (Great Noble) | 30 | 10 | 5 | +2 |
+> | Royal | 100 | 100 | 10 | +3 |
+> 
+> ### Stables
+> 
+> | Quality | Capacity (horses) | Maintenance (pounds/year) | Staff | Living Conditions Modifier |
+> |---------|:-----------------:|:-------------------------:|:-----:|:--------------------------:|
+> | Shoddy (Inn/Farm) | 3 | 0 | 0 | –1 |
+> | Standard (Knight) | 6 | 1 per horse\* | 2 | 0 |
+> | Superior (Noble) | 18 | 2 per horse | 6 | +1 |
+> | Excellent (Great Noble) | 40 | 3 per horse | 12 | +2 |
+> | Royal | 250 | 5 per horse | 36 | +3 |
+> \*Knights do not need to pay this maintenance, however, as it is already calculated in their expenditure.
 
-| Kennels                    |                      |                              |       |                               |
-|----------------------------|----------------------|------------------------------|-------|-------------------------------|
-| Quality                    | Capacity<br>(hounds) | Maintenance<br>(pounds/year) | Staff | Living Conditions<br>Modifier |
-| Shoddy (Inn/Farm)          | 8                    | 0                            | 0     | –1                            |
-| Standard (Knight)          | 16                   | 1                            | 2     | 0                             |
-| Superior (Noble)           | 48                   | 5                            | 6     | +1                            |
-| Excellent (Great<br>Noble) | 80                   | 20                           | 12    | +2                            |
-| Royal                      | 150+                 | 100                          | 36    | +3                            |
-|                            |                      |                              |       |                               |
-
-| Mew<br>s                   |                     |                              |       |                               |
-|----------------------------|---------------------|------------------------------|-------|-------------------------------|
-| Quality                    | Capacity<br>(birds) | Maintenance<br>(pounds/year) | Staff | Living Conditions<br>Modifier |
-| Shoddy (Loft)              | 3                   | 0                            | 0     | –1                            |
-| Standard (Knight)          | 6                   | 0                            | 1     | 0                             |
-| Superior (Noble)           | 15                  | 5                            | 3     | +1                            |
-| Excellent (Great<br>Noble) | 30                  | 10                           | 5     | +2                            |
-| Royal                      | 100                 | 100                          | 10    | +3                            |
-
-| Stables                       |                      |                              |       |                               |
-|-------------------------------|----------------------|------------------------------|-------|-------------------------------|
-| Quality                       | Capacity<br>(horses) | Maintenance<br>(pounds/year) | Staff | Living Conditions<br>Modifier |
-| Shoddy (Inn/Farm)             | 3                    | 0                            | 0     | –1                            |
-| Standard (Knight)             | 6                    | 1 per horse*                 | 2     | 0                             |
-| Superior (Noble)              | 18                   | 2 per horse                  | 6     | +1                            |
-| Excellent (Great<br>Noble) 40 | 3 per<br>horse       | 12                           | +2    |                               |
-| Royal                         | 250                  | 5 per horse                  | 36    | +3                            |
-
-<sup>\*</sup>Knights do not need to pay this maintenance, however, as it is already calculated in their expenditure.
-
-## Living Conditions and Specialists
+### Living Conditions and Specialists
 
 An individual with a score in the relevant Profession Ability equal to at least twice the Living Conditions modifier is required for an establishment to make use of a positive Living Conditions modifier. Alternatively, an individual without the appropriate Ability may dedicate a season each year to running the establishment and thereby preserve the Living Conditions modifier, so long as he has a score in Animal Handling at least three times the positive Living Conditions modifier.
 
-A stress roll of Intelligence + Animal Handling against Ease Factor 9, or Intelligence + Profession Marshal, Profession Falconer, or Profession Master of Kennels as appropriate against Ease Factor 9, should made annually in the winter. A success indicates the establishment is well run. A failure causes a decline of establishment quality by one class, which does not improve until the test is made successfully in a later year, when it reverts one class upwards toward its
+A stress roll of Intelligence + Animal Handling against Ease Factor 9, or Intelligence + Profession Marshal, Profession Falconer, or Profession Master of Kennels as appropriate against Ease Factor 9, should made annually in the winter. A success indicates the establishment is well run. A failure causes a decline of establishment quality by one class, which does not improve until the test is made successfully in a later year, when it reverts one class upwards toward its original quality. Maintenance costs remains at the original level regardless of a temporarily lower quality due to poor maintenance. A botch indicates a catastrophe, of which the most common are fires, outbreaks of disease in the animals, theft, or a situation requiring a story to resolve.
 
+> ## New Virtues
+> 
+> ### Master of Kennels
+> 
+> *Social Status, Minor*
+> 
+> The character manages the kennels for a noble patron, and is responsible for the training, breeding, and health of the animals. He has an appropriate staff under him, depending on the size of the kennels, and often possesses the privilege of riding with the hunt. He may be considered an intimate and important member of the noble household, despite his common birth, and be treated with commensurate respect. He is also expected to organize the huntsmen — that is, the dog handlers — and train servants or locals to perform that role. He should possess the Ability Profession Master of Kennels, which governs the care of the dogs, treatment of their diseases, and acquisition and breeding of hounds. The Ability Animal Handling is used for the training of the animals. A master of kennels receives 50 extra experience points at character generation to spend on the abilities Animal Handling, Etiquette, Hunt, Latin, Profession Master of Kennels, and Ride, and may take Martial Abilities freely.
+> 
+> ### Falconer
+> 
+> *Social Status, Minor*
+> 
+> The character trains hawks and falcons for a noble patron, and is responsible for the training, breeding, and health of the animals. He often has a personal servant to assist, and is an important member of the noble household, treated with great respect. He should possess the Ability Profession Falconer, which governs the care of the birds, treatment of their diseases, and acquisition and breeding of hawks and falcons. The Ability Animal Handling is used for the training of the hawks. A specialist in non-falcons, such as the hawks, is called an austringer.
+> 
+> A falconer receives 50 extra experience points at character generation to spend on the Abilities Animal Handling, Area Lore, Etiquette, Hunt, Latin, Profession Falconer, and Ride. Many falconers are also Educated.
+> 
+> ### Marshal
+> 
+> *Social Status, Minor*
+> 
+> As well as their non-specialist staff, superior stables and above require a specialist to coordinate the care, feeding, and welfare of the animals. This person is called a marshal, and the title holds considerable honor. The Marshal of England is the king's official in charge of his cavalry, but even the marshal of a baron is an important personage, given the vital roles played by horses in warfare and hunting, as well as routine travel.
+> 
+> A marshal should take the Ability Profession Marshal, which deals with understanding, purchasing, and caring for horses. It functions as the Ability Medicine for the purpose of treating veterinary diseases, and for surgery involving these animals. A marshal receives 50 extra experience points at character generation to spend on the abilities Animal Handling, Etiquette, Hunt, Latin, Profession Marshal and Ride, and may take Martial Abilities freely.
+> 
+> A marshal may overseen other specialists, including farriers who make horseshoes; leatherworkers who produce tack, harness, and saddles; and the trained staff who administer day-to-day grooming and mucking out of the stables.
 
-
-#### Master of Kennels
-
-*Social Status, Minor*
-
-The character manages the kennels for a noble patron, and is responsible for the training, breeding, and health of the animals. He has an appropriate staff under him, depending on the size of the kennels, and often possesses the privilege of riding with the hunt. He may be considered an intimate and important member of the noble household, despite his common birth, and be treated with commensurate respect. He is also expected to organize the huntsmen — that is, the dog handlers — and train servants or locals to perform that role. He should possess the Ability Profession Master of Kennels, which governs the care of the dogs, treatment of their diseases, and acquisition and breeding of hounds. The Ability Animal Handling is used for the training of the animals. A master of kennels receives 50 extra experience points at character generation to spend on the abilities Animal Handling, Etiquette, Hunt, Latin, Profession Master of Kennels, and Ride, and may take Martial Abilities freely.
-
-#### Falconer
-
-*Social Status, Minor*
-
-The character trains hawks and falcons for a noble patron, and is responsible for the training, breeding, and health of the animals. He often has a personal servant to assist, and is an important member of the noble household, treated with great respect. He should possess the Ability Profession Falconer, which governs the care of the birds, treatment of their diseases, and acquisition and breeding of hawks and falcons. The Ability Animal Handling is used for the training of the hawks. A specialist in non-falcons, such as the hawks, is called an austringer.
-
-A falconer receives 50 extra experience points at character generation to spend on the Abilities Animal Handling, Area Lore, Etiquette, Hunt, Latin, Profession Falconer, and Ride. Many falconers are also Educated.
-
-#### Marshal
-
-*Social Status, Minor*
-
-As well as their non-specialist staff, superior stables and above require a specialist to coordinate the care, feeding, and welfare of the animals. This person is called a marshal, and the title holds considerable honor. The Marshal of England is the king's official in charge of his cavalry, but even the marshal of a baron is an important personage, given the vital roles played by horses in warfare and hunting, as well as routine travel.
-
-A marshal should take the Ability Profession Marshal, which deals with understanding, purchasing, and caring for horses. It functions as the Ability Medicine for the purpose of treating veterinary diseases, and for surgery involving these animals. A marshal receives 50 extra experience points at character generation to spend on the abilities Animal Handling, Etiquette, Hunt, Latin, Profession Marshal and Ride, and may take Martial Abilities freely.
-
-A marshal may overseen other specialists, including farriers who make horseshoes; leatherworkers who produce tack, harness, and saddles; and the trained staff who administer day-to-day grooming and mucking out of the stables.
-
-original quality. Maintenance costs remains at the original level regardless of a temporarily lower quality due to poor maintenance. A botch indicates a catastrophe, of which the most common are fires, outbreaks of disease in the animals, theft, or a situation requiring a story to resolve.
 
 ## Romance
 
@@ -2858,29 +2677,23 @@ There is one form of noble sport, perhaps akin to hunting, that raises more cont
 
 In 1174 Andreas Capellanus wrote the definitive work on *fin' amors*, entitled *Incipit liber amoris et curtesie,* more often referred to by the shorter title *De Amore*. This book sets the rules of romance, and it is clear why controversy has dogged the work. Capellanus declares that true love between a man and wife is impossible, in contradiction to the teachings of the Church, and the apparently happy marriages of many. It follows, for Capellanus, that one must seek love outside of the marital home, practiced ideally in a love affair between a noble suitor and a married lady. Indeed, if the lady is not married, and hence unobtainable, true love may not blossom.
 
-## The Pursuit of Love
+### The Pursuit of Love
 
 The affair begins with the noble beholding a lady of great worth and beauty, and being entranced by her physical charms. The beholder immediately loses his composure, and from this point on is subject to nothing but thoughts of the lady, and the urgent need to win her favors. Sleep escapes him, and other pursuits hold no excitement; he devotes himself completely to the romantic quest to obtain her love.
 
-The pursuit must be achieved by certain methods alone. A handsome appearance,
-
-
-
-
-honesty of character, and fluent and eloquent speech are the primary methods. However, acts of great valor or heroism inspired by the lady, or dedicated to her, are also part of the pursuit. Love knows no social boundaries, and a male — even a commoner if learned in the arts of love — may seek romance from the noblest lady, even a queen. Here is another threat to the divinely ordered nature of things, and any commoner presumptuous enough to pursue the love of a noble lady runs a terrible risk. Only the clergy should seek to avoid romance. Equally deadly, according to Capellanus, is to seek the heart of a nun, and so vile an infamy that it destroys one's reputation forever. Equally unacceptable is to love a whore, for that cheapens the noble romance to a coarse and commercial prospect.
+The pursuit must be achieved by certain methods alone. A handsome appearance, honesty of character, and fluent and eloquent speech are the primary methods. However, acts of great valor or heroism inspired by the lady, or dedicated to her, are also part of the pursuit. Love knows no social boundaries, and a male — even a commoner if learned in the arts of love — may seek romance from the noblest lady, even a queen. Here is another threat to the divinely ordered nature of things, and any commoner presumptuous enough to pursue the love of a noble lady runs a terrible risk. Only the clergy should seek to avoid romance. Equally deadly, according to Capellanus, is to seek the heart of a nun, and so vile an infamy that it destroys one's reputation forever. Equally unacceptable is to love a whore, for that cheapens the noble romance to a coarse and commercial prospect.
 
 At first the lover should adore his lady secretly, and take every opportunity to seek out her company and gaze lovingly upon her person. Eventually there comes a time when he must profess his love to her, and she then chastely refuse his advances, with scorn and coldness. Even if the lady ardently desires the lover, and deliberately sought his attentions (for many ladies initiate the romance by their actions and subtle encouragements), she must act coldly, and treat the lover as if he was a source of disgust to her. He must then prove his devotion, and pursue her. The pursuit of the lady is primarily a matter of Charm, but appropriate gifts and performances in her honor are to be expected. Gifts may be given and received, but money should not be the means of gaining her heart. At all times both parties must be discreet, and under no circumstances must the lady's husband discover the affair. Trusted servants and friends act as go betweens, and Intrigue is used to arrange meetings in suitably romantic situations.
 
 At all times the lover should be jealous and passionate, and watch out for rivals, suspecting all. He must also eschew all other ladies, for to pursue another or seek comfort elsewhere would be to betray love. He must obey every whim and command of his lady, and prove his moral worth, bravery, and most of all utter devotion. To him salvation is his lady, and she is his religion, she his lord, he her obedient vassal in all matters of the heart.
 
-Finally the lady deigns to grant the lover her favor, and the affair is consummated. In the southern tradition this may imply a full sexual relationship, and adultery. To what
+Finally the lady deigns to grant the lover her favor, and the affair is consummated. In the southern tradition this may imply a full sexual relationship, and adultery. To what extent this actually occurs is little known, since couples who do and don’t all have strong reasons to keep the facts secret, but both parties run the risk of death if an affair is discovered. In France and England the platonic nature of the love is stressed, and adultery denied and decried, as in the popular romance of Tristan and Iseult, where their adultery brings disaster upon the lovers. In these regions, romance is seen as a chaste game, and may even be smilingly approved by trusting husbands. Most husbands, however, with an eye to ensuring their heirs are truly their own, regard the fin’ amors as a dangerous and corrupting pastime, not to be practiced on their wives. 
 
+> Love is an inborn suffering, which results from the sight of, and uncontrolled thinking about, the beauty of the other sex. This feeling makes a man desire before all else the embraces of the other sex, and to achieve the utter fulfillment of the commands of love in the other's embrace by their common desire.
+> 
+> — Andreas Capellanus
 
-Love is an inborn suffering, which results from the sight of, and uncontrolled thinking about, the beauty of the other sex. This feeling makes a man desire before all else the embraces of the other sex, and to achieve the utter fulfillment of the commands of love in the other's embrace by their common desire
-
-— Andreas Capellanus
-
-## The Rules of Love
+### The Rules of Love
 
 Andreas Capellanus lists 12 Laws of Love.
 
@@ -2898,15 +2711,15 @@ Andreas Capellanus lists 12 Laws of Love.
 - 12. You shall not exceed the desires of your lover.
 
 
-## Is Love True?
-
-Historians remain deeply divided over to what extent courtly love was an ideal, and to what extent a reality, in medieval society. Troupes should decide for their saga whether courtly love represents an ideal played at by knights and ladies, or a real practice. Is courtly love an idealized platonic romance mainly playacted, and accepted by many as harmless and diverting, or a tempestuous and real passion leading many to adultery and ruin? In some sagas romance will not feature at all, being merely something troubadours sing about. In others, it will be a real and potent force — this is Mythic Europe after all! It is hard from the extant sources for us to be sure of the truth, so the troupe must decide if it wishes to employ the motif in its stories. Three main considerations apply.
-
-First, no character with the True Love or Lost Love Virtue or Flaw may ever be caught up in romance, except with the object of their affections.
-
-Second, no character should be involved in a romance subplot unless the character actively seeks it out. Keep in mind that a romance can be initiated by a lady as much as her suitor; indeed, scheming to ensnare a noble's love is perfectly acceptable. While Andreas Capellanus writes mainly from the male perspective, the lady is a full partner in whom power is ultimately vested in the relationship. She has the ability to end it at any time, or choose to scorn any potential lover.
-
-Finally, romances should always require stories, rather than being something that "just happens." As the ancient cliché has it, "the path of true love never runs smooth," and complications, opportunities for heroic adventure, and moonlit intrigues are the very stuff of the romance. Stories, not mechanics, should drive a developing relationship between lovers, and the ever-present threat of discovery should add a certain spice.
+> ## Is Love True?
+> 
+> Historians remain deeply divided over to what extent courtly love was an ideal, and to what extent a reality, in medieval society. Troupes should decide for their saga whether courtly love represents an ideal played at by knights and ladies, or a real practice. Is courtly love an idealized platonic romance mainly playacted, and accepted by many as harmless and diverting, or a tempestuous and real passion leading many to adultery and ruin? In some sagas romance will not feature at all, being merely something troubadours sing about. In others, it will be a real and potent force — this is Mythic Europe after all! It is hard from the extant sources for us to be sure of the truth, so the troupe must decide if it wishes to employ the motif in its stories. Three main considerations apply.
+> 
+> First, no character with the True Love or Lost Love Virtue or Flaw may ever be caught up in romance, except with the object of their affections.
+> 
+> Second, no character should be involved in a romance subplot unless the character actively seeks it out. Keep in mind that a romance can be initiated by a lady as much as her suitor; indeed, scheming to ensnare a noble's love is perfectly acceptable. While Andreas Capellanus writes mainly from the male perspective, the lady is a full partner in whom power is ultimately vested in the relationship. She has the ability to end it at any time, or choose to scorn any potential lover.
+> 
+> Finally, romances should always require stories, rather than being something that "just happens." As the ancient cliché has it, "the path of true love never runs smooth," and complications, opportunities for heroic adventure, and moonlit intrigues are the very stuff of the romance. Stories, not mechanics, should drive a developing relationship between lovers, and the ever-present threat of discovery should add a certain spice.
 
 ## Patronage
 
@@ -2922,10 +2735,7 @@ When characters direct their patronage at specific individuals who belong to a c
 
 The main groups who can be influenced by a Reputation arising from patronage are the types listed in **Ars Magica Fifth Edition**, with two additions. Reputations can pertain to Local (meaning all in the vicinity), Clergy, Order of Hermes, Nobles, or Academics. Artists may also be patronized, but the Reputation thus gained applies to one of the other groups, designated as the intended audience. Someone who is known by reputation as a generous patron in one of these groups can expect positive modifiers in future social interactions with others of the same class. Appropriate forms of patronage are discussed for each of these groups in turn in the sections that follow.
 
-Local Reputations generally apply when a noble grants patronage to his own estates or local area. The granting of royal charters is a form of patronage performed by the crown that raises its Reputation, but most nobles, lacking the authority to grant royal charters,
-
-
-are only able to offer feasts, alms, or possibly the relaxation of feudal dues, though the latter creates a dangerous precedent and diminishes the noble's power. Acts of kind charity and impartial justice can go a long way towards gaining a positive Reputation, and a small amount of silver can help in times of hardship. The granting of offices is one very popular way of expressing patronage (see Chapter Two: Politics, Offices). Unfortunately, this form of patronage is unlikely to earn Gratitude points.
+Local Reputations generally apply when a noble grants patronage to his own estates or local area. The granting of royal charters is a form of patronage performed by the crown that raises its Reputation, but most nobles, lacking the authority to grant royal charters, are only able to offer feasts, alms, or possibly the relaxation of feudal dues, though the latter creates a dangerous precedent and diminishes the noble's power. Acts of kind charity and impartial justice can go a long way towards gaining a positive Reputation, and a small amount of silver can help in times of hardship. The granting of offices is one very popular way of expressing patronage (see Chapter Two: Politics, Offices). Unfortunately, this form of patronage is unlikely to earn Gratitude points.
 
 Acting as a patron to the Order of Hermes is fraught with difficulties, discussed in Chapter Four: Interference.
 
@@ -2945,11 +2755,7 @@ Tournaments of the 13th century mean three things to those who take part: experi
 
 Tournaments generally last only a day or two. The first day sees the knights gather, find lodgings, feast, and socialize. As the evening wears on and the office of vespers is sung, the knights may gather for *commencailles*, individual trials of sword and lance that continue while the light lasts.
 
-The melee, a mock battle between hundreds or even thousands of combatants divided into two teams, takes place on the final day of the tournament. On the morning of the melee, the heralds run through the streets and encampments calling the knights to mass. After they have massed, there is often time for the younger knights to resume their *commencailles*. This allows them to be
-
-
-
-seen by potential employers, and provides further opportunity for ransom to be claimed from defeated opponents.
+The melee, a mock battle between hundreds or even thousands of combatants divided into two teams, takes place on the final day of the tournament. On the morning of the melee, the heralds run through the streets and encampments calling the knights to mass. After they have massed, there is often time for the younger knights to resume their *commencailles*. This allows them to be seen by potential employers, and provides further opportunity for ransom to be claimed from defeated opponents.
 
 The main event starts with the *regars*, or review, where both sides parade in all their colors and call out their war cries in a show of high pomp and ceremony. The teams are usually drawn up along national or political lines. Members of each team know who has arrived, who will participate in the melee, and which factions they would naturally fight alongside. Team allegiance is shown through pennons tied to lances or bridles. The heralds make every effort to ensure the teams are roughly equal in strength, and knights generally accept reassignment with good grace.
 
@@ -2961,19 +2767,17 @@ The grand charge always pits two teams against each other but each larger teams 
 
 The night of the melee turns to feasting, and the most prestigious feast is that hosted by the tournament's patron. It is there that the prizes are announced and awarded.
 
-## Staging a Tournament
+### Staging a Tournament
 
-Tournaments range from the grand events of France with thousands of knights riding in the retinues of wealthy nobles to more modest affairs with around one hundred knights, nobles, patrons, and sponsors in attendance. Large and small, tournaments are held throughout the year with the exceptions of Lent and harvest time. Even in winter
+Tournaments range from the grand events of France with thousands of knights riding in the retinues of wealthy nobles to more modest affairs with around one hundred knights, nobles, patrons, and sponsors in attendance. Large and small, tournaments are held throughout the year with the exceptions of Lent and harvest time. Even in winter months the circuit is active and a tournament can usually be found every two weeks. This schedule allows participants time to recover from their wounds and travel between tournament sites. In each country, a large tournament — in excess of a thousand knights — can be found on average once per season, while an event in excess of three thousand will likely take place only once per year.
 
-## Bohorts, Tirocinia, and Jousts
-
-A bohort is an informal and impromptu tournament, essentially a rough-and-tumble between friends and comrades, usually conducted with blunted or even wooden weapons (the latter of which are very often simply sticks taken up from the roadside). Armor is not generally within the spirit of the bohort. Use the non-lethal combat rules on ArM5, page 174 or the additional rules in Chapter Nine: Optional Combat Rules, Option: Non-Lethal Combat.
-
-Tirocinia are tournaments open to younger and less-experienced knights that remove the threat of being targeted by seasoned elders looking for easy ransom. The rules of tirocinia are the same as for open events, but participants over the age of 25 are rare.
-
-The joust sees two knights ride at each other with couched lances. Jousting usually takes place before the melee. At some tournaments, a whole day may be set aside for jousting, providing additional practice and entertainment. The ransoms won and lost are the same as for the melee. The joust is gaining in popularity as an event in itself, as a means of avoiding bans on grand tournaments.
-
-months the circuit is active and a tournament can usually be found every two weeks. This schedule allows participants time to recover from their wounds and travel between tournament sites. In each country, a large tournament — in excess of a thousand knights — can be found on average once per season, while an event in excess of three thousand will likely take place only once per year.
+> ## Bohorts, Tirocinia, and Jousts
+> 
+> A bohort is an informal and impromptu tournament, essentially a rough-and-tumble between friends and comrades, usually conducted with blunted or even wooden weapons (the latter of which are very often simply sticks taken up from the roadside). Armor is not generally within the spirit of the bohort. Use the non-lethal combat rules on ArM5, page 174 or the additional rules in Chapter Nine: Optional Combat Rules, Option: Non-Lethal Combat.
+> 
+> Tirocinia are tournaments open to younger and less-experienced knights that remove the threat of being targeted by seasoned elders looking for easy ransom. The rules of tirocinia are the same as for open events, but participants over the age of 25 are rare.
+> 
+> The joust sees two knights ride at each other with couched lances. Jousting usually takes place before the melee. At some tournaments, a whole day may be set aside for jousting, providing additional practice and entertainment. The ransoms won and lost are the same as for the melee. The joust is gaining in popularity as an event in itself, as a means of avoiding bans on grand tournaments.
 
 France is the tournament heartland, home to the largest events, and knights from all across Mythic Europe journey there to compete. But tournaments can also be found anywhere that European knights and nobles are found, including the Holy Land. Tournaments in England and the Levant, which are often relatively small, are most often sited near towns, while the continent favors locations on the borders between neighboring nobles, where it is common for both to sponsor the event.
 
@@ -2989,18 +2793,15 @@ In 1220, tournaments in England are more rare than on the continent. For much of
 
 Holding a tournament is a costly business. Messengers are employed to attract participants; while criers draw knights to the tourney, envoys take written invitations to select dignitaries. And in the meantime, the tournament site needs preparation, with carpenters and laborers building stands to allow wealthy observers a comfortable view of events. Patrons also engage artists, chroniclers, or poets to record their events for posterity, commissioning artworks to portray their tournaments in the best and most exciting light. And since tournaments attract powerful individuals, grand receptions, feasts, and fitting entertainments must be provided. A degree of opulence is both expected and provided.
 
-Patrons award prizes to those knights who show great courage, and to the knight judged to have been the best. Jewels and artifacts of silver and gold are often awarded. Their value most often comes from being unusual, unique, or masterworks. Patrons take delight in awarding prizes not seen at other tournaments. Crafted items awarded as priz-
+Patrons award prizes to those knights who show great courage, and to the knight judged to have been the best. Jewels and artifacts of silver and gold are often awarded. Their value most often comes from being unusual, unique, or masterworks. Patrons take delight in awarding prizes not seen at other tournaments. Crafted items awarded as prizes are never less than superior quality works (see *City & Guild*, page 69). It is common for noble animals to be awarded as prizes, often with costly harnesses. Falcons, hounds, and horses are popular. Sometimes animals are chosen for their comedy value.
 
-
-## Story Seed: The Silent Tourney
-
-The king has banned all tournaments but there is talk of a private circuit run by a mysterious sponsor. The events are by invitation only and nobody seems to know where they will take place next. After a lapse in piety, a knight known to the covenant receives an invitation.
-
-The sponsor is a corrupting demon and the teams who fight at his tournaments are filled with those who have died at tournament, live in a state of sin, and have been denied God's grace.
-
-After discovering the truth behind the silent tournament, can the magi or their companions help the dead gain release? Can these unfortunate souls be absolved, or are the undead knights too entrenched in sin to be saved? And why is the herald a point of calm in the Infernal maelstrom?
-
-es are never less than superior quality works (see *City & Guild*, page 69). It is common for noble animals to be awarded as prizes, often with costly harnesses. Falcons, hounds, and horses are popular. Sometimes animals are chosen for their comedy value.
+> ## Story Seed: The Silent Tourney
+> 
+> The king has banned all tournaments but there is talk of a private circuit run by a mysterious sponsor. The events are by invitation only and nobody seems to know where they will take place next. After a lapse in piety, a knight known to the covenant receives an invitation.
+> 
+> The sponsor is a corrupting demon and the teams who fight at his tournaments are filled with those who have died at tournament, live in a state of sin, and have been denied God's grace.
+> 
+> After discovering the truth behind the silent tournament, can the magi or their companions help the dead gain release? Can these unfortunate souls be absolved, or are the undead knights too entrenched in sin to be saved? And why is the herald a point of calm in the Infernal maelstrom?
 
 As a rule of thumb, a patron should spend ten Mythic Pounds per point of his Prudhomme Reputation to hold a tournament. Anything less is seen as not befitting his station.
 
@@ -3010,13 +2811,11 @@ Some sponsors pay substantial retainers to companies of knights to fight under t
 
 #### The Tournament Site
 
-A tournament site stretches over acres of land marked out by landmarks such as roads
+A tournament site stretches over acres of land marked out by landmarks such as roads or villages. Most of this land is given over to the melee, allowing the fighting to sprawl out.
 
-## Story Seed: The Falcon of Virtue
-
-A nobleman sends to the covenant for help in trapping a rare bird that he intends to award as a tournament prize. He has heard of a falcon whose feathers burn with the sunlight, whose talons are sharp as flint, whose flight is as silent as the air, and whose temper is as calm as a summer lake. The nobleman is wealthy and prepared to lay down a handsome price for the bird. Upon capturing the bird the covenant discovers it carries a shocking secret. Can they now turn the falcon over to the lord?
-
-or villages. Most of this land is given over to the melee, allowing the fighting to sprawl out.
+> ## Story Seed: The Falcon of Virtue
+> 
+> A nobleman sends to the covenant for help in trapping a rare bird that he intends to award as a tournament prize. He has heard of a falcon whose feathers burn with the sunlight, whose talons are sharp as flint, whose flight is as silent as the air, and whose temper is as calm as a summer lake. The nobleman is wealthy and prepared to lay down a handsome price for the bird. Upon capturing the bird the covenant discovers it carries a shocking secret. Can they now turn the falcon over to the lord?
 
 The lists, usually wooden hoardings, stakes, or earth embankments, mark out the starting points for both sides and are found next to the melee ground. It is here that many of the *commencailles* and much of the individual jousting takes place.
 
@@ -3030,9 +2829,9 @@ Knights arriving at tournament are divided into two teams, according to national
 
 Prices of goods and lodging within towns hosting tournaments are often very high. There is little deference shown for social standing and rooms are quickly taken by those who arrive early. The wealthy often send agents ahead to ensure lodgings are secured.
 
-## Story Seed: A Hermetic Sponsor
-
-A nearby magus is secretly sponsoring a team of knights active in the local tourney circuit. Other knights in the area ask the covenant for aid against the seemingly unbeatable team. But what does the Code say about this? Has the Hermetic sponsor exposed a weakness the covenant can use against him?
+> ## Story Seed: A Hermetic Sponsor
+> 
+> A nearby magus is secretly sponsoring a team of knights active in the local tourney circuit. Other knights in the area ask the covenant for aid against the seemingly unbeatable team. But what does the Code say about this? Has the Hermetic sponsor exposed a weakness the covenant can use against him?
 
 #### Tournament as Fair
 
@@ -3044,11 +2843,7 @@ Heralds are central to the tournament. They range from lowly, unwashed criers to
 
 A tournament's melee is subject to certain rules and customs. The *recets,* and any villages and churches in the melee field, are safe territory and no fighting is allowed within them. In addition, those not taking part are not to be molested. Beyond these rules, there are also points of honor to observe. A noble who enters his company into the melee is expected to ride with them, and gains little credit if he does not place himself in harm's way.
 
-While the rules of tourney are clear, they are not always obeyed. Knights may be fined for breaking rules and in particular may be forced to pay for damages to the host's property or churches. Tactical advantage may outweigh this threat and the knights often do as they please. One noted
-
-
-
-underhand tactic is to ride to the lists prior to *estor* but not join the melee until later, when the fighting has taken its toll on the other participants. The heralds acting as adjudicators are not above purchase, and may be paid to look the other way, allowing such knights free rein.
+While the rules of tourney are clear, they are not always obeyed. Knights may be fined for breaking rules and in particular may be forced to pay for damages to the host's property or churches. Tactical advantage may outweigh this threat and the knights often do as they please. One noted underhand tactic is to ride to the lists prior to *estor* but not join the melee until later, when the fighting has taken its toll on the other participants. The heralds acting as adjudicators are not above purchase, and may be paid to look the other way, allowing such knights free rein.
 
 #### Ransom
 
@@ -3064,60 +2859,56 @@ An independent knight makes an easy target, so most knights entering the tournam
 
 Knights attacking as groups often attempt to separate their target from a defending group. They then grapple or cut the knight's reins and lead his horse, along with its powerless rider, away so as to extract ransom. See the grappling rules in ArM5, page 174. A grappled rider loses control of his horse to his attackers.
 
-## Profession Herald
+> ## Profession Herald
+> 
+> It is the job of the herald to know the tournament circuit, the knights who attend, and their devices, colors, and deeds. The conscientious herald ensures that he knows of upcoming tournaments, and so may find work as a crier sent out to publicize them. The Ability Profession: Herald allows a character to recognize knights by their colors and heraldic devices, and to recall their various victories, defeats, and even injuries. This Ability represents the herald's knowledge of the procedures of a tourney, and helps him adjudicate matters of process and tournament law. It also allows him to locate any tournaments in any area for which he has an Area Lore score of at least 1.
 
-It is the job of the herald to know the tournament circuit, the knights who attend, and their devices, colors, and deeds. The conscientious herald ensures that he knows of upcoming tournaments, and so may find work as a crier sent out to publicize them. The Ability Profession: Herald allows a character to recognize knights by their colors and heraldic devices, and to recall their various victories, defeats, and even injuries. This Ability represents the herald's knowledge of the procedures of a tourney, and helps him adjudicate matters of process and tournament law. It also allows him to locate any tournaments in any area for which he has an Area Lore score of at least 1.
 
-### Magic at the Tournament
+> ## Magic at the Tournament
+> 
+> Magi of House Verditius often send agents to tournaments in anticipation of business. Over the years many minor enchantments have been created and sold specifically for the tournament, including reins that cannot be cut, saddles that grasp their rider firmly, and arms and armor of unnatural quality. Most such enchantments are designed to last only a lifetime. The legality of this remains questionable and the view taken may differ between Tribunals.
+> 
+> There are other minor workers of magic who also offer charms and potions, blessings and sometimes curses, to knights eager for advantage. Faeries, too, may seek out those whose stories attract and feed them, offering them arms, armor, or even horses with unusual powers.
+> 
+> Both the Divine and Infernal can also
+> 
+> be found at tournaments. The devout invoke patron saints and ask for protection on the field and success against their enemies. The unwary or unscrupulous may enter into bargains with diabolic forces to assure victory, wealth, and acclaim.
+> 
+> ### Story Seed: The Craftsman
+> 
+> A local Verditius complains to a Quaesitor that a magus from a neighboring Tribunal is flouting the Code by crossing the border and selling enchanted devices to knights at local tournaments. What is the legal situation? Does the foreign magus know where his devices are being sold? And is the Quaesitor simply becoming a pawn in a vendetta between the two magi?
 
-Magi of House Verditius often send agents to tournaments in anticipation of business. Over the years many minor enchantments have been created and sold specifically for the tournament, including reins that cannot be cut, saddles that grasp their rider firmly, and arms and armor of unnatural quality. Most such enchantments are designed to last only a lifetime. The legality of this remains questionable and the view taken may differ between Tribunals.
-
-There are other minor workers of magic who also offer charms and potions, blessings and sometimes curses, to knights eager for advantage. Faeries, too, may seek out those whose stories attract and feed them, offering them arms, armor, or even horses with unusual powers.
-
-Both the Divine and Infernal can also
-
-be found at tournaments. The devout invoke patron saints and ask for protection on the field and success against their enemies. The unwary or unscrupulous may enter into bargains with diabolic forces to assure victory, wealth, and acclaim.
-
-#### Story Seed: The Craftsman
-
-A local Verditius complains to a Quaesitor that a magus from a neighboring Tribunal is flouting the Code by crossing the border and selling enchanted devices to knights at local tournaments. What is the legal situation? Does the foreign magus know where his devices are being sold? And is the Quaesitor simply becoming a pawn in a vendetta between the two magi?
-
-## Tournament Combat
+### Tournament Combat
 
 Knights in the melee should use the temporary damage rules in Chapter Nine: Optional Combat Rules, Options: Non-Lethal Combat, but in the heat of battle, the fighting may become more earnest. Characters may choose on a round-byround basis whether they intend to use non-lethal combat. Botches in non-lethal combat almost always inflict real damage to one party or another.
 
 The full range of special maneuvers described in Chapter Nine: Optional Combat Rules can be employed in both the *commencailles* and the melee. Combatants may attempt to pull their opponents from their saddles, or cut their reins and lead their horses away.
 
-## The Commencailles
+### The Commencailles
 
 The vespers, or *commencailles,* are an important showcase for individual talent and another source of ransoms for the victors. These contests can take several forms but are most often single combat, either jousting or fencing.
 
 #### Jousting
 
-At the call to charge, two opposing knights, both mounted and armed with lances, attempt to unhorse the other. Each charge comprises a single combat round, and each knight has enough time between charges to take up a new lance or shield. Botches may result in the breaking of equipment or injury to either horse or rider. Use the shock
+At the call to charge, two opposing knights, both mounted and armed with lances, attempt to unhorse the other. Each charge comprises a single combat round, and each knight has enough time between charges to take up a new lance or shield. Botches may result in the breaking of equipment or injury to either horse or rider. Use the shock of the charge rules (see Chapter Nine: Optional Combat Rules, Option: Shock of the Charge) to determine the outcome of each charge.
 
+> ## Melee Events Table
+> 
+> Rolls on this table have a modifier equal to the character's Prudhomme Reputation. The character may also spend Confidence Points on the roll, which can be used to modify the roll in either direction. Botch dice on the roll are equal to 1 + (1 per melee event rolled so far). Botches generally cause accidents, such as falling from a mount, breaking equipment, or seriously injuring an opponent.
+> 
+> | Roll  | Result |
+> |-------|--------|
+> | 0–2   | An inexperienced knight presents as a target. |
+> | 3–4   | A lone Poor knight presents as a target. |
+> | 5–6   | A lone average knight presents as a target. |
+> | 7–8   | A Poor knight protected by a company presents as a target. |
+> | 9–10  | An average knight protected by a company presents as a target. |
+> | 11–12 | A Wealthy knight protected by a company presents as a target. |
+> | 13–14 | The character's company is targeted by a group of equal size. |
+> | 15–16 | The character's company is targeted by a large company of two combat groups. |
+> | 17+   | The character's company is targeted by a large company of three combat groups. |
 
-joust continues until one knights submits. This almost always means that the contest goes beyond lances and horseback, and ends with the two knights engaged on foot.
-
-### Melee Events Table
-
-Rolls on this table have a modifier equal to the character's Prudhomme Reputation. The character may also spend Confidence Points on the roll, which can be used to modify the roll in either direction. Botch dice on the roll are equal to 1 + (1 per melee event rolled so far). Botches generally cause accidents, such as falling from a mount, breaking equipment, or seriously injuring an opponent.
-
-| Roll  | Result                                                                                  |
-|-------|-----------------------------------------------------------------------------------------|
-| 0–2   | An inexperienced knight<br>presents as a target.                                        |
-| 3–4   | A lone Poor knight pres<br>ents as a target.                                            |
-| 5–6   | A lone average knight<br>presents as a target.                                          |
-| 7–8   | A Poor knight protected<br>by a company presents as<br>a target.                        |
-| 9–10  | An average knight<br>protected by a company<br>presents as a target.                    |
-| 11–12 | A Wealthy knight<br>protected by a company<br>presents as a target.                     |
-| 13–14 | The character's company<br>is targeted by a group of<br>equal size.                     |
-| 15–16 | The character's company<br>is targeted by a large<br>company of two combat<br>groups.   |
-| 17+   | The character's company<br>is targeted by a large<br>company of three combat<br>groups. |
-
-of the charge rules (see Chapter Nine: Optional Combat Rules, Option: Shock of the Charge) to determine the outcome of each charge.
-
-The rules of the joust may change between venues. The simplest sees the winner declared if he knocks his opponent from his horse. In some cases, if both riders remain in their saddles after a set number of passes, judges may declare a winner, perhaps by a count of broken lances or by which knight took the lightest hit. In others venues the
+The rules of the joust may change between venues. The simplest sees the winner declared if he knocks his opponent from his horse. In some cases, if both riders remain in their saddles after a set number of passes, judges may declare a winner, perhaps by a count of broken lances or by which knight took the lightest hit. In others venues the joust continues until one knights submits. This almost always means that the contest goes beyond lances and horseback, and ends with the two knights engaged on foot.
 
 #### Fencing
 
@@ -3125,7 +2916,7 @@ Contests between two knights on foot are usually fought in a roped-off ring. As 
 
 It is common for men of lower birth to show their prowess in bare-knuckle fighting. Covenants looking for tough men in need of employment seek out the less seemly parts of tournaments.
 
-## The Grand Charge
+### The Grand Charge
 
 There are two ways to adjudicate the grand charge in play. The first is as a set of random encounters on the tourney field. These present opportunities for the characters to collect ransoms. The second is as a battle between the two armies, with the player characters in the pivotal positions.
 
@@ -3163,9 +2954,9 @@ Deeds done while under the banner of a company also feed that company's Reputati
 
 To gain the benefit of a company Reputation, a knight must travel under the colors of that company or be otherwise identified as a member (by using the company motto, for instance).
 
-
-
-An elderly knight is looking for a way to see his colors ride onto the field of tourney once more and one of the grogs is surprisingly willing to help. Armed in the old knight's armor, riding his horse, and carrying his sword, lance, and shield, the grog finds himself invincible in the melee. He has claimed ransom after ransom and not lost a single contest. But the assembled knights are suspicious and claim witchcraft is afoot. Can the magi extract their increasingly determined grog from the tournament and free him from the old knight's curse?
+> ## Story Seed: The Mantle is Passed
+> 
+> An elderly knight is looking for a way to see his colors ride onto the field of tourney once more and one of the grogs is surprisingly willing to help. Armed in the old knight's armor, riding his horse, and carrying his sword, lance, and shield, the grog finds himself invincible in the melee. He has claimed ransom after ransom and not lost a single contest. But the assembled knights are suspicious and claim witchcraft is afoot. Can the magi extract their increasingly determined grog from the tournament and free him from the old knight's curse?
 
 #### Patronage
 
@@ -3178,31 +2969,29 @@ Those hosting tournaments gain experience points towards their Prudhomme Reputat
 
 Labor Points (see *City & Guild*, page 38) describe how tradesmen, laborers, and merchants develop their business. The same rules can be applied to knights, as many make their living from the tournament circuit rather than drawing income from a fief.
 
-It costs 36 Labor Points per year for an errant knight to sustain himself. The knight gains Dexterity + Single/Great Weapon Labor Points per season on the tourney circuit. The figure is multiplied by two if the character is Poor, by three if the character is average, and by six if the character is Wealthy. This means that an errant knight must tourney for a number of seasons a year determined by his wealth. Knights with the Poor flaw must tourney for three seasons a year,
+It costs 36 Labor Points per year for an errant knight to sustain himself. The knight gains Dexterity + Single/Great Weapon Labor Points per season on the tourney circuit. The figure is multiplied by two if the character is Poor, by three if the character is average, and by six if the character is Wealthy. This means that an errant knight must tourney for a number of seasons a year determined by his wealth. Knights with the Poor flaw must tourney for three seasons a year, an average character for two, and a Wealthy character for one.
 
-## Labor Points from Stories
+> ## Labor Points from Stories
+> 
+> Characters can gain additional Labor Points from stories involving tournaments. For a craftsman, this might mean a knight in need of armor before dawn, a bullying merchant, or a faerie apprentice with a rare gift seeking out a master craftsman for their own ends. For knights, awards have a value in seasons, with a season being equal to the character's (Dexterity + Single/Great Weapon) x Wealth Multiplier. As a guideline, stories bestow half a season's Labor Points if they are a subplot of a wider story, bestow a season's worth of Labor Points if the character faces severe danger or hardship in resolving the subplot, and bestow even more as the character's risk and involvement in the story increase.
 
-Characters can gain additional Labor Points from stories involving tournaments. For a craftsman, this might mean a knight in need of armor before dawn, a bullying merchant, or a faerie apprentice with a rare gift seeking out a master craftsman for their own ends. For knights, awards have a value in seasons, with a season being equal to the character's (Dexterity + Single/Great Weapon) x Wealth Multiplier. As a guideline, stories bestow half a season's Labor Points if they are a subplot of a wider story, bestow a season's worth of Labor Points if the character faces severe danger or hardship in resolving the subplot, and bestow even more as the character's risk and involvement in the story increase.
-
-## William Marshal
-
-In 1220 the memory of William Marshal is still alive, and he is held up as an example of a great knight. Much of William's reputation was earned on the tournament fields, but while he died a wealthy and influential man, his birth gave him few advantages.
-
-Inheriting nothing from his father, William spent most of his childhood in the household of his father's cousin, William de Tancarville, an influential Norman noble. Tancarville introduced him to the tournament where he developed not only his fighting prowess but also his tenacity, resolve, and social connections. Despite early setbacks resulting in poverty, he won ransom after ransom on the field and was soon charged by Henry II of England to tutor his son Henry the Young King.
-
-Though rewarded generously by the Young King, William's ambition got the better of him and he was soon tourneying under his own banner. The promise of even greater wealth lured him to the side of Count Philip of Flanders.
-
-But while William's loyalty on the tournament circuit was for sale, his loyalty to successive kings of England never wavered. (He served Henry II, his son Henry the Young King, Richard, and John before becoming regent for Henry III.). He was rewarded with earldoms, a fruitful dynastic marriage, and huge wealth and political influence.
-
-So powerful was William Marshal, Earl of Pembrokeshire, that he was elected regent to Henry III on the death of John in 1216. And at the age of 70 in 1217, he personally led the fighting in the relief of Lincoln, which led to the expulsion of Louis of France from English shores. William died two years later in 1219.
-
-William Marshal's story is one to which every knight entering the tournament aspires.
-
-an average character for two, and a Wealthy character for one.
+> ## William Marshal
+> 
+> In 1220 the memory of William Marshal is still alive, and he is held up as an example of a great knight. Much of William's reputation was earned on the tournament fields, but while he died a wealthy and influential man, his birth gave him few advantages.
+> 
+> Inheriting nothing from his father, William spent most of his childhood in the household of his father's cousin, William de Tancarville, an influential Norman noble. Tancarville introduced him to the tournament where he developed not only his fighting prowess but also his tenacity, resolve, and social connections. Despite early setbacks resulting in poverty, he won ransom after ransom on the field and was soon charged by Henry II of England to tutor his son Henry the Young King.
+> 
+> Though rewarded generously by the Young King, William's ambition got the better of him and he was soon tourneying under his own banner. The promise of even greater wealth lured him to the side of Count Philip of Flanders.
+> 
+> But while William's loyalty on the tournament circuit was for sale, his loyalty to successive kings of England never wavered. (He served Henry II, his son Henry the Young King, Richard, and John before becoming regent for Henry III.). He was rewarded with earldoms, a fruitful dynastic marriage, and huge wealth and political influence.
+> 
+> So powerful was William Marshal, Earl of Pembrokeshire, that he was elected regent to Henry III on the death of John in 1216. And at the age of 70 in 1217, he personally led the fighting in the relief of Lincoln, which led to the expulsion of Louis of France from English shores. William died two years later in 1219.
+> 
+> William Marshal's story is one to which every knight entering the tournament aspires.
 
 For simplicity it is assumed that any seasons spent at tourney have a balance of wins, losses, and prizes to ensure the character gains the Labor Points he requires to maintain his living. Characters may spend any surplus Labor Points towards increasing their financial and social status as described in *City & Guild*, page 38.
 
-## Awards
+### Awards
 
 Winning awards at tournament is a matter of drawing attention to one's feats and accomplishments. When a character increases his Prudhomme Reputation he comes to the notice of the patron. Martial achievements are certainly rewarded, but so too are great noblesse and generosity.
 
@@ -3210,48 +2999,43 @@ Storyguides might also want to present specific challenges of talent and resolve
 
 The value of a prize should be in keeping with the Reputation of its beneficiary. Storyguides should consider one Mythic Pound per point of Prudhomme Reputation as a baseline.
 
+> ## Money in Ars Magica: A Recap
+> 
+> **Ars Magica** has two compatible systems for measuring wealth: a simple system for troupes who do not like to spend too much time considering money, and a system based on tracking the approximate values of goods and services in Mythic Pounds.
+> 
+> ### The Simple System, From the Core Rulebook
+> 
+> In the simple system a character's level of wealth is an effect of social status, modified by Virtues and Flaws like Wealthy or Poor. In Mythic Europe, a knight who holds at least a single manor has the Social Status Virtue Landed Noble, for example. A character with an area of land so large that it requires infeudation to be run effectively has the Social Status Virtue Great Noble. In this system a character is wealthy or poor compared only to other people of the same social class; a wealthy peasant is less rich than a poor king.
+> 
+> Most manorial lords cannot meet their basic expenses in difficult times without patronage from their lords, or by finding supplemental income through raiding or banditry. That lords are perpetually short of money does not grant them the Poor Flaw. Their precarious financial situation is, rather, the average for their social class. A manorial lord is only poor if disaster has already struck and his social status is at risk. Wealthy manorial lords have sources of income beyond a basic manor. These may include additional land, or the right to collect sources of income usually reserved for greater nobles, like river tolls or port duties.
+> 
+> In the simple system, fiefs increase in value only as a reward for stories. This reward may be directly related to the story, or might have no obvious link within the game setting, but be agreed as a reward by the troupe.
+> 
+> Many people in Mythic Europe believe that the bounty of all land is arises — or fails to — through the grace God. This, to them, explains why the croplands of tyrants produce only lean harvests, and why during periods of anarchy, starvation is so widespread. Conversely, the reign of wise and just kings is rewarded with bountiful crops. This idea is not generally used **Ars Magica** but it provides a rationale for troupes who wish to reward characters for completing great tasks by improving the value of their land.
+> 
+> ### The Mythic Pound System, From Covenants
+> 
+> In this system, published initially in *Covenants,* players keep records using Mythic Pounds. These are units of account based on the value of a pound of silver (rather than coins that the characters spend). The prices of goods and services are estimated so troupes have approximate figures from which to work. Each Mythic Pound can be divided into 20 shillings or 240 pence. Actual coins that characters can spend are almost always silver pennies. In brief, a manor's traditional sources of income equal 20 pounds, and a knight's expenses are a similar amount. If a covenant has a manor and does not owe knight-service on it, then it is a lesser income source.
+> 
+> The expenses of a knight may be calculated using the system given in *Covenants*, and the rules there may be used to tweak the fief's budget. (Those rules measure inhabitants in points, with each point requiring one pound of expenditure.) The manor's inhabitants are considered to be the knight himself (3 points), his family (aggregated as 3 points), his reeve or steward (2 points), his squire (2t points), a couple of veteran men at arms (4 points), and his horses (2 points). He tithes two pounds per year. This leaves two pounds per year surplus that is considered to cover exceptional expenses like scutage, new horses, and repairing buildings that burn down. The lord has other staff, but they are paid in rights to land rather than from his income. These include the priest, miller, baker and, in many places, the shepherd, swineherd, and reeve.
+> 
+> For a character to become wealthy from land he needs more than one manor, preferably without a corresponding debt of additional knight service. Players who do not wish to consider the numbers too deeply should assume that a knight makes ten pounds each year for each manor that does not owe knight service. If knight service is owed, it might be paid out in scutage (a fine paid in lieu of service), which costs up to three pounds per year, met by hiring a mercenary knight, which costs two pounds, or met by sending a knight of the lord's mesnie. Mesnie knights cost about five pounds per year to maintain at a basic standard of chivalric living, but many lords pay much more as largesse.
+> 
+> The average fief in England in 1220 contains five manors. Most of these manors are held by relatives or vassals of the lord. Knights are expected to live slightly beyond their income, regardless of how much that actually is, so even those with additional manors are usually chronically cash-poor, live on credit, and are dependent on the largesse of their lords. Many lords like things this way. This is discussed further in Chapter Two: Politics.
+> 
+> As the 13th century unfolds, unless the player characters do something to radically change society, many knightly families will slip into the wealthier part of the freeman class. Single manors will become increasingly rare as land consolidates in the hands of noblemen and the Church, both of which generally prefer to give their knights cash fiefs.
 
-## Money in Ars Magica: A Recap
-
-**Ars Magica** has two compatible systems for measuring wealth: a simple system for troupes who do not like to spend too much time considering money, and a system based on tracking the approximate values of goods and services in Mythic Pounds.
-
-#### The Simple System, From the Core Rulebook
-
-In the simple system a character's level of wealth is an effect of social status, modified by Virtues and Flaws like Wealthy or Poor. In Mythic Europe, a knight who holds at least a single manor has the Social Status Virtue Landed Noble, for example. A character with an area of land so large that it requires infeudation to be run effectively has the Social Status Virtue Great Noble. In this system a character is wealthy or poor compared only to other people of the same social class; a wealthy peasant is less rich than a poor king.
-
-Most manorial lords cannot meet their basic expenses in difficult times without patronage from their lords, or by finding supplemental income through raiding or banditry. That lords are perpetually short of money does not grant them the Poor Flaw. Their precarious financial situation is, rather, the average for their social class. A manorial lord is only poor if disaster has already struck and his social status is at risk. Wealthy manorial lords have sources of income beyond a basic manor. These may include additional land, or the right to collect sources of income usually reserved for greater nobles, like river tolls or port duties.
-
-In the simple system, fiefs increase in value only as a reward for stories. This reward may be directly related to the story, or might have no obvious link within the game setting, but be agreed as a reward by the troupe.
-
-Many people in Mythic Europe believe that the bounty of all land is arises — or fails to — through the grace God. This, to them, explains why the croplands of tyrants produce only lean harvests, and why during periods of anarchy, starvation is so widespread. Conversely, the reign of wise and just kings is rewarded with bountiful crops. This idea is not generally used **Ars Magica** but it provides a rationale for troupes who wish to reward characters for completing great tasks by improving the value of their land.
-
-## The Mythic Pound System, From Covenants
-
-In this system, published initially in *Covenants,* players keep records using Mythic Pounds. These are units of account based on the value of a pound of silver (rather than coins that the characters spend). The prices of goods and services are estimated so troupes have approximate figures from which to work. Each Mythic Pound can be divided into 20 shillings or 240 pence. Actual coins that characters can spend are almost always silver pennies. In brief, a manor's traditional sources of income equal 20 pounds, and a knight's expenses are a similar amount. If a covenant has a manor and does not owe knight-service on it, then it is a lesser income source.
-
-The expenses of a knight may be calculated using the system given in *Covenants*, and the rules there may be used to tweak the fief's budget. (Those rules measure inhabitants in points, with each point requiring one pound of expenditure.) The manor's inhabitants are considered to be the knight himself (3 points), his family (aggregated as 3 points), his reeve or steward (2 points), his squire (2t points), a couple of veteran men at arms (4 points), and his horses (2 points). He tithes two pounds per year. This leaves two pounds per year surplus that is considered to cover exceptional expenses like scutage, new horses, and repairing buildings that burn down. The lord has other staff, but they are paid in rights to land rather than from his income. These include the priest, miller, baker and, in many places, the shepherd, swineherd, and reeve.
-
-For a character to become wealthy from land he needs more than one manor, preferably without a corresponding debt of additional knight service. Players who do not wish to consider the numbers too deeply should assume that a knight makes ten pounds each year for each manor that does not owe knight service. If knight service is owed, it might be paid out in scutage (a fine paid in lieu of service), which costs up to three pounds per year, met by hiring a mercenary knight, which costs two pounds, or met by sending a knight of the lord's mesnie. Mesnie knights cost about five pounds per year to maintain at a basic standard of chivalric living, but many lords pay much more as largesse.
-
-The average fief in England in 1220 contains five manors. Most of these manors are held by relatives or vassals of the lord. Knights are expected to live slightly beyond their income, regardless of how much that actually is, so even those with additional manors are usually chronically cash-poor, live on credit, and are dependent on the largesse of their lords. Many lords like things this way. This is discussed further in Chapter Two: Politics.
-
-As the 13th century unfolds, unless the player characters do something to radically change society, many knightly families will slip into the wealthier part of the freeman class. Single manors will become increasingly rare as land consolidates in the hands of noblemen and the Church, both of which generally prefer to give their knights cash fiefs.
-
-## Chapter Six
-
-# Manorial Fiefs
+# Chapter Six: Manorial Fiefs
 
 Feudal society is made up of a series of personal relationships. A powerful man offers to loan land, or some other valuable right, to a less powerful man in exchange for his military support, his counsel, and other benefits. These other benefits often include a share of the harvest from the land and may also include services like acting as a judge, garrisoning a castle, or collecting tolls. After this transaction, the more-powerful man is the less powerful man's liege, the less powerful man is the liege's vassal, and the valuable right or land is called a fief.
 
 This arrangement is solemnized by a ritual called the commendation ceremony. During the commendation ceremony, the lord and vassal are tied by oaths before mortal witnesses and God. The form of this ceremony differs between places and times, but a popular version begins with an act of homage. In this, the vassal-to-be kneels before the lord and places his hands together in the position of prayer. The lord then places his hands over the hands of his supplicant, enclosing them. The supplicant then asks to become a vassal and is accepted.
 
-Following this, the new vassal swears an oath of fealty to the lord on a Bible or holy relic. "Fealty" means "faithfulness." The vassal
+Following this, the new vassal swears an oath of fealty to the lord on a Bible or holy relic. "Fealty" means "faithfulness." The vassal promises the liege aid in war, good counsel, and whatever else is usual in the area. The oath of fealty is usually kept brief, so the finer points of what exactly is owed, and on what schedule, are not described. In some areas, there is no break between the act of homage and the oath of fealty, so it is completed with the vassal still on his knees. The lord may reply with an oath of his own, promising land and military support to great vassals, or financial support to lesser vassals.
 
-## Knighthood
-
-The ceremony that creates a knight and the ceremony that creates a vassal are often tied together. This is because a knight is usually created with the understanding that he will join the household of the liege, and fight in his service. He is, therefore, a sort of minor vassal. Most such knights are supported by a salary from their lord. Knights who achieve particular favor may be offered the smallest possible land fief, a manor.
-
-promises the liege aid in war, good counsel, and whatever else is usual in the area. The oath of fealty is usually kept brief, so the finer points of what exactly is owed, and on what schedule, are not described. In some areas, there is no break between the act of homage and the oath of fealty, so it is completed with the vassal still on his knees. The lord may reply with an oath of his own, promising land and military support to great vassals, or financial support to lesser vassals.
+> ## Knighthood
+> 
+> The ceremony that creates a knight and the ceremony that creates a vassal are often tied together. This is because a knight is usually created with the understanding that he will join the household of the liege, and fight in his service. He is, therefore, a sort of minor vassal. Most such knights are supported by a salary from their lord. Knights who achieve particular favor may be offered the smallest possible land fief, a manor.
 
 ## Subinfuedation
 
@@ -3267,48 +3051,41 @@ The basic fief is a single the manor. A manor, for the purposes of the game, com
 
 The simplest manor is made up of a large hall where the lord's representative lives, surrounded by farmlands and a village. Large villages may, however, be divided between two or more manors. Most manors have all of the elements described in the following sections, although many manors may lack one or more of them. The *Domesday Book* even records one manor that had no inhabitants. It was farmed by men from neighboring manors for a fee.
 
-## Alternatives to the Manor With Demesne
+### Alternatives to the Manor With Demesne
 
-This section describes in detail a manor with demesne and resident bailiff. (A demesne — pronounced "domain" — is land farmed on behalf of a lord by his villeins as part of their rent.) This might give the impression that this is the dominant mode of
+This section describes in detail a manor with demesne and resident bailiff. (A demesne — pronounced "domain" — is land farmed on behalf of a lord by his villeins as part of their rent.) This might give the impression that this is the dominant mode ofland use in Mythic Europe, but it is not, because it is dependent on a particular soil type and a particular balance between the cost of labor and the price of grain. The manor with demesne is considered in such detail in this chapter because its alternatives are simpler, and so troupes can design them using the information provided here as a basis.
 
+> ## How Big is a…?
+> 
+> This insert provides average measures of land size to help players get a sense of the scale of medieval landholdings. The terms used are regional English. This book lacks space to describe the thousands of forms of land division in Mythic Europe.
+> 
+> An acre is the amount of land a single person with an ox can plow in one day. The definition of an acre is a historical one predating the use of ox teams; no actual person plows an acre a day with his personal ox in Mythic Europe. In Mythic Europe the size of acres varies, even within kingdoms, depending on local custom. For the sake of simplicity an acre is considered to be 4,840 square yards. An acre has no particular shape, and plowmen prefer fields that are long, thin strips so that they do not need to turn their plows very often. An acre that was square would be just short of seventy yards on a side. For Terram magic affecting dirt to a depth of two feet, this makes it an Individual Target with three size modifiers.
+> 
+> A manor is sufficient land to maintain a knight. It is around six hundred acres in area, although land fertility, manors which collect rights instead of farming, and other considerations can increase or decrease the size of a manor by a third without it being considered exceptional. The prototypical manor is a single unit of land whose residents make some use of the woods, marshes, and waters that surround it, but in most areas manors actually abut each other, and their lands may intermingle in confusing ways.
+> 
+> A landed knight's income from a typical manor is twenty pounds per year, realized as a mixture of labor, goods, and money. This is sufficient to sustain the knight's household and maintain his equipment. The income from a manor is not sufficient to pay for personal crises, such as the need to replace a lost war horse, commission an entire suit of armor, or ransom gear lost at tournament. The manorial system is failing in Mythic Europe. Some knights supplement this income by working as mercenaries, officers of a lord, outlaws, or pirates.
+> 
+> A hide is the amount of land required
+> 
+> to maintain a family of affluent, free peasants. Even neighboring villages have hides of dramatically different sizes. For the sake of visualization, a hide is 120 to 144 acres, adjusted for the fertility of the land and local farming practices. A hide produces four pounds of income for a lord, usually in money or goods. Free peasants make up less than ten percent of the population of most manors. They have inordinate influence in manorial affairs, and are often selected as jurors in manorial courts.
+> 
+> A virgate (or yardland, or rood) is the amount of land a two-ox team could plow in one day. It is either one-quarter or onesixth of a hide, between 24 and 32 acres. Many peasants, called virgaters, rent an area of land this size. This amount of land is sufficient to support a family of unfree peasants, who pay their taxes partially through service on the lord's demesnes. A virgate provides a little surplus in good years, so a virgater with a run of luck can buy off a succession of villein obligations. This frees additional money and allows him to take on extra land. It's unlikely that he, personally, will become free, but he may reasonably hope that the children of his eldest son might, some day. A virgater family, between services, fines, fees, and other forms of usefulness, is worth about a pound a year to a lord.
+> 
+> Some peasants rent an area half the size of a virgate. This is called a bovate in a limited area of Britain, but it has been favored in this book over the usual term "half-virgate." Bovaters supplement their main income, which usually comes from performing some other service, by farming this small area around their homes. Bovaters, for example, are often millers, reeves, shepherds, or the personal servants at the manor. A bovate, in a good year, can support a family of unfree peasants, but is usually intended to supplement the income of a family whose primary income comes from other work.
+> 
+> Cottars have smaller areas of land, ten acres or less, far too small to support a family. They live either by hiring out their services as laborers or by pursuing a trade. Blacksmiths, for example, are often cottars, farming only small personal gardens or tiny pieces of the common land, living in the main by their craft.
+> 
+> As a rough guide, only a handful of peasant families in any given manor have more than a virgate. Twenty percent have a full virgate, thirty percent have a bovate, and fifty percent are cottars. This does not include servants who are landless or have cottar strips.
+> 
+> A village may technically be of any size: a village becomes a town not because of its population, but because of legal rights granted it by a nobleman in a charter. The residents of a town are free in the sense that they do not owe the services of villeinage. A village is literally a place where villeins live. The process by which villages become towns is discussed in *City & Guild*.
+> 
+> The average village has around sixty families, each with five members, and grows very slowly. An average village adds only five new people to its permanent population every two years. Villages larger than five hundred people are all but unknown.
+> 
+> Towns are like villages that have been granted rights by an overlord. The first of these rights, freedom of the residents, is what distinguishes the town from a village. There are, therefore, new towns, with only a handful of families in them. Some planned towns fail, and during this process it is possible that a town's population may dwindle to a few families who then agree to rejoin the manor of the lord who granted the charter. An "average" town has perhaps three hundred people, the same as an average village, although many towns are smaller, and a handful are many times larger. In England, 40% of towns hold their land from the king, 35% from a neighboring lord, and 25% from the Church. In the rest of Europe the proportion that holds from the king is far higher.
+> 
+> A city is a settlement where a cathedral is.
 
-
-## How Big is a…?
-
-This insert provides average measures of land size to help players get a sense of the scale of medieval landholdings. The terms used are regional English. This book lacks space to describe the thousands of forms of land division in Mythic Europe.
-
-An acre is the amount of land a single person with an ox can plow in one day. The definition of an acre is a historical one predating the use of ox teams; no actual person plows an acre a day with his personal ox in Mythic Europe. In Mythic Europe the size of acres varies, even within kingdoms, depending on local custom. For the sake of simplicity an acre is considered to be 4,840 square yards. An acre has no particular shape, and plowmen prefer fields that are long, thin strips so that they do not need to turn their plows very often. An acre that was square would be just short of seventy yards on a side. For Terram magic affecting dirt to a depth of two feet, this makes it an Individual Target with three size modifiers.
-
-A manor is sufficient land to maintain a knight. It is around six hundred acres in area, although land fertility, manors which collect rights instead of farming, and other considerations can increase or decrease the size of a manor by a third without it being considered exceptional. The prototypical manor is a single unit of land whose residents make some use of the woods, marshes, and waters that surround it, but in most areas manors actually abut each other, and their lands may intermingle in confusing ways.
-
-A landed knight's income from a typical manor is twenty pounds per year, realized as a mixture of labor, goods, and money. This is sufficient to sustain the knight's household and maintain his equipment. The income from a manor is not sufficient to pay for personal crises, such as the need to replace a lost war horse, commission an entire suit of armor, or ransom gear lost at tournament. The manorial system is failing in Mythic Europe. Some knights supplement this income by working as mercenaries, officers of a lord, outlaws, or pirates.
-
-A hide is the amount of land required
-
-to maintain a family of affluent, free peasants. Even neighboring villages have hides of dramatically different sizes. For the sake of visualization, a hide is 120 to 144 acres, adjusted for the fertility of the land and local farming practices. A hide produces four pounds of income for a lord, usually in money or goods. Free peasants make up less than ten percent of the population of most manors. They have inordinate influence in manorial affairs, and are often selected as jurors in manorial courts.
-
-A virgate (or yardland, or rood) is the amount of land a two-ox team could plow in one day. It is either one-quarter or onesixth of a hide, between 24 and 32 acres. Many peasants, called virgaters, rent an area of land this size. This amount of land is sufficient to support a family of unfree peasants, who pay their taxes partially through service on the lord's demesnes. A virgate provides a little surplus in good years, so a virgater with a run of luck can buy off a succession of villein obligations. This frees additional money and allows him to take on extra land. It's unlikely that he, personally, will become free, but he may reasonably hope that the children of his eldest son might, some day. A virgater family, between services, fines, fees, and other forms of usefulness, is worth about a pound a year to a lord.
-
-Some peasants rent an area half the size of a virgate. This is called a bovate in a limited area of Britain, but it has been favored in this book over the usual term "half-virgate." Bovaters supplement their main income, which usually comes from performing some other service, by farming this small area around their homes. Bovaters, for example, are often millers, reeves, shepherds, or the personal servants at the manor. A bovate, in a good year, can support a family of unfree peasants, but is usually intended to supplement the income of a family whose primary income comes from other work.
-
-Cottars have smaller areas of land, ten acres or less, far too small to support a family. They live either by hiring out their services as laborers or by pursuing a trade. Blacksmiths, for example, are often cottars, farming only small personal gardens or tiny pieces of the common land, living in the main by their craft.
-
-As a rough guide, only a handful of peasant families in any given manor have more than a virgate. Twenty percent have a full virgate, thirty percent have a bovate, and fifty percent are cottars. This does not include servants who are landless or have cottar strips.
-
-A village may technically be of any size: a village becomes a town not because of its population, but because of legal rights granted it by a nobleman in a charter. The residents of a town are free in the sense that they do not owe the services of villeinage. A village is literally a place where villeins live. The process by which villages become towns is discussed in *City & Guild*.
-
-The average village has around sixty families, each with five members, and grows very slowly. An average village adds only five new people to its permanent population every two years. Villages larger than five hundred people are all but unknown.
-
-Towns are like villages that have been granted rights by an overlord. The first of these rights, freedom of the residents, is what distinguishes the town from a village. There are, therefore, new towns, with only a handful of families in them. Some planned towns fail, and during this process it is possible that a town's population may dwindle to a few families who then agree to rejoin the manor of the lord who granted the charter. An "average" town has perhaps three hundred people, the same as an average village, although many towns are smaller, and a handful are many times larger. In England, 40% of towns hold their land from the king, 35% from a neighboring lord, and 25% from the Church. In the rest of Europe the proportion that holds from the king is far higher.
-
-A city is a settlement where a cathedral is.
-
-land use in Mythic Europe, but it is not, because it is dependent on a particular soil type and a particular balance between the cost of labor and the price of grain. The manor with demesne is considered in such detail in this chapter because its alternatives are simpler, and so troupes can design them using the information provided here as a basis.
-
-Large-field farming, as described here, uses up roughly half of the agricultural land in Mythic Europe. It is only suited to heavy soil types. It is found in most of central England, although it is rare in the east, northwest, and wooded and mountainous parts of the country. It is found in France and Germany, as a rough guide, near large cities. In areas unsuited to this style of farming, farmers instead care for individual plots, or herd
-
-
-sheep or cattle. Each troupe can, therefore, choose any type of agriculture for their covenant, and simply state that the soil, vegetation, or topography make it the suitable choice for their locale.
+Large-field farming, as described here, uses up roughly half of the agricultural land in Mythic Europe. It is only suited to heavy soil types. It is found in most of central England, although it is rare in the east, northwest, and wooded and mountainous parts of the country. It is found in France and Germany, as a rough guide, near large cities. In areas unsuited to this style of farming, farmers instead care for individual plots, or herd sheep or cattle. Each troupe can, therefore, choose any type of agriculture for their covenant, and simply state that the soil, vegetation, or topography make it the suitable choice for their locale.
 
 Demesnes are found on just over half of the manors using the large field system. Before 1220, it was more common for the lord's portion of the cropland, or even the manor as a whole, to be rented out. Players doing their own research should be aware that the period term for renting out land, in England, is "farming," which can be confusing.
 
@@ -3324,7 +3101,7 @@ Even given the potential for profit, few manors have been changed over from crop
 
 The lands of greater nobles, the surplus they produce, and the number of soldiers they are expected to provide are detailed in Chapter Three: A Comparison of Titles.
 
-## Capital Messuage
+### Capital Messuage
 
 A messuage is a small, enclosed piece of land around a house. The capital messuage of an estate is the messuage belonging to the lord. It contains his hall, the outbuildings described in the sections that follow, and curtilage. Many of the structures below are placed in the messuage to increase their security. They contain valuable items, like food and equipment, and proximity to the residence implies that the lord and his personal servants can confront raiders or thieves. In Mythic Europe many workers sleep in their workplaces, providing extra security, but this is less pronounced in manors, particularly those that have bovaters.
 
@@ -3332,24 +3109,19 @@ A messuage is a small, enclosed piece of land around a house. The capital messua
 
 The chief building in a manor is the hall. This is the residence of the lord, if he lives at the manor, or of his appointed deputy, called a bailiff, if the lord does not. Many lords with multiple manors travel between them in a great circuit, exhausting the surplus food collected from the rents of their tenants at each in turn. The bailiff is expected to keep the residence in good order, and to be able to vacate the best lodging when the lord or his steward arrives. Bailiffs and their staff are dealt with in considerable detail in Chapter Seven: The Peasantry. Halls vary considerably in size, construction, and opulence, depending on the value of the manor and the degree to which the lord uses it.
 
-This system of circulating the court of the noble to where his rent is stored as food is swiftly being eclipsed in those parts of Mythic Europe where the economy is strongly monetarized. This is a fortunate circumstance for covenants with agricultural holdings, because most magi prefer to stay near a static laboratory. The unwillingness of most magi to circuit their holdings has, in the past, meant that they could not fully
+This system of circulating the court of the noble to where his rent is stored as food is swiftly being eclipsed in those parts of Mythic Europe where the economy is strongly monetarized. This is a fortunate circumstance for covenants with agricultural holdings, because most magi prefer to stay near a static laboratory. The unwillingness of most magi to circuit their holdings has, in the past, meant that they could not fully utilize the income of their rents. The need to sell their surplus, then use the money to buy food closer to home, has been a necessary expense. The greater nobility of Europe similarly prefer that their surplus food be translated into money by the inhabitants of towns so it can be spent on food and luxuries close to the nobles' preferred residences.
 
+> ## Story Seed: The Foundation Charm
+> 
+> Many halls have a charm in their walls or foundations to protect the building. Such a charm can be placed by a hedge witch (see *Hedge Magic*) or using traditional sacrifices described by local folklore. These charms may cause stories. For example, a sacrificed animal's body may become the spiritual anchor of a faerie that takes the role of the hall's guardian spirit. Characters may have to protect the corpse, or find and destroy it, based on the friendliness of the faerie that has anchored to it. In some pre-Christian areas, humans were occasionally walled into new buildings. Their spirits may seek burial, cause mischief, or have come to terms with their fate and aid the current inhabitants of the hall.
+> 
+> In some areas, the charm is a witch bottle. Witch bottles prevent minor magic users from entering buildings by hexing them if they attempt to do so. These hexes are weak, and easily resisted by Hermetic magic. Magi aware of a properly made witch bottle sometimes leave it in place to see who it harms as a way to identify young Gifted people as potential apprentices, for example.
+> 
+> Witch bottles have a wide variety of effects, which can be simulated using the rules in *Hedge Magic.* These effects usually have two components: they weaken the witch, but they also mark the witch. Attacks on the body are common, so witch bottles may fill a witch's face with boils, strike her blind, fill her so full of urine that she bursts, make blood pour from her nose, or snap the bones of her feet. If you do not have *Hedge Magic* assume that the bottles can detect the magical power to curse (InVi 10, Penetration 5) as well as the Gift (InVi 15, Penetration 0), and that they have a PeCo effect up to level 40, with a Penetration of 5, that they use when triggered.
 
-## Story Seed: The Foundation Charm
-
-Many halls have a charm in their walls or foundations to protect the building. Such a charm can be placed by a hedge witch (see *Hedge Magic*) or using traditional sacrifices described by local folklore. These charms may cause stories. For example, a sacrificed animal's body may become the spiritual anchor of a faerie that takes the role of the hall's guardian spirit. Characters may have to protect the corpse, or find and destroy it, based on the friendliness of the faerie that has anchored to it. In some pre-Christian areas, humans were occasionally walled into new buildings. Their spirits may seek burial, cause mischief, or have come to terms with their fate and aid the current inhabitants of the hall.
-
-In some areas, the charm is a witch bottle. Witch bottles prevent minor magic users from entering buildings by hexing them if they attempt to do so. These hexes are weak, and easily resisted by Hermetic magic. Magi aware of a properly made witch bottle sometimes leave it in place to see who it harms as a way to identify young Gifted people as potential apprentices, for example.
-
-Witch bottles have a wide variety of effects, which can be simulated using the rules in *Hedge Magic.* These effects usually have two components: they weaken the witch, but they also mark the witch. Attacks on the body are common, so witch bottles may fill a witch's face with boils, strike her blind, fill her so full of urine that she bursts, make blood pour from her nose, or snap the bones of her feet. If you do not have *Hedge Magic* assume that the bottles can detect the magical power to curse (InVi 10, Penetration 5) as well as the Gift (InVi 15, Penetration 0), and that they have a PeCo effect up to level 40, with a Penetration of 5, that they use when triggered.
-
-utilize the income of their rents. The need to sell their surplus, then use the money to buy food closer to home, has been a necessary expense. The greater nobility of Europe similarly prefer that their surplus food be translated into money by the inhabitants of
-
-## Castles in Lieu of Halls
-
-On large estates, a castle may replace the hall. Castles have been described in detail in the *Covenants* supplement. An overview of that material is included in Chapter Eight: Massed Combat.
-
-towns so it can be spent on food and luxuries close to the nobles' preferred residences.
+> ## Castles in Lieu of Halls
+> 
+> On large estates, a castle may replace the hall. Castles have been described in detail in the *Covenants* supplement. An overview of that material is included in Chapter Eight: Massed Combat.
 
 Most halls are not fortified; they serve as simple centers of administration and accommodation. The vast majority of halls are constructed of timber and delay attackers only briefly. Those halls that serve as the chief accommodation of their lords are more imposing. In areas where there is, or has been, frequent raiding, manor houses are more formidable. In England, for example, some manor houses that have survived since the Normans subdued the country are built from stone and have defensible ditches or moats. Similarly, on the Scottish border, many lesser nobles live in defensible towers.
 
@@ -3375,11 +3147,7 @@ A barn is a work-building. It is often split into two levels, and the upper leve
 
 #### Curtilage
 
-Curtilage is unroofed land enclosed within the messuage's wall. Lords use this space for a variety of purposes: some have orchards in their curtilage, while others hold court in these yards. The curtilage of a manor may be over an acre, even in small manors.
-
-
-
-Some manors' curtilage is surrounded by a moat used to pen animals and exclude predators. It is not usually designed as a defensive feature.
+Curtilage is unroofed land enclosed within the messuage's wall. Lords use this space for a variety of purposes: some have orchards in their curtilage, while others hold court in these yards. The curtilage of a manor may be over an acre, even in small manors. Some manors' curtilage is surrounded by a moat used to pen animals and exclude predators. It is not usually designed as a defensive feature.
 
 #### Fishponds
 
@@ -3403,31 +3171,25 @@ Steedles are used to raise the stored crops above the ground, to prevent rats an
 
 Stackyards are fenced more robustly than other areas of the messuage. In many areas, where buildings and fences are made of wattle and daub, the fences around the stackyard are triple the usual thickness. This additional effort is required because oxen like to raid stackyards. Oxen are known to push their way through conventional wattled fences, and even through the wattled walls of buildings, to reach the grain drying in the stackyard. The defensibility and limited lines of sight within stackyards make them interesting places to stage combats.
 
+> ## Story Seeds: Dovecotes
+> 
+> Pigeons are delectable; that's why nobles raise them. These delicacies attract both carnivorous familiars and magical animals suitable to become familiars, so characters who prevent raids on a dovecote by such animals may gain both a favor from the lord and a magical creature as well.
+> 
+> Some Mythic Europeans kill crows and hang them in prominent places, to scare the doves away. In Italy animal skulls on poles are placed in the fields, and in Germany carvings of witches are used for similar purpose. Each of these activities excites the interest of faerie powers. Killing crows and nailing them over a field may also draw the interest of the Infernal, whose servants take crow shape.
+> 
+> The British style of scarecrow, a manikin of old clothes and straw, has not been invented in Mythic Europe. In this story seed, they are invented due to a local outbreak of plague. The plague kills the old and the young, so there are no boys to be hired as bird-scarers and replacements must be made. The idea of the scarecrow spreads across the continent, and faeries are strongly drawn to them because they are human in shape, act as guardians, and are replacements for children who have been lost. The scarecrows are capable of taking on many new faerie roles, including forming armies to harm the lords of disgruntled peasants.
+
 ### Farmland
 
 Mythic Europe's economy is essentially agricultural. The economy is monetarizing, and trade is making the cities blossom, which allows colorful people to rise to power and gather armies to do interesting things to each other. Beneath that drama, however, the trade system of Mythic Europe is a method of getting grains and clothes from the areas of production to the centers of population.
 
-Each piece of land has one of six legal statuses. It may be an allod, which means that it is held by the occupant without a feudal relationship. The land may be part of the demesne, which is land reserved for the lord's own use to provide income and maintain his household. The land may be part of the glebe, which is reserved for the maintenance of the Church and its servants. The land may be rented to free peasants. The land may be granted to villeins in return for rents and services. Free men taking up villein land owe service for it, despite their freedom, although they are generally wealthy enough to
-
-## Story Seeds: Dovecotes
-
-Pigeons are delectable; that's why nobles raise them. These delicacies attract both carnivorous familiars and magical animals suitable to become familiars, so characters who prevent raids on a dovecote by such animals may gain both a favor from the lord and a magical creature as well.
-
-Some Mythic Europeans kill crows and hang them in prominent places, to scare the doves away. In Italy animal skulls on poles are placed in the fields, and in Germany carvings of witches are used for similar purpose. Each of these activities excites the interest of faerie powers. Killing crows and nailing them over a field may also draw the interest of the Infernal, whose servants take crow shape.
-
-The British style of scarecrow, a manikin of old clothes and straw, has not been invented in Mythic Europe. In this story seed, they are invented due to a local outbreak of plague. The plague kills the old and the young, so there are no boys to be hired as bird-scarers and replacements must be made. The idea of the scarecrow spreads across the continent, and faeries are strongly drawn to them because they are human in shape, act as guardians, and are replacements for children who have been lost. The scarecrows are capable of taking on many new faerie roles, including forming armies to harm the lords of disgruntled peasants.
-
-hire a laborer to do the actual work. Finally, the land may be unfarmed; that is, it may be wasteland.
+Each piece of land has one of six legal statuses. It may be an allod, which means that it is held by the occupant without a feudal relationship. The land may be part of the demesne, which is land reserved for the lord's own use to provide income and maintain his household. The land may be part of the glebe, which is reserved for the maintenance of the Church and its servants. The land may be rented to free peasants. The land may be granted to villeins in return for rents and services. Free men taking up villein land owe service for it, despite their freedom, although they are generally wealthy enough to hire a laborer to do the actual work. Finally, the land may be unfarmed; that is, it may be wasteland.
 
 The main land types in the heavily farmed sections of Mythic Europe are arable, meadow, pasture, and waste.
 
 #### Arable
 
-The most precious land is the arable, which is used to grow grain and legumes. After the harvest, this land reverts to common use, and is used as a supplement to dedicated grazing land. In 1220, an increasing amount of land is being drawn from meadow into arable land, but a few nobles have noticed that
-
-
-
-the price of wool is so high that it is more profitable to force land the other way.
+The most precious land is the arable, which is used to grow grain and legumes. After the harvest, this land reverts to common use, and is used as a supplement to dedicated grazing land. In 1220, an increasing amount of land is being drawn from meadow into arable land, but a few nobles have noticed that the price of wool is so high that it is more profitable to force land the other way.
 
 Yield on farms is poor. The average winter grain crop is sown at two bushels an acre, and repays that effort with eight bushels of grain. Spring crops are sown at four bushels an acre, and their yield varies, but averages sixteen bushels. The lowest yielding grain, oats, will grow in marginal land where other grains are not profitable.
 
@@ -3451,12 +3213,9 @@ Goats are used as grazers on land that will not support sheep. They do not thriv
 
 Nobles eat beef regularly, but peasants eat it rarely. The average ox is considered to take two years to train, and to work for four, after which it is killed and salted or smoked for winter. Cows are rarely killed until past bearing.
 
-## The Lord's Portion: The Demesne
+### The Lord's Portion: The Demesne
 
-The demesne of the lord is land that is worked for his profit, by his peasants, as part of their rent. In some manors, the demesne is separated from the land of the peasants, while in others it is intermingled. There are advantages to each system: a lord with a separate demesne can watch his crops for theft, and can supervise his laborers more effectively. A demesne that is scattered through
-
-
-the striplands of the manor is worked as the peasants work their own lands, which makes the task less onerous.
+The demesne of the lord is land that is worked for his profit, by his peasants, as part of their rent. In some manors, the demesne is separated from the land of the peasants, while in others it is intermingled. There are advantages to each system: a lord with a separate demesne can watch his crops for theft, and can supervise his laborers more effectively. A demesne that is scattered through the striplands of the manor is worked as the peasants work their own lands, which makes the task less onerous.
 
 Villeins do about a quarter of the work required to plow, sow, and reap the demesne. The rest is done by paid laborers or the lord's liveried famuli, who are described in detail in Chapter Seven: The Peasantry. The famuli are those who live at the manor, or whom the lord is required to feed, for a substantial proportion of the year. The famuli include those who have a little land, like the bovaters, or virtually no land, and are paid in kind for labor.
 
@@ -3470,15 +3229,7 @@ Most towns with the right to hold a fair do so twice a year. More frequent fairs
 
 #### Mills
 
-On certain manors, milling is one of the lord's greatest sources of income, exceeding the value of the crops grown on the
-
-## The Tragedy of the Commons
-
-Players may mistakenly believe that commons are desolate places, destroyed by overuse. After the game period, the Enclosure Movement in England popularized this idea. They suggested that each peasant, acting in his own interest, ran additional stock on the green, which demanded more from the green than it could provide, destroying it. This metaphor is popular in the economic discussion of many environmental problems. The Enclosure Movement's solution was basically to give the green to neighboring landed gentry, who could look after it properly. This also had the useful effect, from their perspective, of making the peasants dependent on day labor, so wages fell.
-
-Greens actually don't operate in this way, because peasants aren't allowed to just choose how many animals they will run on the common. Commons are highly regulated by the manor court, and are defended by the vigilance of every other villager who uses the green. Greens are less productive than if they were cropped with wheat in the sense that they produce less food, but they are more productive in the sense that they provide a minor element of social security, and provide a venue for events required by the social life of the village.
-
-demesne. This is particularly true on those manors where the demesne has been carved up or leased out in previous generations.
+On certain manors, milling is one of the lord's greatest sources of income, exceeding the value of the crops grown on the demesne. This is particularly true on those manors where the demesne has been carved up or leased out in previous generations.
 
 The simplest technology with which grain can be milled into flour is the quern, or hand mill. Querns were widespread in Roman times and virtually every peasant knows how to make one. Querns are illegal in some places, because lords demand that their tenants use the lord's mill. In some areas free men are permitted to use querns. In some areas, the population is too dispersed, or insufficiently interested in agriculture, to make mills worthwhile, and everyone uses a quern.
 
@@ -3496,41 +3247,39 @@ The commons of a village are areas set aside for the use of the villeins, or, in
 
 The use of the green is regulated by the manor court. Each villager is permitted to have some stock graze the green, but the other users of the green, and the hayward, monitor overgrazing. The number of sheep or goats that may forage on the green varies with its size and fertility, and this number of stock may be divided equally by all villagers, or by their obligation to villein service. The right to run some stock on the green, collect a little firewood there, and in some cases plant small gardens or harvest wild nuts and berries, acts to mitigate poverty. Villages without greens have cheaper labor costs, because more workers have to accept day labor or starve.
 
+> ## The Tragedy of the Commons
+> 
+> Players may mistakenly believe that commons are desolate places, destroyed by overuse. After the game period, the Enclosure Movement in England popularized this idea. They suggested that each peasant, acting in his own interest, ran additional stock on the green, which demanded more from the green than it could provide, destroying it. This metaphor is popular in the economic discussion of many environmental problems. The Enclosure Movement's solution was basically to give the green to neighboring landed gentry, who could look after it properly. This also had the useful effect, from their perspective, of making the peasants dependent on day labor, so wages fell.
+> 
+> Greens actually don't operate in this way, because peasants aren't allowed to just choose how many animals they will run on the common. Commons are highly regulated by the manor court, and are defended by the vigilance of every other villager who uses the green. Greens are less productive than if they were cropped with wheat in the sense that they produce less food, but they are more productive in the sense that they provide a minor element of social security, and provide a venue for events required by the social life of the village.
 
-## Waste
+### Waste
 
 On a manor, the waste is land that is not planted. It is vital to the manorial economy because it includes woods and marshlands. Marginal land on the edge of the waste is often used for grazing, is called pasture, and is described earlier.
 
 The wasteland is the domain of the faeries. It is part of the known landscape of the community, but does not fall within the boundaries of the fields that are blessed at various times of the year. Humans who clear land are, for a time at least, going onto faerie lands to spread the Dominion.
 
-## Fisheries and Marshes
+### Fisheries and Marshes
 
 Many communities draw their income from the sea, or from marshland. Fish and salt are both common exports from coastal areas. The duties of villeins who live by the sea vary with the strength and greed of their lord. At minimum, the king or his representative has the right to the proceeds of shipwrecks, to certain species of fish and waterfowl, and to commandeer any villein's vessel at any time. Greater nobles usually have the right to demand the services of ships from towns to which they have granted charters.
 
 Marshes are the source of many useful raw materials. The lord sells the right to use these resources or demands that villeins harvest them on his behalf. The right to cut peat, called turbary, alleviates the lord's monopoly on firewood in some areas. Some marsh plants, particularly sedges, make superior roofing thatch and woven implements. Draining marshland is one of the main ways that additional arable land is bought into production. This is covered in more detail later, in the section on assarting.
 
-## Woods
+### Woods
 
-The woodland on the edge of a community is its main source of wood, which is used for fuel, and as the main resource for the creation of all implements and tools. This means that the demand for wood is insatiable, and lords ration how much of it may be gathered, and by what method. In many areas, a peasant may take whatever wood he can carry, provided that it is lying on the ground or can be pulled down with a hand
+The woodland on the edge of a community is its main source of wood, which is used for fuel, and as the main resource for the creation of all implements and tools. This means that the demand for wood is insatiable, and lords ration how much of it may be gathered, and by what method. In many areas, a peasant may take whatever wood he can carry, provided that it is lying on the ground or can be pulled down with a hand tool. After major storms, wise peasants head for the wood to seek "windfalls," trees that have been knocked over by the storm.
 
-
-## Story Seed: Joining The Navy
-
-Proportionately, far fewer nobles than covenants have private ships. Those nobles who have trade vessels may prepare them as troop transports when needed in war, but even this is rare. It is far more common for a nobleman simply to demand the carriage of troops from a port city, and then turn up on the appointed day with an army motivated by the promise of pillage in some far distant place. Few towns want these men to be both disappointed and nearby, and either accede to the nobleman's demands or haggle a price for carriage. The negotiating position of such a town may appear weak, but a lord with a feudal levy is under extreme time pressure. Even a brief siege destroys his campaign season.
-
-A covenant hears that a powerful nobleman has sent word to a town near the covenant that carriage will be expected on a certain day. The covenant may want to hide their own ships, or offer them for hire, or find other ways to profit from the presence of an army. Might they trick the army into crossing the lands of a troublesome faerie, or rival covenant?
-
-tool. After major storms, wise peasants head for the wood to seek "windfalls," trees that have been knocked over by the storm.
+> ## Story Seed: Joining The Navy
+> 
+> Proportionately, far fewer nobles than covenants have private ships. Those nobles who have trade vessels may prepare them as troop transports when needed in war, but even this is rare. It is far more common for a nobleman simply to demand the carriage of troops from a port city, and then turn up on the appointed day with an army motivated by the promise of pillage in some far distant place. Few towns want these men to be both disappointed and nearby, and either accede to the nobleman's demands or haggle a price for carriage. The negotiating position of such a town may appear weak, but a lord with a feudal levy is under extreme time pressure. Even a brief siege destroys his campaign season.
+> 
+> A covenant hears that a powerful nobleman has sent word to a town near the covenant that carriage will be expected on a certain day. The covenant may want to hide their own ships, or offer them for hire, or find other ways to profit from the presence of an army. Might they trick the army into crossing the lands of a troublesome faerie, or rival covenant?
 
 The lord can often be convinced to sell a particular tree to a peasant for a small sum; trees of the right shape and size are required for building the internal supports of most peasant homes. Villeins are often required to pay the lord for use of his wood, although this service is often in the form of cutting and carting wood for the lord.
 
 In England, much of the woodland belongs to the royal demesne, and most of it is forest, as described in Chapter Five: Leisure, Hunting. A forest warden is sent to inspect the king's woodland on a regular basis. If, standing on a tree stump, he can see two other tree stumps, he has the right to lay a heavy fine on those who have paid for the right to harvest from the king's wood, for overgathering.
 
-The warden also charges nobles who have made illegal clearances in the king's
-
-
-
-forest. This is so unpopular that in the time of King John, the common people of Devon and Cornwall paid the king 2,200 marks and 20 palfreys, and 5,000 marks, respectively, to have their land "desforested." That is, they had all the land, in the whole of their counties, legally reclassified as woodland rather than royal forest, so that no fine would be due for clearances.
+The warden also charges nobles who have made illegal clearances in the king's forest. This is so unpopular that in the time of King John, the common people of Devon and Cornwall paid the king 2,200 marks and 20 palfreys, and 5,000 marks, respectively, to have their land "desforested." That is, they had all the land, in the whole of their counties, legally reclassified as woodland rather than royal forest, so that no fine would be due for clearances.
 
 #### Parks and Lodges
 
@@ -3546,7 +3295,7 @@ The laws protecting warren extend to pests like foxes, which cannot be killed wi
 
 Certain mineral rights are reserved by the king, and major mining operations rapidly evolve into towns. Rights to minor resources are significant on a manorial level. On the principle that the lord owns everything, and has the right to charge for the use of anything, any valuable thing beneath the ground might attract a fee for use. In Mythic Europe a character who finds a gold nugget, or even a gold mine, doesn't own it; just because the lord doesn't know that it exists doesn't mean he doesn't own it. Useful mined resources include slate, quarried stone, flint, potter's clay, fuller's earth, and clay dyes.
 
-## Legal Rights and the Manor Court
+### Legal Rights and the Manor Court
 
 A serf leading a typical life regularly pays fines to his lord. Fines are not, in this case, the result of a criminal act, but are instead a monetary compensation paid to the lord in exchange for him waiving one of his rights. Lords have so many rights, and they are so burdensome to administer, that it has become easier in most places for these breaches and resolutions to become monetary payments.
 
@@ -3554,7 +3303,7 @@ A serf leading a typical life regularly pays fines to his lord. Fines are not, i
 
 A peasant pays a fee to the lord for entering the manor by taking possession of a piece of land. This fee may be varied if the land is poor, to be assarted, or the villein has some skill sought by the lord.
 
-## Heriot, Mortuary, and Laity Objects
+#### Heriot, Mortuary, and Laity Objects
 
 The heriot is a death duty owed when the head of a household dies. The heriot is the peasant's best beast in many places, but far heavier penalties are found in others. In some locales even free men pay the heriot. On some manors the death of a wife also triggers a heriot, and on others a man owes a heriot for every hide he had. On some manors a heriot is just under half of the man's goods, including many of his best beasts, anything he possessed made of metal, all of the wool and sides of bacon he had, and the things his widow will no longer need, such as his tools and clothes. In exceptional cases the heriot is but a token, purely symbolic of the fact that everything the serf owned is the lord's anyway. On one manor, for example, the heriot is the best copper pan from the house.
 
@@ -3572,18 +3321,15 @@ Death duties strike poor widows particularly hard. In addition to the death of h
 
 Lords have a right called tallage, which they exercise sparingly, but may legally employ whenever they wish. By this right a lord may, at any time, and for any reason, tally an amount of money from the manor and his villeins are required under law to supply it to him, with each villein responsible for an amount proportional to his land holding in the manor. The tallage may be as high as the lord wishes, up to and including the sale of everything his villeins own, the repossession of their land, and the sale of their service and progeny to another lord. Tallage does not apply to free men, because the things that they own are theirs, not the lord's, so he may not demand them.
 
-Few lords actually tally exorbitant amounts. To do so causes his serfs to flee the manor and seek work elsewhere, stealing much of the manor's removable wealth
+Few lords actually tally exorbitant amounts. To do so causes his serfs to flee the manor and seek work elsewhere, stealing much of the manor's removable wealth as they go. In times of national crisis, like during civil wars, tallage is very high, its proceeds used to pay for mercenaries. Since many lords embroiled in a civil war feel uncertain that they will hold their lordships though the course of the war and the ensuing negotiations for peace, they take as much as they can, while they can.
 
-
-## Story Seed: The Gite
-
-In France there is a tax called the gite, which is a feast for the lord and his retinue to celebrate his arrival on his tour of inspection of his manors. The gite has become increasingly extravagant over time. In politically unstable areas the gite is now unsustainably large, but this does not bother the nobles because they do not expect to hold their lands in the long term, and so see no point in preserving them. Some nobles now take their gite in coin, but this is difficult to transport, so they give or sell the gite to a friend, political contact, or anyone else who would like to feel like a lord of the manor for a day.
-
-A village that has ties to the covenant has had its gite purchased by a merchant. Merchants who purchase a manor's gite tend to be greedy and cruel on that day even if they are not not on others, because they only have one day to live the vices of the lordship. The village is preparing for the merchant to descend with dozens of people in his retinue, drink and eat as much as they wish, order any beasts killed that they wish, and sleep in whatever houses they wish. The peasants also fear taht the merchant and his retinue will rape indicriminately and burn down a few buildings, and that the lord rather than the peasants — will ultimately be compensated.
-
-It would be difficult for the peasants to arrange it, but if the merchant could be waylaid in the woods, then all might be well. The gite falls only on a certain day, and although the merchant could simply use his guards to force the peasants to submit on a later day, that would be a crime for which the lord could, and would, take him to court for tremendous damages. The lord would not care if the merchant misses his date of opportunity, for he keeps the price he sold it for regardless. The difficulty is the guards that each of the merchant's friends will have with them. The characters do, however, know where the merchant will stop the night before the gite, so there's some chance they can waylay him for the 12 hours necessary to ruin the feast.
-
-as they go. In times of national crisis, like during civil wars, tallage is very high, its proceeds used to pay for mercenaries. Since many lords embroiled in a civil war feel uncertain that they will hold their lordships though the course of the war and the ensuing negotiations for peace, they take as much as they can, while they can.
+> ## Story Seed: The Gite
+> 
+> In France there is a tax called the gite, which is a feast for the lord and his retinue to celebrate his arrival on his tour of inspection of his manors. The gite has become increasingly extravagant over time. In politically unstable areas the gite is now unsustainably large, but this does not bother the nobles because they do not expect to hold their lands in the long term, and so see no point in preserving them. Some nobles now take their gite in coin, but this is difficult to transport, so they give or sell the gite to a friend, political contact, or anyone else who would like to feel like a lord of the manor for a day.
+> 
+> A village that has ties to the covenant has had its gite purchased by a merchant. Merchants who purchase a manor's gite tend to be greedy and cruel on that day even if they are not not on others, because they only have one day to live the vices of the lordship. The village is preparing for the merchant to descend with dozens of people in his retinue, drink and eat as much as they wish, order any beasts killed that they wish, and sleep in whatever houses they wish. The peasants also fear taht the merchant and his retinue will rape indicriminately and burn down a few buildings, and that the lord rather than the peasants — will ultimately be compensated.
+> 
+> It would be difficult for the peasants to arrange it, but if the merchant could be waylaid in the woods, then all might be well. The gite falls only on a certain day, and although the merchant could simply use his guards to force the peasants to submit on a later day, that would be a crime for which the lord could, and would, take him to court for tremendous damages. The lord would not care if the merchant misses his date of opportunity, for he keeps the price he sold it for regardless. The difficulty is the guards that each of the merchant's friends will have with them. The characters do, however, know where the merchant will stop the night before the gite, so there's some chance they can waylay him for the 12 hours necessary to ruin the feast.
 
 On some manors, the peasants have convinced the lord to commute his demands for tallage to a set fee, paid every year. This has advantages to both sides in times of peace. The lord gets his money with less ill will, and the peasants are freed of the uncertainties of tallage at whim.
 
@@ -3597,7 +3343,7 @@ A court meets as is customary for that manor. In some places this is as rarely a
 
 The court often gathers at the manor hall, but this is far from universal. In many areas a particular tree or part of the common is the traditional site for the court. Courts are rarely held in churches, despite their spaciousness. The steward convenes the court, and sees to the rights of the lord. He is attended by the bailiff, and perhaps the messor, who keep order. He is also assisted by a clerk who keeps the manorial rolls, which are long records of previous cases and debts.
 
-## Juries
+### Juries
 
 The court often begins with an empaneling of jurors. Many free men resist the duty of jury, although free men are prized as jurors because they are seen as having more free time than villeins. The agreements that make men free often includes a clause requiring them to continue performing jury service.
 
@@ -3609,12 +3355,9 @@ Juries are often used to decide matters of court custom in cases between villein
 
 Juries of inquisition are groups of men appointed by the court to investigate a matter and report their findings at the next session. For example, in a case of sheep theft the jury might be asked to review the animals, consider the upkeep of fences and hedges between the lands, and use their knowledge of the character of the claimants to come to a decision. The considerations of juries are not private. If some members of the jury obstinately refuse to see reason, as determined by a different jury, then the victorious party in the later suit may sue earlier jury members for failure to provide a unanimous verdict.
 
-## Disputes
+### Disputes
 
-Most of the court's work involves disputes between serfs, or between serfs and the lord. Disputes between serfs provide the lord with fines, so it is cheaper for villeins to come to some agreement on their own before the bailiff becomes aware of the dispute, if they can. A smaller fine is paid when a dispute is settled amicably outside the
-
-
-court. Other villeins deliberately hold disputes until the coming of the court and then demand that their claims be checked against the court roll. There is a small fine for this, perhaps a couple of pence, which is doubled if the court roll is found to not support the villein's argument. Similarly, a man may pay a fine to demand that the court hear his case when the case could instead be summarily dealt with by one of the lesser officers. The court's ruling becomes binding, is added to the manorial roll, and the villein pays about a shilling for the court's time and trouble, or two shillings if the case went against him.
+Most of the court's work involves disputes between serfs, or between serfs and the lord. Disputes between serfs provide the lord with fines, so it is cheaper for villeins to come to some agreement on their own before the bailiff becomes aware of the dispute, if they can. A smaller fine is paid when a dispute is settled amicably outside the court. Other villeins deliberately hold disputes until the coming of the court and then demand that their claims be checked against the court roll. There is a small fine for this, perhaps a couple of pence, which is doubled if the court roll is found to not support the villein's argument. Similarly, a man may pay a fine to demand that the court hear his case when the case could instead be summarily dealt with by one of the lesser officers. The court's ruling becomes binding, is added to the manorial roll, and the villein pays about a shilling for the court's time and trouble, or two shillings if the case went against him.
 
 #### Disputes Based on Weights and Measures
 
@@ -3624,52 +3367,49 @@ Natural measures are supposed to be unarguable, but they generally favor the lor
 
 In some courts, each man is his own measure. A man due three handfuls of oats for carrying a load of oats in his cart is in luck if his hands are big. As a restraining feature, many men are allowed to have as much as they can carry, provided none of it spills. For example, many haycutters are allowed to take from their work as much hay as their scythe can carry, but if the scythe breaks they get nothing and are fined.
 
-## Fines
+### Fines
 
 There are a wide variety of fines levied on peasants. Fines vary between manors, but some of the commonest are described below.
 
-## Story Seeds
-
-#### Tiny Eggs
-
-Faeries often play with natural measures as a way of causing tension in human communities. As an example, a popular natural measure is the egg. Many peasants have a number of eggs incorporated in their dues. If a faerie makes every egg laid on a manor the size of a thimble, it causes tension in the community. Either the lord accepts a reduced income, or the lord's servants try to take more from the peasants, who themselves already have less, as a way of maintaining his income. This sort of trickery often leads to accusations of witchcraft, so magi may feel the need to resolve these kinds of situations.
-
-#### Weight in Gold
-
-A mercenary captain has saved a monastery from raiders, but the abbot foolishly agreed to pay the mercenary his weight in gold in exchange. The local baron has demanded that he be present for the weighing, as an arbiter, and that he be permitted to bring his entire court, as it will amuse them. The baron has done this because he hates the abbot, and the procession of the lord's court will delay the weighing for a month. The mercenary has retired to a nearby town to stuff himself with sweet luxuries before the official weighing.
-
-The abbot is praying for a miracle, because Daniel was able to fix a weigh-in with the help of God. In case there is no miracle, the abbot would like the help of the magi. He has heard that magically created food does not nourish. He'd like the magi to make sure that his rival eats nothing but magically created food for the rest of the month. That should save the abbot a tidy sum, which he'll divide with the magi. If the captain actually loses weight, the priest will pay them a bonus.
-
-#### Warped Consors
-
-An Autumn covenant in a neighboring Tribunal has fallen and its covenfolk, who are in some cases highly Warped, have spread into neighboring towns. This has led to strife with the local nobility and church. For example, a village that has the right to take one handful of salt from every pan boiled has become far richer, at the local lord's expense, by convincing a man Warped with a hand five times normal size to settle locally. Although none of the Warped consors have magical powers, and although they are no longer strictly the business of the Order of Hermes, the sum of their actions has disadvantaged a large proportion of the region's magnates.
+> ## Story Seeds
+> 
+> ### Tiny Eggs
+> 
+> Faeries often play with natural measures as a way of causing tension in human communities. As an example, a popular natural measure is the egg. Many peasants have a number of eggs incorporated in their dues. If a faerie makes every egg laid on a manor the size of a thimble, it causes tension in the community. Either the lord accepts a reduced income, or the lord's servants try to take more from the peasants, who themselves already have less, as a way of maintaining his income. This sort of trickery often leads to accusations of witchcraft, so magi may feel the need to resolve these kinds of situations.
+> 
+> ### Weight in Gold
+> 
+> A mercenary captain has saved a monastery from raiders, but the abbot foolishly agreed to pay the mercenary his weight in gold in exchange. The local baron has demanded that he be present for the weighing, as an arbiter, and that he be permitted to bring his entire court, as it will amuse them. The baron has done this because he hates the abbot, and the procession of the lord's court will delay the weighing for a month. The mercenary has retired to a nearby town to stuff himself with sweet luxuries before the official weighing.
+> 
+> The abbot is praying for a miracle, because Daniel was able to fix a weigh-in with the help of God. In case there is no miracle, the abbot would like the help of the magi. He has heard that magically created food does not nourish. He'd like the magi to make sure that his rival eats nothing but magically created food for the rest of the month. That should save the abbot a tidy sum, which he'll divide with the magi. If the captain actually loses weight, the priest will pay them a bonus.
+> 
+> ### Warped Consors
+> 
+> An Autumn covenant in a neighboring Tribunal has fallen and its covenfolk, who are in some cases highly Warped, have spread into neighboring towns. This has led to strife with the local nobility and church. For example, a village that has the right to take one handful of salt from every pan boiled has become far richer, at the local lord's expense, by convincing a man Warped with a hand five times normal size to settle locally. Although none of the Warped consors have magical powers, and although they are no longer strictly the business of the Order of Hermes, the sum of their actions has disadvantaged a large proportion of the region's magnates.
 
 #### Seizure
 
 The goods of a felon automatically become the possession of his lord. A felon who flees or is put to death leaves his land vacant. A new landholder pays the lord a fee to enter the land, and so death is particularly lucrative for lords, but the death penalty is restricted to the greater nobility in many areas. Some buy the right to kill felons from their kings.
 
-## Sex Taxes: Merchet, Leywrite, Childwrite, and Fines for Celibacy
+> ## Story Seed: Fines for the King
+> 
+> The king of England owns all of England. (This is unusual; generally kings are owed the service of various nobles to various degrees.) This means that the king of England is in a unique position to cause the Order of Hermes discomfort. In this story seed, he does this by claiming that he is owed fines when magi in England are fined.
+> 
+> If a Hermetic magus is found guilty of abusing a magus from a neighboring Tribunal, a fine is often paid. This requires material of value to pass from England to another kingdom. This deprives the king of what is his, because everything that comes from England is his. This means he is due reparation of equal value to the thing lost. The king sends a representative to Tribunal, who is laden with relics to ensure he is not mishandled by magic, to demand the king's rights.
+> 
+> Characters may need to deal with this request from the king. It is likely a ploy to establish an ongoing payment of money in exchange for the king's recognition of the authority of the Hermetic Tribunals as courts. Payment could be a problem, though, because it would be made public and set a precedent that other kings would seek to follow, regardless of the unique legal niceties of the English situation. Characters might also seek the Hermetic magi who arranged the king's intervention. Fingers might be pointed at House Tytalus, whose domus magna floats smugly off the coast of Normandy and is the cause of much strife in its neighboring Tribunals. Could it, however, have been someone else, seeking to embarrass the Tytalus? They have many enemies that have become as cunning as they are.
+
+#### Sex Taxes: Merchet, Leywrite, Childwrite, and Fines for Celibacy
 
 It is legally forbidden for the serfs of different lords to marry. To secure the permission of the lord, each serf pays a fine called merchet. Merchets are higher if the woman is receiving a large dowry, because the lord's permission gives the bridegroom a greater benefit. The merchet is also larger if the bride is moving into the manor of her husband's lord.
 
 The bride's lord collects a larger merchet to be compensated not only for her lost labor, but also for her lost brood. That is, she is fined because her children, if any, will not become her master's serfs. This fine is sometimes lowered when the two lords have adjoining estates, and come to an arrangement concerning the division of the brood between their manors.
 
-Merchet is widely loathed by peasants. They see it as a tax on their children. In theory, if not in practice, the law of the Church forbade any people within seven degrees of consanguinity from marrying each other until 1215. This was found to be so unworkable that a majority of marriages, in many places, were
+Merchet is widely loathed by peasants. They see it as a tax on their children. In theory, if not in practice, the law of the Church forbade any people within seven degrees of consanguinity from marrying each other until 1215. This was found to be so unworkable that a majority of marriages, in many places, were legally incestuous and therefore false. The pope reduced the prohibited degrees to four, so that only people who share a great-greatgrandparent cannot marry. Since peasants live in tiny villages and do not travel far in their lives, their communities are either incestuous or are continually paying for the fresh blood that their community requires. On some manors, lords ask merchet even if their own villeins marry.
 
-
-## Story Seed: Fines for the King
-
-The king of England owns all of England. (This is unusual; generally kings are owed the service of various nobles to various degrees.) This means that the king of England is in a unique position to cause the Order of Hermes discomfort. In this story seed, he does this by claiming that he is owed fines when magi in England are fined.
-
-If a Hermetic magus is found guilty of abusing a magus from a neighboring Tribunal, a fine is often paid. This requires material of value to pass from England to another kingdom. This deprives the king of what is his, because everything that comes from England is his. This means he is due reparation of equal value to the thing lost. The king sends a representative to Tribunal, who is laden with relics to ensure he is not mishandled by magic, to demand the king's rights.
-
-Characters may need to deal with this request from the king. It is likely a ploy to establish an ongoing payment of money in exchange for the king's recognition of the authority of the Hermetic Tribunals as courts. Payment could be a problem, though, because it would be made public and set a precedent that other kings would seek to follow, regardless of the unique legal niceties of the English situation. Characters might also seek the Hermetic magi who arranged the king's intervention. Fingers might be pointed at House Tytalus, whose domus magna floats smugly off the coast of Normandy and is the cause of much strife in its neighboring Tribunals. Could it, however, have been someone else, seeking to embarrass the Tytalus? They have many enemies that have become as cunning as they are.
-
-legally incestuous and therefore false. The pope reduced the prohibited degrees to four, so that only people who share a great-greatgrandparent cannot marry. Since peasants live in tiny villages and do not travel far in their lives, their communities are either incestuous or are continually paying for the fresh blood that their community requires. On some manors, lords ask merchet even if their own villeins marry.
-
-## Story Seed: Tithe of Vis
-
-A representative of the bishop arrives with a writ to examine the covenant, from top to bottom, to determine its compliance with his lord's tithes. Many of the things that magi collect are suited to tithing. Vis arises from the natural processes of the world, and therefore is suitable for tithe. Magi create things from their skills, such as books and magic items, so these things are also tithable. Can the characters hide their vis sources from the bishop's inspector? How does he know about vis? Why does he want to collect it anyway? To sell it back to the covenant, or to force them to perform a small favor?
+> ## Story Seed: Tithe of Vis
+> 
+> A representative of the bishop arrives with a writ to examine the covenant, from top to bottom, to determine its compliance with his lord's tithes. Many of the things that magi collect are suited to tithing. Vis arises from the natural processes of the world, and therefore is suitable for tithe. Magi create things from their skills, such as books and magic items, so these things are also tithable. Can the characters hide their vis sources from the bishop's inspector? How does he know about vis? Why does he want to collect it anyway? To sell it back to the covenant, or to force them to perform a small favor?
 
 Peasants who sidestep the issue of merchet by simply not marrying face an even stiffer fine, for leywrite. Leywrite, the right for laying down, is theoretically an adultery tax. It is charged by the lord on a woman who has deprived him of merchet by making herself unmarriageable by losing her virginity. This is difficult to prove. Leywrite often absorbs a related fee, childwrite, which is a tax on unmarried pregnancy. It is due each time an unmarried serf becomes pregnant. Leywrite is far more common than merchet: it's a particularly lucrative tax.
 
@@ -3677,26 +3417,21 @@ Fines cannot be avoided by celibacy. On many manors, a fine is paid annually by 
 
 #### Fines for Being Fined
 
-It is illegal for a peasant to waste the things his lord owns. The lord owns everything that the peasant owns. Therefore, if the peasant is fined somewhere outside the manorial court, like the ecclesiastical court
+It is illegal for a peasant to waste the things his lord owns. The lord owns everything that the peasant owns. Therefore, if the peasant is fined somewhere outside the manorial court, like the ecclesiastical court or the shire court, then the fine paid has been stolen from the lord, and the peasant owes the lord equivalent compensation.
 
-## Trade
-
-Trade is heavily taxed, but only by the upper nobility or representatives of the king. There are ways for characters to make money from manufacture and trade. These are considered in detail in *City & Guild*.
-
-In this supplement, non-agricultural sources of wealth are treated either as an unremarked component of agricultural income or as a bonus to the character's agricultural income. As an example, a manor by the sea that considers fish and eels as part of its income is nevertheless treated, in the economic rules, as an agricultural manor. The fact that the goods it produces for its lord's use include some fish rather than wheat or honey or cheese is significant to the color of the stories told, but not to the mechanics in these rules. If the same manor is permitted to run a salt kin as service to its lord, and use a portion of the salt to pay its taxes, this is treated as a simple monetary bonus.
-
-A player character nobleman who uses the agricultural surplus of his lands to engage in local and international trade should be designed using the rules given in *City & Guild.*
-
-or the shire court, then the fine paid has been stolen from the lord, and the peasant owes the lord equivalent compensation.
+> ## Trade
+> 
+> Trade is heavily taxed, but only by the upper nobility or representatives of the king. There are ways for characters to make money from manufacture and trade. These are considered in detail in *City & Guild*.
+> 
+> In this supplement, non-agricultural sources of wealth are treated either as an unremarked component of agricultural income or as a bonus to the character's agricultural income. As an example, a manor by the sea that considers fish and eels as part of its income is nevertheless treated, in the economic rules, as an agricultural manor. The fact that the goods it produces for its lord's use include some fish rather than wheat or honey or cheese is significant to the color of the stories told, but not to the mechanics in these rules. If the same manor is permitted to run a salt kin as service to its lord, and use a portion of the salt to pay its taxes, this is treated as a simple monetary bonus.
+> 
+> A player character nobleman who uses the agricultural surplus of his lands to engage in local and international trade should be designed using the rules given in *City & Guild.*
 
 For example, sins may lead to fines in ecclesiastical courts. A man convicted of being a fornicator, if a villein, must pay a fine, and then pay his lord a second fine for paying the first. As another example, in parts of France it is considered a breach of the peace for one person to call another person a serf as a term of abuse, even if the person actually is a serf. Similarly, clever synonyms, like "villein," "bondman," or "rusticum," are illegal words and a fine is due. That fine is paid from the transgressing serf's money, which belongs to the lord, and so a second fine is due.
 
 ## Church
 
-Religion plays a significant role in the life of almost every person in Mythic Europe. In feudal areas, that role is to provide the sacra-
-
-
-ments that mark significant occasions in the life of each person. Each community has a local priest appointed by the bishop, with the duty to care for souls in that community. This priest is called a curate, and the parish that supports him is his living. In many communities that have multiple manors, there are separate churches, and priests, for each manor. This is because the individual churches are owned by their respective secular nobleman and lent to the Church.
+Religion plays a significant role in the life of almost every person in Mythic Europe. In feudal areas, that role is to provide the sacraments that mark significant occasions in the life of each person. Each community has a local priest appointed by the bishop, with the duty to care for souls in that community. This priest is called a curate, and the parish that supports him is his living. In many communities that have multiple manors, there are separate churches, and priests, for each manor. This is because the individual churches are owned by their respective secular nobleman and lent to the Church.
 
 Curates are required to provide the sacraments required by the life of the community. They oversee celebrations of holy days. Each is required to preach four sermons a year, although this rule is only weakly enforced. The curate has the duty to maintain the Church's land in the vicinity of his flock. The income from this land, and the tithes of the community, are used for the priest's own support, to maintain the fabric of the Church, and to aid the poor.
 
@@ -3704,12 +3439,9 @@ Over time, the role of priest has become enmeshed in the financial and political
 
 Curates of minor parishes are likely to have poor education by the standards of the Order of Hermes. Perhaps one-fifth of all the local priests in Mythic Europe are able to do little more than repeat the sacraments by rote, and cannot read Latin in any effective way. The sacraments of these priests are, nonetheless, completely effective, and these priests still serve their communities as resolvers of disputes, witnesses of oaths, and maintainers of the Church lands. Many provide religious education through their sermons, and some provide basic schooling for children.
 
-## Churchyard
+### Churchyard
 
-The churchyard plays an important role in the civic life of the manor. It is common, on Sundays, for many villagers to gather in their churchyards, to drink, dance, and gossip. Informal markets are also held in churchyards. Priests have been forbidding unsol-
-
-
-emn behavior in churchyards as sinful for hundreds of years, but this has not prevented it in most areas. Churchyards are hallowed places, protected by the Divine.
+The churchyard plays an important role in the civic life of the manor. It is common, on Sundays, for many villagers to gather in their churchyards, to drink, dance, and gossip. Informal markets are also held in churchyards. Priests have been forbidding unsolemn behavior in churchyards as sinful for hundreds of years, but this has not prevented it in most areas. Churchyards are hallowed places, protected by the Divine.
 
 ### Glebe
 
@@ -3719,28 +3451,25 @@ Glebes may be cropped in a variety of ways. Glebes may be rented out, which alle
 
 The most contentious of a curate's servants is the "hearth mate." A hearth mate is technically a woman of all work recruited to perform domestic labor. Effectively, the hearth mate is often a wife. Provided the relationship is deniable, or the priest claims to be penitent when found guilty of fornication by ecclesiastical authorities, this does not much damage the prospects of a manorial curate.
 
-## Church and Priest's House
+### Church and Priest's House
 
-Parish churches are not the grand structures of arching stone found in the cities. Most are built in the same way as the houses of manorial lords, so in areas where manor houses are made from timber with thatched roofs, the churches are made the same way. The interiors of churches tend to be highly decorated. The church is one of the few
+Parish churches are not the grand structures of arching stone found in the cities. Most are built in the same way as the houses of manorial lords, so in areas where manor houses are made from timber with thatched roofs, the churches are made the same way. The interiors of churches tend to be highly decorated. The church is one of the few buildings where it is considered inappropriate for servants of the owner of the building to sleep, so priests require residences other than the church building.
 
-
-## Story Seeds
-
-#### Brotherhood of the Black Mask
-
-In England the problem of rectors is felt more intensely than in any other part of Europe. While King John was excommunicate, many livings fell vacant, and when he swore fealty to the pope, many of these were filled with Vatican functionaries who never visited England. Many others were filled with priests who did come to their livings, but did not understand English customs and were considered severe in their interpretation of their rights.
-
-Roughly parallel to the game period, a minor nobleman whose church is given away without his permission forms a league of equally annoyed minor nobles, called the Brotherhood. The Brotherhood robs and beats Italian priests in their part of northern England. As word of the attacks spreads, other nobles, with no connection to the original Brotherhood, join in. If a comparable organization to the Brotherhood appears in the player characters' Tribunal, magi may be targeted. The magi, after all, speak Latin, and in many cases act in strange and possibly foreign ways.
-
-Player characters who attempt to track down the leaders of the Brotherhood face several obstacles. The Brotherhood is more a social movement than an organization, so it has no ultimate leader. Its members often keep what they steal, but many of the brothers have emptied the tithe barns of the local churches and given the food stored there to the peasantry, so they are very popular with the common people. Many Brotherhood attacks are staged by great nobles, seeking revenge on priests they dislike. If there is a coordinating hand behind the best-planned of the attacks, it is likely one of the king's inner circle, who is deliberately spreading disorder for political ends.
-
-#### Swift Assarting
-
-It is possible to assart land far faster than normal by hiring a large workforce and then dismissing them afterward. When a lord does this, it leads to many problems. Petty crime rates rise while the outsiders are in the manor, particularly as their work comes to an end. The workers know they will move on soon and are unlikely to be caught in petty theft. Some groups go further than this, and stage burglaries after their work is done, or become brigands.
-
-In this story seed for a Spring covenant, a band of brigands has begun to raid areas nearby. They have been telling the victims of their crimes that they were once workers from the group that assarted the covenant's lands. The magi, however, know that they assarted their own land magically. They must find this band, determine who they are working for, and figure out what this mysterious individual hopes to achieve by blaming the magi for a series of crimes. In the interim, the magi must deal with aggrieved local lords, who claim compensation for the damage caused by the covenant's reckless practice of hiring massive assarting teams.
-
-buildings where it is considered inappropriate for servants of the owner of the building to sleep, so priests require residences other than the church building.
+> ## Story Seeds
+> 
+> ### Brotherhood of the Black Mask
+> 
+> In England the problem of rectors is felt more intensely than in any other part of Europe. While King John was excommunicate, many livings fell vacant, and when he swore fealty to the pope, many of these were filled with Vatican functionaries who never visited England. Many others were filled with priests who did come to their livings, but did not understand English customs and were considered severe in their interpretation of their rights.
+> 
+> Roughly parallel to the game period, a minor nobleman whose church is given away without his permission forms a league of equally annoyed minor nobles, called the Brotherhood. The Brotherhood robs and beats Italian priests in their part of northern England. As word of the attacks spreads, other nobles, with no connection to the original Brotherhood, join in. If a comparable organization to the Brotherhood appears in the player characters' Tribunal, magi may be targeted. The magi, after all, speak Latin, and in many cases act in strange and possibly foreign ways.
+> 
+> Player characters who attempt to track down the leaders of the Brotherhood face several obstacles. The Brotherhood is more a social movement than an organization, so it has no ultimate leader. Its members often keep what they steal, but many of the brothers have emptied the tithe barns of the local churches and given the food stored there to the peasantry, so they are very popular with the common people. Many Brotherhood attacks are staged by great nobles, seeking revenge on priests they dislike. If there is a coordinating hand behind the best-planned of the attacks, it is likely one of the king's inner circle, who is deliberately spreading disorder for political ends.
+> 
+> ### Swift Assarting
+> 
+> It is possible to assart land far faster than normal by hiring a large workforce and then dismissing them afterward. When a lord does this, it leads to many problems. Petty crime rates rise while the outsiders are in the manor, particularly as their work comes to an end. The workers know they will move on soon and are unlikely to be caught in petty theft. Some groups go further than this, and stage burglaries after their work is done, or become brigands.
+> 
+> In this story seed for a Spring covenant, a band of brigands has begun to raid areas nearby. They have been telling the victims of their crimes that they were once workers from the group that assarted the covenant's lands. The magi, however, know that they assarted their own land magically. They must find this band, determine who they are working for, and figure out what this mysterious individual hopes to achieve by blaming the magi for a series of crimes. In the interim, the magi must deal with aggrieved local lords, who claim compensation for the damage caused by the covenant's reckless practice of hiring massive assarting teams.
 
 The houses of curates in minor parishes are flimsy things. This is because the curates of minor places are usually no wealthier than villeins, given that the tithes and perhaps even the crops from the Church lands are collected by the curate for the rector, rather than for his own use. The curate receives a small wage that is supplemented by farming a small section of the glebe.
 
@@ -3754,24 +3483,19 @@ Non-magical characters may improve their fiefs in a limited number of ways. Most
 
 ### Assarting
 
-Hermetic scholars know that the weather in Mythic Europe is notably drier in the 13th century than it was in preceding years. This has made farmable a great deal of land that was previously marginal. Coupled with the population boom being experienced in Europe, one of the simplest ways of expanding a fief is assarting: carving new cropland or meadow from fertile wasteland. This has been occurring for much of the last century, so marginal land is becoming increasingly scarce.
+ Hermetic scholars know that the weather in Mythic Europe is notably drier in the 13th Century than it was in preceding years. This has made farmable a great deal of land that was previously marginal. Coupled with the population boom being experienced in Europe, one of the simplest ways of expanding a fief is assarting: carving new cropland or meadow from fertile wasteland. This process has been occurring for much of the last century, so marginal land is becoming increasingly scarce.
 
-A single strong laborer with proper tools clears one acre of lightly wooded land per month, if he does no other work. This means that villeins who assart land work much slower than an acre a month because their other duties take precedence. Many lords use only local labor, or hire a small team of famuli who assist with the clearing and then are kept on to work the lord's increased demesne, so that assarting is a gradual but continual process that takes years to have a marked effect.
+A single strong laborer with proper tools clears one acre of lightly wooded land per month, if he does no other work. This means that villeins who are assarting land work much slower than an acre a month, because their other duties take precedence. Many lords use only local labor, or hire a small team of famuli who assist with the clearing and then are kept on to work the lord's increased demesne, so that assarting is a gradual but continual process that takes years to have a marked effect.
 
-There are many ways of assarting land magically. Changing the topography or soil type to allow large-field farming where it was previously impossible, altering water flows for irrigation, and removing trees or reducing them to ash are all simple and popular strategies.
+There are many ways of assarting land magically. Changing the topography or soil type to allow large field farming where it was previously impossible, altering water flows for irrigation, and removing trees or reducing them to ash are all simple and popular strategies.
 
-A covenant that secretly clears land for itself using magic alarms nearby lords. The sudden appearance of cropland in an area that was previously waste indicates to neighboring nobles that the lord of that land has hired an enormous workforce. This, it is assumed, will cause predictable problems when the workforce is dispersed.
+A covenant that secretly clears itself land using magic alarms nearby lords. The sudden appearance of cropland in an area that was previously waste indicates to neighboring nobles that the new lord of has hired an enormous workforce. This, it is assumed, will cause predictable problems when it is dispersed.
 
-## Conquest
+### Conquest
 
-Taking land by conquest is rare among the lower nobility in most of feudal Europe because it requires political skill and perfect tim-
+Taking land by conquest is rare, among the lower nobility, in most of feudal Europe, because it requires political skill and perfect timing. Conquered land must be taken from someone, and the lord of the dispossessed noble appears weak if he does nothing. In some cases, he will do as little as demand a fine and fealty from the invader, but this is seen as a pathetic response by his other vassals who, sensing their lack of security, form coalitions of mutual support that are often provoked into open war. All nobles know this, so unless a lord is beset by more important issues, conquest is rarely able to succeed in the extended term. 
 
-
-ing. Conquered land must be taken from someone, and the lord of the dispossessed noble appears weak if he does nothing in response to conquest. In some cases such lords do as little as demand a fi ne and fealty from the invader, but this is seen as a pathetic response by the lord's other vassals, who, sensing their lack of security, form coalitions of mutual support that are often provoked into open war with each other. All nobles know this, so unless a lord is beset by more important issues, conquest is rarely able to succeed in the extended term.
-
-Nobles often are, however, beset by more important issues. Conquest can take place in times of general anarchy, because there is no lord able to prevent it. It can also take place during civil war, pro-
-
-vided a conqueror chooses the winning side and limits his depredations to followers of the rival cause.
+Nobles often are, however, beset by more important issues. Conquest can take place in times of general anarchy, because there is no lord able to prevent it. It can also take place during civil war, provided a conqueror chooses the winning side and limits his depredations to followers of the rival cause.
 
 ### Land Management
 
@@ -3783,7 +3507,6 @@ Players using City & Guild may develop businesses on the land, using the rules i
 
 Marriage to heiresses and widows is one of the most lucrative ways of extending a character's fi ef. It is dealt with in greater detail in Chapter Two: Politics.
 
-
 ## Purchase
 
 Characters may purchase land from their neighbors. This costs between thirty and fi fty times its annual income, although this may be adjusted downward if the characters allow the seller to retain some of the rights of the land, or agree to take on some of its dues. Characters can get a better price by paying in immediate coin, since large transactions for land are usually paid in installments over many years. In some areas, the lord of a landholder must acquire the right to sell the land from his lord, who typically demands a cut of the price, which correspondingly raises the price.
@@ -3792,74 +3515,65 @@ Characters may purchase land from their neighbors. This costs between thirty and
 
 In Mythic Europe there are some land holdings that are not fi efs, but can be treated as such for the purposes of these rules.
 
-## Allods
+### Allods
 
 In England and Normandy, it is illegal for farmland to exist outside the feudal system. Every piece of land must have a lord, and that lord must hold by permission of the king. In other parts of Mythic Europe it is possible for a person to hold land without owning allegiance to anyone. A piece of land that its lord owns outright is called an allod. Allodial l a n d is signifi cant to the Order of Hermes because this entire system of villages and manors is less than three centuries old, so the oldest covenants in the Order predate it
 
-## Alms and Charities
+### Alms and Charities
 
 and are therefore allods.
 
 The Church is the greatest landholder in Mythic Europe, and individual priests may hold land as if they were noblemen, on behalf of the Church. Some Church land is allodial, because successive groups of monks following the Benedictine model have sought places in the wilderness to settle as monasteries, and peasant land-holdings have grown up around these sites. In England and Normandy this is considered legally impossible because all land is held from the king. There are two main types of non-allodial Church land, which are described in the following sections.
 
-#### alMs land
+#### Alms land
 
 Alms land is land given to the Church for its use, in perpetuity. It is still held from a major noble. The Church may farm the land or offer it to vassals. Other rights, like the right to take tolls, to require knight service, or to take a portion of the fi nes from local courts, stay with the nobleman. This means that the Church is required to have a small standing army and fi ght on both sides of many wars, simply to render service for its lands.
 
-#### charities
+#### Charities
 
-Charities are lands given to the Church in exchange for particular services. The most popular service connected to a charity is the
-
-
-
-provision of sacraments to the residents of a parish. They may also include masses for the soul for the land's initial donor, prayers for the success of a lord's ventures, the provisioning of hospitals and hospices, clerical duties, and teaching the lord's children. Under law, if these services are not provided, the lord can reclaim the land.
+Charities are lands given to the Church in exchange for particular services. The most popular service connected to a charity is the provision of sacraments to the residents of a parish. They may also include masses for the soul for the land's initial donor, prayers for the success of a lord's ventures, the provisioning of hospitals and hospices, clerical duties, and teaching the lord's children. Under law, if these services are not provided, the lord can reclaim the land.
 
 Over time, charities are increasingly being offered to nunneries. They are considered more dependable in providing services than priests or monasteries. Men are too often distracted, in the eyes of some donors, by secular concerns that women are barred from by their gender.
 
 ### Towns With Royal Charters
 
-Towns are founded by the lords who hold the land on which the town stands. Lords create them for several reasons. The higher population of a town means that even if the lord cannot claim as much rent per person as he can for peasants, he still makes additional money by packing more people into the space of the town. The townspeople also provide a ready market for the agricultural products that make up a large portion of the taxes collected by the lord, allowing them to be sold easily
-
-## Story Seed: Catching Up On Masses
-
-If a charity is based on masses for the soul of a dead donor, but the priest hasn't been saying the masses as frequently as he should, then a court can confiscate the land and grant it back to the donor's heir. If the local abbot or bishop has significant power, this is a serious step with possible political consequences. A minor lord may, instead, ask the court to declare that the land be resumed unless the unsaid masses are made good. When this occurs, it is common for a group of priests to be sent to the charity. They perform many masses every day until the backlog, which may comprise many hundreds of masses, is completed. They often perform additional masses, so that there can be no question that the charity remains with the Church. The performance of the many masses in these situations attracts pilgrims, and seems to boost the Dominion.
-
-Such an intense series of masses is one of the possible effects of Hermetic magi encouraging sloth in priests. When a marathon of masses is being said in an area, the creatures of the Faerie realm behave in odd ways. Some are geographically dislocated by the process. Some pretend to be refugees, or to be vacationing away from town. Some seem to go mad. Similarly, minor demons leave their usual haunts and seek new victims in the countryside. Powerful magical creatures, who must stay in Magic auras to avoid being affected by the creeping mundanity of the mortal world, may find their home's aura suppressed, and seek lodging at the covenant.
-
-and quickly converted into manufactured goods. Townsfolk often pay their rent in money, which is convenient when a lord needs to settle his debts with his liege. Towns that already exist are coveted prizes, because the lord has all the benefits of a town with none of the foundation costs.
+Towns are founded by the lords who hold the land on which the town stands. Lords create them for several reasons. The higher population of a town means that even if the lord cannot claim as much rent per person as he can for peasants, he still makes additional money by packing more people into the space of the town. The townspeople also provide a ready market for the agricultural products that make up a large portion of the taxes collected by the lord, allowing them to be sold easily and quickly converted into manufactured goods. Townsfolk often pay their rent in money, which is convenient when a lord needs to settle his debts with his liege. Towns that already exist are coveted prizes, because the lord has all the benefits of a town with none of the foundation costs.
 
 Some towns, however, hold directly from the king. Towns usually gain this right by offering the king money in exchange for a charter during a period of civil strife. Their offer is likely to be accepted if the town's noble overlord is a rebel. A royal charter places a town beyond the rapaciousness of the agricultural aristocracy. The council of such a town, as represented by its mayor, may even act as a feudal overlord itself.
 
+> ## Story Seed: Catching Up On Masses
+> 
+> If a charity is based on masses for the soul of a dead donor, but the priest hasn't been saying the masses as frequently as he should, then a court can confiscate the land and grant it back to the donor's heir. If the local abbot or bishop has significant power, this is a serious step with possible political consequences. A minor lord may, instead, ask the court to declare that the land be resumed unless the unsaid masses are made good. When this occurs, it is common for a group of priests to be sent to the charity. They perform many masses every day until the backlog, which may comprise many hundreds of masses, is completed. They often perform additional masses, so that there can be no question that the charity remains with the Church. The performance of the many masses in these situations attracts pilgrims, and seems to boost the Dominion.
+> 
+> Such an intense series of masses is one of the possible effects of Hermetic magi encouraging sloth in priests. When a marathon of masses is being said in an area, the creatures of the Faerie realm behave in odd ways. Some are geographically dislocated by the process. Some pretend to be refugees, or to be vacationing away from town. Some seem to go mad. Similarly, minor demons leave their usual haunts and seek new victims in the countryside. Powerful magical creatures, who must stay in Magic auras to avoid being affected by the creeping mundanity of the mortal world, may find their home's aura suppressed, and seek lodging at the covenant.
 
-## Discuss Poverty in Your Saga
+> ## Discuss Poverty in Your Saga
+> 
+> Different troupes of Ars Magica players select different degrees of realism for the setting of their stories. The material in this book tends to the historic, rather than the fantastic. (This orientation has been chosen because accurate historical detail is difficult for storyguides to research, but not to remove.) The consequence of this book's historical rather than fantastic position is that the lot of the poor in Mythic Europe seems miserable by modern standards. Worse, it is in part made miserable by rich characters, like the player characters, and by the Church. Troupes should discuss this and choose a degree of realism that suits the stories they wish to tell.
+> 
+> ### The Simplest Choice: The Happy Peasant
+> 
+> Many troupes will find it convenient to simply select the level of peasant happiness for their covenant at creation, as they would any other feature. The covenant design system allows sagas set in flying castles that are defended by undead knights riding mechanical manticores, so choosing happy peasants represents a comparatively mundane option. The rest of this chapter is for troupes who want greater realism, a darker tone, and more extensive material to work into the backgrounds of their companions and grogs.
+> 
+> ### You Don't Want to be a Swineherd! You Want to See the World!
+> 
+> The aspiration to escape poverty and become prosperous is found throughout period folklore and also acts as a powerful driver for player characters. Characters from peasant backgrounds who serve in most covenants find that their working conditions are far superior to those of peasant life.
+> 
+> ### Noble Villains Provide a Change of Pace
+> 
+> How far a lord pushes his rights, and how much harm he does his peasantry as a consequence, is often a matter left to the lord's conscience. In many cases, medieval society's tolerance of the abuse of the peasantry encourages that same abuse.
+> 
+> Nobles who behave villainously with respect to their peasants can provide adversaries that are qualitatively different from monsters and demons, and therefore require different strategies to overcome. This allows players who want their characters to kill monsters and loot their bodies to share the limelight with players who wish to design magi from Houses like Merinita, Jerbiton, and Criamon, which have a weaker focus on combat.
+> 
+> ### The Church Was Sometimes Oppressive
+> 
+> In this chapter, the Church is portrayed as oppressive by modern standards. The Church in the 13th century is an institution of its time. Its members, for the most part, believe that many activities that modern players consider oppressive are morally just. These activities are presented so that stories and character backgrounds may be framed according to these medieval beliefs.
+> 
+> In 1220 the Church's officers also do many things that they know are morally questionable, but are less bad than any alternative they perceive. This is particularly true in financial matters. Much of the work of the papal court is performed by non-resident and pluralist priests, for example. The Church knows this is not ideal, but can see no better option given that the work of the Church is so important. The real-world Church worked through these complex issues over the centuries following the game period.
+> 
+> There is no need for troupes to play in a setting with a realistic Church. Some troupes may prefer that a Church guided constantly toward righteousness by the Holy Spirit. For such troupes, the material here may instead provide examples of the sins of exceptional priests, who can serve as foes during stories.
 
-Different troupes of Ars Magica players select different degrees of realism for the setting of their stories. The material in this book tends to the historic, rather than the fantastic. (This orientation has been chosen because accurate historical detail is difficult for storyguides to research, but not to remove.) The consequence of this book's historical rather than fantastic position is that the lot of the poor in Mythic Europe seems miserable by modern standards. Worse, it is in part made miserable by rich characters, like the player characters, and by the Church. Troupes should discuss this and choose a degree of realism that suits the stories they wish to tell.
-
-## THE SIMPLEST CHOICE: THE HAPPY PEASANT
-
-Many troupes will find it convenient to simply select the level of peasant happiness for their covenant at creation, as they would any other feature. The covenant design system allows sagas set in flying castles that are defended by undead knights riding mechanical manticores, so choosing happy peasants represents a comparatively mundane option. The rest of this chapter is for troupes who want greater realism, a darker tone, and more extensive material to work into the backgrounds of their companions and grogs.
-
-#### You Don't Want to be a Swineherd! You Want to See the World!
-
-The aspiration to escape poverty and become prosperous is found throughout period folklore and also acts as a powerful driver for player characters. Characters from peasant backgrounds who serve in most covenants find that their working conditions are far superior to those of peasant life.
-
-## Noble Villains Provide a Change of Pace
-
-How far a lord pushes his rights, and how much harm he does his peasantry as a consequence, is often a matter left to the lord's conscience. In many cases, medieval society's tolerance of the abuse of the peasantry encourages that same abuse.
-
-Nobles who behave villainously with respect to their peasants can provide adversaries that are qualitatively different from monsters and demons, and therefore require different strategies to overcome. This allows players who want their characters to kill monsters and loot their bodies to share the limelight with players who wish to design magi from Houses like Merinita, Jerbiton, and Criamon, which have a weaker focus on combat.
-
-## THE CHURCH WAS SOMETIMES OPPRESSIVE
-
-In this chapter, the Church is portrayed as oppressive by modern standards. The Church in the 13th century is an institution of its time. Its members, for the most part, believe that many activities that modern players consider oppressive are morally just. These activities are presented so that stories and character backgrounds may be framed according to these medieval beliefs.
-
-In 1220 the Church's officers also do many things that they know are morally questionable, but are less bad than any alternative they perceive. This is particularly true in financial matters. Much of the work of the papal court is performed by non-resident and pluralist priests, for example. The Church knows this is not ideal, but can see no better option given that the work of the Church is so important. The real-world Church worked through these complex issues over the centuries following the game period.
-
-There is no need for troupes to play in a setting with a realistic Church. Some troupes may prefer that a Church guided constantly toward righteousness by the Holy Spirit. For such troupes, the material here may instead provide examples of the sins of exceptional priests, who can serve as foes during stories.
-
-## Chapter Seven
-
-# The Peasantry
+# Chapter Seven: The Peasantry
 
 Peasant life is unpleasant. Peasants, for the most part, live a marginal existence filled with toil. They have little scope to improve their lives, and often lack the education to know how their lives could be improved in the first place. Most peasants never travel more than a few miles from their birthplace.
 
@@ -3869,15 +3583,17 @@ Peasants are not, however, stupid, and many grasp opportunities to escape the wo
 
 There is an ascending scale of wealth and status in peasant communities. Generally, richer peasants have the highest status, and those who have the most land are the wealthiest. Some of the terms used in this section to define land holdings are defined in the Chapter Six: Manorial Fiefs. This section uses English peasantry as its model, although similar social roles are found in most of Mythic Europe.
 
-## The Unemployed and Day Workers
+### The Unemployed and Day Workers
 
-The population of Mythic Europe is swelling rapidly in 1220. In most agricultural areas, for the length of any usual saga, the unemployment rate is around twenty percent outside of the planting and reaping seasons. These people pour into towns looking for a better life, but often find that they are barred from seeking guild-controlled employment. Lacking other skills they turn to crime, which is why the term "villain" has such negative connotations.
+The population of Mythic Europe is swelling rapidly in 1220. In most agricultural areas, for the length of any usual saga, the unemployment rate is around twenty percent outside of the planting and reaping seasons.
+
+These people pour into towns looking for a better life, but often find that they are barred from seeking guild-controlled employment. Lacking other skills they turn to crime, which is why the term "villain" has such negative connotations.
 
 Many day workers tramp the roads, seeking employment. Peak agricultural periods differ for various crops and grazing animals, so many laborers chase work. Others stay in a single village, where they are known as being free to work odd days. These are generally the poorest people in any village.
 
 In France, any stranger who dwells in a manor for more than a year is automatically the villein of the lord, unless he can prove that he is free, or that he is the villein of someone else. A lord is, technically, not permitted to allow his villeins to starve, so many lords force the poor to move on so that they do not gain a claim to the lord's charity. A compromise between vagrants and lords is often reached whereby the itinerant poor keep to Church land, such as pilgrimage sites. This, legally speaking, is outside the manor.
 
-## Famuli and Other Retained Servants
+### Famuli and Other Retained Servants
 
 The famuli are the household staff of the lord. These serfs include agricultural laborers as well as those who provide a second service in addition to labor, like the lord's shepherd, swineherd, and dairymaid. The famuli usually also includes cooking and cleaning staff.
 
@@ -3915,38 +3631,33 @@ Reeves, in most areas, must be villeins. Proof that a peasant has served as a re
 
 Many people dislike being reeve for three main reasons. The reeve is financially responsible for any failure of the administration of the manor that it was his responsibility to prevent. He can be fined if people shirk work or steal, or if equipment breaks because it was poorly maintained, unless he can fine someone else for the fault. The reeve, as the enforcer of the lord's due, is the person who makes sure that the other members of his community don't take easy options when working. As a result, he's hated for the extra hassle he causes and the little thefts of time and material he prevents. Finally, being reeve takes time away from the work the villein could do on his own behalf during harvest season.
 
-The role is so unpopular that on some manors there is land specifically reserved to pay the reeve. On other manors all of the major villeins pay a fee so that they need not have a reeve at all. This fee is as high as a shilling a head a year in some places. In other places, a person elected as reeve may pay a
+The role is so unpopular that on some manors there is land specifically reserved to pay the reeve. On other manors all of the major villeins pay a fee so that they need not have a reeve at all. This fee is as high as a shilling a head a year in some places. In other places, a person elected as reeve may pay a substantial fine to force the manor court to pick an alternative reeve.
 
-
-## Story Seed: The Wandering Poor
-
-The wandering poor are defined by the fact that they do not come from the community — they are strangers. Many are simply poor people. Some have strange customs, but are nonetheless human beings with personal tales of woe that might turn to the better or worse when they encounter the player characters. Some wanderers, however, are far more than they appear. Saints, even God himself in some folktales, take the form of wandering beggars to test the morals of people who profess Christianity, rewarding the good and shaming the hypocritical. Demons also walk the roads and bring temptations with them. Faeries seem to walk the roads, seeking to be nearby when interesting things occur. Some faeries steal children, or enter strange bargains with lords, reeves, or individual peasants, offering treasure or terror.
-
-substantial fine to force the manor court to pick an alternative reeve.
+> ## Story Seed: The Wandering Poor
+> 
+> The wandering poor are defined by the fact that they do not come from the community — they are strangers. Many are simply poor people. Some have strange customs, but are nonetheless human beings with personal tales of woe that might turn to the better or worse when they encounter the player characters. Some wanderers, however, are far more than they appear. Saints, even God himself in some folktales, take the form of wandering beggars to test the morals of people who profess Christianity, rewarding the good and shaming the hypocritical. Demons also walk the roads and bring temptations with them. Faeries seem to walk the roads, seeking to be nearby when interesting things occur. Some faeries steal children, or enter strange bargains with lords, reeves, or individual peasants, offering treasure or terror.
 
 Reeves gain wealth from five sources. Most are forgiven all, or part, of their rent. Reeves are usually paid a small wage: generally double whatever is being paid to other laborers, and for the entire year rather than simply the harvest periods. This wage is sometimes given as grain from the demesne, and may be increased by the right to be fed by the lord either for the whole year, or during the planting and reaping seasons. Reeves are excused many services to the lord, allowing them extra time with their own crops and crafts, other than at harvest and planting. Reeves, as mentioned above, may be granted the use of certain lands during their tenure. The final source of wealth for reeves is corruption, and most villeins consider corruption among reeves to be rife.
 
 It is the corruption of reeves that makes the searching annual audits, which prepare the figures for the steward, necessary. Reeves have a tremendous opportunity to take bribes for unprovable returns, like the right to finish work early or be assigned the easy bit of the haymaking. They also have many opportunities to steal directly from the lord. Regardless, a reeve owes the lord any goods or services not collected or remitted in his term.
 
-## Story Seeds: Famuli Matters
-
-The stories of the famuli are similar to the stories about servants in many other genres. Theirs is the "below stairs" view of the world of the nobility or magi. Servants know their masters intimately and even if they like their masters, they recognize their weaknesses and human foibles. Stories set among the servants can allow a change of pace from the heroic stories which involve magi.
-
-#### Cleaning Up
-
-The famuli are the hidden characters who clean up the stage between the episodes in the lives of the magi. If a horde of faeries attacks the covenant, it is the famuli who tidy up afterwards by rebuilding damaged walls, washing the blood off the courtyard, carting away the bits the magi don't want for experiments, and finding ways to bury them. This style of story works best for covenants with magi who deal with immediate crises and then retire swiftly to their laboratories.
+> ## Story Seeds: Famuli Matters
+> 
+> The stories of the famuli are similar to the stories about servants in many other genres. Theirs is the "below stairs" view of the world of the nobility or magi. Servants know their masters intimately and even if they like their masters, they recognize their weaknesses and human foibles. Stories set among the servants can allow a change of pace from the heroic stories which involve magi.
+> 
+> ### Cleaning Up
+> 
+> The famuli are the hidden characters who clean up the stage between the episodes in the lives of the magi. If a horde of faeries attacks the covenant, it is the famuli who tidy up afterwards by rebuilding damaged walls, washing the blood off the courtyard, carting away the bits the magi don't want for experiments, and finding ways to bury them. This style of story works best for covenants with magi who deal with immediate crises and then retire swiftly to their laboratories.
 
 There are many other positions to which villeins are elected by the manor court. The most significant of these is the office of messor (or beadle), which is usually coupled with the office of hayward. The beadle acts as the reeve's enforcer. He implements the customs of the manor, summons people to the court, collects fines, and warns people that they will be due for services and tallages. The hayward is the overseer of the harvesting laborers and the guard of the harvested crop. He is also the person charged with the health of the pasture, so he is the confiscator of wandering stock. The hayward is paid, much like the reeve, by reduction of his rent, excusal from services, use of reserved meadow, and feeding at the lord's expense at harvest time. He is also sometimes given free seed corn. Haywards tend to hold less substantial lands than reeves, so their effective rewards for office are less.
 
-Other lesser offices include woodward, who cares for the lord's plantations, forester, who cares for the lord's hunting wood, and herdsman. In East Anglia there are peasants who are charged with the maintenance of
+Other lesser offices include woodward, who cares for the lord's plantations, forester, who cares for the lord's hunting wood, and herdsman. In East Anglia there are peasants who are charged with the maintenance of dykes. On some manors, plowmen are appointed by the lord and live as his officers, although in most places a lord's plowmen are simply famuli. Ale-tasters, who ensure ale brewed on the manor is of sufficient quality for sale, are often women.
 
-## The Church Supports Serfdom
+> ## The Church Supports Serfdom
+> 
+> The church in 1220 does not see keeping serfs as evil. Most Churchmen even considerer slavery morally acceptable provided masters stay within certain limits of behavior. Serfdom, which is better than slavery, is actively supported by the Church.
 
-The church in 1220 does not see keeping serfs as evil. Most Churchmen even considerer slavery morally acceptable provided masters stay within certain limits of behavior. Serfdom, which is better than slavery, is actively supported by the Church.
-
-dykes. On some manors, plowmen are appointed by the lord and live as his officers, although in most places a lord's plowmen are simply famuli. Ale-tasters, who ensure ale brewed on the manor is of sufficient quality for sale, are often women.
-
-## Half-free
+### Half-free
 
 A half-free peasant is one who is a free man or woman, as described below, but who has accepted the rental of villein land from a lord, and therefore owes villein service. Half-free peasants are sometimes wealthy enough to pay a hired worker to carry out their villein service. A half-free peasant is free of non-agricultural taxes and services, like a free peasant.
 
@@ -3954,15 +3665,11 @@ A half-free peasant is one who is a free man or woman, as described below, but w
 
 A free man or free woman is, in this case, an agricultural worker who does not owe service to the lord for land. Freedom from service is rarely absolute; the exact nature of freedom varies in accordance with manor custom. This means that in some areas, for example, free men are still required to serve as jurors, members of the military levy, or supervisors of unfree laborers at harvest. These requirements vary not only between neighboring manors, but between free men of the same manor. Many free peasants owe the Church a small fee, called church-scot, each year in November. A free tenant can theoretically leave his farm at any time by ceasing to pay the rent, but this usually leaves him in poverty.
 
-Free parents have children who are also free. A free person who marries a servile one makes his spouse free for the length of the marriage, although she reverts to servile
-
-
-
-status upon the partner's death or if they separate. The children of such a union are, usually, free, although customs vary. A free peasant must pay a fine for freeing a spouse by marriage, and can generally arrange a higher fine to ensure that the partner does not return to servile status after the marriage ends.
+Free parents have children who are also free. A free person who marries a servile one makes his spouse free for the length of the marriage, although she reverts to servile status upon the partner's death or if they separate. The children of such a union are, usually, free, although customs vary. A free peasant must pay a fine for freeing a spouse by marriage, and can generally arrange a higher fine to ensure that the partner does not return to servile status after the marriage ends.
 
 Free peasants make up less than ten percent of the population of most manors, but on some manors, all of the peasants are free. This is particularly common on assarts and in newly founded towns, where men are offered freedom in exchange for their sweat and shillings. Free peasants are most common on royal manors, and are more common on secular manors than ecclesiastical ones. This is because setting villeins free is a common form of charity among secular rulers, particularly in their wills, but to free villeins is forbidden to Churchmen by canon law.
 
-## Officers
+### Officers
 
 A manor's officers hold positions of trust from the lord and administer the manor's affairs. There is a great confusion of manorial officers. The same titles are used on neighboring manors for different jobs, and the titles on the same manor may change over time without any observable change in workload for the officer. As a general rule, though, there are two free men who are highly significant to the running of the manor.
 
@@ -3970,11 +3677,11 @@ The steward, or seneschal, is the lord's representative on the manor. He is requ
 
 The steward is the master of all of the other manorial servants of the fief, and is paid highly for his services. The payment varies by the size of the estate from half a pound a year for a free man on a manor, to twenty pounds a year for stewards who are maintained as knights, to vast grants of land for those who act as stewards on behalf of kings.
 
-## Story Seed: The Rolls
-
-The records of the manorial court are kept on rolls of parchment, and special decisions are sewn onto the rolls. A peasant who could tamper with the rolls, by sewing on a ruling that indicated that he was personally free and only acted like a villein because he held villein land, could gain substantial advantage. The main barrier to this is that the roll is guarded and the villein illiterate.
-
-A villein brings a scheme to change the roll to the attention of the magi. He has a little money from a crime, which he can't spend publicly, and offers it for the aid of someone who can write in Latin. The magi, considering his plan, might give him the letter free, provided he also adds another document to the rolls that is to their advantage. They might also give him greater assistance, because it would be embarrassing for him to be caught before the two additions had been made to the roll.
+> ## Story Seed: The Rolls
+> 
+> The records of the manorial court are kept on rolls of parchment, and special decisions are sewn onto the rolls. A peasant who could tamper with the rolls, by sewing on a ruling that indicated that he was personally free and only acted like a villein because he held villein land, could gain substantial advantage. The main barrier to this is that the roll is guarded and the villein illiterate.
+> 
+> A villein brings a scheme to change the roll to the attention of the magi. He has a little money from a crime, which he can't spend publicly, and offers it for the aid of someone who can write in Latin. The magi, considering his plan, might give him the letter free, provided he also adds another document to the rolls that is to their advantage. They might also give him greater assistance, because it would be embarrassing for him to be caught before the two additions had been made to the roll.
 
 The bailiff (or beadle, or sergeant) is the controller of the daily operation of the manor, through the reeve. A bailiff may be responsible for a handful of manors, if they form a tight group and travel between them is easy. The bailiff answers twice a year to the steward, and must give a detailed account of the manor's finances. Bailiffs are almost always free men who live locally to the manor, and in most places they have the right to live in the manor house. Bailiffs are, more than any other manorial official, most likely to be attacked by aggrieved peasants.
 
@@ -3986,7 +3693,7 @@ The term "bailie" is used in northern France to describe an official with a role
 
 The standard of living of peasants is strongly affected by the proximity of towns. In areas where flight from the manor is viable, standards are higher. As the living conditions improve in towns, so too the living conditions in the hinterlands of the towns improve. The sections that follow most accurately describe manors more than two days from a major town.
 
-## Housing
+### Housing
 
 Many peasant houses have a single room. Wealthier peasants might, however, have a chamber, pantry, buttery (a room where alcohol, not butter, is kept), and separate kitchen. Many peasant homes contain a byre, a room for penning animals.
 
@@ -3996,41 +3703,37 @@ Wattle and daub is a technique for wall building. A weave of twigs is created to
 
 Peasant houses are often roofed with thatch or wooden shingles. Thatch is made from straw, which is a byproduct of the grain harvest. Rye straw is considered superior to wheat straw for this purpose. In some areas reeds are used instead of straw, because these make the most durable roofs. Thatched roofs are often built with a higher pitch than shingle roofs, because this allows more rapid runoff.
 
-Thatch roofs provide good insulation, but are slightly permeable, so many peasants do not have chimneys. The smoke from their fires rises through the thatch and reduces infestations by insects. Thatch roofs are difficult to extinguish once they have caught
+Thatch roofs provide good insulation, but are slightly permeable, so many peasants do not have chimneys. The smoke from their fires rises through the thatch and reduces infestations by insects. Thatch roofs are difficult to extinguish once they have caught fire, though, and in some cities new thatched roofs are forbidden. In London, thatched roofs now have a layer of plaster on their underside, which acts as a fire retardant. In other areas, the thatch lies on a layer of turf, which improves its insulating properties.
 
-
-
-## Peasant Loyalty
-
-Peasants in Mythic Europe are not required to be loyal to their lord. Most have never seen their lord, and only see his steward twice a year. Some lords, who have heads filled with poetic tales, believe that their peasants sit in their hovels blessing their lord for his charities, and do boon works because they love their lord so much. In Mythic Europe, unless your troupe decides otherwise, this is simply naive. Peasants may be happy or unhappy because of the actions of their lords, but they are never loyal to strangers. Peasants who interact with their lords may develop a personal bond of loyalty, but this is rare.
-
-Players used to computer games may feel that lowering taxes should make peasants more manageable, because this is a common game mechanic. It doesn't work well in Mythic Europe, however, except in the very short term. Peasants, when they become rich enough to have free time, use it to organize politically. Rather than becoming complacent with their gains, rich villeins become increasingly politically restive. This is particularly true if nearby towns offer greater personal freedom and a higher standard of living.
-
-Military household servants — the mesnie — are an exception to the idea that loyalty is not expected of servants. As knights, they are expected to be loyal to their lord, provided their lord maintains their standard of living and dignity. The loyalty of the mesnie may be tracked using the system given in *Covenants*, page 38, or simply assumed to be strong while times are good and less good during difficulty. Characters may take Virtues and Flaws to change the loyalty of their underlings.
-
-#### Community Loyalty
-
-Magi can prevent their rich peasants from becoming restive by offering them a deal better than that provided by the nearest town's royal charter. These peasants do not become loyal to the magi, who likely remain strangers because of The Gift. They may, however, be loyal to the community that the magi create and govern, or to the community's figurehead if they know him personally. Many peasants support covenants simply from self-interest. When magi attempt to develop communities with very high living standards, this creates resistance from nearby nobles and Churchmen, which provides opportunities for stories.
-
-#### Flight and Rebellion
-
-The loyalty mechanic given in *Covenants*, beginning on page 36, is suited to organizations of magi, perhaps with the occasional nobleman as their peer or servant, who are somewhat distant from the rest of the world. The *Covenants* rules are suitable for the large households of senior nobles, but they don't work as well when modeling the relationships of lesser nobles to their agricultural peasants. Noblemen lack the means or ability to provide many of the factors that make covenants loyal, and further lack the capacity for magical retribution. To their benefit, however, they also lack The Gift's social penalties.
-
-A peasant flees the land when it seems he has better prospects elsewhere. This choice may be based on individual factors, like fear of being punished for a particular crime, or wider factors, like rumors of war. The presence of large towns makes the decision to flee far easier for peasants, as do stories of successful flight carried back to their village by travelers with messages from those who have left.
-
-Peasants rebel when they feel they have no other choice. Rebellions are rare, because they tend to end badly, with the rebel leaders put to death. This occurs despite laws that prevent lesser nobles from usurping the mortal justice of the king. Short of armed rebellion, some peasants choose — as a group — to refuse to labor. Such villeins can be evicted and replaced, but this is expensive for their lord, and this inconvenience sometimes leads to a change in his policies.
-
-#### Nothing Grows for the Wicked
-
-Players may prefer a more folkloristic approach to peasant loyalty. In many ballads, the reign of a good king is marked by God with fertile harvests, while the reign of a bad king is blighted with famine. Similarly, if the player characters are virtuous and successful, then God raises the standard of living of the peasants in the covenant's area of influence. The peasants notice this and attribute it to the magi. This generates community loyalty.
-
-Troupes using this system select good harvests rather than making the annual roll called for by the Mythic Pound system (see *Covenants*). Alternatively, peasant characters from the covenant's lands, when they appear in stories, may always be portrayed as happy and wealthy. This system is not used through the rest of the chapter.
-
-fire, though, and in some cities new thatched roofs are forbidden. In London, thatched roofs now have a layer of plaster on their underside, which acts as a fire retardant. In other areas, the thatch lies on a layer of turf, which improves its insulating properties.
+> ## Peasant Loyalty
+> 
+> Peasants in Mythic Europe are not required to be loyal to their lord. Most have never seen their lord, and only see his steward twice a year. Some lords, who have heads filled with poetic tales, believe that their peasants sit in their hovels blessing their lord for his charities, and do boon works because they love their lord so much. In Mythic Europe, unless your troupe decides otherwise, this is simply naive. Peasants may be happy or unhappy because of the actions of their lords, but they are never loyal to strangers. Peasants who interact with their lords may develop a personal bond of loyalty, but this is rare.
+> 
+> Players used to computer games may feel that lowering taxes should make peasants more manageable, because this is a common game mechanic. It doesn't work well in Mythic Europe, however, except in the very short term. Peasants, when they become rich enough to have free time, use it to organize politically. Rather than becoming complacent with their gains, rich villeins become increasingly politically restive. This is particularly true if nearby towns offer greater personal freedom and a higher standard of living.
+> 
+> Military household servants — the mesnie — are an exception to the idea that loyalty is not expected of servants. As knights, they are expected to be loyal to their lord, provided their lord maintains their standard of living and dignity. The loyalty of the mesnie may be tracked using the system given in *Covenants*, page 38, or simply assumed to be strong while times are good and less good during difficulty. Characters may take Virtues and Flaws to change the loyalty of their underlings.
+> 
+> #### Community Loyalty
+> 
+> Magi can prevent their rich peasants from becoming restive by offering them a deal better than that provided by the nearest town's royal charter. These peasants do not become loyal to the magi, who likely remain strangers because of The Gift. They may, however, be loyal to the community that the magi create and govern, or to the community's figurehead if they know him personally. Many peasants support covenants simply from self-interest. When magi attempt to develop communities with very high living standards, this creates resistance from nearby nobles and Churchmen, which provides opportunities for stories.
+> 
+> #### Flight and Rebellion
+> 
+> The loyalty mechanic given in *Covenants*, beginning on page 36, is suited to organizations of magi, perhaps with the occasional nobleman as their peer or servant, who are somewhat distant from the rest of the world. The *Covenants* rules are suitable for the large households of senior nobles, but they don't work as well when modeling the relationships of lesser nobles to their agricultural peasants. Noblemen lack the means or ability to provide many of the factors that make covenants loyal, and further lack the capacity for magical retribution. To their benefit, however, they also lack The Gift's social penalties.
+> 
+> A peasant flees the land when it seems he has better prospects elsewhere. This choice may be based on individual factors, like fear of being punished for a particular crime, or wider factors, like rumors of war. The presence of large towns makes the decision to flee far easier for peasants, as do stories of successful flight carried back to their village by travelers with messages from those who have left.
+> 
+> Peasants rebel when they feel they have no other choice. Rebellions are rare, because they tend to end badly, with the rebel leaders put to death. This occurs despite laws that prevent lesser nobles from usurping the mortal justice of the king. Short of armed rebellion, some peasants choose — as a group — to refuse to labor. Such villeins can be evicted and replaced, but this is expensive for their lord, and this inconvenience sometimes leads to a change in his policies.
+> 
+> #### Nothing Grows for the Wicked
+> 
+> Players may prefer a more folkloristic approach to peasant loyalty. In many ballads, the reign of a good king is marked by God with fertile harvests, while the reign of a bad king is blighted with famine. Similarly, if the player characters are virtuous and successful, then God raises the standard of living of the peasants in the covenant's area of influence. The peasants notice this and attribute it to the magi. This generates community loyalty.
+> 
+> Troupes using this system select good harvests rather than making the annual roll called for by the Mythic Pound system (see *Covenants*). Alternatively, peasant characters from the covenant's lands, when they appear in stories, may always be portrayed as happy and wealthy. This system is not used through the rest of the chapter.
 
 Most peasant houses have no luxuries. The floor is usually beaten earth, strewn with straw. There is a table, a few stools, and a chest for clothes. Some peasants have bed frames, while others sleep on sacks of straw or wool off-cuts. Some prefer to sleep on lofts that are reached with a ladder. Richer peasants have more furniture.
 
-## Food and Drink
+### Food and Drink
 
 The main food of the peasants is bread. It is sometimes made from wheat, but in many areas wheat is grown primarily to pay the rent of the lord, or for sale. Rye and barley bread are common. Even in areas where wheat is consumed by peasants, their bread is often made from maslin. Maslin is a mixture of the lowest class of the manor's main grain (usually wheat or barley) with some cheaper foodstuff. This is usually rye, but may be barely or even beans.
 
@@ -4047,17 +3750,15 @@ Ale is vital to the economies of many manors. It provides a source of nourishmen
 
 One handbook for senior clerics and estate managers lists the sins described in the following sections as popular with peasants who seek to increase their material wealth at the risk of their souls. Characters performing any of these sins will be substantially wealthier than their more pious neighbors, but expensive piety is rare in peasant families.
 
-## Paying Tithes Inadequately
+### Paying Tithes Inadequately
 
-One tenth of everything that a person gets must be given to the Church. Theological theories that would limit tithes to the natural increase of plants and animals aside, every person owes tithes, for everything of
+One tenth of everything that a person gets must be given to the Church. Theological theories that would limit tithes to the natural increase of plants and animals aside, every person owes tithes, for everything of value, always. Every person, it is assumed, lies about his tithes and defrauds the Church. The mortuary, a charge described in Chapter Six: Manorial Fiefs, is always levied on the dying. Its function is to make things right between the Church and the dying thief.
 
-## Story Seed: Excommunication
-
-Peasants who do not pay their tithes are cursed. That is, they are excommunicated by their priests. The widespread use of excommunication calls demons to an area, as they sense an easy harvest of souls.
-
-A bishop near the covenant has pronounced an anathema on all those in his see who have failed him in the matter of tithes. Since those who knowingly have contact with an excommunicant are also excommunicated, he has placed large numbers of souls outside the protection of the Church. Various competing factions of demons flock to his see, and create mischief for the magi and each other. The characters can stop this by getting the bishop to lift his ban.
-
-value, always. Every person, it is assumed, lies about his tithes and defrauds the Church. The mortuary, a charge described in Chapter Six: Manorial Fiefs, is always levied on the dying. Its function is to make things right between the Church and the dying thief.
+> ## Story Seed: Excommunication
+> 
+> Peasants who do not pay their tithes are cursed. That is, they are excommunicated by their priests. The widespread use of excommunication calls demons to an area, as they sense an easy harvest of souls.
+> 
+> A bishop near the covenant has pronounced an anathema on all those in his see who have failed him in the matter of tithes. Since those who knowingly have contact with an excommunicant are also excommunicated, he has placed large numbers of souls outside the protection of the Church. Various competing factions of demons flock to his see, and create mischief for the magi and each other. The characters can stop this by getting the bishop to lift his ban.
 
 Common peasant rationales for paying lesser amounts include subtracting the expenses of collecting the harvest before the division, paying for only the primary crop of the field, not tithing byproducts of the harvest like straw, tithing with the worst of the fruit or grain instead of the best, paying late, delivering tithes to a local church instead of the church appointed to the manor, or docking the pay of a poor-quality priest.
 
@@ -4065,135 +3766,116 @@ Senior officers of the Church may, out of a sense of mercy, excuse the tithe in 
 
 The Church puts a little leeway into tithe-exemption calculations. People who think they are likely to starve if they pay their tithe can only be compelled to pay by sending armed men to arrest them and seize their property. This is, itself, expensive, and so on some manors, it's not considered worth the effort. On other manors, strict enforcement is thought to be the obligation of the lord for the spiritual betterment of the peasantry, and so uneconomic tithes are levied anyway.
 
-## The Economics of Tithing
+> ## The Economics of Tithing
+> 
+> Tithing effectively swallows twenty percent of the income of most peasants. This is because the tithe is ten percent of the peasant's crop, rather than ten percent of what he has left once his seed corn for the next year, wages for laborers, and taxes to his lord have been accounted for. In areas where farm yields are higher, tithing is less onerous, but in much of Mythic Europe, average land returns less than four bushels of grain for every bushel planted. Lay lords and monasteries, because they do not owe themselves rent, sometimes farm land even more marginal than this.
+> 
+> By tradition, tithes are divided in the following way. One-quarter of all tithes go to the rector of the manor. One-quarter goes to the support of his curate and other priests. One-quarter is used to maintain the fabric of the church building. Finally, one-quarter is used to feed the poor. Many authorities, even within the Church, claim that this system is not followed in practice in many places. They point to the rundown churches found on some manors, and the lack of a dole for the poor, as signs that the priests are keeping too much for themselves.
+> 
+> Some demons try to persuade priests that monks, having no personal possessions, are therefore poor. As such, it is not necessary for the Church to give the final quarter of the tithe to the servile poor. They are less deserving, the demons argue, because their work is less important than prayer.
 
-Tithing effectively swallows twenty percent of the income of most peasants. This is because the tithe is ten percent of the peasant's crop, rather than ten percent of what he has left once his seed corn for the next year, wages for laborers, and taxes to his lord have been accounted for. In areas where farm yields are higher, tithing is less onerous, but in much of Mythic Europe, average land returns less than four bushels of grain for every bushel planted. Lay lords and monasteries, because they do not owe themselves rent, sometimes farm land even more marginal than this.
-
-By tradition, tithes are divided in the following way. One-quarter of all tithes go to the rector of the manor. One-quarter goes to the support of his curate and other priests. One-quarter is used to maintain the fabric of the church building. Finally, one-quarter is used to feed the poor. Many authorities, even within the Church, claim that this system is not followed in practice in many places. They point to the rundown churches found on some manors, and the lack of a dole for the poor, as signs that the priests are keeping too much for themselves.
-
-Some demons try to persuade priests that monks, having no personal possessions, are therefore poor. As such, it is not necessary for the Church to give the final quarter of the tithe to the servile poor. They are less deserving, the demons argue, because their work is less important than prayer.
-
-## Paying the Lord Less Than You Owe
+### Paying the Lord Less Than You Owe
 
 The simplest way for a peasant to have more money is to give less to the lord than is owed. This is difficult where there are cash rents, but is relatively simple in areas where rent is paid in the form of goods. Typical techniques include giving the lord the smallest fish, fruit, or eggs, and the worst quality grain.
 
-One practice considered particularly pernicious is seen close to some of the capitals of Mythic Europe. The peasants of a
+One practice considered particularly pernicious is seen close to some of the capitals of Mythic Europe. The peasants of a lord simultaneously refuse to pay their taxes. This holds his lifestyle to ransom. This tactic generally only works if the lord is unable to bring force to bear, such as if he is deeply in debt or needs the money to pay the king's scutage.
 
+> ## Story Seed: Claiming the Covenant
+> 
+> In some parts of Mythic Europe, anyone who lives on a lord's holding for more than a year, and lacks written proof that they are free, is automatically a villein. This can cause trouble for a covenant that hides its magical status, because it means that every servant of the covenant, and even the magi themselves, are legally the property of the local baron. Even if the baron does not attempt to press his claim and force the magi to take to the plow, he feels he has a right to a large payment in exchange for their manumission.
+> 
 
-## Story Seed: Claiming the Covenant
-
-In some parts of Mythic Europe, anyone who lives on a lord's holding for more than a year, and lacks written proof that they are free, is automatically a villein. This can cause trouble for a covenant that hides its magical status, because it means that every servant of the covenant, and even the magi themselves, are legally the property of the local baron. Even if the baron does not attempt to press his claim and force the magi to take to the plow, he feels he has a right to a large payment in exchange for their manumission.
-
-lord simultaneously refuse to pay their taxes. This holds his lifestyle to ransom. This tactic generally only works if the lord is unable to bring force to bear, such as if he is deeply in debt or needs the money to pay the king's scutage.
-
-## Paying the Lord Only What You Owe
+### Paying the Lord Only What You Owe
 
 If a lord is getting only what he is owed, by custom and law, and this leads him into a life that is below what his peers enjoy, it is the moral duty of his peasants to give him more. The lord, technically, owns everything they own anyway. See the concept of tallage in Chapter Six: Manorial Fiefs for more detail.
 
-## Not Resting on Holy Days
+### Not Resting on Holy Days
 
-Refraining from work on the sabbath and on the holy days of the Church isn't a privilege, it's a duty. The holy days on which a peasant is forbidden to work theoretically take up about a quarter of the year. This is so uneconomic that no lord of the manor respects it, and all serfs work on lesser holy days. Peasants who do refrain from work on a holy day are expected to make up the day owed to the lord from their free time. Similarly, it is considered wrong to take in only the mass of the service (such as by waiting
+Refraining from work on the sabbath and on the holy days of the Church isn't a privilege, it's a duty. The holy days on which a peasant is forbidden to work theoretically take up about a quarter of the year. This is so uneconomic that no lord of the manor respects it, and all serfs work on lesser holy days. Peasants who do refrain from work on a holy day are expected to make up the day owed to the lord from their free time. Similarly, it is considered wrong to take in only the mass of the service (such as by waiting outside the church with others to conduct business until the moment of the mass, then rushing inside, then departing again when the mass is done). Meeting after church to drink and dance is also considered sinful, but it is common.
 
-## Story Seed: Sending Lawyers and Money
+> ## Story Seed: Sending Lawyers and Money
+> 
+> In the classic form of peasants withholding their tax (which causes the most alarm among the writers of estate management handbooks), a group of peasants sends a delegation to the capital to hire a lawyer. They give the lawyer the money that they owe to their lord, to argue against the lord in a court of law. If the peasants win, they have lost nothing: their fees for the lawyer are smaller than the continual stream of fees that the lord could otherwise demand. If the lord wins, he has still suffered a great expense, great disruption to his domestic staff if he had no cash in reserve, and is unlikely to be able to collect the full amount his peasants owe him regardless.
+> 
+> The characters become involved because the carrier of the peasants' message is a redcap. When the redcap is found dead, the characters must determine who is responsible, and where the money has gone.
 
-In the classic form of peasants withholding their tax (which causes the most alarm among the writers of estate management handbooks), a group of peasants sends a delegation to the capital to hire a lawyer. They give the lawyer the money that they owe to their lord, to argue against the lord in a court of law. If the peasants win, they have lost nothing: their fees for the lawyer are smaller than the continual stream of fees that the lord could otherwise demand. If the lord wins, he has still suffered a great expense, great disruption to his domestic staff if he had no cash in reserve, and is unlikely to be able to collect the full amount his peasants owe him regardless.
-
-The characters become involved because the carrier of the peasants' message is a redcap. When the redcap is found dead, the characters must determine who is responsible, and where the money has gone.
-
-outside the church with others to conduct business until the moment of the mass, then rushing inside, then departing again when the mass is done). Meeting after church to drink and dance is also considered sinful, but it is common.
-
-## Perjury on Behalf of Lords
+### Perjury on Behalf of Lords
 
 Many peasants, as a way of increasing their financial well-being, are tempted to lie in court disputes on behalf of their lord. This is particularly prevalent in boundary disputes. Lying on behalf of one's lord in the royal court is one of the fastest ways to make easy money.
 
-## Stealing from Neighbors
+### Stealing from Neighbors
 
-The two most common thefts in Mythic Europe are of firewood and stock. Stolen stock is relatively easy to hide, because all sheep look identical when skinned. Stolen
+The two most common thefts in Mythic Europe are of firewood and stock. Stolen stock is relatively easy to hide, because all sheep look identical when skinned. Stolen firewood is even easier to hide: wood looks like other wood and the evidence literally goes up in smoke. Communal fields allow many other opportunities for theft. These include moving border markers, plowing in ignorance of the markers, and over-reaping such that one's scythe cuts down a little of a neighbor's crop.
 
-
-The lord of a local village is marrying for the second time. He demands the peasants pay an extra tax, to allow him the sort of feast required by his new father-in-law, who is a baron. This extra tax will impoverish the village. The characters may prevent this, or encourage it, to find ways to benefit from the lord's greed and the peasants' suffering.
-
-The characters may seek to prevent the tax being tallied. They may do this by sabotaging the marriage. This is difficult, but not impossible, because although the lord does not usually dwell at the manor, he will be in residence for a few weeks before the nuptials take place.
-
-The characters may instead encourage the nobleman to impoverish his people. They may do this by offering rare and expensive delights and entertainments for the feast, through their intermediaries. This leaves the villagers and lord open to the covenant's financial influence. It allows the covenant to lure away the manor's tradesmen, and may even make the village so marginal that the lord would accept a cash offer for it, or the role of tame nobleman.
-
-firewood is even easier to hide: wood looks like other wood and the evidence literally goes up in smoke. Communal fields allow many other opportunities for theft. These include moving border markers, plowing in ignorance of the markers, and over-reaping such that one's scythe cuts down a little of a neighbor's crop.
+> ## Story Seed: Saving a Village, or Saving For a Village
+> 
+> The lord of a local village is marrying for the second time. He demands the peasants pay an extra tax, to allow him the sort of feast required by his new father-in-law, who is a baron. This extra tax will impoverish the village. The characters may prevent this, or encourage it, to find ways to benefit from the lord's greed and the peasants' suffering.
+> 
+> The characters may seek to prevent the tax being tallied. They may do this by sabotaging the marriage. This is difficult, but not impossible, because although the lord does not usually dwell at the manor, he will be in residence for a few weeks before the nuptials take place.
+> 
+> The characters may instead encourage the nobleman to impoverish his people. They may do this by offering rare and expensive delights and entertainments for the feast, through their intermediaries. This leaves the villagers and lord open to the covenant's financial influence. It allows the covenant to lure away the manor's tradesmen, and may even make the village so marginal that the lord would accept a cash offer for it, or the role of tame nobleman.
 
 ### Changing Priests Without Permission, or Deducting Tithe for his Flaws
 
-Some unscrupulous priests allow their flocks to pay an incomplete tithe. This leads peasants into sin, encouraging them to shop around for the priest who will give them the best rate regarding their tithes and other du-
+Some unscrupulous priests allow their flocks to pay an incomplete tithe. This leads peasants into sin, encouraging them to shop around for the priest who will give them the best rate regarding their tithes and other duties. Medieval peasants are not permitted to choose who their priests should be. They are required to accept the care of their souls by the person appointed to them by the bishop, regardless of his competence or piety.
 
+> ## Story Seed: Lying for the Lord
+> 
+> A peasant flees to the covenant seeking protection. His lord asked him, along with a group of compurgators, to lie about the ownership of a piece of land that was in dispute. Some of the others who acted as witnesses have gone missing, and the peasant thinks they have been murdered. He is not sure if his lord had them killed to make sure that they cannot tell the truth to the royal court, or if the slighted party carried out the killings, taking revenge. In truth it is far worse that this: a demon is murdering parties on both sides of the dispute, hoping to trigger a regional war.
 
-## Story Seed: Lying for the Lord
+> ## Story Seed: Deodand Donkey
+> 
+> Stealing from neighbors is considered particularly heinous if the neighbor is frail, but this stops few criminally minded people because the elderly are such easy victims. The covenant has unknowingly bought a donkey that was stolen from an elderly man who died when it bucked him. It was stolen by a neighbor when it wandered out of its byre afterward, seeking grass. This animal, because it has caused a death, should be given to the Church. Theoretically the price of its sale would be used to provide for the dead man's relatives, but effectively this is just another tax.
+> 
+> The deodand donkey contains a little of the ghost of the dead man. The fragment of his spirit that resides in the deodand is angry at his death. It can transform its host animal into a spectral, centaur-like creature with the hindquarters of a donkey. It uses its powers to cause trouble in the area where it is kept, until it is given to the Church or destroyed.
 
-A peasant flees to the covenant seeking protection. His lord asked him, along with a group of compurgators, to lie about the ownership of a piece of land that was in dispute. Some of the others who acted as witnesses have gone missing, and the peasant thinks they have been murdered. He is not sure if his lord had them killed to make sure that they cannot tell the truth to the royal court, or if the slighted party carried out the killings, taking revenge. In truth it is far worse that this: a demon is murdering parties on both sides of the dispute, hoping to trigger a regional war.
+> ## Story Seed: The Bishop's Mistress
+> 
+> There is a folk story about the hearth mate of a priest who heard that the bishop was on his way to reprimand her partner for living with a woman. It is said that she filled a basket with good things to eat and took a shortcut through the woods. Reaching the bishop's party before he arrived in town, she was asked who she was, and where she traveled, all alone in the wood. She answered that she was taking food to the bishop's mistress, whom she had heard was with child. The bishop, mortified by his shame, returned home.
+> 
+> A bishop on good, or at least neutral, terms with the Order has contacted the covenant and asked for help. He is the bishop in the story. The strange part, for him, is that he doesn't actually have a mistress, and yet everyone he meets seems to believe he does. His home has a room for her, decorations selected by her, and clothes that she seems to have discarded for the maids to wash. One of his rooms has become a nursery, and between visits someone is filling it with furniture and toys. He does not know if this is some mundane trick engineered to drive him mad, if the mistress of the priest made a deal with the faeries of the wood, or if demons are bedeviling him.
 
-## Story Seed: Deodand Donkey
+Even a local priest who is heretical should be assessed and removed by the bishop, not judged by laymen. Some peasants ignore this and deduct a fine from their tithe for the things their priest does that they are sure are sins. This is unacceptable to the Church. The Church has, however, made some rulings that allow parishioners to ignore their priests. The most significant of these, to the daily life of peasants, is that they are enjoined not to attend the services of priests who live as if married. They are still required to tithe in such cases, although most do so parsimoniously.
 
-Stealing from neighbors is considered particularly heinous if the neighbor is frail, but this stops few criminally minded people because the elderly are such easy victims. The covenant has unknowingly bought a donkey that was stolen from an elderly man who died when it bucked him. It was stolen by a neighbor when it wandered out of its byre afterward, seeking grass. This animal, because it has caused a death, should be given to the Church. Theoretically the price of its sale would be used to provide for the dead man's relatives, but effectively this is just another tax.
+### Sexual Abstinence
 
-The deodand donkey contains a little of the ghost of the dead man. The fragment of his spirit that resides in the deodand is angry at his death. It can transform its host animal into a spectral, centaur-like creature with the hindquarters of a donkey. It uses its powers to cause trouble in the area where it is kept, until it is given to the Church or destroyed.
+Many peasants limit the size of their families by abstinence or contraception. This is a sin because it is robs a lord of the peasant's brood, and reduces the size of the family available to support the peasant in his old age. Unsupported elderly peasants become a drain on the economy of the manor or the Church, so failing to have sufficient children is considered antisocial.
 
-ties. Medieval peasants are not permitted to choose who their priests should be. They are required to accept the care of their souls by the person appointed to them by the bishop, regardless of his competence or piety.
-
-Even a local priest who is heretical should
-
-## Story Seed: The Bishop's Mistress
-
-There is a folk story about the hearth mate of a priest who heard that the bishop was on his way to reprimand her partner for living with a woman. It is said that she filled a basket with good things to eat and took a shortcut through the woods. Reaching the bishop's party before he arrived in town, she was asked who she was, and where she traveled, all alone in the wood. She answered that she was taking food to the bishop's mistress, whom she had heard was with child. The bishop, mortified by his shame, returned home.
-
-A bishop on good, or at least neutral, terms with the Order has contacted the covenant and asked for help. He is the bishop in the story. The strange part, for him, is that he doesn't actually have a mistress, and yet everyone he meets seems to believe he does. His home has a room for her, decorations selected by her, and clothes that she seems to have discarded for the maids to wash. One of his rooms has become a nursery, and between visits someone is filling it with furniture and toys. He does not know if this is some mundane trick engineered to drive him mad, if the mistress of the priest made a deal with the faeries of the wood, or if demons are bedeviling him.
-
-be assessed and removed by the bishop, not judged by laymen. Some peasants ignore this and deduct a fine from their tithe for the things their priest does that they are sure are sins. This is unacceptable to the Church. The Church has, however, made some rulings that allow parishioners to ignore their priests. The most significant of these, to the daily life of peasants, is that they are enjoined not to attend the services of priests who live as if married. They are still required to tithe in such cases, although most do so parsimoniously.
-
-## Sexual Abstinence
-
-Many peasants limit the size of their families by abstinence or contraception. This is a sin because it is robs a lord of the peasant's brood, and reduces the size of the family available to support the peasant in his old
-
-## Story Seed: Gift to the Faeries
-
-Many mothers of illegitimate children, or of children in families that are too large, leave their babies exposed in the wilderness, comforted by the idea that they will be taken and raised by the faeries. The lack of corpses in the traditional sites where children are abandoned reinforces this hope.
-
-Each site has its own explanation. In some the children are taken and raised by faeries, or given to mothers who want children but cannot have them. In others, faeries or other predators consume the children. In Transylvania and the Alps, these places are monitored by magi, who find that a surprising proportion of these children are Gifted. Even those who are not become highly loyal servants to the secret communities that rescued them from death.
-
-In this story seed, a noble whose son has died on crusade is desperate for an heir. He knows he has a bastard son, and seeks him out only to find that his mother abandoned him on the Waif Rock, a faerie site near her village. He asks the magi to find his child, and return him home. Perhaps he has been taken by the faeries. Perhaps he is now a servant of the covenant. Perhaps the characters can just pick a suitable servant and claim he is the lost son returned. If they substitute a fake, eventually the prodigal returns, filled with faerie power and mischief.
-
-age. Unsupported elderly peasants become a drain on the economy of the manor or the Church, so failing to have sufficient children is considered antisocial.
+> ## Story Seed: Gift to the Faeries
+> 
+> Many mothers of illegitimate children, or of children in families that are too large, leave their babies exposed in the wilderness, comforted by the idea that they will be taken and raised by the faeries. The lack of corpses in the traditional sites where children are abandoned reinforces this hope.
+> 
+> Each site has its own explanation. In some the children are taken and raised by faeries, or given to mothers who want children but cannot have them. In others, faeries or other predators consume the children. In Transylvania and the Alps, these places are monitored by magi, who find that a surprising proportion of these children are Gifted. Even those who are not become highly loyal servants to the secret communities that rescued them from death.
+> 
+> In this story seed, a noble whose son has died on crusade is desperate for an heir. He knows he has a bastard son, and seeks him out only to find that his mother abandoned him on the Waif Rock, a faerie site near her village. He asks the magi to find his child, and return him home. Perhaps he has been taken by the faeries. Perhaps he is now a servant of the covenant. Perhaps the characters can just pick a suitable servant and claim he is the lost son returned. If they substitute a fake, eventually the prodigal returns, filled with faerie power and mischief.
 
 ### Working in Old Age
 
-Elderly people who work are considered avaricious. Instead, society expects that they should turn their lands over to their children. On many manors it is usual, before the land is handed over, for a written contract to be sown to the manorial roll. This lays out precisely how much the retired person may expect each year, in grain, cheese, money, and clothes. It almost always promises "a place
+Elderly people who work are considered avaricious. Instead, society expects that they should turn their lands over to their children. On many manors it is usual, before the land is handed over, for a written contract to be sown to the manorial roll. This lays out precisely how much the retired person may expect each year, in grain, cheese, money, and clothes. It almost always promises "a place by the fire." In some parts of Mythic Europe, people over forty are considered to be aged, but they are not expected to turn over their lands until a more advanced age.
 
+> ### Story Seed: Even Demons Have Limits
+> 
+> A local baron is taking to ridiculous extremes the idea that his servants are required to labor for him cheerfully and with a whole heart, working people almost to death. The characters are contacted by an agent of a local demon of greed, who does his best to hide his involvement, retaining the guise of a local taverner. The demon believes that the peasants of the area are too exhausted to sin properly. The demon thinks that he has the lord's soul safely claimed by now, but regrets that his experiment has cost him the souls of the exhausted peasantry. The demon hopes that the characters will be able to somehow intervene with the lord to ease the peasants' burden, that all will be able to freely sin again.
 
-
-### Story Seed: Even Demons Have Limits
-
-A local baron is taking to ridiculous extremes the idea that his servants are required to labor for him cheerfully and with a whole heart, working people almost to death. The characters are contacted by an agent of a local demon of greed, who does his best to hide his involvement, retaining the guise of a local taverner. The demon believes that the peasants of the area are too exhausted to sin properly. The demon thinks that he has the lord's soul safely claimed by now, but regrets that his experiment has cost him the souls of the exhausted peasantry. The demon hopes that the characters will be able to somehow intervene with the lord to ease the peasants' burden, that all will be able to freely sin again.
-
-by the fire." In some parts of Mythic Europe, people over forty are considered to be aged, but they are not expected to turn over their lands until a more advanced age.
-
-## Story Seed: Misguided Faeries
-
-Characters breaking the taboo of working in old age attract faeries that represent their fear of decrepitude and powerlessness. Magi also attract these creatures, despite the fact that a magus in his sixties is only middle aged. These faeries, lacking experience with magi, cannot see the magicians for what they really are, or at least pretend they cannot. This makes their attacks humorously ineffective, if still annoying.
+> ## Story Seed: Misguided Faeries
+> 
+> Characters breaking the taboo of working in old age attract faeries that represent their fear of decrepitude and powerlessness. Magi also attract these creatures, despite the fact that a magus in his sixties is only middle aged. These faeries, lacking experience with magi, cannot see the magicians for what they really are, or at least pretend they cannot. This makes their attacks humorously ineffective, if still annoying.
 
 ### Moving Manor
 
-Flight is theft, because a peasant's labor is not his own, to dispense as he wishes. It also encourages lords to attempt to buy popularity, by meeting the rising living standards in nearby towns. The Church has mixed views on this, but in large sections of the Church this is seen as wrong, because physical poverty leads to a desirable spiritual state, and because this forces the ecclesiastical landlords
+Flight is theft, because a peasant's labor is not his own, to dispense as he wishes. It also encourages lords to attempt to buy popularity, by meeting the rising living standards in nearby towns. The Church has mixed views on this, but in large sections of the Church this is seen as wrong, because physical poverty leads to a desirable spiritual state, and because this forces the ecclesiastical landlords to offer more for farm labor than is traditional, which prevents them from spending this surplus on charity, crusading, and other good works. Offering more for labor encourages people who ask for more than is customarily theirs — that is, it encourages thieves.
 
-## Story Seed: The Inn of Good Rest
-
-A character of interest to the covenant dies of poisoning and the characters decide to investigate. They discover there have been a series of poisonings, all pilgrims who have worshiped at a local shrine. The deaths are being caused by the followers of the faerie lord to whom the shire's site was sacred before the coming of Christianity. They run a brothel, and occasionally kill pilgrims who visit it. They do this because their faerie patron guards the border between the profane and sacred, and feel that they further this by killing people who are at spiritual risk.
-
-Some pilgrims mistakenly assume that since pilgrimage washes clean some of their sins, they can perform some of the more interesting sins the night before the pilgrimage concludes and not suffer any spiritual ills. The faerie lord, is more influenced by commonly believed stories than by theological accuracy, and has, his followers use slow-acting poison, because it is sure not to kill any given victim before his pilgrimage is complete. The faerie's followers believe that they can catch the pilgrims just after they enter a state of grace, killing them before they can sully themselves again.
-
-to offer more for farm labor than is traditional, which prevents them from spending this surplus on charity, crusading, and other good works. Offering more for labor encourages people who ask for more than is customarily theirs — that is, it encourages thieves.
+> ## Story Seed: The Inn of Good Rest
+> 
+> A character of interest to the covenant dies of poisoning and the characters decide to investigate. They discover there have been a series of poisonings, all pilgrims who have worshiped at a local shrine. The deaths are being caused by the followers of the faerie lord to whom the shire's site was sacred before the coming of Christianity. They run a brothel, and occasionally kill pilgrims who visit it. They do this because their faerie patron guards the border between the profane and sacred, and feel that they further this by killing people who are at spiritual risk.
+> 
+> Some pilgrims mistakenly assume that since pilgrimage washes clean some of their sins, they can perform some of the more interesting sins the night before the pilgrimage concludes and not suffer any spiritual ills. The faerie lord, is more influenced by commonly believed stories than by theological accuracy, and has, his followers use slow-acting poison, because it is sure not to kill any given victim before his pilgrimage is complete. The faerie's followers believe that they can catch the pilgrims just after they enter a state of grace, killing them before they can sully themselves again.
 
 ### Not Working Hard
 
 A peasant is required, by scripture, to cheerfully work to his utmost to please his lord. A peasant choosing not to exhaust himself in his labors for his lord, who does not have a heart filled with a desire to serve, is in a state of sin. A peasant who makes a contract with his lord such that he is not required to work to exhaustion is seeking license to sin, and such licenses are false documents.
 
-
-## Being Hard on Pilgrims and the Poor
+### Being Hard on Pilgrims and the Poor
 
 Peasants are required to aid pilgrims and the poor. Providing for the poor is increasingly difficult in Mythic Europe, due to the booming population. Some peasants believe that the poor should be provided for from the tithes of the Church. They therefore surmise that it is not their duty to succor the poor, given that they, themselves, live a marginal existence.
 
@@ -4205,8 +3887,6 @@ For many serfs, freedom is an important goal. A serf who is free has the right t
 
 Manumission, the freeing of serfs by lords, is favored by the teaching of the Church, but is rarely practiced by senior Churchmen. Far fewer serfs from Church lands are made free than from the lands of lay rulers. This is because secular lords, at death or to give thanks for the birth of an heir, often bestow charity on the poor. One of the forms this charity takes is the manumission of serfs. Churchmen almost never give charity in this form.
 
-#### Lords of Men
-
 #### Manumission by Lay Lords
 
 The process by which lay lords give manumissions varies between kingdoms. In France, for example, a lord may only free a serf if the lord's feudal superiors, up to the king himself, give him license to do so. In England, this is not the case; a lord personally owns the service of his serfs and may do as he wishes with them.
@@ -4217,42 +3897,41 @@ In many areas, because it is believed that serfs technically do not own anything
 
 If a boy begins schooling to become a priest, then he is free. The father of the child then owes the lord a fine. This is far smaller than the usual fee for manumission. For player characters, assume this sum to be ten shillings, and the duty to say masses for the soul of the lord on a regular basis. In some areas if such a person ceases to be a priest — for example, if he is cast out of the holy office due to scandal — then he becomes a serf again.
 
-## Manumission by the Church
+### Manumission by the Church
 
-Manumission of serfs is explicitly forbidden to senior Churchmen, banned as a form of alienation of property from the Church. Senior Churchmen, in theory, hold no property of their own. They instead administer the property of the Church, which they cannot sell. How much is the lifetime labor of a peasant worth? How much, in addition, the
-
+Manumission of serfs is explicitly forbidden to senior Churchmen, banned as a form of alienation of property from the Church. Senior Churchmen, in theory, hold no property of their own. They instead administer the property of the Church, which they cannot sell. How much is the lifetime labor of a peasant worth? How much, in addition, the work of every descendant, though all generations until doomsday? No peasant has that sort of money, and so he cannot pay his worth to the Church.
 
 More practical Churchmen counter with the idea that sale of Church assets, at the going rate, does not diminish the Church's holdings. They feel that it is right to free serfs for money, provided that they don't pocket the money themselves. Refusal to release any serfs is seen as a way of keeping priests away from this temptation. The Church, practically speaking, does manumit serfs, but almost exclusively in exchange for money, and only when finances are unusually weak.
 
-## Manumission by Membership of a Town's Guild
+### Manumission by Membership of a Town's Guild
 
 In many areas it is possible to become free by being a member of a town's guild for a period of time. The idea that a person becomes free by living in a town for a year and a day oversimplifies this legal point. To become free the person must not stray from the town, and must be accepted as a resident by the authorities of the town. This generally requires guild membership, which, in turn, generally requires the active support of a wealthy patron who gives the villein employment. It is, therefore, far easier for villeins who have relatives living in a town to escape villeinage in this way.
 
-## Manumission by Force of Crusading Sentiment
+### Manumission by Force of Crusading Sentiment
 
 It is felt by many people that there is something ignoble about forcing one who has fought for the cross back into serfdom. Legally, a crusader has no right to claim his freedom. Effectively, in most kingdoms, a man who has been able to attend crusade as part of the retinue of a great lord is freed by his service to God.
-
 
 ## The Agricultural Year
 
 The agricultural year is divided into four uneven seasons by the work done at that time, which is dependent on climate. Roughly speaking, winter runs from September 29 (which is the first day of the administrative year) until Christmas. Twelve days of recreation follow Christmas, and then spring begins. Spring lasts until Easter. Easter again is followed by a week of festivities, and heralds Summer, which ends at the start of August. Autumn lasts until the end of September.
 
-## Two- or Three-Field Rotation
+### Two or Three Field Rotation
 
 All of the villeins labor together during the sowing and reaping, but most manors have distinctly marked blocks belonging to individuals within the great fields. Plowing is done by individuals, or by teams of men who lend each other oxen and plows in turn, so that they form a complete ox team. Reaping is done by individual crop owners and their servants.
 
 In a three-field manor, wheat or rye is planted in autumn in the first field. An alternate crop, which varies by climate and locale, is planted in the spring in the second field.
 
+Popular crops include oats, vetches, beans, peas, and barley. The third field is left fallow. In the following year, the wheat is moved to the fallow field, the secondary crop to the wheat field, and the secondary crop field is left fallow. In the two-field system, one field is left fallow while the other is divided in half and planted much like the second field in the three-field system.
 
 Parts of either field may be sown with crops other than the main one selected for that season. The field is divided into sections, called furlongs, which are long rectangles. The manor court selects what is planted in each furlong, and all holders of land in that furlong must plant the correct crop. This makes planting and harvesting easier. This also allows the manorial court to ensure that a village has the correct balance of crops.
 
-## Story Seed: A New Crusade
+> ## Story Seed: A New Crusade
+> 
+> Crusades are extremely expensive. They create problems for peasants unable to resist the tallage of their lords (as described in Chapter Six: Manorial Fiefs), but also provide opportunities for those who have sufficient power to stare down their lords. At the beginning of the Third Crusade, peasants throughout England found that their lords wanted a great deal of money very quickly. They sold manumissions and land cheaply. They were willing to grant concessions on villein fees and services. Some were even willing to sell their demesne lands, determined to make their fortune in the Holy Land or be buried there.
+> 
+> A new crusade is also an opportunity for covenants with spare money, or who are willing to engage in usury. The demands of the lords for money in coin make it difficult to come by. Usurers respond by raising their interest rates. A covenant willing to loan money to the local peasants at a cheap rate could become very popular, while one willing to loan money at the going rate would be unpopular, but comparatively wealthy.
 
-Crusades are extremely expensive. They create problems for peasants unable to resist the tallage of their lords (as described in Chapter Six: Manorial Fiefs), but also provide opportunities for those who have sufficient power to stare down their lords. At the beginning of the Third Crusade, peasants throughout England found that their lords wanted a great deal of money very quickly. They sold manumissions and land cheaply. They were willing to grant concessions on villein fees and services. Some were even willing to sell their demesne lands, determined to make their fortune in the Holy Land or be buried there.
-
-A new crusade is also an opportunity for covenants with spare money, or who are willing to engage in usury. The demands of the lords for money in coin make it difficult to come by. Usurers respond by raising their interest rates. A covenant willing to loan money to the local peasants at a cheap rate could become very popular, while one willing to loan money at the going rate would be unpopular, but comparatively wealthy.
-
-## August and September
+### August and September
 
 August and September are the months for the harvest. Every serf is required to give extra service to his lord, which can make bringing in his own crops difficult. Even freemen are usually required to work at this time, although their work is supervising the day laborers they have hired to do their physical labor. After the harvest, poor people wander the fields looking for missed grain. They are permitted to keep these gleanings as an act of charity. After this, the cattle are set loose in this field, to graze on the wheat stubble. The peasant then takes his tithe to the Church and his rent to the lord. By tradition the harvest is meant to be complete by Michaelmas (29 September) because that is the day of reckoning for manorial taxes, not only for the peasants, but also for the reeve, who must give account up until this day, and who is replaced or reaffirmed in office on this day.
 
@@ -4260,76 +3939,71 @@ On many manors pigs must have rings through their snouts after Michaelmas. This 
 
 Cattle are bred in September. This allows them to calf after winter ends.
 
-## Richard's Deed
+> ## Richard's Deed
+> 
+> King Richard — who was always more at home in Normandy than England said at the start of the Third Crusade that he would sell London, if only he could find a buyer. In Mythic Europe, kings can't say silly things like that without someone, or something, answering their summons.
+> 
+> Magi might have bought London. There have always been rumors in the Order that House Tytalus wanted to take him up on the offer. Many other covenants, at this time, sought charters from the king guaranteeing their rights. There is also a Mercer House in London that seems to thrive.
+> 
+> Faeries would gladly have bought the right to access some or all of London, for their court. This gives them a Right of Entry, as described in *Realms of Power: Faerie*, which lessens the impact of the Dominion. It also provides great hunting opportunities for some dark faeries. Those that cannot cross thresholds without being invited in would be free to attack people in their homes in London because Richard is their landlord, and so can "invite in" whatever he likes.
+> 
+> Richard may have sold similar rights to demons, thinking them magi or faeries.
 
-King Richard — who was always more at home in Normandy than England said at the start of the Third Crusade that he would sell London, if only he could find a buyer. In Mythic Europe, kings can't say silly things like that without someone, or something, answering their summons.
-
-Magi might have bought London. There have always been rumors in the Order that House Tytalus wanted to take him up on the offer. Many other covenants, at this time, sought charters from the king guaranteeing their rights. There is also a Mercer House in London that seems to thrive.
-
-Faeries would gladly have bought the right to access some or all of London, for their court. This gives them a Right of Entry, as described in *Realms of Power: Faerie*, which lessens the impact of the Dominion. It also provides great hunting opportunities for some dark faeries. Those that cannot cross thresholds without being invited in would be free to attack people in their homes in London because Richard is their landlord, and so can "invite in" whatever he likes.
-
-Richard may have sold similar rights to demons, thinking them magi or faeries.
 
 The player characters may seek the title deed for London, if by seizing it they prevent a demon from burning down the town, or a malevolent faerie from spreading a sickness. The Deed of London is kept in a regio, closely guarded by demons or faeries.
 
+### October
 
+The movement of the cattle onto the wheat field leaves the fallow field free for a third, slightly deeper, plowing. After this is complete the peasants make preparations for winter. The most important preparation is the gathering of wood. This is used as fuel, but is also the raw material for the craft work that the peasants expect to do over winter. This usually includes house repairs. As the weather became progressively worse, increasing amounts of work are done indoors. Threshing, for example, needs to be completed. October ends with All Saint’s Eve, Hallowe’en, when the dead are thought to walk.
 
-### January
+Sheep are bred in October. Breeding can occur earlier, but October breeding allows them to drop their lambs after the worst of winter.
 
-## February
+### November
 
-The movement of the cattle onto the wheat field leaves the fallow field free for a third, slightly deeper, plowing. After this is complete the peasants make preparations for winter. The most important preparation is the gathering of wood. This is used as fuel, but is also the raw material for the craft work that the peasants expect to do over winter. This usually includes house repairs. As the weather became progressively worse, increasing amounts of work are done
+Martinmas, the Feast of the Plowman, is celebrated with a feast on the 11th of November. The annual slaughter of beasts that the peasants do not wish to feed through the winter begins, in some areas, as early as Michaelmas, but is usually the work of this slower part of the year. Cows are rarely slaughtered if they are still capable of bearing calves, but oxen that are older than six are often killed, as they are considered to be at the end of their strength. Sheep are only killed for lack of fodder, if their health fails, or on special occasions, because they are considered to have better value alive. 
 
-to walk. Sheep are bred in October. Breeding can occur earlier, but October breeding allows them to drop their lambs after the worst of winter.
-
-indoors. Threshing, for example, needs to be completed. October ends with All Saint's Eve, Hallowe'en, when the dead are thought
-
-## November
-
-*October*
-
-Martinmas, the Feast of the Plowman, is celebrated with a feast on the 11th of November. The annual slaughter of beasts that the peasants do not wish to feed through the winter begins, in some areas, as early as Michaelmas, but is usually the work of this slower part of the year. Cows are rarely slaughtered if they are still capable of bearing calves, but oxen that are older than six are often killed, as they are considered to be at the end of their strength. Sheep are only killed for lack of fodder, if their health fails, or on special occasions, because they are considered to have better value alive.
-
-## December
+### December
 
 Christmas usually marks the end of fieldwork, other than the spreading of manure or agricultural lime, until the following January. Many use this time to perform craft work, make repairs around their houses, and beget children. The time of the year between Christmas and Epiphany is set aside for festivals and prayer. It is a time for lords to grant largesse to their followers. Peasants owe their lords their respects and regards, a sort of theoretically voluntary tax, usually of poultry.
 
+### January
+
 A feast is held to celebrate the resumption of work, although in colder climes there is little to be done in the fields at this time. In many areas plow races are held. In Britain bands of young men travel the streets asking for money for the plow, and destroying the yards of those who refuse. Animal husbandry begins in January, with the breeding of pigs and the first lambing. Lambing in England occurs in March, but in pleasanter climes comes earlier.
 
-Once the ground has softened a little, whatever soiled straw a peasant has collected during the winter is laid on the surface of his land, so that when the plow turns the soil, the straw and manure are dug in. On manors that are relatively warm, and that have many sheep, ewes are sometimes shorn in this month to prepare them for lambing in March. Calving beings in February.
+### February
 
-The middle of February is commemorated as the day of the Purification of the Virgin. This refers to a ceremony that mothers perform after giving birth to make them spir-
+Once the ground has softened a little, whatever soiled straw a peasant has collected during the winter is laid on the surface of his land, so that when the plow turns the soil, the straw and manure are dug in. On manors that are relatively warm, and that have many sheep, ewes are sometimes shorn in this month to prepare them for lambing in March. Calving beings in February. 
 
-## Story Seeds: Faeries at Christmas
+The middle of February is commemorated as the day of the Purification of the Virgin. This refers to a ceremony that mothers perform after giving birth to make them spiritually clean enough to re-enter the church. It involves a procession with candles, a feast, and — in parts of France — eating crepes.
 
-In many areas a game is played where a bean, or silver trinket, is hidden in a treat and the person who finds this foreign object in his serving is the king of revels for the feast. Some people believe that, in ancient times, these bean kings were killed by the pagans. Dark faeries, who do not care if a story is true or false as long as it ends in screaming and blood, have difficulty finding admittance to communities on Christmas, and so they rarely hunt bean kings. A bean king who wanders, however, might find himself pursued, if his term is up, or treated with the greatest courtesy and showered with gifts, if his day has time remaining.
+> ## Story Seeds: Faeries at Christmas
+> 
+> In many areas a game is played where a bean, or silver trinket, is hidden in a treat and the person who finds this foreign object in his serving is the king of revels for the feast. Some people believe that, in ancient times, these bean kings were killed by the pagans. Dark faeries, who do not care if a story is true or false as long as it ends in screaming and blood, have difficulty finding admittance to communities on Christmas, and so they rarely hunt bean kings. A bean king who wanders, however, might find himself pursued, if his term is up, or treated with the greatest courtesy and showered with gifts, if his day has time remaining.
+> 
+> One way for faeries to enter the human lands during the 12 days of Christmas is to take on the role of mummers. Mummers are humans who form bands, put on masks, and then parade, beg for money, or fight. Many bands of mummers perform traditional plays. The mixture of traditional roles, artistically performed stories, and transgressions made possible by assumed identities draws in some of the strangest and most obscure faeries, who are only ever discovered if they are forced to remove their masks.
+> 
+> In this story seed some faeries conspire to make real the things that are only the pretenses of the mummer's play. The actor playing the fool loses his wits for a year until he plays the same role again. The actor playing a woman similarly has his gender changed, until she can repeat her performance the following year. The characters do not know that these curses are of limited duration and seek the assistance of the player characters. They are aided in their quest to fix this trick by a prop from the play: the pills of the doctor, which bring the dead hero back to life, can now cure all wounds instantly, and contain Corpus vis.
 
-One way for faeries to enter the human lands during the 12 days of Christmas is to take on the role of mummers. Mummers are humans who form bands, put on masks, and then parade, beg for money, or fight. Many bands of mummers perform traditional plays. The mixture of traditional roles, artistically performed stories, and transgressions made possible by assumed identities draws in some of the strangest and most obscure faeries, who are only ever discovered if they are forced to remove their masks.
+> ## Story Seed: Holly and Baby
+> 
+> A hedge witch has reason for vengeance on a noble lady. She put a small holly branch over the window of the nursery of the lady's child last Candlemas night. Dark faeries, able to enter the house because of the invitation of the holly, killed the child in its cot, leaving it cold and lifeless with not a mark.
+> 
+> The revenge of the witch, however, is not yet finished. This year she plans to put up the holly again, so that a faerie, in the shape of the dead child, will attack the mother. Characters may prevent this by removing the holly, or they may appease the faeries entirely by burning a candle in every window of the noble lady's house. The witch will try to snuff one of the candles and hang more holly. How do the characters monitor all of the candles at once?
 
-In this story seed some faeries conspire to make real the things that are only the pretenses of the mummer's play. The actor playing the fool loses his wits for a year until he plays the same role again. The actor playing a woman similarly has his gender changed, until she can repeat her performance the following year. The characters do not know that these curses are of limited duration and seek the assistance of the player characters. They are aided in their quest to fix this trick by a prop from the play: the pills of the doctor, which bring the dead hero back to life, can now cure all wounds instantly, and contain Corpus vis.
-
-## Story Seed: Holly and Baby
-
-A hedge witch has reason for vengeance on a noble lady. She put a small holly branch over the window of the nursery of the lady's child last Candlemas night. Dark faeries, able to enter the house because of the invitation of the holly, killed the child in its cot, leaving it cold and lifeless with not a mark.
-
-The revenge of the witch, however, is not yet finished. This year she plans to put up the holly again, so that a faerie, in the shape of the dead child, will attack the mother. Characters may prevent this by removing the holly, or they may appease the faeries entirely by burning a candle in every window of the noble lady's house. The witch will try to snuff one of the candles and hang more holly. How do the characters monitor all of the candles at once?
-
-
-
-On any festive day when the weather is suitable, peasants may play football. The rules of football vary greatly from place to place.Whichever team gets the ball back to a designated spot in their village (or to their end of the village, in a game played by halves of a single village) is the winner.
-
-- Each side may have an unlimited number of players. Players have a side by birth or residence. That is, those born in the poor part of a town, in many places, must play for that part of the town.
-- Killing the players of the other side is forbidden, but striking them with a certain degree of force is inevitable.
-- Striking members of your own team is allowed. On some manors, it's considered impossible to commit an assault during a football match, because the crowd of drunken football players will swear that whoever is charged before the manor court didn't strike the blow.
-- Players may trespass where they like. Trampling crops is permitted — but low — play in many areas. As with assault, there's no way to assign blame.
-
-itually clean enough to re-enter the church. It involves a procession with candles, a feast, and — in parts of France — eating crepes.
+> ## Story Seed: Mob Football
+> 
+> On any festive day when the weather is suitable, peasants may play football. The rules of football vary greatly from place to place. Whichever team gets the ball back to a designated spot in their village (or to their end of the village, in a game played by halves of a single village) is the winner.
+> 
+> - Each side may have an unlimited number of players. Players have a side by birth or residence. That is, those born in the poor part of a town, in many places, must play for that part of the town.
+> - Killing the players of the other side is forbidden, but striking them with a certain degree of force is inevitable.
+> - Striking members of your own team is allowed. On some manors, it's considered impossible to commit an assault during a football match, because the crowd of drunken football players will swear that whoever is charged before the manor court didn't strike the blow.
+> - Players may trespass where they like. Trampling crops is permitted — but low — play in many areas. As with assault, there's no way to assign blame.
 
 Candlemas is considered an excellent day for divination by hedge witches. Even the untalented know simple folk observances. These include predictions of lean times for those who don't still have half their flour and hay, and a present end to winter if Candlemas is rainy. Candlemas is also a day to predict the death of relatives by listening for soul bells.
 
 Peasants caution that greenery used to make the house colorful for Christmas must be taken down before this day. To fail to do so angers the spirits of dead children, and this is one of the many origin stories of faeries. Faeries express their annoyance with tricks or, in the worst case, by killing someone who lives in the house. They prefer to kill children, who are like themselves.
 
-## March
+### March
 
 Lambing occurs slightly before sowing. This is busy time on manors that graze sheep, particularly those that graze in preference to cropping. Lambing on estates with large herds is done in pasture, which requires more work than barn lambing, because some ewes seek privacy while giving birth. Humans are often able to rectify problems that might otherwise kill a ewe or lamb, and sometimes are able to graft orphaned lambs onto ewes whose lambs have died.
 
@@ -4343,35 +4017,31 @@ At the beginning of Lent, in some areas, a great feast is held to use up forbidd
 
 Easter is a time for processions of various types, and for the veiling of the cross until Good Friday. A vigil is held between Good Friday and Easter Sunday, and it is believed by many peasants that Infernal powers are strongest at this time. The week after Easter is a holiday for peasants according to the Church, although most lords do not accept this and merely allow peasants to work their time in some other week. As the weather is warming, sports and games are popular.
 
-The week after Easter ends, in parts of England, with Hocktide Monday and Tues-
-
-
-Three of the girls of the village are pregnant. They are greatly distressed, because two of them claim not to have known men, and their prospects of marriage have been seriously damaged. Investigation demonstrates that all three were kidnapped at Hocktide by a man they thought was their beau, and each of them gave him a kiss as their ransom. When their children are born, it is obvious that they have a faerie father. The characters may wish to shield the children from the abuse that is likely to follow. They may also seek the father, because faerie satyromaniacs can't be left to make mischief so close to the covenant.
-
-day. The celebration of Hocktide varies from place to place, sometimes including bizarre rituals of mutual flagellation by husbands and wives. In its more usual form, women use ropes to capture male travelers and refuse to release them until they pay a penny, or a kiss in some cases, on the Monday, and the men return the favor on the Tuesday. The money collected is spent on a worthy cause.
+The week after Easter ends, in parts of England, with Hocktide Monday and Tuesday. The celebration of Hocktide varies from place to place, sometimes including bizarre rituals of mutual flagellation by husbands and wives. In its more usual form, women use ropes to capture male travelers and refuse to release them until they pay a penny, or a kiss in some cases, on the Monday, and the men return the favor on the Tuesday. The money collected is spent on a worthy cause.
 
 In this month the fallow field must be given a shallow plowing to kill the weeds. Weaning begins, which prompts dairying. Piglets are born, a process called farrowing.
 
-## May
+> ## Story Seed: Faerie Kidnapper
+> 
+> Three of the girls of the village are pregnant. They are greatly distressed, because two of them claim not to have known men, and their prospects of marriage have been seriously damaged. Investigation demonstrates that all three were kidnapped at Hocktide by a man they thought was their beau, and each of them gave him a kiss as their ransom. When their children are born, it is obvious that they have a faerie father. The characters may wish to shield the children from the abuse that is likely to follow. They may also seek the father, because faerie satyromaniacs can't be left to make mischief so close to the covenant.
+
+### May
 
 During this month the peasants perform such labors as are required by the customs of the manor. This may include construction work, maintenance, or warfare. The month begins with the celebration of May Day. It is also the month for capturing swarms of wild bees to create hives.
 
 In some areas, strict sexual morality is abandoned on May Day and people spend the night in the forest. May Day celebrations often involve fires around which people dance, or over which people leap. Some people think their rye will grow as tall as they leap over the fire, although Hermetic magi have never demonstrated this to be true. Peasants "bring in the May" by carrying flowers and green boughs back to their homes in the morning.
 
+> ## Story Seed: Rogation Blood
+> 
+> There is always some concern at Rogation that a parent will not hurt a boy sufficiently for him to remember the landmarks. In one village the blood of so many virgin boys spilled on a particular stone, year after year, is a sacrifice to an almost-forgotten pagan god. When the Rogation becomes so lax that there is not enough blood, the deity stirs to seek repayment for the village's debt.
 
-## Story Seed: Rogation Blood
-
-There is always some concern at Rogation that a parent will not hurt a boy sufficiently for him to remember the landmarks. In one village the blood of so many virgin boys spilled on a particular stone, year after year, is a sacrifice to an almost-forgotten pagan god. When the Rogation becomes so lax that there is not enough blood, the deity stirs to seek repayment for the village's debt.
-
-## Story Seed: Wake Day
-
-Wakes are celebrations where people stay up the night before a feast day. Wake Day is a special wake that is celebrated at different times on various manors. The wake is celebrated on the evening before the day of the patron saint of the Church in the manor. Festivities vary, to suit that saint. In many areas the saint reflects the local industry.
-
-Informally, many Jerbiton-influenced covenants celebrate September 26 as their Wake Day. This is the Feast of Saints Cyprian and Justina of Antioch. Cyprian was a sorcerer, and perhaps a diabolist, who tried to use his powers to seduce a Christian virgin, but then forsook evil when his spells failed. He is the patron of the church at Valnastium, the domus magna of House Jerbiton.
-
-A character comes to the player characters on Wake Day and claims to be a penitent Infernalist. He offers to name the nobleman who recruited him, and the other members of his coven. How can the player characters be sure he is telling the truth? Do they give him a chance to live a life of atonement, or assume that he is an agent of the Infernal attempting some scheme?
-
-#### Lords of Men
+> ## Story Seed: Wake Day
+> 
+> Wakes are celebrations where people stay up the night before a feast day. Wake Day is a special wake that is celebrated at different times on various manors. The wake is celebrated on the evening before the day of the patron saint of the Church in the manor. Festivities vary, to suit that saint. In many areas the saint reflects the local industry.
+> 
+> Informally, many Jerbiton-influenced covenants celebrate September 26 as their Wake Day. This is the Feast of Saints Cyprian and Justina of Antioch. Cyprian was a sorcerer, and perhaps a diabolist, who tried to use his powers to seduce a Christian virgin, but then forsook evil when his spells failed. He is the patron of the church at Valnastium, the domus magna of House Jerbiton.
+> 
+> A character comes to the player characters on Wake Day and claims to be a penitent Infernalist. He offers to name the nobleman who recruited him, and the other members of his coven. How can the player characters be sure he is telling the truth? Do they give him a chance to live a life of atonement, or assume that he is an agent of the Infernal attempting some scheme?
 
 Many peasants run their cattle or sheep between two May Day fires, to defend them against the curses of hedge witches and this is — in some areas — completely effective. This may be because local witches sometimes make sure the effect works, to protect their village from interlopers. The Beltaine rituals can hex those who practice magic, which includes Hermetic magi who are lax in renewing their Parma Magica while outside their covenant's Aegis.
 
@@ -4379,7 +4049,7 @@ The Rogation Days begin forty days after Easter. On these days, the people of a 
 
 In May or June, Pentecost is celebrated. This day, 49 days after Easter, represents the giving of the Commandments to Moses, and the entry of the Holy Spirit into the apostles before they began the ministry detailed the Book of Acts. A feast, dancing, and horse racing are popular on this day. Pentecost is often followed by a week of holidays.
 
-## June
+### June
 
 Shearing occurs in this month.
 
@@ -4393,13 +4063,11 @@ Midsummer is the traditional start of haymaking. Each laborer can cut about an a
 
 By tradition, the last day of July is the last day of haymaking; in August the manor switches to reaping its harvest. Many manors finish haymaking more quickly than this, provided the weather is fine. During July women harvest, prepare, and spin flax and linen, to make cloth or string. Men weed their fields. For this they use a pair of sticks, one forked, the other with a blade at its end. At the end of July, after the meadow has recovered from haymaking, it is reopened to stock.
 
-
-
-# Massed Combat
+# Chapter Eight: Massed Combat
 
 The focus of **Ars Magica** is on telling stories, and the field of battle is no exception to this. This chapter provides rules for raising armies and running battles with the player characters at the heart of the action, with their resolve and fighting spirit deciding the outcome of the day.
 
-*Medieval Armies*
+## Medieval Armies
 
 Across Mythic Europe, all armies contain troops that fall into the same broad categories. Knights are the best-armored and often the best-trained troops on the battlefield. Serjeants are lighter cavalry. They are professional soldiers retained by a noble or wealthy master.
 
@@ -4421,13 +4089,13 @@ Armies are drawn from three main sources. The core of a noble's army comes from 
 
 The size and composition of the forces a lord can raise varies across Mythic Europe, but the table below shows the average number of standard combat groups (each consisting of five fully equipped men) that can be raised in strongly feudal areas.
 
-| Title                        | Knights | Serjeants | Infantry &<br>Archers | when on<br>d)<br>home groun<br>Levies ( |
-|------------------------------|---------|-----------|-----------------------|-----------------------------------------|
-| Poor/Average<br>Landed Noble | 0       | 1         | 2                     | 2                                       |
-| Wealthy<br>Landed Noble      | 1       | 1         | 10                    | 10                                      |
-| Greater Baron                | 4       | 4         | 40                    | 40                                      |
-| Earl or Count                | 10      | 10        | 100                   | 100                                     |
-| Duke                         | 25      | 25        | 150                   | 150                                     |
+| Title | Knights | Serjeants | Infantry & Archers | Levies (when on home ground) |
+|-------|:-------:|:---------:|:------------------:|:----------------------------:|
+| Poor/Average Landed Noble | 0 | 1 | 2 | 2 |
+| Wealthy Landed Noble | 1 | 1 | 10 | 10 |
+| Greater Baron | 4 | 4 | 40 | 40 |
+| Earl or Count | 10 | 10 | 100 | 100 |
+| Duke | 25 | 25 | 150 | 150 |
 
 Note that the cavalry element of these forces can be renewed during the course of a war. For example if a lord has six household knights and five of them die in a cavalry charge gone wrong, then it's possible for the lord to simply appoint replacements, which doesn't cost the lord any money. Peasant levies can also be renewed in a similar way, if the lord can recruit additional peasants from outside his lands.
 
@@ -4443,101 +4111,94 @@ A character who acts as the leader of a region may use his personal authority an
 
 A character wishing to call on his allies for support makes a Presence + Leadership + Affinity score simple roll and looks up the result — which corresponds to the proportion by which his core force is multiplied — on the Allied Troops Table.
 
-
-The Church has issued two proclamations directly concerning the waging of war. The Peace of God (Pax Dei) attempts to protect certain classes of people who are to be exempt from violence. These are principally the poor, Churchmen, and merchants. The Truce of God (Treuga Dei) restricts the days on which war can be waged. This means that Fridays, Sundays, holy days, and Lent are exempt from fighting.
-
-Breaking either the Pax Dei or the Treuga Dei is considered an unchristian act, as is the execution of prisoners. Captains fearful for their souls, and those who ask for the blessings of saints, do well to obey these articles of war, but easier paths are often more attractive.
-
-#### Chevauchee
-
-The chevauchee is a tactic used to weaken the resolve of a population and to provoke an army into confrontation. Enemy territory is ravaged, crops are burned, and the people are driven from their land to the relative safety of towns and castles. The chevauchee not only secures territory and supplies for the ravaging army but also denies them to the enemy. Even defending armies may leave destruction in their wake as they spoil crops and poison wells in order to deny the enemy. This tactic is used across Mythic Europe and the Levant.
-
-Land put to chevauchee is subject to disease and famine, with farmland spoiled and livestock and population alike slaughtered. Those returning to such an area suffer a –2 Living Conditions modifier (in addition to any existing modifiers) to their next Aging roll. In extreme cases some areas may develop a Malevolent Infernal aura (see *Realms of Power: The Infernal*, pages 11 and 15).
+> ## The Articles of War
+> 
+> The Church has issued two proclamations directly concerning the waging of war. The Peace of God (Pax Dei) attempts to protect certain classes of people who are to be exempt from violence. These are principally the poor, Churchmen, and merchants. The Truce of God (Treuga Dei) restricts the days on which war can be waged. This means that Fridays, Sundays, holy days, and Lent are exempt from fighting.
+> 
+> Breaking either the Pax Dei or the Treuga Dei is considered an unchristian act, as is the execution of prisoners. Captains fearful for their souls, and those who ask for the blessings of saints, do well to obey these articles of war, but easier paths are often more attractive.
+> 
+> ### Chevauchee
+> 
+> The chevauchee is a tactic used to weaken the resolve of a population and to provoke an army into confrontation. Enemy territory is ravaged, crops are burned, and the people are driven from their land to the relative safety of towns and castles. The chevauchee not only secures territory and supplies for the ravaging army but also denies them to the enemy. Even defending armies may leave destruction in their wake as they spoil crops and poison wells in order to deny the enemy. This tactic is used across Mythic Europe and the Levant.
+> 
+> Land put to chevauchee is subject to disease and famine, with farmland spoiled and livestock and population alike slaughtered. Those returning to such an area suffer a –2 Living Conditions modifier (in addition to any existing modifiers) to their next Aging roll. In extreme cases some areas may develop a Malevolent Infernal aura (see *Realms of Power: The Infernal*, pages 11 and 15).
 
 #### Mercenary Budget
 
-Living on the very edge of solvency is an expectation of the noble lifestyle. Fortunately, nobles see hiring mercenaries as an appropriate way to express wealth, and so mercenaries can be hired from the money usually spent on the luxuries of life like fine meals and entertainment. This does not low-
-
-## Allied Troops Table
-
-The proportion in the table below is applied as a modifier to the size of the noble's own vassal army. To be clear, a character must roll better than 12 to raise additional allied forces past his own core force.
-
-| Total | Proportion |  |
-|-------|------------|--|
-| 6     | Half       |  |
-| 12    | Equal      |  |
-| 18    | Double     |  |
-| 24    | Treble     |  |
-
-The following table suggests modifiers to this roll.
-
-| Situation                                                                                             | Modifier |
-|-------------------------------------------------------------------------------------------------------|----------|
-| Raising an army in winter                                                                             | –3       |
-| Raising an army around harvest                                                                        | –1       |
-| The same lord raised an army the previous season                                                      | –3       |
-| The same lord raised an army earlier in the same year<br>(not cumulative with previous season, above) | –1       |
-| Raising an army during an active crusade                                                              | –3       |
-| The lord has the Wealthy Virtue                                                                       | +1       |
-| The lord has the Poor Flaw                                                                            | –1       |
-| The lord has the Inspirational Virtue                                                                 | +3       |
-| The lord has the Difficult Underlings Flaw                                                            | –2       |
-| The lands of the affinity are under threat                                                            | +1       |
-| The lord is in revolt against his own liege                                                           | –2       |
-| The lord has a Major social Virtue                                                                    | +3       |
-| The lord has a Minor social Virtue                                                                    | +1       |
-| The lord has a Minor social Flaw                                                                      | –1       |
-| The lord has a Major social Flaw                                                                      | –3       |
-| The promise of wealth and/or title (the spoils from a<br>city, for instance)                          | +3       |
-
-er the living standard of the lord, although it may concern dependent characters in the lord's household. In times of peace a lord who spends all of his money on soldiers is considered a brute. In times of war, a man who spends too much of his money on anything but soldiers is seen as an adolescent.
+Living on the very edge of solvency is an expectation of the noble lifestyle. Fortunately, nobles see hiring mercenaries as an appropriate way to express wealth, and so mercenaries can be hired from the money usually spent on the luxuries of life like fine meals and entertainment. This does not lower the living standard of the lord, although it may concern dependent characters in the lord's household. In times of peace a lord who spends all of his money on soldiers is considered a brute. In times of war, a man who spends too much of his money on anything but soldiers is seen as an adolescent.
 
 The table below shows the average amount of money in Mythic Pounds that a noble may spend on mercenary troops based on his wealth.
 
+> ## Allied Troops Table
+> 
+> The proportion in the table below is applied as a modifier to the size of the noble's own vassal army. To be clear, a character must roll better than 12 to raise additional allied forces past his own core force.
+> 
+> | Total | Proportion |
+> |-------|------------|
+> | 6     | Half       |
+> | 12    | Equal      |
+> | 18    | Double     |
+> | 24    | Treble     |
+> 
+> The following table suggests modifiers to this roll.
+> 
+> | Situation                                                                                             | Modifier |
+> |-------------------------------------------------------------------------------------------------------|:--------:|
+> | Raising an army in winter                                                                             | –3       |
+> | Raising an army around harvest                                                                        | –1       |
+> | The same lord raised an army the previous season                                                      | –3       |
+> | The same lord raised an army earlier in the same year<br>(not cumulative with previous season, above) | –1       |
+> | Raising an army during an active crusade                                                              | –3       |
+> | The lord has the Wealthy Virtue                                                                       | +1       |
+> | The lord has the Poor Flaw                                                                            | –1       |
+> | The lord has the Inspirational Virtue                                                                 | +3       |
+> | The lord has the Difficult Underlings Flaw                                                            | –2       |
+> | The lands of the affinity are under threat                                                            | +1       |
+> | The lord is in revolt against his own liege                                                           | –2       |
+> | The lord has a Major social Virtue                                                                    | +3       |
+> | The lord has a Minor social Virtue                                                                    | +1       |
+> | The lord has a Minor social Flaw                                                                      | –1       |
+> | The lord has a Major social Flaw                                                                      | –3       |
+> | The promise of wealth and/or title (the spoils from a<br>city, for instance)                          | +3       |
+
 | Title        | Poor | Average | Wealthy |
-|--------------|------|---------|---------|
+|--------------|:----:|:-------:|:-------:|
 | Landed Noble | 0    | 2       | 5       |
 | Baron        | 0    | 40      | 100     |
 | Earl (Count) | 0    | 100     | 250     |
 | Duke         | 0    | 250     | 500+    |
 
-Characters lacking sufficient surplus money sometimes take out loans against their source of income. A character who is Poor may not do this. A character who is average may become Poor and in exchange borrow five times the average mercenary budget of someone of
+Characters lacking sufficient surplus money sometimes take out loans against their source of income. A character who is Poor may not do this. A character who is average may become Poor and in exchange borrow five times the average mercenary budget of someone of his class in coin. This loan may be paid off with the spoils of war or through stories.
 
+> ## Mercenary Units
+> 
+> The table below lists the costs of typical mercenary combat groups.
+> 
+> | Type      | Mythic Pounds | Value  |
+> |-----------|:-------------:|:------:|
+> | Knights   | 15            | Exp.   |
+> | Serjeants | 5             | Exp.   |
+> | Infantry  | 2             | Std.   |
+> | Archers   | 2             | Std.   |
+> | Levies    | 1             | Inexp. |
 
-## Mercenary Units
-
-The table below lists the costs of typical mercenary combat groups.
-
-| Type      | Mythic<br>Pounds | Value  |
-|-----------|------------------|--------|
-| Knights   | 15               | Exp.   |
-| Serjeants | 5                | Exp.   |
-| Infantry  | 2                | Std.   |
-| Archers   | 2                | Std.   |
-| Levies    | 1                | Inexp. |
-|           |                  |        |
-
-#### credit to pay those the character would like to pay, as well as (in either case) the power to collect the character's lands if he defaults on his loan. Some kings and banks have this much power, as do the bankers for the Church. Transactions of this magnitude may take many weeks to complete, and so are not suited to lightning war.
-
-In most areas lords cannot easily sell their land to raise extra funds. In those areas where the sales of lands is possible, the king's share of any transaction is often so large as to make the value of any such transaction questionable.
-
-## Winning the Battle from Afar
-
-These rules assume that player characters take an active and pivotal role in the fighting. Where this is not the case, the storyguide should simply decide the outcome of the battle, basing his decision on two factors. First, the demands of the wider story in which the battle figures, and second, the actions taken by player characters to influence the battle.
-
-## Crusaders
-
-The Church may also attempt to raise an army to crusade. It draws its funding from its own holy orders, the vassals on its own lands, and the obedience of those living under the protection of the Church. A character with the Senior Clergy Virtue (see *Realms of Power: The Divine*, page 93) is treated as having an affinity equal to the most prominent noble within his diocese or see. He makes a Holy Influence roll (see *Realms of Power: The Divine*, page 38) and compares his total to the Army Size Table.
-
-### Covenants
-
-Chapter Five of *Covenants* provides guidelines for the cost of maintaining an armed force. The prices of units listed here are only used when the covenant recruits additional mercenary forces. In this case, the covenant is restricted only in the amount of money it can raise or conjure.
-
-his class in coin. This loan may be paid off with the spoils of war or through stories.
+> ### Covenants
+> 
+> Chapter Five of *Covenants* provides guidelines for the cost of maintaining an armed force. The prices of units listed here are only used when the covenant recruits additional mercenary forces. In this case, the covenant is restricted only in the amount of money it can raise or conjure.
 
 A character who is Wealthy may become average and gain five times the difference between the Wealthy and average mercenary budgets for his class, or may become Poor and borrow five times the budget for a Wealthy person of his class.
 
-Note that these transactions depend on the availability of a banker with enough money to loan the character, or enough
+Note that these transactions depend on the availability of a banker with enough money to loan the character, or enough credit to pay those the character would like to pay, as well as (in either case) the power to collect the character's lands if he defaults on his loan. Some kings and banks have this much power, as do the bankers for the Church. Transactions of this magnitude may take many weeks to complete, and so are not suited to lightning war.
+
+In most areas lords cannot easily sell their land to raise extra funds. In those areas where the sales of lands is possible, the king's share of any transaction is often so large as to make the value of any such transaction questionable.
+
+> ## Winning the Battle from Afar
+> 
+> These rules assume that player characters take an active and pivotal role in the fighting. Where this is not the case, the storyguide should simply decide the outcome of the battle, basing his decision on two factors. First, the demands of the wider story in which the battle figures, and second, the actions taken by player characters to influence the battle.
+
+> ## Crusaders
+> 
+> The Church may also attempt to raise an army to crusade. It draws its funding from its own holy orders, the vassals on its own lands, and the obedience of those living under the protection of the Church. A character with the Senior Clergy Virtue (see *Realms of Power: The Divine*, page 93) is treated as having an affinity equal to the most prominent noble within his diocese or see. He makes a Holy Influence roll (see *Realms of Power: The Divine*, page 38) and compares his total to the Army Size Table.
 
 ## Heroic Endeavors
 
@@ -4549,34 +4210,30 @@ These rules use either the standard combat rules from ArM5, Chapter 11, or the o
 
 Before the battle, both armies vie for territorial advantage by generating a Deployment Total as they deploy their force.
 
-> **Deployment Total: Intelligence + Area Lore + Stress Die**
+**Deployment Total: Intelligence + Area Lore + Stress Die**
 
 If he wishes, an army commander may assign a lieutenant to determine the best ground. If the commander does this, the lieutenant generates the Deployment Total. If the commander is unhappy with his lieutenant's advice, he may then generate his own Deployment Total. However, if he does generate his own Deployment Total, the commander must use it, even if it is lower than his lieutenant's.
 
 Territorial advantage is calculated at the beginning of the battle based on each side's
 
-## The Flow of Battle
+> ## The Flow of Battle
+> 
+> Battles are carried out by following these steps:
+> 
+> - 1. Commanders determine Territorial Advantage.
+> - 2. The Weight of Numbers modifier is determined and assigned.
+> - 3. The storyguide assigns and plays out as a combat encounter a battlefield event for each participating player character in turn. After each battlefield event, the losses are counted on both sides and the Weight of Numbers modifier is optionally recalculated.
+> - 4. Victory is decided and the outcome of the battle is described.
 
-Battles are carried out by following these steps:
-
-- 1. Commanders determine Territorial Advantage.
-- 2. The Weight of Numbers modifier is determined and assigned.
-- 3. The storyguide assigns and plays out as a combat encounter a battlefield event for each participating player character in turn. After each battlefield event, the losses are counted on both sides and the Weight of Numbers modifier is optionally recalculated.
-- 4. Victory is decided and the outcome of the battle is described.
-
-## Knights Banneret and Mercenary Captains
-
-Characters with certain status or Virtues, such as a Knight Banneret or a Mercenary Captain, always treat their company as a single combat group regardless of any Weight of Numbers modifiers.
+> ## Knights Banneret and Mercenary Captains
+> 
+> Characters with certain status or Virtues, such as a Knight Banneret or a Mercenary Captain, always treat their company as a single combat group regardless of any Weight of Numbers modifiers.
 
 Deployment Totals, and does not change until one side surrenders the field.
 
 **Territorial Advantage: Deployment Total – Enemy Deployment Total**
 
-Storyguides should designate specific features on the battlefield (a chapel, a series
-
-
-
-of hills, a bridge, etc.). These provide the settings for battlefield events. The supernatural auras present should also be considered. Infernal auras, for instance, have damaging and insidious effects that cause wounds to open more easily or promote maltreatment of prisoners (see *Realms of Power: The Infernal*, page 10).
+Storyguides should designate specific features on the battlefield (a chapel, a series of hills, a bridge, etc.). These provide the settings for battlefield events. The supernatural auras present should also be considered. Infernal auras, for instance, have damaging and insidious effects that cause wounds to open more easily or promote maltreatment of prisoners (see *Realms of Power: The Infernal*, page 10).
 
 #### Using Magic to Seize Advantage
 
@@ -4586,17 +4243,13 @@ Magic aids in seizing territorial advantage, such as by misdirecting enemy troop
 
 The size of an army is measured in standard combat groups of five individuals. If the troupe's army outnumbers the enemy army, then the troupe gains a bonus to the event totals generated during this battle. If the enemy has the advantage, the troupe suffers a penalty. The magnitude of these bonuses and penalties are determined using the table beginning at the top of the next column.
 
-| Ratio of Army Sizes   | Bonus/Penalty |
-|-----------------------|---------------|
-| (rounded<br>n)<br>dow |               |
-|                       |               |
-
-| 1:1 | none |
-|-----|------|
-| 3:2 | ±1   |
-| 2:1 | ±2   |
-| 3:1 | ±3   |
-| 4:1 | ±4   |
+| Ratio of Army Sizes (rounded down) | Bonus/Penalty |
+|:----------------------------------:|:-------------:|
+| 1:1                                | none          |
+| 3:2                                | ±1            |
+| 2:1                                | ±2            |
+| 3:1                                | ±3            |
+| 4:1                                | ±4            |
 
 This bonus is calculated at the beginning of the battle but should be recalculated during the battle to account for losses on either side.
 
@@ -4608,11 +4261,11 @@ The storyguide decides how these battlefield events are spaced. Different events
 
 Wherever and whenever they are set, each stage of the battle has a target ease factor that increases as the battle wears on. While three events are typical, storyguides should feel free to vary this.
 
-| Description                   | Battle Ease<br>Factor |
-|-------------------------------|-----------------------|
-| Engaged                       | 9                     |
-| Advantage or Setback          | 12                    |
-| Imminent Victory or<br>Defeat | 15                    |
+| Description| Battle Ease Factor|
+|------------|:-----------------:|
+| Engaged | 9 |
+| Advantage or Setback | 12 |
+| Imminent Victory or Defeat | 15 |
 
 The troupe selects a focal player character for each stage of the battle, upon whose efforts the story is focused at that moment. That character attempts to win the event by calculating an Event Total at least equal to the Battle Ease Factor as below.
 
@@ -4624,10 +4277,7 @@ A character may choose a combination of Maneuver, Enemy, and Size that are not s
 
 **Event Bonus: Maneuver + Enemy + Size**
 
-For example, during the "Engaged" stage of a battle, a character with Stamina +2 and Leadership 4 with a Territorial Advantage of 1 and no Weight of Numbers bonus needs an
-
-
-Event Bonus of at least 2 in order to reach the Battle Ease Factor of 9.
+For example, during the "Engaged" stage of a battle, a character with Stamina +2 and Leadership 4 with a Territorial Advantage of 1 and no Weight of Numbers bonus needs an Event Bonus of at least 2 in order to reach the Battle Ease Factor of 9.
 
 The troupe is assumed to have the initiative (replacing the initiative roll) on starting a battlefield event, but may surrender the initiative for that event to gain a +1 bonus to the Event Total. Unless otherwise stated, each battlefield event lasts five combat rounds.
 
@@ -4677,8 +4327,7 @@ The Enemy of a battlefield event describes the kind of opponents the characters 
 
 #### Wounds and Attrition
 
-At the end of each battlefield event, the defeated side loses a number of combat groups equal to the event's Size characteristic multiplied by the winning side's Weight of Numbers bonus (if positive), representing the efforts of the winning side elsewhere
-
+At the end of each battlefield event, the defeated side loses a number of combat groups equal to the event's Size characteristic multiplied by the winning side's Weight of Numbers bonus (if positive), representing the efforts of the winning side elsewhere on the battlefield. The type of the units lost should match the event’s Enemy characteristic. (These losses are in addition to any losses sustained in the course of the event itself.)
 
 In addition, the commander of the losing side must make a Morale roll (see Chapter Nine: Optional Combat Rules) against Ease Factor 6. On a failure, the commander can attempt to rally his forces (Ease Factor 9) at the beginning of the next event. If this fails, apply the behaviors of Disordered or Routed groups to the losing army.
 
@@ -4688,7 +4337,7 @@ The Morale rules in Chapter Nine: Optional Combat Rules can also be applied duri
 
 #### Example Battlefield Events
 
-#### Skirmish
+**Skirmish**
 
 Event Bonus +0
 
@@ -4696,7 +4345,7 @@ Event Bonus +0
 
 (+0 Defend, +0 Lesser, +0 Inexpensive)
 
-#### Hold the Line
+**Hold the Line**
 
 Event Bonus +2
 
@@ -4706,19 +4355,17 @@ The character must receive the enemy charge and hold the line. The enemy group e
 
 (+0 Defend, +1 Even, +1 Standard)
 
-#### Rescue
+**Rescue**
 
 Event Bonus +5
 
 *Maneuver: Run the Gauntlet, Size: Lesser, Enemy: Special*
 
-
-
 One of the character's knights is thrown from his horse and rolls into the river. The character must rescue the knight before he drowns. Storyguides may require Athletics rolls to reach the river, Swim rolls to find the sinking knight, and further Athletics rolls to drag him to the side. Once the knight has been brought to the bank, there are be enemy troops to fight off. All rolls during this event are made with stress dice and have two botch dice. The event is lost if the knight drowns or the character is swept away in the rescue attempt. Use the deprivation rules on ArM5, page 180 to provide the maximum duration for this event.
 
 (+2 Run the Gauntlet, +0 Lesser, +3 Special)
 
-#### Loose
+**Loose**
 
 Event Bonus +5
 
@@ -4728,7 +4375,7 @@ The enemy cavalry round for a charge. The character's archer group must loose ar
 
 (+1 Attack, +2 Outnumbered, +2 Expensive)
 
-#### On All Sides
+**On All Sides**
 
 Event Bonus +5
 
@@ -4738,7 +4385,7 @@ The character and his combat group become separated from their unit and the enem
 
 (+0 Defend, +3 Overwhelmed, +2 Expensive)
 
-#### Ransom
+**Ransom**
 
 Event Bonus +6
 
@@ -4748,7 +4395,7 @@ The enemy captain is separated from his own formation. A single Expensive enemy 
 
 (+3 Take, +0 Lesser, +3 Special)
 
-#### Feint
+**Feint**
 
 Event Bonus +7
 
@@ -4758,7 +4405,7 @@ The character must take a small force and offer the enemy flank a target. He mus
 
 (+2 Run the Gauntlet, +3 Overwhelmed, +2 Expensive)
 
-#### Seize the Colors
+**Seize the Colors**
 
 Event Bonus +8
 
@@ -4768,7 +4415,7 @@ The enemy continually rally to their standard. If that can be taken, morale will
 
 (+3 Take, +2 Outnumbered, +3 Special)
 
-#### A "Heroic" Maneuver
+**A "Heroic" Maneuver**
 
 Event Bonus +9
 
@@ -4784,7 +4431,7 @@ make a Discipline roll (Ease Factor 9) to prevent their flank from being pulled 
 
 (+2 Run the Gauntlet, +3 Overwhelmed, +4 Baggage)
 
-#### Alone Against the Many
+**Alone Against the Many**
 
 Event Bonus +11
 
@@ -4794,7 +4441,7 @@ The character, alone, must defend the burning gatehouse for five rounds, prevent
 
 (+4 Heroic Gesture, +4 I Stand Alone, +3 Special)
 
-## The Aftermath of Battle
+### The Aftermath of Battle
 
 Each battle is fought over an objective such as to defend the town, take the bridge, or destroy the enemy siege engines. If the enemy concedes or loses outright, the objective is achieved. A successful battle earns the victorious characters one Confidence Point for each successful battlefield event whether they took part in that event or not. The leader of the army also gains 1 experience point towards an appropriate Reputation.
 
@@ -4802,38 +4449,37 @@ After a battle, the wounded are tended by the many chirurgeons amid the camp fol
 
 Prisoners taken on the battlefield face two very different fates depending on their class. Men of rank are usually ransomed, being stripped of arms and armor and released on assurance of payment. Soldiers of no standing are either executed (as Richard Lionheart did to 3,000 men at Acre) or mutilated. The kings of eastern Europe particularly use the blinding of captives as an example to others.
 
+> ## Standard Combat Groups
+> 
+> Groups of knights, serjeants, and infantry are treated as trained groups, while archer, levy, and baggage units are untrained, However, a group that serves together for a season is treated as trained thereafter. Each group is assumed to be five individuals.
+> 
+> | Unit     | Weapon                         | Init | Atk | Def | Dam | Soak | Group Bonus |
+> |----------|--------------------------------|:----:|:---:|:---:|:---:|:----:|:-----------:|
+> | Knight   | Lance, Heater Shield (M)       | +1   | +17 | +16 | +6  | +10  | +15         |
+> |          | Long sword, Heater Shield (M)  | +2   | +16 | +16 | +7  | +10  | +15         |
+> | Serjeant | Spear, Round Shield (M)        | +2   | +12 | +9  | +8  | +7   | +12         |
+> |          | Long sword, Round Shield (M)   | +1   | +10 | +8  | +7  | +7   | +12         |
+> | Infantry | Poleaxe                        | +1   | +13 | +7  | +13 | +5   | +9          |
+> |          | Mace, Round Shield             | +1   | +11 | +9  | +10 | +5   | +9          |
+> | Archer   | Bow                            | +0   | +10 | +6  | +8  | +1   | +0          |
+> |          | Bow, Long                      | –1   | +11 | +6  | +10 | +1   | +0          |
+> |          | Crossbow                       | +6   | +12 | +11 | +8  | +1   | +0          |
+> |          | Hatchet, Buckler               | +1   | +9  | +6  | +6  | +1   | +0          |
+> | Levy     | Spear, Round Shield            | +3   | +6  | +6  | +7  | +2   | +0          |
+> |          | Knife                          | +1   | +5  | +6  | +4  | +2   | +0          |
+> | Baggage  | Bludgeon                       | –2   | +5  | +1  | +5  | +3   | +0          |
+> 
+> ### Mercenary Troops
+> 
+> The table above lists the statistics for standard units of each type, but throughout the **Ars Magica** period there are also specialist troops from Welsh longbowmen to Flemish pikemen to Genoese crossbowmen. Their combat statistics may vary from those above and these soldiers are highly sought after as mercenaries. And of course, as this is Mythic Europe, there is always the potential for strange and supernatural units to be deployed by the ambitious or the unwary.
+> 
+> Most armies rely on mercenary forces for a large proportion of their skilled contingent. As can be expected of men paid to fight and kill, the conduct of many mercenary troops leaves much to be desired. Nearly thirty years ago, Richard Lionheart sought to create a paid standing army by employing professional soldiers for what was to be his final clash with the forces of Philip II of France. His army included Welsh men-at-arms, Brabantine mercenaries, and even Saracen fighters. Richard's knights received one shilling per day while his mounted serjeants received four pence per day, double the two pence per day earned by the infantry.
 
-Groups of knights, serjeants, and infantry are treated as trained groups, while archer, levy, and baggage units are untrained, However, a group that serves together for a season is treated as trained thereafter. Each group is assumed to be five individuals.
+Characters with some social standing may claim the ransoms that they capture on the battlefield, though lesser characters must usually forego such rights. Although magi are not protected by class etiquette, their power and influence is such that any magus captured in battle is likely to be ransomed to his covenant rather than killed or maimed.
 
-| Unit     | Weapon                              | Init | Atk | Def | Dam | Soak | Group<br>Bonus |
-|----------|-------------------------------------|------|-----|-----|-----|------|----------------|
-| Knight   | Lance, Heater<br>Shield (M)         | +1   | +17 | +16 | +6  | +10  | +15            |
-|          | Long sword,<br>Heater Shield<br>(M) | +2   | +16 | +16 | +7  | +10  | +15            |
-| Serjeant | Spear, Round<br>Shield (M)          | +2   | +12 | +9  | +8  | +7   | +12            |
-|          | Long sword,<br>Round Shield<br>(M)  | +1   | +10 | +8  | +7  | +7   | +12            |
-| Infantry | Poleaxe                             | +1   | +13 | +7  | +13 | +5   | +9             |
-|          | Mace, Round<br>Shield               | +1   | +11 | +9  | +10 | +5   | +9             |
-| Archer   | Bow                                 | +0   | +10 | +6  | +8  | +1   | +0             |
-|          | Bow, Long                           | –1   | +11 | +6  | +10 | +1   | +0             |
-|          | Crossbow                            | +6   | +12 | +11 | +8  | +1   | +0             |
-|          | Hatchet, Buckler                    | +1   | +9  | +6  | +6  | +1   | +0             |
-| Levy     | Spear, Round<br>Shield              | +3   | +6  | +6  | +7  | +2   | +0             |
-|          | Knife                               | +1   | +5  | +6  | +4  | +2   | +0             |
-| Baggage  | Bludgeon                            | –2   | +5  | +1  | +5  | +3   | +0             |
-
-#### Mercenary Troops
-
-The table above lists the statistics for standard units of each type, but throughout the **Ars Magica** period there are also specialist troops from Welsh longbowmen to Flemish pikemen to Genoese crossbowmen. Their combat statistics may vary from those above and these soldiers are highly sought after as mercenaries. And of course, as this is Mythic Europe, there is always the potential for strange and supernatural units to be deployed by the ambitious or the unwary.
-
-Most armies rely on mercenary forces for a large proportion of their skilled contingent. As can be expected of men paid to fight and kill, the conduct of many mercenary troops leaves much to be desired. Nearly thirty years ago, Richard Lionheart sought to create a paid standing army by employing professional soldiers for what was to be his final clash with the forces of Philip II of France. His army included Welsh men-at-arms, Brabantine mercenaries, and even Saracen fighters. Richard's knights received one shilling per day while his mounted serjeants received four pence per day, double the two pence per day earned by the infantry.
-
-Characters with some social standing may claim the ransoms that they capture on the battlefield, though lesser characters must usually forego such rights. Although magi
-
-are not protected by class etiquette, their power and influence is such that any magus captured in battle is likely to be ransomed to his covenant rather than killed or maimed.
-
-
-
-A young magus, stripped of his talisman, arrives at the covenant. He admits to having been caught up in a conflict through his own naivety and also confesses, to his shame, that he was captured and has been ransomed. His captor has promised the return of his talisman on receipt of something the magus simply cannot provide. He asks the covenant for help in securing both his talisman and his good name.
+> #Story Seed: A Wizard’s Ransom
+> 
+> A young magus, stripped of his talisman, arrives at the covenant. He admits to having been caught up in a conflict through his own naivety and also confesses, to his shame, that he was captured and has been ransomed. His captor has promised the return of his talisman on receipt of something the magus simply cannot provide. He asks the covenant for help in securing both his talisman and his good name.
 
 Battles are almost always fought during daylight hours, and forces usually retreat from the field as evening approaches. If the day is neither won nor lost, a temporary truce holds and the dead and wounded are collected from the field.
 
@@ -4843,31 +4489,31 @@ It is the attempt to capture castles that usually determines the paths of milita
 
 It is for the troupe to determine when a castle finally becomes indefensible. Player characters should always have the chance to turn things around, through story events. A castle may fall only to be retaken by a relief force or through player character subterfuge.
 
-## Castles
+> ## Magic on the Battlefield
+> 
+> The battlefield is a loud and confusing place. The potential targets of a magus's spells clash and intermix with his allies, constantly obscuring his view. A magus engaged in a battle must make a Concentration roll against an. Ease Factor of12 to cast spells. A magus who is not yet engaged or is standing off observing the melee must make an a Concentration roll against an Ease Factor of 9 in order to cast spells. A battle is always a stressful situation.
+> 
+> ### Target: Group
+> 
+> The Hermetic Group target represents a continuous recognizable group of up to ten individuals. This target is rarely useful in a battle. Although these rules describe combat groups as being of a set size, they are never so simply arranged on the battlefield, almost always instead presenting as a united mass with other troops. However, if a unit of any kind can be separated from the army then a spell using the Group target, with one magnitude spent to increase the size of of the target (to 100 individuals), then a spell can be cast to affect all combat groups within that unit.
+> 
+> ### Target: Boundary
+> 
+> The standard Boundary target covers an area roughly circular with a diameter of 100 paces. It must also be marked out by a well-defined natural or man-made boundary. This is rarely enough to encompass a complete battlefield and nor is the battlefield likely to conveniently marked out. Boosting the spell level by one magnitude increases the diameter to around 300 paces.
+
+> ## Example Battle
+> 
+> The forces of Milan are amassed against the troupe's larger Veronese army. Neither side gained Territorial Advantage in deploying their troops. The battle opens with an Ease Factor 9 battlefield event. The lead character for this event has a Stamina + Leadership (battle) of 5 and a +2 Weight of Numbers modifier. He needs an Event Bonus of +2 to reach the Ease Factor. The storyguide describes the enemy charge; the character must Hold the Line (+0 Defend, +1 Even, +1 Standard). As vanguard of his combat group the character engages in a combat encounter with a single enemy combat group that is smaller than his own (since his army outnumbers the enemy). Luck is on his side and the enemy group is quickly routed. The enemy is pushed back and takes losses.
+> 
+> Some time later, the fighting has intensified. The second character to lead an event has a Stamina + Leadership (battle) of 5 as well, and the Weight of Numbers modifier is still +2. But the Ease Factor is now 12, so an Event Bonus of at least +5 is required. The storyguide describes how the character's commander has become surrounded and is thrown from his horse. The Rescue event is used and provides the necessary +5 bonus. The character is successful at resolving the event and the army rallies to its commander.
+> 
+> Almost immediately, the enemy knights round for a charge on the left flank. The last character to lead an event, an experienced knight, has a Stamina + Leadership (battle) of 7, with the same +2 Weight of Numbers modifier. As the Ease Factor is now 15 he must have an Event Bonus worth +6. The enemy charge has left the enemy commander exposed. Seizing the opportunity, the character attempts to capture and Ransom (+3 Take, +0 Lesser, +3 Special) the enemy commander. While the character's combat group takes on the commander's bodyguards, the character engages in single combat with the commander. Despite taking wounds, the character knocks his opponent from his horse and forces surrender. With the fall of their commander the enemy troops either rout or submit to ransom and the day is won.
+
+### Castles
 
 Castles are described in detail in *Covenants*. A limited version of that material is repeated here.
 
-## Magic on the Battlefield
-
-The battlefield is a loud and confusing place. The potential targets of a magus's spells clash and intermix with his allies, constantly obscuring his view. A magus engaged in a battle must make a Concentration roll against an. Ease Factor of12 to cast spells. A magus who is not yet engaged or is standing off observing the melee must make an a Concentration roll against an Ease Factor of 9 in order to cast spells. A battle is always a stressful situation.
-
-#### Target: Group
-
-The Hermetic Group target represents a continuous recognizable group of up to ten individuals. This target is rarely useful in a battle. Although these rules describe combat groups as being of a set size, they are never so simply arranged on the battlefield, almost always instead presenting as a united mass with other troops. However, if a unit of any kind can be separated from the army then a spell using the Group target, with one magnitude spent to increase the size of of the target (to 100 individuals), then a spell can be cast to affect all combat groups within that unit.
-
-#### Target: Boundary
-
-The standard Boundary target covers an area roughly circular with a diameter of 100 paces. It must also be marked out by a well-defined natural or man-made boundary. This is rarely enough to encompass a complete battlefield and nor is the battlefield likely to conveniently marked out. Boosting the spell level by one magnitude increases the diameter to around 300 paces.
-
-## Example Battle
-
-The forces of Milan are amassed against the troupe's larger Veronese army. Neither side gained Territorial Advantage in deploying their troops. The battle opens with an Ease Factor 9 battlefield event. The lead character for this event has a Stamina + Leadership (battle) of 5 and a +2 Weight of Numbers modifier. He needs an Event Bonus of +2 to reach the Ease Factor. The storyguide describes the enemy charge; the character must Hold the Line (+0 Defend, +1 Even, +1 Standard). As vanguard of his combat group the character engages in a combat encounter with a single enemy combat group that is smaller than his own (since his army outnumbers the enemy). Luck is on his side and the enemy group is quickly routed. The enemy is pushed back and takes losses.
-
-Some time later, the fighting has intensified. The second character to lead an event has a Stamina + Leadership (battle) of 5 as well, and the Weight of Numbers modifier is still +2. But the Ease Factor is now 12, so an Event Bonus of at least +5 is required. The storyguide describes how the character's commander has become surrounded and is thrown from his horse. The Rescue event is used and provides the necessary +5 bonus. The character is successful at resolving the event and the army rallies to its commander.
-
-Almost immediately, the enemy knights round for a charge on the left flank. The last character to lead an event, an experienced knight, has a Stamina + Leadership (battle) of 7, with the same +2 Weight of Numbers modifier. As the Ease Factor is now 15 he must have an Event Bonus worth +6. The enemy charge has left the enemy commander exposed. Seizing the opportunity, the character attempts to capture and Ransom (+3 Take, +0 Lesser, +3 Special) the enemy commander. While the character's combat group takes on the commander's bodyguards, the character engages in single combat with the commander. Despite taking wounds, the character knocks his opponent from his horse and forces surrender. With the fall of their commander the enemy troops either rout or submit to ransom and the day is won.
-
-
+#### Every Castle Sends a Message
 
 Castles serve three functions. A castle acts as a refuge from military forces, so it defends territory. A castle acts as a staging ground for armies, so it threatens its neighbors. A castle costs a fortune to create and maintain, and in many places requires the permission of the king to build, so it communicates the status of its owner. A castle, then, is a claim to political power, backed with the threat of force.
 
@@ -4897,18 +4543,17 @@ A small tower cannot act as a staging area for large military groups, and alarms
 
 Minor castles may be selected by characters who are Landed or Great Nobles. Characters who maintain these castles must pay two pounds per year, out of the money that they are described as being able to spend frivolously in Chapter Two: Politics, to maintain their fortifications. They may also wish to hire extra guards, at the rate of one pound per man per year for mediocre servants.
 
-#### Shell Keep
+**Shell Keep**
 
 The shell keep is a modification of the motte-and-bailey castle. A motte is an artificial mound of earth, between ten and one hundred feet tall, on which a wooden tower is built. This tower overlooks and defends a courtyard that is surrounded by a ditch, embankment, and wooden palisade. This courtyard is called the bailey. Some noblemen still build motte-and-bailey castles in 1220.
 
 Most motte-and-bailey castles have been strengthened with stonework since their creation. A problem for a nobleman planning improvements is that the motte dominates the bailey, and so cannot be ignored, but is not strong enough to hold a stone tower keep of the style found in more modern castles. Such noblemen usually build a shell keep.
 
-A shell keep is a stone wall, usually two stories high, that replaces the wooden palisade atop the motte. The wall is thin compared to other fortifications, between eight and fifteen feet, and has a crenelated walkway. Some structures like this are so large that it is not clear if they are a shell keep or a small inner bailey: Restormel in Cornwall is 40 yards across. Within its ring, buildings are constructed. These are usually wooden,
-
+A shell keep is a stone wall, usually two stories high, that replaces the wooden palisade atop the motte. The wall is thin compared to other fortifications, between eight and fifteen feet, and has a crenelated walkway. Some structures like this are so large that it is not clear if they are a shell keep or a small inner bailey: Restormel in Cornwall is 40 yards across. Within its ring, buildings are constructed. These are usually wooden, or thin stone, and lack defensive use, but are far more spacious, airy, and comfortable to live in than those of a conventional keep. The center of the ring of buildings is usually a courtyard. 
 
 The wooden palisade around the bailey is also replaced, by a thick stone wall about ten feet high. This has a crenelated walk. Entry to the castle now lies through the lowest story of a square tower, two stories high.
 
-#### Tower Keep
+**Tower Keep**
 
 Most tower keeps were built during the 12th century and are, generally, four stories high and square or rectangular. Entry is via an external stairway to the second floor. The keep is usually topped with crenelated battlements. Newer keeps may be polygonal or, most recently, round, in profile.
 
@@ -4922,11 +4567,7 @@ Great castles are only held by Great Nobles or their officers. Players who selec
 
 A curtain wall is a crenelated wall around a bailey. The wall is around thirty feet high and between eight and twenty feet thick. It has an exterior of dressed stones and is filled with a rubble core. Mural towers protect a curtain wall.
 
-Most mural towers built before 1200 are square in cross-section. Round and semicircular towers are the preferred types for contemporary building. Most towers are enclosed buildings, but some — particularly semicircular towers — have no masonry on
-
-
-
-the inside face, so that if they are captured, they do not provide the enemy with cover. Others are closed until they reach the level of the parapet, and are then open.
+Most mural towers built before 1200 are square in cross-section. Round and semicircular towers are the preferred types for contemporary building. Most towers are enclosed buildings, but some — particularly semicircular towers — have no masonry on the inside face, so that if they are captured, they do not provide the enemy with cover. Others are closed until they reach the level of the parapet, and are then open.
 
 A castle may have as many mural towers as suits the troupe. Framlingham has 13 towers, including two for its gate, while others built at the same time are rectangular baileys with a fat tower at each corner and two at the gate. There are two disadvantages to having a dozen towers: they are expensive to build, maintain, and garrison, and they declare to all nearby nobles that their owner intends to rule the county someday. Every extra tower makes a castle more difficult to ignore.
 
@@ -4940,13 +4581,9 @@ A courtyard castle focuses on the defense of the bailey, forgoing a keep entirel
 
 A gatehouse keep is a large building, usually three stories high, that serves as gatehouse and keep for the castle. Its lowest level is given over to storage and the entry to the bailey. The middle level is used for living space, equipment for the drawbridge and portcullis, and murder holes. The lord and his family dwell on the uppermost level.
 
-#### Barbican and Moat
+**Barbican and Moat**
 
-A barbican, for game purposes, is a series of works that limit the access to the gate-
-
-#### Lords of Men
-
-house by an invader. This includes barbican walls and yards, which channel an invader into a narrow space overlooked by archers. It includes barriers like portcullises, drawbridges, fall-away causeways, murder holes, pit traps, and whatever other fiendish devices the player characters can come up with to kill invaders.
+A barbican, for game purposes, is a series of works that limit the access to the gatehouse by an invader. This includes barbican walls and yards, which channel an invader into a narrow space overlooked by archers. It includes barriers like portcullises, drawbridges, fall-away causeways, murder holes, pit traps, and whatever other fiendish devices the player characters can come up with to kill invaders.
 
 A moat is a body of water at least twenty feet wide and six feet deep that surrounds the castle. The key function of a moat is to prevent enemies from mining under the castle's walls. The walls can rise either directly from the moat, or from a berm, which is a small circuit of land that separates the moat and the castle. If the moat flows swiftly into a natural body of water, like a stream or lake, then its water is fresh. Otherwise, a moat is a stagnant ditch that is probably an open sewer. Many castles do not have moats, and instead use ditches. A moat has no upkeep fee; it's a free choice for characters with castles that have curtain walls.
 
@@ -4954,7 +4591,7 @@ Moats are often used to augment gate defenses. Some castles have a barbican on a
 
 A barbican and moat are included in the cost of a castle with curtain walls. A small castle lacking these features, but which has a barbican and moat, costs two pounds more than a normal small castle to maintain.
 
-## Describing Castles
+### Describing Castles
 
 A castle is described by three main characteristics: Garrison, Defenses, and Supplies. Each characteristic has a measure of quality and an interval. Intervals vary from "day" to "year," and the lowest interval pertaining to a given castle determines how often key siege events are played out when the castle is besieged.
 
@@ -4962,12 +4599,12 @@ A castle is described by three main characteristics: Garrison, Defenses, and Sup
 
 The castle Garrison is measured in combat groups, usually a combination of infantry and levies, though larger castles also include knights, serjeants, and archers.
 
-| Units         | Interval | Weight of<br>Numbers | Example                              |
-|---------------|----------|----------------------|--------------------------------------|
-| 10 or<br>less | Day      | +1                   | motte<br>and<br>bailey<br>castle     |
-| 11 to<br>20   | Week     | +2                   | small<br>castle                      |
-| 21 to<br>40   | Month    | +3                   | large<br>castle or<br>walled<br>town |
-| 41 or<br>more | Season   | +4                   | city                                 |
+| Units | Interval | Weight of Numbers | Example |
+|-------|----------|-------------------|---------|
+| 10 or less | Day | +1 | motte and bailey castle |
+| 11 to 20 | Week | +2 | small castle |
+| 21 to 40 | Month | +3 | large castle or walled town |
+| 41 or more | Season | +4 | city |
 
 The garrison units should be described as for field warfare. The defending garrison may also include siege engines (see Siege Engines).
 
@@ -4977,22 +4614,21 @@ Defenses describes both castle walls and other specific defensive engineering, e
 
 Permanent defensive enchantments also add +1 to the overall Defense Bonus.
 
-| Defense<br>Quality | Interval | Defense<br>Bonus | Example                          |
-|--------------------|----------|------------------|----------------------------------|
-| Shoddy             | Day      | +1               | Make<br>shift<br>defenses        |
-| Standard           | Week     | +2               | Any free<br>castle<br>choice     |
-| Superior           | Month    | +3               | Any<br>minor<br>castle<br>choice |
-| Excel<br>lent      | Season   | +4               | Any<br>great<br>castle<br>choice |
+| Defense Quality | Interval | Defense Bonus | Example |
+|-----------------|----------|---------------|---------|
+| Shoddy | Day | +1 | Makeshift defenses |
+| Standard | Week | +2 | Any free castle choice |
+| Superior | Month | +3 | Any minor castle choice |
+| Excellent | Season | +4 | Any great castle choice |
 
 Regardless of the castle's actual shape and construction, each castle is considered to have four sides or walls, corresponding to the cardinal compass points.
 
 The castle's size, along with its Defense Bonus, determines how many damage levels each wall has, according to the following table.
 
-
-| Size             | Example                                                | Damage<br>Level<br>Modifier |
-|------------------|--------------------------------------------------------|-----------------------------|
-| +5 to +8         | A house,<br>watch tower,<br>barbican, or<br>shell keep | 3                           |
-| +9 and<br>larger | A fortified<br>castle, town,<br>or city                | 4                           |
+| Size | Example | Damage Level Modifier |
+|------|---------|-----------------------|
+| +5 to +8 | A house, watch tower, barbican, or shell keep | 3 |
+| +9 and larger | A fortified castle, town, or city | 4 |
 
 The castle's Defense Bonus is multiplied by the damage level modifier from the above table to determine the castle's damage levels. The walls of a fortified city (taking the curtain walls great castle choice) each have 4 x 4 = 16 damage levels, while the walls of a tower keep have 3 x 3 = 9 damage levels.
 
@@ -5000,16 +4636,16 @@ The castle's Defense Bonus is multiplied by the damage level modifier from the a
 
 Supplies include the food, water, and raw materials stored inside the castle, and the ability of the castle to resupply itself. Castles are almost never completely cut off as a besieging army is rarely large enough to encircle what is often difficult and porous terrain.
 
-| Supply<br>Quality | Interval | Siege<br>Condi<br>tions<br>Bonus | Example                   |
-|-------------------|----------|----------------------------------|---------------------------|
-| Shoddy            | Week     | +1                               | Easily<br>surround<br>ed  |
-| Standard          | Month    | +3                               | Large<br>reserves         |
-| Superior          | Season   | +5                               | Situated<br>on a river    |
-| Excel<br>lent     | Year     | +7                               | Situated<br>on the<br>sea |
+| Supply Quality | Interval | Siege Conditions Bonus | Example |
+|----------------|----------|------------------------|---------|
+| Shoddy | Week | +1 | Easily surrounded |
+| Standard | Month | +3 | Large reserves |
+| Superior | Season | +5 | Situated on a river |
+| Excellent | Year | +7 | Situated on the sea |
 
 It is worth noting that a castle with excellent supplies is able to hold out against a siege for years. Stories providing the opportunity to improve or reduce the Supply Quality may be run, such as organizing a blockade to prevent resupply from the sea.
 
-## Life Under Siege
+### Life Under Siege
 
 A siege begins with the arrival of the attacking army in the area of the castle. This gives the defenders time to pull supplies and the garrison back inside the defenses. A castle keeps only those resources that support it during the siege; children, the sick, and the elderly are frequently sent from castles awaiting siege. Cities, being harder to stockade, have better supplies and rarely send their populations away. But this often means that they are more sensitive to deprivation than a garrison of soldiers, and may look to sue for terms with a besieging force.
 
@@ -5031,12 +4667,13 @@ A failed roll reduces the castle's supplies characteristic by one level, which i
 
 Unless a story event intervenes, the castle surrenders after failing a supplies roll while having shoddy supplies. Otherwise, all player characters in the besieged castle make deprivation checks as per ArM5, page 180.
 
+> ## Making Supply Rolls
+> 
+> If it's not important to track a given siege with great precision, instead of making individual rolls, consider rolling in batches. For example, for roll involving castle with shoddy supplies, roll four dice to quickly resolve the passing of a month. Or, if the castle has standard supplies, roll three dice each season.
 
-If it's not important to track a given siege with great precision, instead of making individual rolls, consider rolling in batches. For example, for roll involving castle with shoddy supplies, roll four dice to quickly resolve the passing of a month. Or, if the castle has standard supplies, roll three dice each season.
-
-## Story Seed: Refugees
-
-A nearby town is besieged and the some of the elderly, the young, and the infirm flee to the covenant for sanctuary. After granting them access, the covenfolk seem drawn to the town's plight. How do the magi contend with calls from the covenfolk to resupply the besieged town?
+> ## Story Seed: Refugees
+> 
+> A nearby town is besieged and the some of the elderly, the young, and the infirm flee to the covenant for sanctuary. After granting them access, the covenfolk seem drawn to the town's plight. How do the magi contend with calls from the covenfolk to resupply the besieged town?
 
 ### Siege Engines
 
@@ -5046,30 +4683,29 @@ Siege engines are used both to coney forces inside a castle and to bring down it
 
 A siege is represented in play through a series of decisive events. The first is played when the siege is first invested, with subsequent events at intervals determined by the lowest of the castle's characteristics.
 
-The besieging army is proactive and chooses how it will attack the castle. There are three options: undermining the walls, launching an artillery assault, or scaling the defenses. For its part, the castle garrison is rarely passive, and can respond to these tac-
-
-
-
-|           |      |     |     | Siege Engines |      |        |                  |      |
-|-----------|------|-----|-----|---------------|------|--------|------------------|------|
-|           | Init | Atk | Def | Dam           | Crew | Range  | Mythic<br>Pounds | Cost |
-| Ballista  | +5   | +5  | 6*  | +15**         | 3    | 50     | 5                | Exp. |
-| Mangonel  | –3   | +3  | 6*  | +20**         | 5    | 20–150 | 10               | Exp. |
-| Trebuchet | –4   | +1  | 6*  | +25**         | 5    | 50–200 | 15               | Exp. |
-
-<sup>\*</sup> As these engines are essentially static, the Defense is not rolled but is instead an Ease Factor.
-
-#### Notes
-
-**Ballista:** Reloading a ballista is a two-round Extended Action (as per the combat actions in Chapter Eight, Optional Combat Rules) that takes the full crew.
-
-**Mangonel and Trebuchet:** When used against castle walls, a mangonel or trebuchet use the rules described in the Artillery section. In standard combat, both of these weapons target combat groups rather than individuals. Reloading these weapons takes two minutes and requires the whole crew.
-
-The cost of these weapons in Mythic Pounds represents either the cost of building of them on-site or transporting them from a central armory. It also represents the cost of provisioning sufficient ammunition, which for the catapult devices, involves teams of quarrymen and an army of carts to transport stone to the engines.
-
-tics by sallying out, counter-mining, or even launching an artillery assault of their own. Attempts to gain entry through subterfuge and trickery are best left as roleplaying opportunities.
+The besieging army is proactive and chooses how it will attack the castle. There are three options: undermining the walls, launching an artillery assault, or scaling the defenses. For its part, the castle garrison is rarely passive, and can respond to these tactics by sallying out, counter-mining, or even launching an artillery assault of their own. Attempts to gain entry through subterfuge and trickery are best left as roleplaying opportunities.
 
 Unlike battles where victory can easily be decided, sieges have a natural lifespan and the castle garrison can not remain unsupported indefinitely. The rules for stockade as described above run alongside any military efforts.
+
+> ## Siege Engines
+> 
+> | Engine | Init | Atk | Def | Dam | Crew | Range | Mythic Pounds | Cost |
+> |--------|:----:|:---:|:---:|:---:|:----:|:-----:|:-------------:|------|
+> | Ballista | +5 | +5 | 6\* | +15\*\* | 3 | 50 | 5 | Exp. |
+> | Mangonel | –3 | +3 | 6\* | +20\*\* | 5 | 20–150 | 10 | Exp. |
+> | Trebuchet | –4 | +1 | 6\* | +25\*\* | 5 | 50–200 | 15 | Exp. |
+> 
+> \* As these engines are essentially static, the Defense is not rolled but is instead an Ease Factor.
+> 
+> \*\* Treated as non-combat damage (see ArM5, page 181).
+> 
+> #### Notes
+> 
+> **Ballista:** Reloading a ballista is a two-round Extended Action (as per the combat actions in Chapter Eight, Optional Combat Rules) that takes the full crew.
+> 
+> **Mangonel and Trebuchet:** When used against castle walls, a mangonel or trebuchet use the rules described in the Artillery section. In standard combat, both of these weapons target combat groups rather than individuals. Reloading these weapons takes two minutes and requires the whole crew.
+> 
+> The cost of these weapons in Mythic Pounds represents either the cost of building of them on-site or transporting them from a central armory. It also represents the cost of provisioning sufficient ammunition, which for the catapult devices, involves teams of quarrymen and an army of carts to transport stone to the engines.
 
 #### Troop Deployment
 
@@ -5089,34 +4725,29 @@ Starting at a safe distance from the walls, the mine, supported by wooden posts,
 
 If the castle has a moat treat the Defense Quality as one step higher for the purpose of determine the Defense Bonus. If the Mine Attack Total exceeds the Castle Defense, the mine attack is successful.
 
+> ## Story Seed: Construction
+> 
+> A powerful noble begins taking trees from a nearby magical forest to construct siege engines. If challenged, he agrees to stop, but at a price; he wants the magi to work their magic and breach the castle.
 
-<sup>\*\*</sup> Treated as non-combat damage (see ArM5, page 181).
-
-## Story Seed: Construction
-
-A powerful noble begins taking trees from a nearby magical forest to construct siege engines. If challenged, he agrees to stop, but at a price; he wants the magi to work their magic and breach the castle.
-
-## New Abilities
-
-#### Profession Sapper
-
-The planning and execution of tunneling operations to undermine castle walls is governed by the Ability Profession Sapper. It includes the siting of mines, the coordination of laborers, and the eventual firing of the tunnels. It also covers counter-mining activities, which are used to defend against the sapper's art. This Ability may not be used untrained, though characters with Profession Miner may conduct mining operations with three botch dice.
-
-**Specialities**: specific types of wall. (General)
-
-#### Profession Siege Engineer
-
-The Ability Profession Siege Engineer describes the ability to design and construct siege engines, as well as the understanding of defensive engineering. Most siege engineers oversee construction rather than construct the devices themselves. Siege engineers are in high demand from wealthy clients needing defenses against siege, and from armies needing to breach those defenses.
-
-**Specialities**: ballistae, mangonels, trebuchets, siege towers, castle walls. (Academic)
-
-#### Siege Weapon
-
-The Siege Weapon ability governs the operation of siege weapons, either individually for small engines, or as the leader of a crew for larger engines.
-
-**Specialities**: ballistae, mangonels, trebuchets. (Martial)
-
-#### Lords of Men
+> ## New Abilities
+> 
+> #### Profession Sapper
+> 
+> The planning and execution of tunneling operations to undermine castle walls is governed by the Ability Profession Sapper. It includes the siting of mines, the coordination of laborers, and the eventual firing of the tunnels. It also covers counter-mining activities, which are used to defend against the sapper's art. This Ability may not be used untrained, though characters with Profession Miner may conduct mining operations with three botch dice.
+> 
+> **Specialities**: specific types of wall. (General)
+> 
+> #### Profession Siege Engineer
+> 
+> The Ability Profession Siege Engineer describes the ability to design and construct siege engines, as well as the understanding of defensive engineering. Most siege engineers oversee construction rather than construct the devices themselves. Siege engineers are in high demand from wealthy clients needing defenses against siege, and from armies needing to breach those defenses.
+> 
+> **Specialities**: ballistae, mangonels, trebuchets, siege towers, castle walls. (Academic)
+> 
+> #### Siege Weapon
+> 
+> The Siege Weapon ability governs the operation of siege weapons, either individually for small engines, or as the leader of a crew for larger engines.
+> 
+> **Specialities**: ballistae, mangonels, trebuchets. (Martial)
 
 A successful mine attack reduces the castle's Defense Quality by one step. A botched defense roll reduces the Defense Quality an additional step while a botched attack kills the sapper's unit (or requires a rescue story event to save them).
 
@@ -5140,134 +4771,118 @@ The most direct way of assaulting a castle is the escalade, in which the attacki
 
 The besieging commander may either use an escalade to probe for weaknesses and thin the garrison, in which case a single battlefield event is played out in the current check interval. Alternatively, the attacker can attempt to take the castle in one battle, in which case the standard battle rules apply using the castle walls as a backdrop.
 
-In the case of an event where the attack-
+In the case of an event where the attacker simply tries to win the castle in a single battle, the defending garrison gains some advantages. The garrison characteristic's Weight of Numbers modifier is used in place of a Weight of Numbers modifier based on the defending side's quantity of units, and the castle's Defense Bonus is used in place of Territorial Advantage. In some cases, it is advisable for the attacking army to break down the defenses with undermining and artillery before attempting such an assault.
 
-## Option: External Defenses
+The battlefield events rules presented earlier in this chapter should be used to determine the outcome of an escalade assault, with the following modifications:
 
-Some castles have key defenses outside of their main structures that the attacking force must take before the castle itself can be assaulted. The Accursed Tower at the siege of Acre in 1191 is one such example. A separately purchased, additional minor castle can effectively be used to defend a larger partner. In these cases, the besieging army must first take the lesser defending structure before moving onto the main castle itself. Such features have their own Defense Bonus but rely on the larger castle's supplies and garrison.
+- The escalade involves only those troops assigned to the nominated wall.
+- Each victory by the attacking side reduces the castle's garrison characteristic by one step (beginning with the next siege event).
+- The attacking army must use a tower or ladders to scale any standing walls.
+- Baggage troops cannot be targeted by the attacking army.
 
-## Escalade Weapons and Defenses
+If the attacking army wins a battle against a shoddy wall they breach the castle, which then becomes the backdrop for a standard battle using the battle rules presented earlier in this chapter.
 
-Siege towers are built on wheeled bases that can be moved up against the castle walls. These allow troops to gain a foothold on the walls while protected from archers. A more direct route is to use ladders and ropes to scale the walls. This is much more dangerous but can be more quickly, and more troops advanced. A cat is a covered mobile shelter used to defend attacking troops from a castle garrison as they move into position at the base of the castle walls. Battering rams are treated as bludgeons. Using a ram against a castle door forces a stress check (see *City & Guild*, page 77) against the vanguard's Brawl attack total.
+> ## Option: External Defenses
+> 
+> Some castles have key defenses outside of their main structures that the attacking force must take before the castle itself can be assaulted. The Accursed Tower at the siege of Acre in 1191 is one such example. A separately purchased, additional minor castle can effectively be used to defend a larger partner. In these cases, the besieging army must first take the lesser defending structure before moving onto the main castle itself. Such features have their own Defense Bonus but rely on the larger castle's supplies and garrison.
 
-Incendiaries are used primarily by the defenders to dissuade attackers from scaling the walls. Boiling water, oil, and hot sand are all commonly used. Treat each of these as a bludgeon for the purposes of Initiative and Attack totals, but use the heat and corrosion table for damage (see ArM5, page 181). Of course, anything could conceivably be pitched over the walls in defense against an escalade, and troupes should feel free to explore their creativity.
+> ## Escalade Weapons and Defenses
+> 
+> Siege towers are built on wheeled bases that can be moved up against the castle walls. These allow troops to gain a foothold on the walls while protected from archers. A more direct route is to use ladders and ropes to scale the walls. This is much more dangerous but can be more quickly, and more troops advanced. A cat is a covered mobile shelter used to defend attacking troops from a castle garrison as they move into position at the base of the castle walls. Battering rams are treated as bludgeons. Using a ram against a castle door forces a stress check (see *City & Guild*, page 77) against the vanguard's Brawl attack total.
+> 
+> Incendiaries are used primarily by the defenders to dissuade attackers from scaling the walls. Boiling water, oil, and hot sand are all commonly used. Treat each of these as a bludgeon for the purposes of Initiative and Attack totals, but use the heat and corrosion table for damage (see ArM5, page 181). Of course, anything could conceivably be pitched over the walls in defense against an escalade, and troupes should feel free to explore their creativity.
 
-er simply tries to win the castle in a single battle, the defending garrison gains some advantages. The garrison characteristic's Weight of Numbers modifier is used in place
+#### Counterattack
 
+As a response to any besieging action, or as an action during stockade, the garrison may send out troops to attack the enemy directly. These actions have a Battle Ease Factor of 9. Neither Territorial Advantage nor Weight of Numbers apply The sallying force must leave the castle, reach their target, and return to the safety of the walls. The intention is to attack and eliminate certain troops (visible mining operations, siege artillery, etc ) A successful event removes those units from the enemy armty. The besieging baggage units are normally defended and so may not be targeted.
 
+The garrison may also use any siege engines it has to target the attacker's siege engines. Engines are targeted individually. Each hit forces a damage check against the attack total with damage levels lost according to the size of the attacking group. If not using the damage rules from *City & Guild*, assume that a single hit from a mangonel or trebuchet is enough to destroy a siege engine.
 
+> ## Example Siege Events
+> 
+> ### Scale the ladders
+> 
+> Event Bonus +7
+> 
+> *Man: Run the Gauntlet, Size: Overwhelmed, Enemy: Standard*
+> 
+> The character must scale the ladders while the defenders assault him with archery and boiling oil The character is third on the ladder, gaining partial cover from the two soldiers ahead of him It takes three rounds to reach the top of the ladder, each of which requires a Dexterity + Climb stress roll against Ease Factor 6 Once at the top, the character must stand his ground against a combat group of standard troops for two more rounds while the rest of his men arrive. 
+> 
+> (+2 Run the Gauntlet, +3 Overwhelmed, +2 Standard)
+> 
+> (+2 Run the Gauntlet, +3 Overwhelmed, +2 Standard)
+> 
+> ### open the gates
+> 
+> Event Bonus +8
+> 
+> *Man: Run the Gauntlet, Size: I Stand Alone, Enemy: Expensive*
+> 
+> Inside the castle (such as in the wake of the Scale the Ladders event described previously), the character spots a group of defenders shoring up the gates, which are under pressure from the attacking force on the outside. The character must tip boiling water onto them before the men-at-arms defending them scale the stairs and attack the character. Tipping the water takes a Strength + Athletics stress roll against Ease Factor 9. There are three botch dice. On a botch the character douses himself with the boiling water. The attacking force will arrive in three rounds. If the defenders are scattered by then, the attackers will be able to breach the gate.
+> 
+> (+2 Run the Gauntlet, +4 I Stand Alone, +2 Expensive)
+> 
+> ### Take the Marshal
+> 
+> Event Bonus +9
+> 
+> *Man: Take, Size: Overwhelmed, Enemy: Special*
+> 
+> The knight marshal controlling the castle rides at the head of three groups of knights attempting to charge down the character and his group. The character must bring the marshal down and either kill him or force his surrender To complicate matters, the character's escape route is blocked.
+> 
+> (+3 Take, +3 Overwhelmed, +3 Special)
 
-of.a.Weight.of.Numbers.modifier.based.on. the. defending. side's. quantity. of. units,. and. the.castle's.Defense.Bonus.is.used.in.place.of. Territorial.Advantage..In.some.cases,.it.is.advisable.for.the.attacking.army.to.break.down. the.defenses.with.undermining.and.artillery. before.attempting.such.an.assault.
-
-The. battlefield. events. rules. presented. earlier.in.this.chapter.should.be.used.to.determine.the.outcome.of.an.escalade.assault,. with.the.following.modifications:
-
-- The.escalade.involves.only.those.troops. assigned.to.the.nominated.wall. •
-- Each.victory.by.the.attacking.side.reduces.the.castle's.garrison.characteristic.by. one.step.(beginning.with.the.next.siege. event). •
-- The.attacking.army.must.use.a.tower.or. ladders.to.scale.any.standing.walls. •
-- Baggage. troops. cannot. be. targeted. by. the.attacking.army. •
-
-If.the.attacking.army.wins.a.battle.against. a.shoddy.wall.they.breach.the.castle,.which. then. becomes. the. backdrop. for. a. standard. battle.using.the.battle.rules.presented.earlier. in.this.chapter.
-
-#### counterattack
-
-As. a. response. to. any. besieging. action,. or.as.an.action.during.stockade,.the.garrison. may. send. out. troops. to. attack. the. enemy. directly.. These. actions. have. a. Battle. Ease. Factor. of. 9.. Neither. Territorial. Advantage. nor.Weight.of.Numbers.apply..The.sallying. force.must.leave.the.castle,.reach.their.tar-
-
-### Example Siege Events
-
-#### scale the ladders
-
-Event.Bonus.+7
-
-*Man: Run the Gauntlet, Size: Overwhelmed, Enemy: Standard*
-
-The. character. must. scale. the. ladders. while. the. defenders. assault. him. with. archery. and. boiling. oil.. The. character. is. third.on.the.ladder,.gaining.partial.cover. from. the. two. soldiers. ahead. of. him.. It. takes.three.rounds.to.reach.the.top.of.the. ladder,.each.of.which.requires.a.Dexterity. +.Climb.stress.roll.against.Ease.Factor.6.. Once.at.the.top,.the.character.must.stand. his.ground.against.a.combat.group.of.standard.troops.for.two.more.rounds.while.the. rest.of.his.men.arrive.
-
-(+2. Run. the. Gauntlet,. +3. Overwhelmed,.+2.Standard)
-
-#### open the gates
-
-Event.Bonus.+8
-
-*Man: Run the Gauntlet, Size: I Stand Alone, Enemy: Expensive*
-
-Inside.the.castle.(such.as.in.the.wake. of.the.Scale.the.Ladders.event.described. previously),.the.character.spots.a.group.of. defenders.shoring.up.the.gates,.which.are. under.pressure.from.the.attacking.force.on. the.outside..The.character.must.tip.boiling. water.onto.them.before.the.men-at-arms. defending.them.scale.the.stairs.and.attack. the. character.. Tipping. the. water. takes. a. Strength. +. Athletics. stress. roll. against. Ease.Factor.9..There.are.three.botch.dice.. On.a.botch.the.character.douses.himself. with.the.boiling.water..The.attacking.force. will.arrive.in.three.rounds..If.the.defenders. are.scattered.by.then,.the.attackers.will.be. able.to.breach.the.gate.
-
-(+2. Run. the. Gauntlet,. +4. I. Stand. Alone,.+2.Expensive)
-
-#### take t he Marshal
-
-Event.Bonus.+9
-
-*Man: Take, Size: Overwhelmed, Enemy: Special*
-
-The. knight. marshal. controlling. the. castle.rides.at.the.head.of.three.groups.of. knights. attempting. to. charge. down. the. character. and. his. group.. The. character. must. bring. the. marshal. down. and. either. kill.him.or.force.his.surrender..To.complicate.matters,.the.character's.escape.route. is.blocked.
-
-(+3. Take,. +3. Overwhelmed,. +3. Special)
-
-get,.and.return.to.the.safety.of.the.walls..The. intention. is. to. attack. and. eliminate. certain. troops.(visible.mining.operations,.siege.artillery,.etc.)..A.successful.event.removes.those.
-
-units. from. the. enemy. army.. The. besieging. baggage.units.are.normally.defended.and.so. may.not.be.targeted.
-
-The.garrison.may.also.use.any.siege.en-
-
-
-gines it has to target the attacker's siege engines. Engines are targeted individually. Each hit forces a damage check against the attack total with damage levels lost according to the size of the attacking group. If not using the damage rules from *City & Guild*, assume that a single hit from a mangonel or trebuchet is enough to destroy a siege engine.
-
-## Aftermath
+### Aftermath
 
 With the castle taken and the siege over, the castle's new masters decide on its fate. The behavior of the victor is something to be roleplayed, but castles and cities generally suffer more the longer they hold out. Those responsible for holding out against the siege risk being taken and killed. Other men of value are likely to be ransomed, either bring imprisoned locally or forced out of the castle as a hostage of the attacker. Civilians are likely to be robbed, and worse, by the victorious army. Unless they escape, the defending garrison is frequently hanged as an example to others.
 
 Depending on its location, its importance, and the needs of the wider campaign, it is is usual for the attacking force to appoint a governor and leave behind a force in the castle to secure it.
 
+> ## Siege Magic
+> 
+> On finding themselves besieged by a determined Milanese force, the magi of Castro Selvaggio worked together to create a number of spells and rituals to help them outlast their attackers. The following laboratory texts survived the sacking of the castle. It is not known precisely how the castle fell, but suspicion quickly fell upon the covenant's Milanese rivals.
+> 
+> ### Conjuration of Bread
+> 
+> CrHe 35
+> 
+> R: Touch, D: Mom, T: Group, Ritual
+> 
+> This ritual creates enough bread to support a moderately sized covenant for a season. The bread is a long-lived ciabatta which lasts if stored well. The ritual is enough to provide a +7 bonus to all Supply rolls made by a besieged castle in that season.
+> 
+> (Base 3, +1 Touch, +2 Group, +5 size)
+> 
+> ### Raise the Veronese Flag
+> 
+> CrIm 30
+> 
+> R: Voice, D: Sun, T: Group
+> 
+> This spell creates the illusion of ten Veronese men-at-arms manning the castle walls. Each soldier moves and speaks (though they seem to have Veronese accents, they form no intelligible words) but never strays from its post. Using this spell, the Veronese magi fooled the Milanese force into thinking that all of the castle walls were protected.
+> 
+> (Base 2, +2 Voice, +2 Sun, +2 Group, +2 movement and complexity)
+> 
+> ### Raise the Siege
+> 
+> ReMe 30
+> 
+> R: Arc, D: Sun, T: Ind
+> 
+> Given an arcane connection to the besieging commander, this spell suggests a pessimistic view of any siege assessment. The effect is not sudden, but rather, is reinforced through the day as the commander reviews the siege. On an Intelligence + Leadership simple roll against Ease Factor 12 the commander resists the suggestions made by the spell.
+> 
+> (Base 5, +4 Arc, +1 Sun)
+> 
+> ### Seal the Breach
+> 
+> CrTe 20
+> 
+> R: Touch, D: Mom, T: Ind, Ritual
+> 
+> This ritual conjures a section of wall in a shape marked out during the casting of the spell. It is designed to knit together with adjoining sections of existing fortifications to repair already standing walls. The spell is enough to repair a single section of wall collapsed through mining or artillery assault (restoring up to five damage levels).
+> 
+> (Base 3, +1 Touch, +2 size, +1 finesse, ritual minimum level 20)
 
-## Siege Magic
-
-On finding themselves besieged by a determined Milanese force, the magi of Castro Selvaggio worked together to create a number of spells and rituals to help them outlast their attackers. The following laboratory texts survived the sacking of the castle. It is not known precisely how the castle fell, but suspicion quickly fell upon the covenant's Milanese rivals.
-
-#### Conjuration of Bread
-
-CrHe 35
-
-R: Touch, D: Mom, T: Group, Ritual
-
-This ritual creates enough bread to support a moderately sized covenant for a season. The bread is a long-lived ciabatta which lasts if stored well. The ritual is enough to provide a +7 bonus to all Supply rolls made by a besieged castle in that season.
-
-(Base 3, +1 Touch, +2 Group, +5 size)
-
-#### Raise the Veronese Flag
-
-CrIm 30
-
-R: Voice, D: Sun, T: Group
-
-This spell creates the illusion of ten Veronese men-at-arms manning the castle walls. Each soldier moves and speaks (though they seem to have Veronese accents, they form no intelligible words) but never strays from its post. Using this spell, the Veronese magi fooled the Milanese force into thinking that all of the castle walls were protected.
-
-(Base 2, +2 Voice, +2 Sun, +2 Group, +2 movement and complexity)
-
-#### Raise the Siege
-
-ReMe 30
-
-R: Arc, D: Sun, T: Ind
-
-Given an arcane connection to the besieging commander, this spell suggests a pessimistic view of any siege assessment. The effect is not sudden, but rather, is reinforced through the day as the commander reviews the siege. On an Intelligence + Leadership simple roll against Ease Factor 12 the commander resists the suggestions made by the spell.
-
-(Base 5, +4 Arc, +1 Sun)
-
-#### Seal the Breach
-
-CrTe 20
-
-R: Touch, D: Mom, T: Ind, Ritual
-
-This ritual conjures a section of wall in a shape marked out during the casting of the spell. It is designed to knit together with adjoining sections of existing fortifications to repair already standing walls. The spell is enough to repair a single section of wall collapsed through mining or artillery assault (restoring up to five damage levels).
-
-(Base 3, +1 Touch, +2 size, +1 finesse, ritual minimum level 20)
-
-
-## Chapter Nine
-
-# Optional Combat Rules
+# Chapter Nine: Optional Combat Rules
 
 This chapter expands on the **Ars Magica Fifth Edition** combat rules to add many new possibilities, including tactical movement and mounted combat. Most of the new rules introduced here are presented as options that you can use in your saga if you want a more- ̶detailed combat system or disregard if you prefer to keep things simple.
 
@@ -5281,7 +4896,7 @@ This section introduces more formal rules that categorize common character actio
 
 Contrary to what their name suggests, combat rounds can be useful for situations other than combat. A storyguide can use them any time she wants to keep close track of what two or more characters are doing, moment-by-moment. They're best for scenes where the order of the characters' actions could affect the outcome. A chase scene, a certamen, or even a complicated courtly dance could all be resolved by dividing the action into rounds and having each character act once per round, in a specific order.
 
-## Initiative
+### Initiative
 
 The basics of initiative are explained in ArM5, pages 171–172.
 
@@ -5297,9 +4912,7 @@ If new characters approach a battle in progress, there's no need to roll Initiat
 
 An action is something a character can choose to do when it's his turn in the combat sequence. The ArM5 rules say that a character can act once per round (on his turn); these rules elaborate on what it means to "act." Normally, a character can perform one action on his turn.
 
-Actions include anything the storyguide
-
-agrees a character can reasonably do in about six seconds. Attacking is an action; so is casting a formulaic or spontaneous spell.
+Actions include anything the storyguide agrees a character can reasonably do in about six seconds. Attacking is an action; so is casting a formulaic or spontaneous spell.
 
 A character can only perform an action on his turn in the combat sequence.
 
@@ -5324,10 +4937,7 @@ It would be impossible to list every possible action, but some common examples i
 
 #### Reactions
 
-A common situation in combat arises when a character must immediately respond to some external event, such as making a Defense roll to avoid an enemy's attack or a
-
-
-Concentration roll to maintain a spell. These rolls are called reactions. Reactions are not actions and don't interfere with the character's ability to perform an action later in the same round.
+A common situation in combat arises when a character must immediately respond to some external event, such as making a Defense roll to avoid an enemy's attack or a Concentration roll to maintain a spell. These rolls are called reactions. Reactions are not actions and don't interfere with the character's ability to perform an action later in the same round.
 
 - A character can perform a reaction any time the storyguide asks him to, even if it's not the character's turn, and even if the character hasn't yet had his first turn since the battle began.
 - There is no limit to how many reactions a character can *attempt* in a round (though there may be practical limitations to how many he can successfully complete).
@@ -5378,6 +4988,7 @@ Alternatively, a character can perform up to four fast actions on his turn inste
 
 A character can only perform a fast action on the first round of an extended action, before actually starting the extended action. Once the extended action is begun, the character can't perform fast actions until after it's finished.
 
+Examples of fast actions:
 
 - Draw a weapon
 - Drop an item
@@ -5389,7 +5000,7 @@ A character can only perform a fast action on the first round of an extended act
 - Transform to or from heartbeast form (specifically, outer heartbeast form; see ArM5, page 92 and *Houses of Hermes: Mystery Cults*, page 22).
 - Shoot a readied bow or crossbow, if the troupe is using the optional ready missiles rules (see Option: Ready Missiles, later in this chapter).
 
-## Delaying Actions
+### Delaying Actions
 
 A character or group can choose to delay its action as it would delay its opportunity to act according to the regular rules of initiative (see ArM5, page 171). There are many reasons one might want to do this: a wary magus might be unsure of an opponent's motives and prefer not to make the first aggressive move, or a knight might choose to defend a narrow bridge, attacking the first enemy who tries to cross.
 
@@ -5401,11 +5012,7 @@ If more than one character has delayed his action, then the delaying character w
 
 If you are using the fast actions option, a character may choose to delay his action, his fast action, or both.
 
-The choice to delay an action does not
-
-
-
-change the character's order in the combat sequence in future turns.
+The choice to delay an action does not change the character's order in the combat sequence in future turns.
 
 **Example:** *A tavern confrontation between Paul the turb warrior and two ruffians, Alan and Bruce, comes to blows. Paul's player rolls well on Initiative, getting a 10. Alan's Initiative Total is 8 and Bruce's is 7. Paul gets to go first, but is not sure whether one ruffian, or both, will attack him. He only wants to hit the ones who swing at him, so he delays. Alan goes next, but isn't sure about taking on someone as tough as Paul, so he also delays, waiting for Bruce to make the first move. Bruce is more hot-headed, and attacks. Paul withstands the attack. Now all the characters who delayed their actions have a chance to respond, in descending order of Initiative Totals. Paul has the higher Initiative Total of the two characters who delayed, so he has the first choice to respond. He attacks Bruce and lands a hefty blow. Then Alan, who also delayed his action, gets to respond. He attacks Paul and misses. The first round of combat ends. On the next round, Paul's Initiative Total is still 10 and he still goes first. Combat proceeds according to the normal sequence (from highest to lowest Initiative Totals) unless someone decides to delay again.*
 
@@ -5433,11 +5040,7 @@ See Charging on Foot, later in this chapter, for rules on interrupting an oppone
 
 Note that it's only possible to interrupt an extended action in the round it is started, but keep in mind that an opponent's extended action can also be foiled by distracting him (see Extended Actions, earlier in this chapter).
 
-**Example:** *Marla the grog is patrolling a hallway in the covenant when she spots a cloaked intruder. The storyguide calls for initiative rolls. Marla's player rolls a 9 and the intruder's Initiative is 7. Marla draws her sword as a fast action and delays her action, waiting for the intruder to make the next move. The intruder bolts for the exit; Marla attempts to interrupt him and* 
-
-
-
-*move to cut off his retreat. The storyguide asks them both to roll Action Priority Totals using Quickness + Athletics – Encumbrance. Marla's player rolls well and gets a 16; the intruder only gets 11. Marla dashes ahead of the intruder and makes it to the door before him. The intruder's action was spent running for the door, even though he was beaten there, so the first round of combat ends. It's round two, and Marla's turn.*
+**Example:** *Marla the grog is patrolling a hallway in the covenant when she spots a cloaked intruder. The storyguide calls for initiative rolls. Marla's player rolls a 9 and the intruder's Initiative is 7. Marla draws her sword as a fast action and delays her action, waiting for the intruder to make the next move. The intruder bolts for the exit; Marla attempts to interrupt him and move to cut off his retreat. The storyguide asks them both to roll Action Priority Totals using Quickness + Athletics – Encumbrance. Marla's player rolls well and gets a 16; the intruder only gets 11. Marla dashes ahead of the intruder and makes it to the door before him. The intruder's action was spent running for the door, even though he was beaten there, so the first round of combat ends. It's round two, and Marla's turn.*
 
 #### Option: Fast Casting as Interruption
 
@@ -5449,7 +5052,7 @@ The main advantage to this option is that it makes interrupting actions and Fast
 
 The rules in this section allow troupes to handle characters' movement on the battlefield in as much or as little detail as they wish. Exact movement rates often don't matter, but in certain situations, such as when valiant knights charge through a hail of arrows to smite down enemy archers, distance and movement can make a great deal of difference to the story.
 
-## Moving in Combat
+### Moving in Combat
 
 Moving is an action. Characters can't move and attack in the same round, unless they are mounted and/or charging (see Charging on Foot and Mounted Movement, both later in this chapter). Also, note that characters who are engaged in combat (either in melee or in missile combat) must disengage in order to move (see Engaging and Disengaging, below).
 
@@ -5466,58 +5069,55 @@ A character who chooses to move as his action can choose any of the following ra
 
 **Run: 4 x (10 + Quickness – Encumbrance) paces per round**
 
-## Movement and Groups
+### Movement and Groups
 
 All of the movement rules in this chapter are written in terms of individual characters, but apply equally to groups. Groups of characters move together as a single unit. Their speed is that of the *slowest* member. They use the vanguard's Characteristics and Abilities to resolve any rolls related to movement.
 
-## Obstacles, Barriers, and Movement
+### Obstacles, Barriers, and Movement
 
 Do not worry about terrain unless doing so adds to the excitement of battle, rather than distracting from it.
 
-Difficult terrain significantly slows a character's movement. For simplicity, all difficult terrain slows movement to one-half normal speed (unless the storyguide chooses otherwise). Examples of difficult terrain include rubble, dense undergrowth, knee-deep water, and upward slopes steeper than about 45 degrees. Attack and Defense rolls, and
+Difficult terrain significantly slows a character's movement. For simplicity, all difficult terrain slows movement to one-half normal speed (unless the storyguide chooses otherwise). Examples of difficult terrain include rubble, dense undergrowth, knee-deep water, and upward slopes steeper than about 45 degrees. Attack and Defense rolls, and rolls related to movement, suffer an extra botch die when the character is on difficult terrain. If you are using the advanced group combat rules in this chapter, a group must make a Discipline check when it crosses difficult terrain.
 
-## Terrain Examples
-
-The following examples cover some common situations and can be used as a guide for other terrain types. Note that some terrain, like ice, can be both difficult and hazardous.
-
-#### Difficult Terrain
-
-Movement speed halved (round up), extra botch die.
-
-- Dense undergrowth
-- Ice
-- Rubble
-- Slope, upward, 45 degrees or steeper
-- Snow (knee-deep or deeper)
-- Water (knee-deep or deeper)
-
-#### Hazards
-
-Extra botch die (or dice), botch potentially more serious.
-
-- Ice
-- Mud, slippery
-- Precipice
-- Rock, loose or crumbly
-- Slope, upward or downward, 45 degrees or steeper
-- Ship or wagon, moving
-- Battlefield littered with bodies, broken weapons, etc.
-
-#### Obstacles
-
-Requires special action to move across.
-
-| Action                             | Action<br>Type | Stress<br>Roll           | Factor<br>Ease |
-|------------------------------------|----------------|--------------------------|----------------|
-| Force open a<br>normal door        | Ext.           | Str                      | 9              |
-| Force open<br>a reinforced<br>door | Ext.           | Str                      | 12             |
-| Open a door<br>or window           | Std.           | none<br>needed           | n/a            |
-| Pick a lock                        | 5-rd.<br>Ext.  | Dex +<br>Leger<br>demain | 12*            |
-
-<sup>\*</sup> See *City & Guild*, page 78, for more information.
-
-
-rolls related to movement, suffer an extra botch die when the character is on difficult terrain. If you are using the advanced group combat rules in this chapter, a group must make a Discipline check when it crosses difficult terrain.
+> ## Terrain Examples
+> 
+> The following examples cover some common situations and can be used as a guide for other terrain types. Note that some terrain, like ice, can be both difficult and hazardous.
+> 
+> ### Difficult Terrain
+> 
+> Movement speed halved (round up), extra botch die.
+> 
+> - Dense undergrowth
+> - Ice
+> - Rubble
+> - Slope, upward, 45 degrees or steeper
+> - Snow (knee-deep or deeper)
+> - Water (knee-deep or deeper)
+> 
+> ### Hazards
+> 
+> Extra botch die (or dice), botch potentially more serious.
+> 
+> - Ice
+> - Mud, slippery
+> - Precipice
+> - Rock, loose or crumbly
+> - Slope, upward or downward, 45 degrees or steeper
+> - Ship or wagon, moving
+> - Battlefield littered with bodies, broken weapons, etc.
+> 
+> ### Obstacles
+> 
+> Requires special action to move across.
+> 
+> | Action | Action Type | Stress Roll | Ease Factor |
+> |--------|-------------|-------------|-------------|
+> | Force open a normal door | Ext. | Str | 9 |
+> | Force open a reinforced door | Ext. | Str | 12 |
+> | Open a door or window | Std. | none needed | n/a |
+> | Pick a lock | 5-rd. Ext. | Dex + Legerdemain | 12\* |
+> 
+> \* See *City & Guild*, page 78, for more information.
 
 A hazard is a terrain feature that increases the likelihood of accidents. Slippery, crumbling, and moving surfaces (such as the deck of a ship) are the most common sorts of hazards. The edge of a cliff or a narrow bridge would also count as a hazard. Hazards do not slow movement, but they add one botch die (or more, at the storyguide's discretion) to any stress roll a character makes while on them. Furthermore, the effects of a botch are potentially more serious near a hazard. (See ArM5, page 7, for a discussion of botches and their effects.) Some terrain, such as slippery mud, is both difficult terrain and a hazard.
 
@@ -5534,7 +5134,7 @@ Once engaged, the character must disengage in order to move away from his oppone
 The details in this section clarify and elaborate on these definitions, and present some optional embellishments to them. Combat should work just as well if the storyguide just relies on those two rules and her own judgment.
 
 
-## Engaging in Combat
+### Engaging in Combat
 
 A character becomes engaged in combat whenever he is close enough to an enemy to attack or be attacked. The precise distance this represents depends on how the character and his enemy are armed.
 
@@ -5554,7 +5154,7 @@ When a character who's engaged tries to disengage and fails, then the character'
 
 Note that disengaging does not necessarily imply the character leaves combat. One could disengage from one opponent in order to move and engage another.
 
-
+#### Engagement and Defenders
 
 The defenders option (see ArM5, page 173) lets a character or group protect someone else in combat. This prevents anyone from attacking the character being protected.
 
@@ -5588,8 +5188,7 @@ A defender can only protect one other character, and only as long as that charac
 
 **Example:** *Ignatio the shield grog and Victor the redcap are carrying an urgent message when they are beset by three highwaymen, two armed with short spears and one with a bow. All players roll Initiative and the order in which the characters will act is: first highwayman, Victor, Ignatio, second highwayman (armed with the bow), third highwayman.*
 
-*The first highwayman attacks Victor and hits, inflicting a Light Wound. On Victor's turn, he activates an enchanted item he has (The Invisible Shield) that protects him from metal weapons. Ignatio is un-*
-
+*The first highwayman attacks Victor and hits, inflicting a Light Wound. On Victor's turn, he activates an enchanted item he has (The Invisible Shield) that protects him from metal weapons. Ignatio is unaware of this item and declares he will act as defender for Victor. The second highwayman shoots an arrow at Victor; Ignatio, as Victor’s defender, has an immediate chance to interrupt. Both Ignatio and the highwayman roll for action priority. Ignatio’s total is 11 (+1 Quickness + 7 Single Weapon Ability (including specialty) – 2 Encumbrance + 5 stress roll) versus the archer’s 8 (0 Quickness + 5 Bows Ability + 3 stress roll). Ignatio interrupts the shot, so the archer’s only choice is to shoot Ignatio instead of Victor, or waste his action entirely. He shoots Ignatio and hits, but Ignatio suffers no wound thanks to his impressive Soak score. Now the third highwayman attacks, and Ignatio gets to interrupt him. This time, the highwayman wins the action priority roll, so he slips past Ignatio and attacks Victor. However, his attack misses due to Victor’s magical ward.*
 
 *The second round begins. The first highwayman, who attacked Victor last round, tries to do so again. Ignatio is still acting as Victor's defender because being a defender is an extended action, and an extended action lasts until just before the character's next turn. Ignatio interrupts the attack, successfully this time. The first highwayman is now engaged with Ignatio, and has to attack Ignatio or forfeit his action. He swings and misses. Now it's Victor's turn. Victor feels he doesn't need Ignatio's protection any more, so he draws his sword and attacks the third highwayman (becoming engaged with him). Ignatio can no longer defend Victor against that opponent. On Ignatio's turn, Ignatio realizes that he and Victor are each engaged with one opponent, and decides his best option is to stop defending Victor and attack the first highwayman, with whom he's already engaged.*
 
@@ -5601,11 +5200,7 @@ Rules for disengaging from combat may be found on page 173 of ArM5. In the conte
 
 Disengaging is a reaction, not an action. A character must disengage whenever he attempts a move action while engaged.
 
-To disengage, a character must generate a Defense Total, and all opponents who attacked him since last round generate Attack Totals (as a reaction). If the character's Defense Total is greater than or equal to the highest Attack Total, the character may move normally. Otherwise, the character's movement stops and he remains engaged. The failed attempt to move still counts as his action for the round, so he can't perform an-
-
-
-
-other (except possibly a fast action).
+To disengage, a character must generate a Defense Total, and all opponents who attacked him since last round generate Attack Totals (as a reaction). If the character's Defense Total is greater than or equal to the highest Attack Total, the character may move normally. Otherwise, the character's movement stops and he remains engaged. The failed attempt to move still counts as his action for the round, so he can't perform another (except possibly a fast action).
 
 If a character fails to disengage and tries again the following round, he gains a +3 bonus to his Defense Total for his roll to disengage only. This bonus increases by +3 each round until the character escapes or combat ends, so, for instance, a character who tries to disengage for three consecutive rounds has a +6 bonus on the third round. The bonus resets to zero if the character attacks or performs some other action besides movement.
 
@@ -5623,11 +5218,7 @@ A character automatically ceases to be engaged in combat when any of the followi
 
 #### Option: Reckless Disengagement
 
-The requirement that a character disengage from combat assumes that a character's self-preservation impulse always prevents him from turning his back on an opponent in the midst of mortal combat. As an option, the storyguide can allow characters to disregard self-preservation and simply move
-
-#### Lords of Men
-
-away. As a consequence of this reckless act, the character's opponent gets a free attack and the character gets no Defense roll: his Defense Total is 0. Needless to say, this is extremely dangerous in most circumstances, but it may be a sensible thing to do if the character enjoys a magical immunity to his opponents' weapons.
+The requirement that a character disengage from combat assumes that a character's self-preservation impulse always prevents him from turning his back on an opponent in the midst of mortal combat. As an option, the storyguide can allow characters to disregard self-preservation and simply move away. As a consequence of this reckless act, the character's opponent gets a free attack and the character gets no Defense roll: his Defense Total is 0. Needless to say, this is extremely dangerous in most circumstances, but it may be a sensible thing to do if the character enjoys a magical immunity to his opponents' weapons.
 
 ## Attacking and Defending
 
@@ -5647,31 +5238,29 @@ On foot, a charging character gains a bonus to his melee Attack roll equal to hi
 
 It is less effective to charge across difficult terrain. A character who charges across difficult terrain can still move and attack in the same round, and must still spend a Fatigue level, but does *not* gain the Attack bonus.
 
-## Option: Condensed Notation for Combat Scores
-
-Players may find it convenient to write combat scores in "condensed notation." For each weapon, write two numbers for the Defense score, separated from each other by a slash. The first number is for the weapon only, and the second is for the weapon-shield combination. Label these lines as "weapon/ shield' (substituting the names of the specific weapon and shield in question, of course).
-
-It is a good idea to include a separate line on the character sheet that gives the Defense score for the character's shield (without weapons), which is needed against missile attacks.
-
-For example, the standard soldier (see ArM5, page 22) has the following condensed notation combat scores:
-
-Axe/Heater Shield: Init +0, Attack +12, Defense +9/+11, Damage +7
-
-Fist: Init –1, Attack +7, Defense +7, Damage +1
-
-Heater Shield: Defense +11
-
-This may not seem to save much space, but note that it covers all possible weapon/shield combinations, and there is no need to re-calculate combat scores if, for example, a combatant's shield breaks.
-
 See Mounted Combat, later in this chapter, for rules covering charging on horseback.
+
+> ## Option: Condensed Notation for Combat Scores
+> 
+> Players may find it convenient to write combat scores in "condensed notation." For each weapon, write two numbers for the Defense score, separated from each other by a slash. The first number is for the weapon only, and the second is for the weapon-shield combination. Label these lines as "weapon/ shield' (substituting the names of the specific weapon and shield in question, of course).
+> 
+> It is a good idea to include a separate line on the character sheet that gives the Defense score for the character's shield (without weapons), which is needed against missile attacks.
+> 
+> For example, the standard soldier (see ArM5, page 22) has the following condensed notation combat scores:
+> 
+> Axe/Heater Shield: Init +0, Attack +12, Defense +9/+11, Damage +7
+> 
+> Fist: Init –1, Attack +7, Defense +7, Damage +1
+> 
+> Heater Shield: Defense +11
+> 
+> This may not seem to save much space, but note that it covers all possible weapon/shield combinations, and there is no need to re-calculate combat scores if, for example, a combatant's shield breaks.
 
 #### Option: Interrupting a Charge
 
 If you are using the interrupting actions option (see Option: Interruption Actions, earlier in this chapter), a character who is charging on foot uses his Combat Ability as the relevant Ability in his Action Priority Total. The character who is interrupting should use Athletics if he's trying to move out of the way of the charge, or a Combat Ability if he's trying to attack the charging character. One may interrupt a charge using either missile or melee weapons.
 
 If you are not using the interrupting actions rule, you can still use this option. If you do so, a character who wants to interrupt a charge must delay his action, and can then attack in response to the charge.
-
-
 
 #### Option: Ready Missiles
 
@@ -5689,8 +5278,7 @@ A creature can only constrict a victim whose Size is less than its own. Constric
 
 As long as a grappling creature maintains the grapple, its opponent is considered deprived of air (see ArM5, page 180). The victim must make a Stamina check every thirty seconds, that is, every five rounds, or suffer the normal effects of deprivation. Constriction is a slow way to slay an opponent.
 
-
-## Defending
+### Defending
 
 Defending against an attack (that is, generating a Defense Total) is a reaction, not an action. A character who comes under attack nearly always gets a Defense roll, even if he doesn't see the attack coming (though he would suffer major penalties to his Defense Total in that case). There is no limit to the number of Defense rolls a player may make for his character in one round.
 
@@ -5706,11 +5294,7 @@ The only time a character doesn't get a Defense roll is when he's totally helple
 
 To make combat flow quicker and reduce the amount of arithmetic involved, you can replace the stress die in characters' Defense Totals with a constant value of 6. That is, characters don't roll Defense; Defense simply becomes something akin to an Ease Factor for the Attack roll.
 
-This option takes some of the variability out of combat. It eliminates the possibility of a Defense botch, but it also eliminates the possibility of a very high Defense roll warding off an otherwise unavoidable attack. It tends to make characters with powerful combat scores a bit more powerful with respect to
-
-
-
-weak combatants, because the weaker fighters normally rely on luck in order to win.
+This option takes some of the variability out of combat. It eliminates the possibility of a Defense botch, but it also eliminates the possibility of a very high Defense roll warding off an otherwise unavoidable attack. It tends to make characters with powerful combat scores a bit more powerful with respect to weak combatants, because the weaker fighters normally rely on luck in order to win.
 
 The storyguide should feel free to apply this option selectively, for example, only to non-player characters instead of player characters, or only to "cannon fodder" opponents and not to the main villains of the saga.
 
@@ -5742,6 +5326,7 @@ Shields may be combined with Evasion under certain circumstances. A shield helps
 
 You can use Evasion with the diceless defense option (see Option: Diceless Defense, earlier in this chapter); just replace the stress die in the Evasion Total with a constant value of 6.
 
+#### Option: Lasting Consequences of Serious Damage
 
 This optional rule was originally printed in *Art & Academe*, page 43.
 
@@ -5759,16 +5344,13 @@ Once in a while, it's all right for the storyguide to alter the outcomes of a di
 
 In that spirit, the storyguide can choose to reduce a Major Wound suffered by a character, and instead give him a less serious wound and a new Flaw representing some permanent maiming or disability. For example, the storyguide might replace an Incapacitating wound with a Heavy Wound and the Flaw Missing Hand.
 
-Defense botches are a good time to exercise this option. The storyguide might choose to use this option only for companions or magi, or only for the main character(s) in a given story, or no more once per character. It's important to treat all the players' characters fairly, so if you use this option to save one character but not another, be pre-
-
-
-pared to explain why. Better yet, discuss this option with your troupe and agree ahead of time how you'll use it in your saga.
+Defense botches are a good time to exercise this option. The storyguide might choose to use this option only for companions or magi, or only for the main character(s) in a given story, or no more once per character. It's important to treat all the players' characters fairly, so if you use this option to save one character but not another, be prepared to explain why. Better yet, discuss this option with your troupe and agree ahead of time how you'll use it in your saga.
 
 As a rule of thumb, an Incapacitating Wound can be reduced to a Heavy Wound plus a Minor Flaw, while a Fatal Wound can be reduced to either an Incapacitating Wound plus a Minor Flaw, or a Heavy Wound plus a Major Flaw. The storyguide should feel free to vary from that guideline as her judgment and the needs of the story dictate.
 
 Appropriate Flaws to apply with this option include:
 
-#### Minor Flaws
+**Minor Flaws**
 
 - Afflicted Tongue
 - Disfigured
@@ -5780,7 +5362,7 @@ Appropriate Flaws to apply with this option include:
 - Missing Hand
 - Palsied Hands
 
-#### Major Flaws
+**Major Flaws**
 
 - Blind
 - Crippled
@@ -5795,33 +5377,31 @@ This section expands on the brief treatment of mounted combat in **Ars Magica Fi
 Fighting from horseback is the dominant model throughout Mythic Europe. A mounted warrior enjoys the following benefits:
 
 - A mounted character gains a situational bonus to both Defense and melee Attacks equal to his Ride skill or +3,whichever is less. The Attack bonus applies to melee attacks only. Note that this bonus applies regardless of whether the mounted character's opponent is mounted or on foot.
-- A mounted character's steed gets to perform an action each round. For simplicity, this happens on the rider's turn in the combat sequence (which is easi-
-
-## Suggestions for Combat Botches
-
-The following are some suggested effects for combat botches, listed in roughly increasing order of severity.
-
-- Damage your weapon; make a stress check (see The Clash of Weapons, later in this chapter, or *City & Guild,* page 77).
-- Become disoriented; miss your next turn.
-- Stumble; −3 to Defense rolls until your next turn.
-- Horse panics (if mounted).
-- Shield breaks.
-- Drop your weapon or break a bowstring.
-- Collide with an ally; both suffer –3 to Defense until next turn.
-- Fall prone.
-- Weapon breaks.
-- Fall from horse (if mounted).
-- Twist an ankle; take a Light Wound and you cannot run or charge until it's healed.
-- Horse falls (if mounted).
-- Strike an ally.
-
-er than keeping track of a separate turn for the horse). Typically, a rider uses his action to attack and the horse uses its action to move. The rider decides which action comes first. Note that a mounted character must still disengage from combat in order to move away from an opponent.
+- A mounted character's steed gets to perform an action each round. For simplicity, this happens on the rider's turn in the combat sequence (which is easier than keeping track of a separate turn for the horse). Typically, a rider uses his action to attack and the horse uses its action to move. The rider decides which action comes first. Note that a mounted character must still disengage from combat in order to move away from an opponent.
 
 - Only a mounted character can properly wield a lance. For a dismounted fighter, a lance functions as a long spear, which is less effective.
 - A mounted charge has special benefits over a charge on foot: the horse, not the rider, expends a Fatigue level, and there are optional rules for unhorsing or knocking down the target. (See Charging on Horseback and Option: Shock of the Charge, both later in this chapter).
 - A rider can usually perform extended actions while his horse is moving, though doing so typically requires a Dexterity + Ride roll against an Ease Factor that depends on the horse's gait (see Effects of Mounted Movement, later in this chapter).
 
-## Untrained Mounts
+> ## Suggestions for Combat Botches
+> 
+> The following are some suggested effects for combat botches, listed in roughly increasing order of severity.
+> 
+> - Damage your weapon; make a stress check (see The Clash of Weapons, later in this chapter, or *City & Guild,* page 77).
+> - Become disoriented; miss your next turn.
+> - Stumble; −3 to Defense rolls until your next turn.
+> - Horse panics (if mounted).
+> - Shield breaks.
+> - Drop your weapon or break a bowstring.
+> - Collide with an ally; both suffer –3 to Defense until next turn.
+> - Fall prone.
+> - Weapon breaks.
+> - Fall from horse (if mounted).
+> - Twist an ankle; take a Light Wound and you cannot run or charge until it's healed.
+> - Horse falls (if mounted).
+> - Strike an ally.
+
+### Untrained Mounts
 
 The benefits of being mounted described in the previous section assume the character's steed is trained for battle. Most horses in Mythic Europe are trained only for riding, not combat.
 
@@ -5833,40 +5413,39 @@ An untrained horse automatically panics whenever it is engaged in melee. See Con
 
 A horse has four gaits, which are listed on the Mounted Movement Rates table. The horse can use any gait on a given round; there is no need to "build up speed" between being stationary one round and galloping the next.
 
-## Charging on Horseback
+### Charging on Horseback
 
 A mounted charge is similar to a charge on foot: the character can move and then attack in the same round, and gains a bonus to the Attack roll equal to the character's Combat Ability (in addition to the normal situational bonus for mounted combat, equal to the lesser of Ride Ability or +3). Of course, since a horse is faster than a human, a mounted charge can travel a greater distance than an infantry charge. Furthermore, it is the horse, not the rider, who expends a Fatigue level. If you are using the shock of the charge optional rule, the charge's target may be knocked sprawling by the impact.
 
 A rider cannot use exertion in the same round he charges; the whole point of a mounted charge is to take advantage of the horse's strength and mass, not the rider's. However, since a rider can always move and attack in the same round (unless engaged), it's possible to move on horseback and use exertion on either Attack or Defense. This can grant the same combat bonus as a charge (if the rider exerts on his Attack roll) but the horse doesn't have to spend a Fatigue level and the shock of the charge option doesn't come into play.
 
-
-## Mounted Movement Rates
-
-Horses have four gaits, each of which has a different movement rate.
-
-| Gait       | –3 or<br>less | –2 to<br>–1 | 0  | +1 to<br>+2 | +3 to<br>+4 | +5 |
-|------------|---------------|-------------|----|-------------|-------------|----|
-| Walk/Amble | 7             | 8           | 10 | 12          | 15          | 18 |
-| Trot       | 12            | 15          | 20 | 25          | 30          | 35 |
-| Canter     | 20            | 25          | 30 | 35          | 45          | 50 |
-| Gallop     | 30            | 40          | 50 | 60          | 70          | 80 |
-
-#### Effects of Mounted Movement
-
-A horse's gait affects a rider's ability to shoot missiles from horseback, the amount of damage taken for falling off the horse, the Ease Factor for the Dexterity + Ride roll needed to carry out extended actions, and, optionally, his Defense score against ranged attacks.
-
-A horse must make a Fatigue test every round it moves at a gallop.
-
-| Gait                  | Penalty<br>to Miss<br>ile<br>Attacks | Falling<br>Damage                   | Extended<br>Action Ease<br>Factor | Defensive<br>Bonus<br>(Optional) |
-|-----------------------|--------------------------------------|-------------------------------------|-----------------------------------|----------------------------------|
-| None (stationary)     | 0                                    | Horse's Size* +<br>stress die       | 0                                 | 0                                |
-| Walk/Amble or<br>Trot | −1                                   | (Horse's Size +<br>2)* + stress die | 6                                 | +1                               |
-| Canter                | −3                                   | (Horse's Size +<br>4)* + stress die | 9                                 | +3                               |
-| Gallop −6             | –6                                   | (Horse's Size +<br>6)* + stress die | 12                                | +6                               |
-
-\* The bonus (but not the die result) is doubled if the character falls on a hard surface, and halved if he lands on a soft surface like plowed earth.
-
 Like a foot charge, a mounted charge can't cross difficult terrain and still get the Attack bonus. However, a rider can move normally (i.e., without charging) and exert on Attack.
+
+> ## Mounted Movement Rates
+> 
+> Horses have four gaits, each of which has a different movement rate.
+> 
+> | Gait | –3 or less | –2 to –1 | 0 | +1 to +2 | +3 to +4 | +5 |
+> |------|:----------:|:--------:|:-:|:--------:|:--------:|:--:|
+> | Walk/Amble | 7 | 8 | 10 | 12 | 15 | 18 |
+> | Trot | 12 | 15 | 20 | 25 | 30 | 35 |
+> | Canter | 20 | 25 | 30 | 35 | 45 | 50 |
+> | Gallop | 30 | 40 | 50 | 60 | 70 | 80 |
+> 
+> ### Effects of Mounted Movement
+> 
+> A horse's gait affects a rider's ability to shoot missiles from horseback, the amount of damage taken for falling off the horse, the Ease Factor for the Dexterity + Ride roll needed to carry out extended actions, and, optionally, his Defense score against ranged attacks.
+> 
+> A horse must make a Fatigue test every round it moves at a gallop.
+> 
+> | Gait | Penalty to Missile Attacks | Falling Damage | Extended Action Ease Factor | Defensive Bonus (Optional) |
+> |------|:--------------------------:|----------------|:---------------------------:|:--------------------------:|
+> | None (stationary) | 0 | Horse's Size\* + stress die | 0 | 0 |
+> | Walk/Amble or Trot | −1 | (Horse's Size + 2)\* + stress die | 6 | +1 |
+> | Canter | −3 | (Horse's Size + 4)\* + stress die | 9 | +3 |
+> | Gallop | –6 | (Horse's Size + 6)\* + stress die | 12 | +6 |
+> 
+> \* The bonus (but not the die result) is doubled if the character falls on a hard surface, and halved if he lands on a soft surface like plowed earth.
 
 #### Option: Shock of the Charge
 
@@ -5882,6 +5461,7 @@ A rider with a cantled saddle, as used in tournaments or warfare, gains a +3 bon
 
 **Resist Charge While on Foot: Str + Size + Combat Ability + stress die vs. Damage Total (before Soak) + Size of attacker's horse**
 
+If the roll fails, the target falls from his horse or is knocked down. He lands prone, and may take additional damage from the fall (see Falling from Horseback, later in this chapter).
 
 #### Shooting Missiles from Horseback
 
@@ -5914,11 +5494,7 @@ A horse has a relatively low Defense score, at least compared to a knight or tra
 
 When a horse suffers a wound, the effects on the rider vary depending on the severity of the wound:
 
-• **Light Wound:** No effect on the rider; the horse's Wound Penalties don't hinder
-
-#### Lords of Men
-
-the rider's attacks.
+• **Light Wound:** No effect on the rider; the horse's Wound Penalties don't hinder the rider's attacks.
 
 - **Medium Wound:** The horse may panic; the rider must make a Presence + Ride roll vs. Ease Factor 9 to control it.
 - **Heavy Wound:** The horse rears or stumbles; the rider must make a Dexterity + Ride roll vs. Ease Factor 9 or fall from the saddle. The horse stops moving immediately and cannot charge or move faster than a trot. This aborts a charge, if one was in progress. Furthermore, the horse may panic; the rider must make a Presence + Ride roll vs. Ease Factor 9 to control it. A horse that sustains a Heavy Wound is usually euthanized after the battle.
@@ -5930,12 +5506,11 @@ Horses untrained for battle panic whenever they are engaged in melee. Any horse 
 
 **Maintain or Regain Control of Panicked Horse: Presence + Ride vs. Ease Factor 6 – horse's total Wound Penalties**
 
-A rider may roll once as a reaction the moment his horse panics. If that roll fails, the rider may make another attempt as an action, and may keep trying until he succeeds. Once controlled, the horse remains under con-
+A rider may roll once as a reaction the moment his horse panics. If that roll fails, the rider may make another attempt as an action, and may keep trying until he succeeds. Once controlled, the horse remains under control until something new causes it to panic again.
 
-## Story Seed: The Wounded Steed
-
-A knight and his men arrive at the covenant looking for a learned man to heal his horse, wounded in battle weeks previously. On investigating the wound, which stubbornly refuses to heal, the magi find that it was magically inflicted and cannot heal until the next full moon. What's more, the knights carry the bag of a redcap known to the covenant. How did the horse pick up its injury and how have the knights come to possess the redcap's bag?
-
+> ## Story Seed: The Wounded Steed
+> 
+> A knight and his men arrive at the covenant looking for a learned man to heal his horse, wounded in battle weeks previously. On investigating the wound, which stubbornly refuses to heal, the magi find that it was magically inflicted and cannot heal until the next full moon. What's more, the knights carry the bag of a redcap known to the covenant. How did the horse pick up its injury and how have the knights come to possess the redcap's bag?
 
 A panicked horse usually attempts to disengage from combat and gallop to safety, but there is one important exception. The natural instinct of a wounded or frightened horse is to surge *forward* as fast as possible. If a horse is injured in mid-charge (such as by an opponent's delayed action under an optional rule) and panics, its rider can complete the charge normally. The horse is still panicked, and behaves accordingly starting on the following round.
 
@@ -5978,14 +5553,13 @@ If a horse is Incapacitated, killed, or knocked prone or unconscious, the rider 
 
 To avoid this, the rider may attempt to leap from the saddle as a reaction. If this fails, the character takes falling damage and must make a Quickness + Ride – Encumbrance + stress die roll vs. Ease Factor 6. If that also fails, the horse lands on the rider, inflicting stress die + horse's Size + 6 damage. The character is also pinned under the horse, requiring another character to make a Strength roll vs. Ease Factor (6 + (horse's Size) to pull him out.
 
-
 ## Battlefield Situations
 
 Conditions on the battlefield are everchanging. Characters in an **Ars Magica** story might take cover against arrows, defend a crenelated wall, or fight a desperate melee in the darkness of an underground catacomb. This section provides suggestions and guidelines for how to make these dramatic situations affect the outcome of battle.
 
 These rules are meant to add a greater tactical dimension to combat. Do not feel obliged to use them if your troupe is uninterested in such things. They do make combat more complex and potentially more timeconsuming to play. They are best applied with imagination and dramatic flair. Ideally, players should visualize the battlefield and come up with creative ways for their characters to gain an advantage.
 
-## General Situational Modifiers
+### General Situational Modifiers
 
 Most battlefield situations boil down to a bonus to Attack or Defense rolls (or both). The bonus may apply only to a limited subset of rolls: for example, a bonus to Defense against missile attacks, or a bonus to Attack rolls with one-handed melee weapons.
 
@@ -5993,11 +5567,11 @@ Storyguides can assign any numeric value to a situational modifier, but it is of
 
 Situational modifiers are best expressed as bonuses or penalties that apply to the character in the unusual situation. It is clearer to say "a character in a tree gets a +3 bonus to Defense" than to say "enemies attacking a character in a tree get a –3 penalty to Attack," even though the two statements are mathematically equivalent.
 
-
+### Specific Situations
 
 It would be impossible to enumerate every possible combat situation that could arise from the imaginations of players and storyguides. Instead, players should handle unforeseen situations by analogy with these examples.
 
-#### COVER
+#### Cover
 
 Strictly speaking, cover refers to shelter that is sturdy enough to actually stop incoming attacks. (Material that merely hides the character from view, such as foliage or a tapestry, is called concealment in these rules. See Concealment, Darkness, and Invisibility, later in this chapter.)
 
@@ -6005,27 +5579,25 @@ The Defense bonus from cover applies against both missile and melee attacks.
 
 If a character has both cover and concealment, only the highest Defense bonus applies.
 
-| Amount of<br>Cover | Defense<br>Bonus | Example                                                    |
-|--------------------|------------------|------------------------------------------------------------|
-| One-quarter        | +3               | Standing<br>behind a<br>slender tree                       |
-| One-half           | +6               | Standing<br>behind a corner<br>or in an open<br>doorway    |
-| Three-<br>quarters | +9               | Standing<br>behind a chest-<br>high wall                   |
-| Near total         | +12              | Standing<br>behind a<br>loophole or a<br>door that is ajar |
+| Amount of Cover | Defense Bonus | Example |
+|-----------------|---------------|---------|
+| One-quarter | +3 | Standing behind a slender tree |
+| One-half | +6 | Standing behind a corner or in an open doorway |
+| Three-quarters | +9 | Standing behind a chest-high wall |
+| Near total | +12 | Standing behind a loophole or a door that is ajar |
 
-## CONCEALMENT, DARKNESS, AND INVISIBILITY
+#### Concealment, Darkness, and Invisibility
 
 Armies in Mythic Europe usually avoid fighting in darkness or fog. Such conditions make it nearly impossible to command an army (at least, through non-magical means). In an **Ars Magica** story, of course, characters may find themselves battling diabolists in the gloom of an underground temple or ambushing intruders amid a magically created fog.
 
-Whenever a character is difficult to see, whether that difficulty arises from darkness, a screen of foliage, or magical invisibility,
+Whenever a character is difficult to see, whether that difficulty arises from darkness, a screen of foliage, or magical invisibility, he gains a bonus to Defense (or Evasion). If he can attack in melee without becoming clearly visible, he also gains an Attack bonus — it's hard to defend against an attack one doesn't see coming. The extent of the bonus depends on how well concealed the character is.
 
-he gains a bonus to Defense (or Evasion). If he can attack in melee without becoming clearly visible, he also gains an Attack bonus — it's hard to defend against an attack one doesn't see coming. The extent of the bonus depends on how well concealed the character is.
-
-| Con-<br>ceal-<br>ment | Examples                                                                                 | Melee Attack Bonus | Defense Bonus |
-|-----------------------|------------------------------------------------------------------------------------------|--------------------|---------------|
-| Light                 | Fog, shadows,<br>moonlight,<br>underbrush,<br>half of body<br>concealed                  | +1                 | +3            |
-| Medium                | Smoke, faint<br>moonlight,<br>dense foliage,<br>three-quarters<br>of body con-<br>cealed | +3                 | +6            |
-| Heavy                 | Typical dark<br>night                                                                    | +6                 | +9            |
-| Total                 | Lightless<br>underground<br>cave                                                         | +9                 | +9            |
+| Concealment | Examples | Melee Attack Bonus | Defense Bonus |
+|-------------|----------|--------------------|---------------|
+| Light | Fog, shadows, moonlight, underbrush, half of body concealed | +1 | +3 |
+| Medium | Smoke, faint moonlight, dense foliage, three-quarters of body concealed | +3 | +6 |
+| Heavy | Typical dark night | +6 | +9 |
+| Total | Lightless underground cave | +9 | +9 |
 
 These bonuses and penalties apply to both the attacker and the defender.
 
@@ -6033,28 +5605,25 @@ Houses of Hermes: Societates, pages 32–33, gives detailed rules for using invi
 
 Also, characters who can't clearly see their allies or surroundings suffer extra botch dice to Attack and Defense. A single extra botch die would be appropriate on a foggy, but otherwise open, battlefield, while as many as four or five botch dice could be called for in a chaotic nighttime melee in a forest. Darkness tends to make difficult or hazardous terrain disproportionately worse; rocky ground that adds one botch die in daylight might add three in the dark. This is one of the reasons the mundanes of Mythic Europe avoid fighting at night.
 
-#### HIGHER GROUND
+#### Higher Ground
 
 When a character is fighting from an elevated position, whether he is atop a castle rampart or a tavern staircase, he enjoys an advantage that often translates to a +1 bonus to Attack and Defense in both melee and missile combat against opponents lower than himself.
 
 Mounted characters do not normally qualify for this bonus, because height advantage is already accounted for in the usual bonus for mounted combat (see ArM5, page 174). However, a horseman charging down a steep embankment would qualify for the higher-ground bonus.
 
-## Light Sources and Range of Visibility
-
-How well a character can see an opponent, and at what distance, can make a difference for missile combat. Poor visibility grants increasing levels of concealment to characters at greater distances. At the storyguide's discretion, a Perception roll of 9+ can sometimes reduce (by one step) the level of concealment due to poor visibility.
-
-The table below gives the longest range in paces at which a given level of concealment applies. For example, in moonlight a character would have medium concealment at a range of twenty paces, and heavy concealment between 21 and 50 paces (though the storyguide shouldn't feel compelled to calculate distances to the exact pace!).
-
-| Conditions         | None | Light | MEDIUM | HEAVY | Total |
-|--------------------|------|-------|--------|-------|-------|
-| Moonlight          | n/a  | 0     | 20     | 50    | 100   |
-| Torchlight         | 3    | 5     | 10     | 15    | 25    |
-| Heavy Rain         | 10   | 20    | 30     | 50    | 100   |
-| Fog                | n/a  | 0     | 20     | 40    | 80    |
-| Heavy Smoke or Fog | n/a  | 0     | 2      | 4     | 10    |
-|                    |      |       |        |       |       |
-
-
+> ## Light Sources and Range of Visibility
+> 
+> How well a character can see an opponent, and at what distance, can make a difference for missile combat. Poor visibility grants increasing levels of concealment to characters at greater distances. At the storyguide's discretion, a Perception roll of 9+ can sometimes reduce (by one step) the level of concealment due to poor visibility.
+> 
+> The table below gives the longest range in paces at which a given level of concealment applies. For example, in moonlight a character would have medium concealment at a range of twenty paces, and heavy concealment between 21 and 50 paces (though the storyguide shouldn't feel compelled to calculate distances to the exact pace!).
+> 
+> | Conditions | None | Light | Medium | Heavy | Total |
+> |------------|:----:|:-----:|:------:|:-----:|:-----:|
+> | Moonlight | n/a | 0 | 20 | 50 | 100 |
+> | Torchlight | 3 | 5 | 10 | 15 | 25 |
+> | Heavy Rain | 10 | 20 | 30 | 50 | 100 |
+> | Fog | n/a | 0 | 20 | 40 | 80 |
+> | Heavy Smoke or Fog | n/a | 0 | 2 | 4 | 10 |
 
 #### Fighting Indoors and in Narrow Spaces
 
@@ -6075,11 +5644,7 @@ There are no specific bonuses for fighting indoors, but indoor battlefields comm
 
 This section is an optional replacement for the non-lethal combat rules on ArM5, pages 174-175. It makes two significant changes to non-lethal combat: there are a greater variety of non-lethal attacks and maneuvers possible, and unarmed attacks (scuffling) no longer cause Fatigue loss.
 
-The reasons these rules replace Fatigue loss from scuffling combat with a new mechanic is that, in the standard ArM5 scuffling rules, depleting an opponent's Fatigue levels can be quicker and easier than inflict-
-
-#### Lords of Men
-
-ing serious wounds with weapons. In ArM5, creatures can sustain an unlimited number of wounds and still fight (at least until the end of the battle, after which a wounded character's activities become restricted as described on ArM5, page 178). Contrariwise, all creatures have a fairly limited reserve of Fatigue levels and are helpless once those are depleted. The loss of a single Fatigue level is therefore potentially more serious than a single Light Wound. Against magi, knights who are already tired, or creatures who are hard to seriously injure (due to large Size, high Soak, or both), the standard ArM5 scuffling rules make it much faster to wear an opponent down by causing Fatigue loss than by inflicting wounds. This chapter fixes that problem and ensures that bare-knuckled punches are always less effective than the blows of a mace.
+The reasons these rules replace Fatigue loss from scuffling combat with a new mechanic is that, in the standard ArM5 scuffling rules, depleting an opponent's Fatigue levels can be quicker and easier than inflicting serious wounds with weapons. In ArM5, creatures can sustain an unlimited number of wounds and still fight (at least until the end of the battle, after which a wounded character's activities become restricted as described on ArM5, page 178). Contrariwise, all creatures have a fairly limited reserve of Fatigue levels and are helpless once those are depleted. The loss of a single Fatigue level is therefore potentially more serious than a single Light Wound. Against magi, knights who are already tired, or creatures who are hard to seriously injure (due to large Size, high Soak, or both), the standard ArM5 scuffling rules make it much faster to wear an opponent down by causing Fatigue loss than by inflicting wounds. This chapter fixes that problem and ensures that bare-knuckled punches are always less effective than the blows of a mace.
 
 ### Non-Lethal Damage: Bruises
 
@@ -6087,9 +5652,7 @@ Instead of inflicting loss of Fatigue levels, or wounds as regular weapons do, n
 
 The word "Bruise" doesn't mean the character literally suffers a bruise to the flesh, though that can be a result. The term is meant to suggest trauma that, while certainly painful and debilitating, is less lifethreatening than typical wounds. However, a very severe Bruise can cause a character to be Incapacitated and even eventually die.
 
-Calculate Damage from a non-lethal at-
-
-tack as usual, by subtracting the target's Soak score from the Damage Total. Consult the Damage Table on ArM5, page 171, but instead of suffering a wound, the target suffers a Bruise of the same level of severity.
+Calculate Damage from a non-lethal attack as usual, by subtracting the target's Soak score from the Damage Total. Consult the Damage Table on ArM5, page 171, but instead of suffering a wound, the target suffers a Bruise of the same level of severity.
 
 The Bruise Table shows the penalties for each category of Bruise, and its recovery statistics. The most severe categories of Bruises leave regular wounds behind after the character recovers from the Bruise itself.
 
@@ -6103,39 +5666,35 @@ After resting for the required Recovery Period, make a Recovery roll for each Br
 
 If the Recovery Total equals or exceeds the Improvement Ease Factor for the Bruise, the Bruise improves to the next category. Heavy and worse Bruises leave residual wounds behind. The wound takes effect only *after* the Bruise improves for the first time; apply its Wound Penalty only then. Note that a single Bruise only leaves a single wound; an Incapacitating Bruise does not leave a Medium Wound when it heals to being a Heavy Bruise, and then a Light Wound when it heals to being a Medium Bruise; rather, the character is left with a single Medium Wound.
 
-For purposes of Ritual magical healing, a Bruise is considered equivalent to the residual wound it would leave. Both the Bruise and the residual wound are healed by the same
+For purposes of Ritual magical healing, a Bruise is considered equivalent to the residual wound it would leave. Both the Bruise and the residual wound are healed by the same Ritual. For example, *Chirurgeon's Healing Touch* could instantly heal a Heavy Bruise, leaving neither Bruise nor wound behind.
 
-|                |             | Bruise Table         |                            |                   |
-|----------------|-------------|----------------------|----------------------------|-------------------|
-| Bruise Level   | Penalty     | Recovery<br>Interval | Improvement<br>Ease Factor | Residual<br>Wound |
-| Light          | ̶1          | Quarter Hour         | 10                         | None              |
-| Medium         | ̶3          | One Hour             | 12                         | None              |
-| Heavy          | ̶5          | Two Hours            | 15                         | Light Wound       |
-| Incapacitating | Unconscious | Two Hours            | 15                         | Medium<br>Wound   |
-| Fatal          | Unconscious | Two Hours            | 15                         | Incapacitating    |
+> ## Bruise Table
+> 
+> | Bruise Level | Penalty | Recovery Interval | Improvement Ease Factor | Residual Wound |
+> |--------------|:-------:|:-----------------:|:-----------------------:|:--------------:|
+> | Light | –1 | Quarter Hour | 10 | None |
+> | Medium | –3 | One Hour | 12 | None |
+> | Heavy | –5 | Two Hours | 15 | Light Wound |
+> | Incapacitating | Unconscious | Two Hours | 15 | Medium Wound |
+> | Fatal | Unconscious | Two Hours | 15 | Incapacitating |
 
-
-
-## Your Arms are Too Short to Box with that Giant
-
-*Realms of Power: Magic* proposes, on page 85, a different way to represent the unlikelihood of defeating a fifty-foot dragon by means of fisticuffs. The rules in that book are less a wholesale change to unarmed combat than the material presented here, and they are compatible with the scuffling rules in ArM5.
-
-The **Ars Magica Fifth Edition** combat rules are oriented toward characters of human size. Some special considerations apply to combat between humans and giants (or other very large creatures). As noted on ArM5, page 192, a 3-point difference in Size is approximately a tenfold difference in mass. This weight advantage gives giants an advantage in certain combat situations. For instance, it does not seem plausible that a 175-pound man should have an easy time grappling and pinning a 1,750-pound giant!
-
-The storyguide can simply rule that attempting to punch, grapple, or disarm a giant is completely ineffective. For a more complicated, but less arbitrary, approach, use the following rule of thumb: a giant gains a special bonus equal to double the difference between its Size and a smaller opponent's Size, which is applied to Defense rolls against scuffling and grappling, Defense rolls against being disarmed, and so on. This bonus does not apply against regular attacks with melee or missile weapons, however.
-
-Ritual. For example, *Chirurgeon's Healing Touch* could instantly heal a Heavy Bruise, leaving neither Bruise nor wound behind.
+> ## Your Arms are Too Short to Box with that Giant
+> 
+> *Realms of Power: Magic* proposes, on page 85, a different way to represent the unlikelihood of defeating a fifty-foot dragon by means of fisticuffs. The rules in that book are less a wholesale change to unarmed combat than the material presented here, and they are compatible with the scuffling rules in ArM5.
+> 
+> The **Ars Magica Fifth Edition** combat rules are oriented toward characters of human size. Some special considerations apply to combat between humans and giants (or other very large creatures). As noted on ArM5, page 192, a 3-point difference in Size is approximately a tenfold difference in mass. This weight advantage gives giants an advantage in certain combat situations. For instance, it does not seem plausible that a 175-pound man should have an easy time grappling and pinning a 1,750-pound giant!
+> 
+> The storyguide can simply rule that attempting to punch, grapple, or disarm a giant is completely ineffective. For a more complicated, but less arbitrary, approach, use the following rule of thumb: a giant gains a special bonus equal to double the difference between its Size and a smaller opponent's Size, which is applied to Defense rolls against scuffling and grappling, Defense rolls against being disarmed, and so on. This bonus does not apply against regular attacks with melee or missile weapons, however.
 
 ### Weapons and Bruises
 
-Characters may use weapons to inflict Bruises rather than wounds, but suffer a −3 penalty to their Attack Total when they do
-
+Characters may use weapons to inflict Bruises rather than wounds, but suffer a −3 penalty to their Attack Total when they do so, due to the awkwardness of striking with the flat of the blade or the butt of the spear.
 
 As an option, your troupe may wish to allow bludgeons, clubs, staves, improvised weapons (such as bottles and chairs), and cudgels (but not maces and hammers) to deal Bruises without an Attack penalty.
 
 Wooden practice swords, brittle tournament lances, and the like also inflict Bruises instead of wounds, with no Attack penalty.
 
-## Special Effects
+### Special Effects
 
 Sometimes the best way to defeat an enemy is not to wound him, but to disarm him or drag him off his horse. Resolve such indirect forms of attack by making a regular Attack roll, opposed by a reaction (usually Defense) from the target. Each maneuver requires a certain Attack Advantage in order to succeed. If the attacker achieves or exceeds the required Attack Advantage, the maneuver succeeds. In special maneuvers, either character can use exertion on either attack or defense as usual.
 
@@ -6147,22 +5706,20 @@ A trip or throw causes the defender to fall prone while the attacker remains sta
 
 A grapple inflicts no damage, but holds the defender so he can't escape and his actions are hindered. The defender is caught in a hold or lock that lasts until the start of the attacker's next turn. After that, the attacker must succeed at a new grapple to maintain the hold. The grappled defender suffers a –6 penalty on all attacks and most reactions, including Defense and Evasion, and can't perform spellcasting gestures. He can escape by succeeding at a grapple of his own, or by inflicting any level of wound or Bruise on the character who's holding him. It is possible to grapple while prone.
 
-A pin can hold the target to either the ground or to a wall or vertical surface (such
+A pin can hold the target to either the ground or to a wall or vertical surface (such as a large tree). To pin a target to the ground, he must be prone first, and while the attacker may be standing initially, he also becomes prone during the pin attempt (regardless of whether it succeeds or fails). If the pin succeeds, the defender is helpless and cannot perform any actions (except casting spells or activating enchanted items, provided they do not require gestures). The pin lasts until the attacker's next action, when he must succeed at a new pin to keep the defender immobilized.
 
-
-
-| Example Maneuver | Attack Total              | Defense Choices                                                   | Advantage<br>Required |
-|------------------|---------------------------|-------------------------------------------------------------------|-----------------------|
-| Trip or Throw    | Brawl Attack              | Defense, Evasion, or stress<br>die + Dex + Brawl + Size           | 3                     |
-| Grapple          | Brawl Attack              | Defense, Evasion, or stress<br>die + Str + Brawl + Size           | 1                     |
-| Pin              | Brawl Attack              | Brawl, Defense, Evasion, or<br>stress die + Str + Brawl<br>+ Size | 6                     |
-| Tackle           | Brawl Attack              | Defense, Evasion, or stress<br>die + Dex + Brawl + Size           | 1                     |
-| Disarm           | Any Attack                | Defense<br>or Evasion                                             | 9                     |
-| Grab Worn Item   | Brawl Attack              | Defense, Evasion, or stress<br>die + Str + Brawl + Size           | 6                     |
-| Unseat Rider     | Brawl or<br>Weapon Attack | Defense, Evasion, or stress<br>die + Dex + Ride                   | 6                     |
-| Wrest Weapon     | Brawl Attack              | Defense, Evasion, or<br>Melee Attack                              | 12                    |
-
-as a large tree). To pin a target to the ground, he must be prone first, and while the attacker may be standing initially, he also becomes prone during the pin attempt (regardless of whether it succeeds or fails). If the pin succeeds, the defender is helpless and cannot perform any actions (except casting spells or activating enchanted items, provided they do not require gestures). The pin lasts until the attacker's next action, when he must succeed at a new pin to keep the defender immobilized.
+> ## Example Maneuvers Table
+> 
+> |Example Maneuver | Attack Total | Defense Choices | Advantage Required |
+> |------------------|:------------:|-----------------|:------------------:|
+> | Trip or Throw | Brawl Attack | Defense, Evasion, or stress die + Dex + Brawl + Size | 3 |
+> | Grapple | Brawl Attack | Defense, Evasion, or stress die + Str + Brawl + Size | 1 |
+> | Pin | Brawl Attack | Brawl, Defense, Evasion, or stress die + Str + Brawl + Size | 6 |
+> | Tackle | Brawl Attack | Defense, Evasion, or stress die + Dex + Brawl + Size | 1 |
+> | Disarm | Any Attack | Defense or Evasion | 9 |
+> | Grab Worn Item | Brawl Attack | Defense, Evasion, or stress die + Str + Brawl + Size | 6 |
+> | Unseat Rider | Brawl or Weapon Attack | Defense, Evasion, or stress die + Dex + Ride | 6 |
+> | Wrest Weapon | Brawl Attack | Defense, Evasion, or Melee Attack | 12 |
 
 A tackle causes the attacker and his opponent to fall prone. No damage results. If the tackle fails, both characters remain standing, but if the attacker botches, he falls. Getting up is an action.
 
@@ -6182,16 +5739,14 @@ Any group can learn to fight together by spending a season practicing together. 
 
 **Shorten Training Time: Communication + Leadership + stress die**
 
-The Ease Factor depends on the amount of training time available. If the roll fails, then
+The Ease Factor depends on the amount of training time available. If the roll fails, then the group cannot become a trained group until the end of the season. If it botches, then the season's training is wasted. Some Virtues, such as Inspirational, may provide a bonus if the storyguide sees fit; the Difficult Underlings Flaw most likely provides a penalty.
 
-## Story Seed: Big Angus and the Prize
-
-The task was simple: guard the money while the magi took the merchant aside to negotiate prices. But after some confusion with a band of acrobats, one thing led to another and now the money has gone missing. But there's hope. The grogs can win the amount they lost by defeating Big Angus the prize fighter in bare-knuckle fight. The townfolk say it can't be done, but that's only because no one has ever beaten Big Angus before. Is there more to Big Angus than meets the eye? And what do the grogs do when they find out that the prize money has gone missing? On whom do the grogs vent their frustrations — the fight organizers, or the acrobats who started the whole misadventure?
-
-the group cannot become a trained group until the end of the season. If it botches, then the season's training is wasted. Some Virtues, such as Inspirational, may provide a bonus if the storyguide sees fit; the Difficult Underlings Flaw most likely provides a penalty.
+> ## Story Seed: Big Angus and the Prize
+> 
+> The task was simple: guard the money while the magi took the merchant aside to negotiate prices. But after some confusion with a band of acrobats, one thing led to another and now the money has gone missing. But there's hope. The grogs can win the amount they lost by defeating Big Angus the prize fighter in bare-knuckle fight. The townfolk say it can't be done, but that's only because no one has ever beaten Big Angus before. Is there more to Big Angus than meets the eye? And what do the grogs do when they find out that the prize money has gone missing? On whom do the grogs vent their frustrations — the fight organizers, or the acrobats who started the whole misadventure?
 
 | Training Time | Ease Factor |
-|---------------|-------------|
+|---------------|:-----------:|
 | Two Months    | 6           |
 | Six Weeks     | 9           |
 | One Month     | 12          |
@@ -6202,14 +5757,11 @@ The characters being trained still gain experience only at the end of the season
 
 ### The Leader's Actions
 
-Issuing orders to command a group in combat is usually a fast action. (If you are not using the fast actions option, then the group leader can make one command-related die roll per round for free.) The leader acts at the same point in the combat sequence as the rest of the group. In cases where it matters whether the group acts first or the leader
+Issuing orders to command a group in combat is usually a fast action. (If you are not using the fast actions option, then the group leader can make one command-related die roll per round for free.) The leader acts at the same point in the combat sequence as the rest of the group. In cases where it matters whether the group acts first or the leader ters whether the group acts first or the leader makes the Leadership roll first, the leader gets to decide the order in which the dice are rolled.
 
-
-*Story Seed: The Greatest Weapon*
-
-While practicing on the training field just outside the covenant enclosure, the turb becomes the target for some faerie sport. Whisked from their covenant by a court of faerie knights, the grogs are confronted by martial challenges, one by one, and told by their tormentors that they may use their best weapon in each fight. How long until the grogs discover that teamwork may be their greatest weapon?
-
-ters whether the group acts first or the leader makes the Leadership roll first, the leader gets to decide the order in which the dice are rolled.
+> ## Story Seed: The Greatest Weapon
+> 
+> While practicing on the training field just outside the covenant enclosure, the turb becomes the target for some faerie sport. Whisked from their covenant by a court of faerie knights, the grogs are confronted by martial challenges, one by one, and told by their tormentors that they may use their best weapon in each fight. How long until the grogs discover that teamwork may be their greatest weapon?
 
 If the leader (or any member of the group, for that matter) wants to remain in the group but do something other than attack, that's permissible. Simply don't count that individual as part of the group when calculating the group's combat bonus or resolving Damage. For example, if a group of two grogs plus a leader is fighting, and the leader chooses to spend his action doing something other than attacking (say, casting a spell), then the group's combat bonus is capped at +x (instead of +y), and when the group hits, it inflicts Damage two times, rather than three times.
 
@@ -6223,14 +5775,14 @@ Effective group tactics require both discipline and morale. In battle, both of t
 
 A Discipline roll is required whenever a group is tempted to break formation, either because they are executing a tricky maneuver or because the enemy seems vulnerable (tempting the group's members to pursue them). Making a Discipline roll is a reaction, not an action. If a Discipline roll fails, the group temporarily becomes disordered (see Disordered Groups, later in this chapter).
 
-#### Group Discipline: leader's Presence + leader's Leadership + stress die
+**Group Discipline: leader's Presence + leader's Leadership + stress die**
 
 If everyone in the group has a positive Loyal Personality Trait, the group gains an additional bonus equal to the lowest Loyal score among the members.
 
-#### Example Discipline Ease Factors
+**Example Discipline Ease Factors**
 
 | Event                                                | Ease Factor |
-|------------------------------------------------------|-------------|
+|------------------------------------------------------|:-----------:|
 | Group moves across dif<br>ficult terrain             | 3           |
 | Group runs (without<br>charging)                     | 6           |
 | Enemy disengages<br>(without routing)                | 6           |
@@ -6240,23 +5792,22 @@ If everyone in the group has a positive Loyal Personality Trait, the group gains
 
 #### Morale
 
-All groups need to make Morale rolls when bad things happen on the battlefield. Morale rolls are reactions, not actions. A
-
+All groups need to make Morale rolls when bad things happen on the battlefield. Morale rolls are reactions, not actions. A group that fails a Morale check becomes disordered. If the group is already disordered and then fails a Morale check, it routs.
 
 **Group Morale: leader's Presence + leader's Leadership + stress die** 
 
 If everyone in the group has a positive Brave Personality Trait, the group gains a bonus to the Morale roll equal to the lowest Brave score in the group.
 
-#### Example Morale Ease Factors
+**Example Morale Ease Factors**
 
-| Event                                                                     | Ease Factor |
-|---------------------------------------------------------------------------|-------------|
-| Taking wounds from mis<br>sile fire when having no<br>missiles of its own | 6           |
-| Charged by an approxi<br>mately equal force                               | 6           |
-| Charged by an obviously<br>superior force                                 | 9           |
-| Ambushed or attacked<br>from the rear                                     | 9           |
-| All members of the group<br>reach Wound Penalty of<br>−3 or worse         | 9           |
-| The vanguard or leader<br>killed, Incapacitated, or<br>disabled by magic  | 9           |
+| Event | Ease Factor |
+|-------|:-----------:|
+| Taking wounds from missile fire when having no missiles of its own | 6 |
+| Charged by an approximately equal force | 6 |
+| Charged by an obviously superior force | 9 |
+| Ambushed or attacked from the rear | 9 |
+| All members of the group reach Wound Penalty of −3 or worse | 9 |
+| The vanguard or leader killed, Incapacitated, or disabled by magic | 9 |
 
 #### Disordered Groups
 
@@ -6264,11 +5815,7 @@ A group that fails a Discipline or Morale check becomes disordered. This is a ba
 
 A trained group that is disordered functions as an untrained group. If it fails a second Discipline check, it functions like a disordered untrained group.
 
-An untrained group that is disordered can't attack effectively. Only half of its at-
-
-
-
-tacks (round up) can hit, and the others automatically miss. That is, instead of inflicting damage once per member of the group, it only inflicts damage half that many times.
+An untrained group that is disordered can't attack effectively. Only half of its attacks (round up) can hit, and the others automatically miss. That is, instead of inflicting damage once per member of the group, it only inflicts damage half that many times.
 
 If a group that is disordered fails a Morale check (but not a Discipline check), it becomes routed.
 
@@ -6284,18 +5831,16 @@ If a group becomes disordered or routed, the leader may attempt to rally it as a
 
 > **Rally a Group: Presence + Leadership + stress die**
 
-#### Lords of Men
-
 The Ease Factor to rally a group depends on whether the group is engaged in combat and how many casualties it has taken. A casualty is a member of the group who has a Medium Wound or worse, or is unconscious or unable to fight due to magical effects.
 
-| Situation                                     | Rally Ease<br>Factor |
-|-----------------------------------------------|----------------------|
-| Not engaged in combat                         | 3                    |
-| Taking enemy missile fire                     | 6                    |
-| Engaged in melee                              | 9                    |
-| Routed and being hotly<br>pursued             | 12                   |
-| Group has sustained<br>casualties             | +1 to Ease<br>Factor |
-| Group has sustained 50%<br>casualties or more | +3 to Ease<br>Factor |
+| Situation | Rally Ease Factor |
+|-----------|:-----------------:|
+| Not engaged in combat | 3 |
+| Taking enemy missile fire | 6 |
+| Engaged in melee | 9 |
+| Routed and being hotly pursued | 12 |
+| Group has sustained casualties | +1 to Ease Factor |
+| Group has sustained 50% casualties or more | +3 to Ease Factor |
 
 #### Groups With No Leader
 
@@ -6303,39 +5848,31 @@ Ordinarily, a group that loses its vanguard or leader splits into individuals (s
 
 A group with no vanguard can't attack, but uses the Defense score of its best member. The leader of a group can designate a new vanguard in the middle of battle, as a fast action. If successful, this takes effect immediately, and the group's future rolls are based on the new vanguard's statistics. The leader can automatically choose a new vanguard (no roll required) if the group spends a round without attacking or defending.
 
-#### Replace a Vanguard in Combat: leader's Presence + leader's Leadership + stress die vs. Ease Factor 9
+**Replace a Vanguard in Combat: leader's Presence + leader's Leadership + stress die vs. Ease Factor 9**
 
 A group with no leader automatically fails any Morale or Discipline check. A new leader can assume command automatically if the group spends a round without fighting (i.e., without making any Attack or Defense rolls). Alternatively, a member of the group may assume command in combat as a fast action.
 
-#### Assume Leadership in Combat: Presence + Leadership + stress die vs. Ease Factor 9
+**Assume Leadership in Combat: Presence + Leadership + stress die vs. Ease Factor 9**
 
 If more than one character succeeds at this roll in the same round, the one with the highest total becomes the leader.
 
-
-## Supplement
-
-# Arms & Armor
+# Supplement: Arms & Armor
 
 This supplement includes updated rules for crossbows, statistics for late medieval arms and armor, expanded rules for armor, and a few new optional weapons rules. In addition, it reprints some weapon-related rules from other ArM5 supplements (*City & Guild* and *Ancient Magic*) for ease of reference, and includes consolidated melee and missile weapon tables that list all the weapons from this previous ArM5 books all in one place.
 
 Arms and armor are the tools of the warrior's trade. Even nobles who do not personally fight have an interest in the equipping of their knights, sergeants, and men-at-arms.
 
-A few weapons have regional availability. Historically, they were common only in certain geographic areas; see Notes on Weapons for an explanation of each case. •
-
-We give statistics for late-medieval equipment for players who are interested in them. If your saga starts in 1220, magi, with their Longevity Rituals, can easily live into the 14th century. Even if they do, there is no reason why the history of Mythic Europe needs to parallel that of the real world. You may prefer to keep your saga in the high Middle Ages forever.
-
-## New Weapon Rules
-
-For clarity, weapons are categorized as crushing, piercing, or slashing, according to the type of injuries they cause (see *Art & Academe*, pages 43-44). This has no effect on their Damage or other statistics, but can be useful in deciding how the weapon interacts with magical effects or other rules. For example, the spell *Edge of the Razor* (ArM5, page 154) only works on "edged or pointed" weapons.
-
 ## Equipment Availability
 
 It may be useful to troupes to know approximately where and when, in historical Europe, certain weapons and armor were in use, especially if they want to set their saga earlier or later in Mythic Europe's history. As just one more example of how this information may be useful, the storyguide may sometimes want to outfit a ghost, faerie, or other character in equipment from a bygone age.
 
-- The ancient period, for this purpose, includes anything up until the collapse of the Western Roman Empire around 480 a d . •
-- The early medieval period spans the sixth through tenth centuries. •
-- The high period begins in the 11th century and lasts until the end of the 13th. •
-- The late medieval period starts at the beginning of the 14th century. •
+- The ancient period, for this purpose, includes anything up until the collapse of the Western Roman Empire around 480 a d .
+- The early medieval period spans the sixth through tenth centuries.
+- The high period begins in the 11th century and lasts until the end of the 13th.
+- The late medieval period starts at the beginning of the 14th century.
+- A few weapons have regional availability. Historically, they were common only in certain geographic areas; see Notes on Weapons for an explanation of each case.
+
+We give statistics for late-medieval equipment for players who are interested in them. If your saga starts in 1220, magi, with their Longevity Rituals, can easily live into the 14th century. Even if they do, there is no reason why the history of Mythic Europe needs to parallel that of the real world. You may prefer to keep your saga in the high Middle Ages forever.
 
 ## Quality of Arms and Armor
 
@@ -6347,85 +5884,84 @@ Superior armor grants +1 to Protection. (A superior helmet's bonus applies only 
 
 Excellent quality items grant a bonus of +2, +3, or even higher (see *City & Guild*, page 69). For weapons, the bonus applies to *both* Attack and Defense rolls.
 
-## Primitive and Blunted Weapons
+## New Weapon Rules
+
+For clarity, weapons are categorized as crushing, piercing, or slashing, according to the type of injuries they cause (see *Art & Academe*, pages 43-44). This has no effect on their Damage or other statistics, but can be useful in deciding how the weapon interacts with magical effects or other rules. For example, the spell *Edge of the Razor* (ArM5, page 154) only works on "edged or pointed" weapons.
+
+### Primitive and Blunted Weapons
 
 Stone weapons do less damage than metal ones. Subtract 2 from their Damage modifiers, to a minimum Damage modifier of +1. Statistics for several stone weapons are given on page 95 of *Ancient Magic*.
 
 Slashing and piercing weapons may be blunted to reduce injury in tournaments. Subtract 3 from the Damage modifier of a blunted weapon. This can reduce the Damage modifier below zero.
 
-## Option: Try Using the Other End
+### Option: Try Using the Other End
 
 Several weapons, such as swords, can deal two categories of damage. The wielder may normally choose to deal either sort of damage, as he chooses.
 
-As an optional rule, the order in which damage categories are listed on the Weapon Table becomes significant. The first category is the weapon's normal mode of use. Apply a
+As an optional rule, the order in which damage categories are listed on the Weapon Table becomes significant. The first category is the weapon's normal mode of use. Apply a –1 Attack penalty if it is used to deal its other damage type, due to awkwardness.
 
+> ## Melee Weapon Table
+> 
+> | Item | Ability | Init | Atk | Dfn | Dam | Str | Load | Cost | Avail | Types | Damage Levels | Notes |
+> |------|---------|:----:|:---:|:---:|:---:|:---:|:----:|--------|---------|:-----:|:-------------:|-------|
+> | Unarmed | Brawl | 0 | 0 | 0 | 0 | n/a | n/a | n/a | All | C | n/a | |
+> | Kick | Brawl | –1 | 0 | –1 | 3 | n/a | n/a | n/a | All | C | n/a | |
+> | Gauntlet | Brawl | 0 | 0 | 1 | 2 | –3 | 0 | Inexp. | All | C | 2 | |
+> | Bludgeon | Brawl | 0 | 2 | 0 | 2 | –2 | 1 | Inexp. | All | C | 1 | |
+> | Dagger | Brawl | 0 | 2 | 0 | 3 | –3 | 0 | Inexp. | All | P,S | 2 | |
+> | Knife | Brawl | 0 | 1 | 0 | 2 | –6 | 0 | Inexp. | All | P,S | 2 | |
+> | Axe | Single | 1 | 4 | 0 | 6 | 0 | 1 | Std. | All | S | 2 | |
+> | Club | Single | 1 | 2 | 1 | 3 | –2 | 1 | Inexp. | All | C | 1 | |
+> | Dueling Stick, Short | Single | 2 | 4 | 1 | 2 | –2 | 1 | Inexp. | Ancient | C | 2 | Ancient Magic, page 95 |
+> | Falchion | Single | 1 | 4 | 1 | 4 | 0 | 1 | Std. | Late | S | 2 | |
+> | Hatchet | Single | 0 | 3 | 0 | 4 | –2 | 1 | Inexp. | All | S | 2 | |
+> | Lance | Single | 2 | 4 | 0 | 5 | 0 | 2 | Std. | High | P | 1 | |
+> | Mace | Single | 1 | 3 | 0 | 8 | 0 | 2 | Std. | All | C | 2 | |
+> | Mace and Chain | Single | 2 | 3 | 0 | 7 | 0 | 2 | Std. | Early | C | 2 | |
+> | Net\* | Single | –1 | 2 | 2 | 0 | –1 | 3 | Std. | Ancient | S | 2 | Guardians of the Forest, page 134 |
+> | Spear | Single | 2 | 2 | 0 | 5 | –1 | 1 | Inexp. | All | P | 1 | |
+> | Sword, Short | Single | 1 | 3 | 1 | 5 | –1 | 1 | Std. | All | P,S | 2 | |
+> | Sword, Long\*\* | Single | 2 | 4 | 1 | 6 | 0 | 1 | Exp. | All | S,P | 2 | |
+> | Shield, Buckler | Single | n/a | n/a | 1 | n/a | –2 | 1 | Std. | High | n/a | 2 | |
+> | Shield, Round | Single | n/a | n/a | 2 | n/a | –1 | 2 | Inexp. | All | n/a | 1 | |
+> | Shield, Heater | Single | n/a | n/a | 3 | n/a | 0 | 2 | Std. | High | n/a | 2 | |
+> | Shield, Infantry | Single | n/a | n/a | 4 | n/a | 0 | 3 | Std. | Ancient | n/a | 2 | New |
+> | Trident | Single | 3 | 3 | 3 | 5 | 1 | 3 | Exp. | Ancient | P | 2 | Guardians of the Forest, page 134 |
+> | Whip\* | Single | 2 | 1 | 1 | –3 | –2 | 2 | Inexp. | All | C, S | 1 | New |
+> | Cudgel | Great | 1 | 4 | 1 | 2 | 1 | 2 | Inexp. | All | C | 2 | |
+> | Farm Implement | Great | 1 | 3 | 1 | 5 | 0 | 2 | Inexp. | All | P,S | 1 | |
+> | Flail | Great | 1 | 3 | 1 | 8 | 0 | 2 | Inexp. | All | C | 2 | |
+> | Halberd\*\*\* | Great | 2 | 4 | 1 | 10 | 1 | 2 | Std. | Late | S, P | 2 | |
+> | Pole Arm\*\*\* | Great | 3 | 4 | 1 | 8 | 0 | 2 | Std. | High | S,P | 2 | |
+> | Pole Axe | Great | 1 | 5 | 0 | 11 | 1 | 2 | Std. | All | S | 2 | |
+> | Spear, Long | Great | 3 | 3 | 1 | 7 | 0 | 3 | Inexp. | All | P | 1 | Includes boar spear, Lion & Lily, page 120 |
+> | Sword, Great | Great | 2 | 5 | 2 | 9 | 1 | 2 | Exp. | Late | S,P | 2 | |
+> | Staff | Great | 2 | 3 | 3 | 2 | –1 | 2 | Inexp. | All | C | 2 | |
+> | Warhammer | Great | 0 | 6 | 0 | 12 | 2 | 3 | Inexp. | All | C | 2 | |
+> 
+> \* A net or whip may be used to trip, grapple, or disarm using wielder's Single Weapon + Weapon Attack Bonus in lieu of Brawl.
+> 
+> \*\* There are several variations on the long sword, including the late Roman spatha (*Houses of Hermes: True Lineages*, page 127) and the Mongol saber (*Ancient Magic*, page 17).
+> 
+> \*\*\* A halberd or pole arm may be used to unseat a rider.
 
-
-## Melee Weapon Table
-
-| Item                 | Ability | Init | Atk | Dfn | Dam | Str | Load | Cost   | Avail   | Types | Damage<br>Levels | Notes                                         |
-|----------------------|---------|------|-----|-----|-----|-----|------|--------|---------|-------|------------------|-----------------------------------------------|
-| Unarmed              | Brawl   | 0    | 0   | 0   | 0   | n/a | n/a  | n/a    | All     | C     | n/a              |                                               |
-| Kick                 | Brawl   | –1   | 0   | –1  | 3   | n/a | n/a  | n/a    | All     | C     | n/a              |                                               |
-| Gauntlet             | Brawl   | 0    | 0   | 1   | 2   | –3  | 0    | Inexp. | All     | C     | 2                |                                               |
-| Bludgeon             | Brawl   | 0    | 2   | 0   | 2   | –2  | 1    | Inexp. | All     | C     | 1                |                                               |
-| Dagger               | Brawl   | 0    | 2   | 0   | 3   | –3  | 0    | Inexp. | All     | P,S   | 2                |                                               |
-| Knife                | Brawl   | 0    | 1   | 0   | 2   | –6  | 0    | Inexp. | All     | P,S   | 2                |                                               |
-| Axe                  | Single  | 1    | 4   | 0   | 6   | 0   | 1    | Std.   | All     | S     | 2                |                                               |
-| Club                 | Single  | 1    | 2   | 1   | 3   | –2  | 1    | Inexp. | All     | C     | 1                |                                               |
-| Dueling Stick, Short | Single  | 2    | 4   | 1   | 2   | –2  | 1    | Inexp. | Ancient | C     | 2                | Ancient Magic, page<br>95                     |
-| Falchion             | Single  | 1    | 4   | 1   | 4   | 0   | 1    | Std.   | Late    | S     | 2                |                                               |
-| Hatchet              | Single  | 0    | 3   | 0   | 4   | –2  | 1    | Inexp. | All     | S     | 2                |                                               |
-| Lance                | Single  | 2    | 4   | 0   | 5   | 0   | 2    | Std.   | High    | P     | 1                |                                               |
-| Mace                 | Single  | 1    | 3   | 0   | 8   | 0   | 2    | Std.   | All     | C     | 2                |                                               |
-| Mace and Chain       | Single  | 2    | 3   | 0   | 7   | 0   | 2    | Std.   | Early   | C     | 2                |                                               |
-| Net*                 | Single  | –1   | 2   | 2   | 0   | –1  | 3    | Std.   | Ancient | S     | 2                | Guardians of the Forest,<br>page 134          |
-| Spear                | Single  | 2    | 2   | 0   | 5   | –1  | 1    | Inexp. | All     | P     | 1                |                                               |
-| Sword, Short         | Single  | 1    | 3   | 1   | 5   | –1  | 1    | Std.   | All     | P,S   | 2                |                                               |
-| Sword, Long**        | Single  | 2    | 4   | 1   | 6   | 0   | 1    | Exp.   | All     | S,P   | 2                |                                               |
-| Shield, Buckler      | Single  | n/a  | n/a | 1   | n/a | –2  | 1    | Std.   | High    | n/a   | 2                |                                               |
-| Shield, Round        | Single  | n/a  | n/a | 2   | n/a | –1  | 2    | Inexp. | All     | n/a   | 1                |                                               |
-| Shield, Heater       | Single  | n/a  | n/a | 3   | n/a | 0   | 2    | Std.   | High    | n/a   | 2                |                                               |
-| Shield, Infantry     | Single  | n/a  | n/a | 4   | n/a | 0   | 3    | Std.   | Ancient | n/a   | 2                | New                                           |
-| Trident              | Single  | 3    | 3   | 3   | 5   | 1   | 3    | Exp.   | Ancient | P     | 2                | Guardians of the Forest,<br>page 134          |
-| Whip*                | Single  | 2    | 1   | 1   | –3  | –2  | 2    | Inexp. | All     | C, S  | 1                | New                                           |
-| Cudgel               | Great   | 1    | 4   | 1   | 7   | 1   | 2    | Inexp. | All     | C     | 2                |                                               |
-| Farm Implement       | Great   | 1    | 3   | 1   | 5   | 0   | 2    | Inexp. | All     | P,S   | 1                |                                               |
-| Flail                | Great   | 1    | 3   | 1   | 8   | 0   | 2    | Inexp. | All     | C     | 2                |                                               |
-| Halberd***           | Great   | 2    | 4   | 1   | 10  | 1   | 2    | Std.   | Late    | S, P  | 2                |                                               |
-| Pole Arm***          | Great   | 3    | 4   | 1   | 8   | 0   | 2    | Std.   | High    | S,P   | 2                |                                               |
-| Pole Axe             | Great   | 1    | 5   | 0   | 11  | 1   | 2    | Std.   | All     | S     | 2                |                                               |
-| Spear, Long          | Great   | 3    | 3   | 1   | 7   | 0   | 3    | Inexp. | All     | P     | 1                | Includes boar spear,<br>Lion & Lily, page 120 |
-| Sword, Great         | Great   | 2    | 5   | 2   | 9   | 1   | 2    | Exp.   | Late    | S,P   | 2                |                                               |
-| Staff                | Great   | 2    | 3   | 3   | 2   | –1  | 2    | Inexp. | Early   | C     | 2                |                                               |
-| Warhammer            | Great   | 0    | 6   | 0   | 12  | 2   | 3    | Inexp. | All     | C     | 2                |                                               |
-
-<sup>\*</sup> A net or whip may be used to trip, grapple, or disarm using wielder's Single Weapon + Weapon Attack Bonus in lieu of Brawl.
-
-<sup>\*\*\*</sup> A halberd or pole arm may be used to unseat a rider.
-
-
-<sup>\*\*</sup> There are several variations on the long sword, including the late Roman spatha (*Houses of Hermes: True Lineages*, page 127) and the Mongol saber (*Ancient Magic*, page 17).
-
-
-|                    |          |      |     |     |     | Missile Weapon Table |     |      |        |         |       |                  |                                  |
-|--------------------|----------|------|-----|-----|-----|----------------------|-----|------|--------|---------|-------|------------------|----------------------------------|
-| Item               | Ability  | Init | Atk | Dfn | Dam | Range                | Str | Load | Cost   | Avail   | Types | Damage<br>Levels | Notes                            |
-| Axe,<br>Throwing   | Thrown   | 0    | 0   | 2   | 6   | 5                    | 0   | 1    | Std.   | All     | S     | 2                |                                  |
-| Javelin            | Thrown   | 0    | 2   | 0   | 5   | 10                   | 0   | 1    | Std.   | All     | P     | 2                |                                  |
-| Knife              | Thrown   | 0    | 1   | 0   | 2   | 5                    | –2  | 0    | Inexp. | All     | P     | 2                |                                  |
-| Sling              | Thrown   | –3   | 1   | 0   | 4   | 20                   | –3  | 0    | Inexp. | All     | P     | 1                |                                  |
-| Rock,<br>sharpened | Thrown   | 0    | 0   | 1   | 3   | 5                    | –1  | 1    | Inexp. | Ancient | C, S  | 1                | Ancient<br>Magic,<br>page 17     |
-| Stone              | Thrown   | 0    | 1   | 0   | 2   | 5                    | –1  | 1    | Inexp. | All     | C     | n/a              |                                  |
-| Bow                | Bow      | –1   | 3   | 0   | 6   | 15                   | –1  | 1    | Std.   | All     | P     | 2                |                                  |
-| Bow,<br>Composite  | Bow      | –2   | 4   | 0   | 7   | 30                   | 2   | 2    | Exp.   | All     | P     | 2                | Ancient<br>Magic,<br>page 17     |
-| Bow, Horse         | Bow      | –2   | 5   | 0   | 8   | 15                   | 2   | 2    | Exp.   | All     | P     | 2                | Ancient<br>Magic,<br>page 17     |
-| Bow, Long          | Bow      | –2   | 4   | 0   | 8   | 30                   | 2   | 2    | Exp.   | Late    | P     | 2                |                                  |
-| Crossbow           | Crossbow | 5    | 5   | 0   | 8*  | 25                   | 1   | 2    | Exp.   | High    | P     | 2                | Replaces<br>Covenants<br>page 18 |
-| Arbalest           | Crossbow | 5    | 5   | 0   | 10* | 30                   | –1  | 3    | Exp.   | High    | P     | 2                | New                              |
-| Arbalest,<br>heavy | Crossbow | 5    | 5   | 0   | 12* | 35                   | 1   | 2    | Exp.   | Late    | P     | 2                | New                              |
-
-–1 Attack penalty if it is used to deal its other damage type, due to awkwardness.
+> ## Missile Weapon Table
+> 
+> | Item | Ability | Init | Atk | Dfn | Dam | Range | Str | Load | Cost | Avail | Types | Damage Levels | Notes |
+> |------|---------|:----:|:---:|:---:|:---:|:-----:|:---:|:----:|------|-------|:-----:|:-------------:|-------|
+> | Axe, Throwing | Thrown | 0 | 0 | 2 | 6 | 5 | 0 | 1 | Std. | All | S | 2 | |
+> | Javelin | Thrown | 0 | 2 | 0 | 5 | 10 | 0 | 1 | Std. | All | P | 2 | |
+> | Knife | Thrown | 0 | 1 | 0 | 2 | 5 | –2 | 0 | Inexp. | All | P | 2 | |
+> | Sling | Thrown | –3 | 1 | 0 | 4 | 20 | –3 | 0 | Inexp. | All | P | 1 | |
+> | Rock, sharpened | Thrown | 0 | 0 | 1 | 3 | 5 | –1 | 1 | Inexp. | Ancient | C, S | 1 | Ancient Magic, page 17 |
+> | Stone | Thrown | 0 | 1 | 0 | 2 | 5 | –1 | 1 | Inexp. | All | C | n/a | |
+> | Bow | Bow | –1 | 3 | 0 | 6 | 15 | –1 | 1 | Std. | All | P | 2 | |
+> | Bow, Composite | Bow | –2 | 4 | 0 | 7 | 30 | 2 | 2 | Exp. | All | P | 2 | Ancient Magic, page 17 |
+> | Bow, Horse | Bow | –2 | 5 | 0 | 8 | 15 | 2 | 2 | Exp. | All | P | 2 | Ancient Magic, page 17 |
+> | Bow, Long | Bow | –2 | 4 | 0 | 8 | 30 | 2 | 2 | Exp. | Late | P | 2 | |
+> | Crossbow | Crossbow | 5 | 5 | 0 | 8\* | 25 | 1 | 2 | Exp. | High | P | 2 | Replaces Covenants page 18 |
+> | Arbalest | Crossbow | 5 | 5 | 0 | 10\* | 30 | –1 | 3 | Exp. | High | P | 2 | New |
+> | Arbalest, heavy | Crossbow | 5 | 5 | 0 | 12\* | 35 | 1 | 2 | Exp. | Late | P | 2 | New |
 
 ### Option: The Clash of Weapons
 
@@ -6435,7 +5971,7 @@ Check for weapon breakage whenever the attacker's melee Attack Total exactly equ
 
 To determine whose weapon might break, roll Strengh + Weapon Ability + a simple die for each character. Whoever rolls lower must then roll to see if his weapon breaks. If the defender must roll for breakage, he may choose to roll for either his weapon or his shield. This roll for weapon breakage is similar to a stress check for equipment (see *City & Guild*, page 77), but the Ease Factor is lower because weapons are generally designed to withstand combat use.
 
-#### Weapon Breakage: stress die + Weapon Ability vs. Ease Factor 9
+**Weapon Breakage: stress die + Weapon Ability vs. Ease Factor 9**
 
 If the check fails, the item loses a damage level. Most weapons and shields have two damage levels. They break when the last damage level is lost (but function normally until then). Some weapons, notably spears and lances, are particularly fragile, and have only one damage level.
 
@@ -6454,7 +5990,6 @@ The user's Strength does not add to Damage for crossbows. Use the Damage value g
 Spanning a crossbow is an Extended Action. The number of rounds required depends on the type of spanning mechanism (see Notes on Weapons, later in this chapter).
 
 If you are using the Ready Missiles option, shooting a loaded crossbow is a fast action rather than an action. This enables the crossbowman to shoot and then take cover, or to shoot and immediately begin reloading his weapon.
-
 
 ## Missile Weapon Descriptions
 
@@ -6482,11 +6017,9 @@ If you are using the Ready Missiles option, shooting a loaded crossbow is a fast
 
 **Rock, Sharpened:** A very primitive weapon, sometimes used by faeries and the like. See *Ancient Magic*, page 95.
 
-#### Lords of Men
-
 **Shield, Infantry:** A large shield that can only be used on foot, usually oval or rectangular in shape. The convex, rectangular scutum of the Roman legionary is an infantry shield.
 
-**Sword, Bastard:** A large, late-medieval sword suitable for one-handed or two-handed use. If used two-handed, treat it as a great sword. If used one handed, its Str and Load remain at +1 and 1, respectively, but all its other statistics are those of a long sword.
+**Sword, Bastard:** A large, late-medieval sword suitable for one-handed or two-handed use. If used two-handed, treat it as a great sword. If used one handed, its Str and Load remain at +1 and 2, respectively, but all its other statistics are those of a long sword.
 
 **Whip:** A whip is not a very good weapon, but it may be used to make trip, grapple, or disarm attempts, or to unseat a rider.
 
@@ -6494,104 +6027,95 @@ If you are using the Ready Missiles option, shooting a loaded crossbow is a fast
 
 The **Ars Magica Fifth Edition** rulebook provides the statistics for several generic types of armor (see ArM5, page 176). This section expands on those rules to incorporate a wider variety of historical armor types, and gives rules for constructing armor out of layers of different material.
 
-## Armor Materials
+### Armor Materials
 
 The following categories expand and supersede those described on page 176 of ArM5. Note that the statistics for these armor materials are fully compatible with those in ArM5. These new categories simply cover a broader variety of historical armor materials.
 
 #### Inexpensive Materials
 
-- Padded armor is usually made of woolen or linen fabric quilted into dense layers. Other forms include heavy felt, suede, or leather stuffed with horsehair, and thick furs such as bearskin. •
-- Boiled leather is very tough, but stiff. Also use these statistics for similar, semiresilient materials like rawhide, or even faerie armor made of tree bark. •
+- Padded armor is usually made of woolen or linen fabric quilted into dense layers. Other forms include heavy felt, suede, or leather stuffed with horsehair, and thick furs such as bearskin.
+- Boiled leather is very tough, but stiff. Also use these statistics for similar, semiresilient materials like rawhide, or even faerie armor made of tree bark.
 
 #### Standard Materials
 
-Reinforced armor is leather or padded material strengthened by many small, hard plates or rings. These reinforcements are usually metal, but horn, bone, •
-
-## Weapon Table Key
-
-The melee and missile weapons tables list the following statistics:
-
-**Ability** refers to the Ability used to calculate combat scores while using that weapon. Characters with no score in a weapon Ability can use the weapon untrained; treat their relevant Ability as zero, and add three extra botch dice unless the weapon is a crossbow.
-
-**Init** is the weapon's Weapon Initiative Modifier.
-
-**Atk** is the weapon's Weapon Attack Modifier.
-
-**Dfn** is the weapon's Weapon Defense Modifier.
-
-**Dam** is the weapon's Damage Modifier. **Range** is the range increment for the missile weapon, in paces.
-
-**Str** is the minimum Strength required to use the weapon effectively.
-
-**Load** is the Load of the weapon; see Encumbrance on ArM5, page 178.
-
-**Cost** states how expensive the weapon is. Most characters can afford Standard or Inexpensive equipment, but this can be affected by their Virtues and Flaws.
-
-**Avail** gives the time period (or geographic region) in which the weapon first came into widespread use. See Equipment Availability, later.
-
-**Types** lists the type(s) of damage the weapon inflicts: Crushing, Piercing, or Slashing.
-
-**Damage Levels** indicate how many damage levels the weapon can sustain before it breaks. This only pertains when using the optional Clash of Weapons rule, earlier.
-
+- Reinforced armor is leather or padded material strengthened by many small, hard plates or rings. These reinforcements are usually metal, but horn, bone,
 and whalebone are sometimes used.
+- Rigid scale includes any sort of non-metallic scale or lamellar armor. Armor of boiled-leather scales is worn throughout Mythic Europe; horn and whalebone are sometimes used as well.
+- Metal scale includes all kinds of metal lamellar. Brigandine is essentially a lateperiod type of metal scale.
 
-- Rigid scale includes any sort of non-metallic scale or lamellar armor. Armor of boiled-leather scales is worn throughout Mythic Europe; horn and whalebone are sometimes used as well. •
-- Metal scale includes all kinds of metal lamellar. Brigandine is essentially a lateperiod type of metal scale. •
+> ## Weapon Table Key
+> 
+> The melee and missile weapons tables list the following statistics:
+> 
+> **Ability** refers to the Ability used to calculate combat scores while using that weapon. Characters with no score in a weapon Ability can use the weapon untrained; treat their relevant Ability as zero, and add three extra botch dice unless the weapon is a crossbow.
+> 
+> **Init** is the weapon's Weapon Initiative Modifier.
+> 
+> **Atk** is the weapon's Weapon Attack Modifier.
+> 
+> **Dfn** is the weapon's Weapon Defense Modifier.
+> 
+> **Dam** is the weapon's Damage Modifier. **Range** is the range increment for the missile weapon, in paces.
+> 
+> **Str** is the minimum Strength required to use the weapon effectively.
+> 
+> **Load** is the Load of the weapon; see Encumbrance on ArM5, page 178.
+> 
+> **Cost** states how expensive the weapon is. Most characters can afford Standard or Inexpensive equipment, but this can be affected by their Virtues and Flaws.
+> 
+> **Avail** gives the time period (or geographic region) in which the weapon first came into widespread use. See Equipment Availability, later.
+> 
+> **Types** lists the type(s) of damage the weapon inflicts: Crushing, Piercing, or Slashing.
+> 
+> **Damage Levels** indicate how many damage levels the weapon can sustain before it breaks. This only pertains when using the optional Clash of Weapons rule, earlier.
 
 #### Expensive Materials
 
-Mail is the term characters in Mythic Europe would use for chain mail. Mail shirts and hauberks are available in the •
+Mail is the term characters in Mythic Europe would use for chain mail. Mail shirts and hauberks are available in the ancient period; full mail is an invention of the early Middle Ages.
 
+- Plate armor is made of solid pieces of metal. The ancient Greeks and Romans had plate cuirasses and greaves, but by the early Middle Ages, all-plate harness fell out of use. The full plate listed on the Expanded Armor Table is late-medieval, Gothic style plate (c. 1400) and has a different Protection-to-Load ratio than its ancient counterpart. The complex armor design rules do not cover 15th-century full plate.
+- Plate and mail is a combination of mail strengthened with various metal plates. It gives better overall protection than the ancient, all-plate harness. Historically, a few medieval examples of breastplates (worn over mail) re-appeared by 1200, but they were not common until about 1300. Plate jambes were added around 1320, and full plate appeared around 1360.
 
-
-
-## Expanded Armor Table
-
-Add together the Protection and Load of the body armor, helmet, and any surcoat worn. Retain fractions until the end of the calculation and then round up to the next whole number.
-
-#### Body Armors
-
-|                |      | Cuirass/Jerkin<br>Haubergeon |      |      | Hauberk | Full* |      |      |
-|----------------|------|------------------------------|------|------|---------|-------|------|------|
-| Armor          | Prot | Load                         | Prot | Load |         | Load  | Prot | Load |
-| Padded         | +1   | 1.5                          | +1   | 1.5  | +1      | 1.5   | +1   | 1.5  |
-| Boiled Leather | +2   | 3                            | n/a  | n/a  | n/a     | n/a   | +3   | 4.5  |
-| Reinforced     | +2   | 2                            | +2.5 | 2.5  | +3      | 3     | +3.5 | 3.5  |
-| Rigid Scale    | +2   | 2                            | +2.5 | 2.5  | +3.5    | 3.5   | +4.5 | 4.5  |
-| Metal Scale    | +3   | 3                            | +4   | 4    | +5      | 5     | +6   | 6    |
-| Mail           | +3   | 1.5                          | +4   | 2    | +5      | 2.5   | +7   | 3.5  |
-| Plate          | +3   | 3                            | n/a  | n/a  | n/a     | n/a   | +12  | 6    |
-| Plate and Mail | +4   | 2                            | +6   | 3    | +8      | 4     | +10  | 5    |
-
-<sup>\*</sup> Greaves are already included in the full armor listed; don't add them again.
-
-#### Surcoats and Greaves
-
-| Surcoat and Greaves     | Prot | Load | Cost        |
-|-------------------------|------|------|-------------|
-| Gambeson                | +1   | 1.5  | Inexpensive |
-| Coat of Plates          | +2   | 2    | Expensive   |
-| Boiled-leather greaves* | +1   | +1   | Inexpensive |
-| Plate jambes*           | +1   | 1    | Expensive   |
-| Plate-and-mail jambes*  | +2   | 0.5  | Expensive   |
-
-<sup>\*</sup> Greaves and jambes are already included in the full armor listed; don't add them again.
-
-#### Helmets
-
-| Helmet       | Prot | Load | Perception Penalty | Cost                           |
-|--------------|------|------|--------------------|--------------------------------|
-| Cap, Iron    | 0    | 0    | 0                  | Inexpensive                    |
-| Coif/Camail  | +0.5 | 0    | 0                  | Expensive                      |
-| Helmet, Open | +1   | 1    | –1                 | Standard                       |
-| Helm         | +2   | 2    | –3                 | Expensive                      |
-| Bascinet     | +2   | 1    | –1                 | Expensive (late medieval only) |
-
-
-ancient period; full mail is an invention of the early Middle Ages.
-
-- Plate armor is made of solid pieces of metal. The ancient Greeks and Romans had plate cuirasses and greaves, but by the early Middle Ages, all-plate harness fell out of use. The full plate listed on the Expanded Armor Table is late-medieval, Gothic style plate (c. 1400) and has a different Protection-to-Load ratio than its ancient counterpart. The complex armor design rules do not cover 15th-century full plate. •
-- Plate and mail is a combination of mail strengthened with various metal plates. It gives better overall protection than the ancient, all-plate harness. Historically, a few medieval examples of breastplates (worn over mail) re-appeared by 1200, but they were not common until about 1300. Plate jambes were added around 1320, and full plate appeared around 1360. •
+> ## Expanded Armor Table
+> 
+> Add together the Protection and Load of the body armor, helmet, and any surcoat worn. Retain fractions until the end of the calculation and then round up to the next whole number.
+> 
+> #### Body Armors
+> 
+> | Armor | Cuirass/Jerkin Prot | Cuirass/Jerkin Load | Haubergeon Prot | Haubergeon Load | Hauberk Prot | Hauberk Load | Full\* Prot | Full\* Load |
+> |-------|:-------------------:|:-------------------:|:---------------:|:---------------:|:------------:|:------------:|:-----------:|:-----------:|
+> | Padded | +1 | 1.5 | +1 | 1.5 | +1 | 1.5 | +1 | 1.5 |
+> | Boiled Leather | +2 | 3 | n/a | n/a | n/a | n/a | +3 | 4.5 |
+> | Reinforced | +2 | 2 | +2.5 | 2.5 | +3 | 3 | +3.5 | 3.5 |
+> | Rigid Scale | +2 | 2 | +2.5 | 2.5 | +3.5 | 3.5 | +4.5 | 4.5 |
+> | Metal Scale | +3 | 3 | +4 | 4 | +5 | 5 | +6 | 6 |
+> | Mail | +3 | 1.5 | +4 | 2 | +5 | 2.5 | +7 | 3.5 |
+> | Plate | +3 | 3 | n/a | n/a | n/a | n/a | +12 | 6 |
+> | Plate and Mail | +4 | 2 | +6 | 3 | +8 | 4 | +10 | 5 |
+> 
+> \* Greaves are already included in the full armor listed; don't add them again.
+> 
+> #### Surcoats and Greaves
+> 
+> | Surcoat and Greaves | Prot | Load | Cost |
+> |---------------------|:----:|:----:|------|
+> | Gambeson | +1 | 1.5 | Inexpensive |
+> | Coat of Plates | +2 | 2 | Expensive |
+> | Boiled-leather greaves\* | +1 | +1 | Inexpensive |
+> | Plate jambes\* | +1 | 1 | Expensive |
+> | Plate-and-mail jambes\* | +2 | 0.5 | Expensive |
+> 
+> \* Greaves and jambes are already included in the full armor listed; don't add them again.
+> 
+> #### Helmets
+> 
+> | Surcoat and Greaves | Prot | Load | Cost |
+> |---------------------|:----:|:----:|------|
+> | Gambeson | +1 | 1.5 | Inexpensive |
+> | Coat of Plates | +2 | 2 | Expensive |
+> | Boiled-leather greaves\* | +1 | +1 | Inexpensive |
+> | Plate jambes\* | +1 | 1 | Expensive |
+> | Plate-and-mail jambes\* | +2 | 0.5 | Expensive (late medieval only) |
 
 ## Armor Outfittings
 
@@ -6625,7 +6149,7 @@ The converse also holds true: if a character's body is well-protected but his he
 
 **Camail:** A mail hood that covers the head, forehead, and lower face.
 
-**Chapel de fer:** French term for a kettle hat.
+**Chapelle de fer:** French term for a kettle hat.
 
 **Chausses:** Leggings made of mail.
 
@@ -6633,11 +6157,9 @@ The converse also holds true: if a character's body is well-protected but his he
 
 **Coif:** An open-faced mail hood.
 
-**Cuirass:** A breastplate and backplate;
+**Cuirass:** A breastplate and backplate; the most basic sort of rigid body armor.
 
-the most basic sort of rigid body armor.
-
-**Cuirboulli:** A form of boiled leather made by boiling in oil rather than water.
+**Cuir boulli:** A form of boiled leather made by boiling in oil rather than water.
 
 **Fauld:** Lamellar hip protection, worn with late-medieval plate armor.
 
@@ -6681,28 +6203,23 @@ the most basic sort of rigid body armor.
 
 **Vambraces:** Armor for the arms.
 
-
-
-## Option: Complex Armor Design
+### Option: Complex Armor Design
 
 These optional rules allow players to create their own armor from any combination of materials, and calculate its Protection and Load. The Expanded Armor Table is sufficient to outfit most grogs, knights, and other characters, but these rules might prove useful for creating exotic armor for faeries and the like, or for reproducing a specific, historical armor.
 
-First, make a list of all the materials that comprise the armor. Decide which parts of the body are covered by each material. Add up the corresponding Protection values for all the areas covered by that material. Some materials on some parts of the body correspond to a Protection of zero. Once you have the Protection total for all pieces of that material, multiply it by the Load Factor for that material and retain any fraction to get the total Load of that material. Continue this process for all the other materials worn. Finally, add up all the Protection and Load values for the different materials and
+First, make a list of all the materials that comprise the armor. Decide which parts of the body are covered by each material. Add up the corresponding Protection values for all the areas covered by that material. Some materials on some parts of the body correspond to a Protection of zero. Once you have the Protection total for all pieces of that material, multiply it by the Load Factor for that material and retain any fraction to get the total Load of that material. Continue this process for all the other materials worn. Finally, add up all the Protection and Load values for the different materials and round up to the next whole number.
 
-|                |       | Complex Armor Design Table |           |               |              |                    |
-|----------------|-------|----------------------------|-----------|---------------|--------------|--------------------|
-| Type           | Torso | Hips and<br>Thi<br>ghs     | Shi<br>ns | Upper<br>Arms | Fore<br>arms | Load<br>Fac<br>tor |
-| Padded         | 1     | 0                          | 0         | 0             | 0            | 1.5                |
-| Boiled leather | 2     | 0.5                        | 0.5       | 0             | 0            | 1.5                |
-| Reinforced     | 2     | 0.5                        | 0.5       | 0.5           | 0            | 1                  |
-| Rigid scale    | 2     | 1                          | 0.5       | 0.5           | 0.5          | 1                  |
-| Metal scale    | 3     | 1                          | 0.5       | 1             | 0.5          | 1                  |
-| Mail           | 3     | 1                          | 1         | 1             | 1            | 0.5                |
-| Plate          | 3     | 1                          | 1         | 0.5           | 0.5          | 1                  |
-| Plate and mail | 4     | 2                          | 1         | 2             | 1            | 0.5                |
-
-round up to the next whole number.
+> ## Complex Armor Design Table
+> 
+> | Type | Torso | Hips and Thighs | Shins | Upper Arms | Forearms | Load Factor |
+> |------|:-----:|:---------------:|:-----:|:----------:|:--------:|:-----------:|
+> | Padded | 1 | 0 | 0 | 0 | 0 | 1.5 |
+> | Boiled leather | 2 | 0.5 | 0.5 | 0 | 0 | 1.5 |
+> | Reinforced | 2 | 0.5 | 0.5 | 0.5 | 0 | 1 |
+> | Rigid scale | 2 | 1 | 0.5 | 0.5 | 0.5 | 1 |
+> | Metal scale | 3 | 1 | 0.5 | 1 | 0.5 | 1 |
+> | Mail | 3 | 1 | 1 | 1 | 1 | 0.5 |
+> | Plate | 3 | 1 | 1 | 0.5 | 0.5 | 1 |
+> | Plate and mail | 4 | 2 | 1 | 2 | 1 | 0.5 |
 
 The reason some entries on the table are zero is that some parts of the body are more vulnerable than others. Covering the torso, for example, makes a relatively big difference to overall Protection, compared to covering the forearms. It's not that wearing padding on the forearm doesn't help the forearm, it's that wearing padding on the forearm doesn't help very much in comparison to putting padding on the torso. Non-vital areas need a lot of armor to get a point of Protection, while the same armor over a vital spot would correspond to several points of Protection.
-
-


### PR DESCRIPTION
This PR performs a substantial cleanup of Lords of Men.

It restores and standardizes much of the Markdown structure, fixes many obvious OCR and line-break issues, reconstructs numerous damaged tables, and incorporates the official errata (some were missing).

This book was particularly difficult to recover because of broken table extraction, misplaced line breaks, damaged inserts, and several sections affected by severe OCR corruption.