### PR TITLE
tiny change to - "Ars Magica 4e - Sanctuary of Ice [..].md"

### DIFF
--- a/reviewed/Ars Magica 4e - Sanctuary of Ice - The Greater Alps Tribunal.md
+++ b/reviewed/Ars Magica 4e - Sanctuary of Ice - The Greater Alps Tribunal.md
@@ -265,9 +265,7 @@ Ostrakons traveling to a distant tribunal are vulnerable. They lack the regular 
 >
 >Ostracism's not a Roman thing originally, but yes, each tribunal there's a secret ballot and the one with the most votes against him has to leave the Greater Alps for twenty-one years or be Marched. No Primus of Criamon's ever been ostracized, but the Jerbitons go, because they designed the system. You are allowed to just drop a blank sherd in the pot though. Sometimes no-one goes. Exile ends the day before Tribunal, so some magi are ostracized a second time…
 >
->Well of course we export troublemakers to other tribunals. That's what other tribunals are for! You notice that the large covenants send their younger
->
->magi out to the wilds to blow off their steam, then bring them home once they've trained an apprentice, or had a Twilight experience, or proved their maturity in some other way? That's a deliberate policy of exporting trouble. Anyway, what covenant wants some child around when they could have someone worth vouching for instead? There are only so many rooks of vis, and if you are pledging one, then why pledge it on someone's acne-riddled whelp? A bit of sea salt clears that acne up, by the way. That's why we send them toward the coast. Any coast will do.
+>Well of course we export troublemakers to other tribunals. That's what other tribunals are for! You notice that the large covenants send their younger magi out to the wilds to blow off their steam, then bring them home once they've trained an apprentice, or had a Twilight experience, or proved their maturity in some other way? That's a deliberate policy of exporting trouble. Anyway, what covenant wants some child around when they could have someone worth vouching for instead? There are only so many rooks of vis, and if you are pledging one, then why pledge it on someone's acne-riddled whelp? A bit of sea salt clears that acne up, by the way. That's why we send them toward the coast. Any coast will do.
 
 ### Alpine Hoplites
 


### PR DESCRIPTION
There was/is a paragraph in the quoted text in "Ostracism" that is broken over two paragraphs. 

Dunno if this made sense in the original (due to an image or such interspersed?), but here it just broke the flow of reading.