### PR TITLE
Cleanup of Houses of Hermes: Societates

### DIFF
--- a/wip/Ars Magica 5e - Houses of Hermes - Societates.md
+++ b/wip/Ars Magica 5e - Houses of Hermes - Societates.md
@@ -1,296 +1,381 @@
+# Houses of Hermes: Societates
+A sourcebook for Ars Magica 5th Edition.
 
-### Societates
+> *Open License Markdown version by applejuice1965 & OriginalMadman, https://github.com/OriginalMadman/Ars-Magica-Open-License*
+> 
+> *[Completion state: Text manually fixed, all official Errata included.]*
+> 
+> *Based on the material for Ars Magica, ©1993–2024,  licensed by Trident, Inc. d/b/a Atlas Games®, under [Creative Commons Attribution-ShareAlike 4.0 International license 4.0](https://creativecommons.org/licenses/by-sa/4.0/) ("CC-BY-SA 4.0"). Order of Hermes, Tremere, Doissetep, and Grimgroth are trademarks of Paradox Interactive AB and are used with permission.*
+
+Within the Order of Hermes, four Houses are drawn together by a common cause. These are the Societates.
+
+House Flambeau celebrates fighting for a cause; the justice of the cause and the honor of the fighter are equally important. House Jerbiton seeks beauty in life: creating it, preserving it, and living it. House Tytalus thrives on combat: between nature and law in the soul of the magus, and with the world around him. Finally, House Ex Miscellanea gathers many diverse traditions, from healers tracing their lineage to ancient Greece, to necromancers with barely a century of history.
+
+This book details the Societates, providing vital rules and background for your saga.
 
 # Credits
 
-**autHors:** Erik Dahl (Columbae, Rusticani), Timothy Ferguson (Jerbiton), Andrew Gronosky (Flambeau), John Post (Donatores, Pharmacoepians, Seirenes), Mark Shirley (Tytalus, Ex Miscellanea, Pralicians, Sahirs), Nick Simmonds (Cult of Orpheus)
+**Authors:** Erik Dahl (Columbae, Rusticani), Timothy Ferguson (Jerbiton), Andrew Gronosky (Flambeau), John Post (Donatores, Pharmacoepians, Seirenes), Mark Shirley (Tytalus, Ex Miscellanea, Pralicians, Sahirs), Nick Simmonds (Cult of Orpheus)
 
-**ProJect.management,.develoPment,.&.editing:.**David Chart **cover.illustration:.**Grey Thornberry
+**Project Management, Development, & Editing:** David Chart
 
-**interior. art:.**Kelley Hensing, Rhonda Libbey, Brad McDevitt, Tony Parker
+**Cover Illustration:** Grey Thornberry
 
-**ars.magica.FiFtH.edition.trade.dress:.**J. Scott Reeves **layout,.art.direction,.&.ProoFreading:** Jeff Tidball **additional.ProoFreading**: John Nephew
+**Interior Art:** Kelley Hensing, Rhonda Libbey, Brad McDevitt, Tony Parker
 
-**First. round. Playtesters:** Christian Jensen-Romer, Kevin Sides, Lloyd Graney, Pete Hiley, Luke Price, Ed Woods; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Angus MacDonald, Sarah MacDonald, Wendell Joyner, Kathy Stricklen, Brian Watson, Quetta Watson; Matt Ryan, Alexis Kristan Heinz, Daniel Ilut, Robert W.B. Llwyd, Tobias Wheeler; Soraya Ghiasi, Matthew L. Seidl; Volker Bürkel, Christoph Safferling, Andrew Smith; Sean Winslow, Andrew Crabtree, Andrew Reeves
+**Ars Magica Fifth Edition Trade Dress:** J. Scott Reeves
 
-**second.round.Playtesters:** Christian Jensen-Romer, Ben Hayes, Luke Price, Kevin Sides, Lloyd Graney, Peter Hiley; Jason Fryer, Emily Dyson, Matt Dyson; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Angus MacDonald, Brian Watson, Quetta Watson, Sarah MacDonald, Steve Woyach, Wendell "BSP" Joyner; Neil Taylor
+**Layout, Art Direction, & Proofreading:** Jeff Tidball
 
-**tHird.round.Playtesters:.**Mark Barltrop, Mark Lawford, David Stavely, Simon Turner; Christopher Allen, Rob Andrusco, Eyal Barnea, Bard Bloom, Vicki Bloom, Dan Rice; Christian Jensen-Romer, Kevin Sides, Luke Price, Lloyd Graney, Ben Hayes, Pete Hiley; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Nicholas Peterson, Jennifer McPherson, Michael Pisarsky, Kristi Pisarsky; Neil Taylor, Sheila Thomas
+**Additional Proofreading:** John Nephew
 
-**sPecial.tHanks:.**Jerry Corrick and the gang at the Source
+**First round Playtesters:** Christian Jensen-Romer, Kevin Sides, Lloyd Graney, Pete Hiley, Luke Price, Ed Woods; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Angus MacDonald, Sarah MacDonald, Wendell Joyner, Kathy Stricklen, Brian Watson, Quetta Watson; Matt Ryan, Alexis Kristan Heinz, Daniel Ilut, Robert W.B. Llwyd, Tobias Wheeler; Soraya Ghiasi, Matthew L. Seidl; Volker Bürkel, Christoph Safferling, Andrew Smith; Sean Winslow, Andrew Crabtree, Andrew Reeves
 
+**Second Round Playtesters:** Christian Jensen-Romer, Ben Hayes, Luke Price, Kevin Sides, Lloyd Graney, Peter Hiley; Jason Fryer, Emily Dyson, Matt Dyson; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Angus MacDonald, Brian Watson, Quetta Watson, Sarah MacDonald, Steve Woyach, Wendell "BSP" Joyner; Neil Taylor
 
+**Third Round Playtesters:** Mark Barltrop, Mark Lawford, David Stavely, Simon Turner; Christopher Allen, Rob Andrusco, Eyal Barnea, Bard Bloom, Vicki Bloom, Dan Rice; Christian Jensen-Romer, Kevin Sides, Luke Price, Lloyd Graney, Ben Hayes, Pete Hiley; Donna Giltrap, Malcolm Harbrow, Aaron Hicks, Richard Love; Nicholas Peterson, Jennifer McPherson, Michael Pisarsky, Kristi Pisarsky; Neil Taylor, Sheila Thomas
 
-**Ars Magica** players participate in a thriving fan community by subscribing to email discussion lists (like the Berkeley list), compiling archives of game material (such as Project Redcap), maintaining fan-created web sites, and running demos through Atlas Games' Special Ops program. To learn more, visit www.atlas-games.com/ArM5. You can also participate in discussion of **Ars Magica** at the offi cial Atlas Games forums located at www.atlas-games.com/forum.
+**Special Thanks:** Jerry Corrick and the gang at the Source
+
+**Ars Magica** players participate in a thriving fan community by subscribing to email discussion lists (like the Berkeley list), compiling archives of game material (such as Project Redcap), maintaining fan-created web sites, and running demos through Atlas Games' Special Ops program. To learn more, visit www.atlas-games.com/ArM5. You can also participate in discussion of **Ars Magica** at the official Atlas Games forums located at www.atlas-games.com/forum.
 
 Copyright 2007 Trident, Inc. d/b/a Atlas Games. All rights reserved. Reproduction of this work by any means without written permission from the publisher, except short excerpts for the purpose of reviews, is expressly prohibited.
 
 **Ars Magica**, Mythic Europe, Houses of Hermes: Societates, Ancient Magic, City & Guild, Realms of Power: The Infernal, Realms of Power: The Divine, Houses of Hermes: Mystery Cults, Houses of Hermes: True Lineages, The Mysteries, Covenants, Guardians of the Forests, The Broken Covenant of Calebais, and Charting New Realms of Imagination are trademarks of Trident, Inc. Order of Hermes, Tremere, and Doissetep are trademarks of White Wolf, Inc. and are used with permission.
 
-> **Saint Paul, Minnesota • info@atlas-games.com Digital Edition Version 1.0 • July 2009**
-
-### Societates
+**Saint Paul, Minnesota - info@atlas-games.com - Digital Edition Version 1.0 - July 2009**
 
 # Table of Contents
 
-| Introduction                              | 5<br>House Acclaim 31                           |   | Electing the Primus51                              |  |
-|-------------------------------------------|-------------------------------------------------|---|----------------------------------------------------|--|
-|                                           | New Flaws 31                                    |   | The Current Primus and His Family52                |  |
-|                                           | Miles31                                         |   | The Primus's Policies52                            |  |
-|                                           | Rules for Magical Combat 32                     |   | Valnastium 53                                      |  |
-| House Flambeau                            | 6<br>Fighting Invisibly32                       |   | League Membership 53                               |  |
-|                                           | Locating an Invisible Character32               |   | Designing a League53                               |  |
-| History6                                  | Invisibility and Group Combat33                 |   | Example Leagues54                                  |  |
-| Flambeau and the Early Order 7            | New Magic Rules 33                              |   | Design Notes for Jerbiton Magi55                   |  |
-| The Controversy over Wizard's War 8       | Effect Modification for Enchanted Items33       |   | Less Intelligent Magi? 55                          |  |
-| The Second Generation 9                   | Spell Mastery Special Abilities33               |   | Free Virtue 55                                     |  |
-| The Founder's End 9                       | New Spells 34                                   |   | Favored Virtues and Flaws 55                       |  |
-| The House Under Apromor 10                |                                                 |   | New Virtues and Flaws 56                           |  |
-| The Schism War 10                         |                                                 |   | New Virtues 56                                     |  |
-| The Rise of the Milites 11                | House Jerbiton 3                                | 9 | Muse56                                             |  |
-| The Normandy Crisis 11                    |                                                 |   | Mystical Choreography56                            |  |
-| House Flambeau in 122011                  |                                                 |   | Supernatural Beauty56                              |  |
-| House Culture 12                          | The History of House Jerbiton39                 |   | New Flaws 56                                       |  |
-| The Primus 12                             | Flavius of Jerbiton, the Founder39              |   | Brutal Artist56                                    |  |
-| Domus Magna 13                            | The League of Iconophiles, the Tradition of the |   |                                                    |  |
-| Joining House Flambeau 14                 | Founder's Teacher40                             |   | Envied Beauty56                                    |  |
-| Societas Flambonis: The Milites 15        | The Apprenticeship of the Founder40             |   | Urban Magic57                                      |  |
-| Societas Flambonis: The Cult of Mercury16 | Valnastium Founded40                            |   | Lacunae57                                          |  |
-| Societas Flambonis: The Mithraians 17     | The Order of Hermes Forms40                     |   | Small Effects and High Penetration                 |  |
-| Flambeau Concepts 18                      | Attitude to the Order41                         |   | Bonuses 58                                         |  |
-| Hoplites18                                | The House After the Founder41                   |   | Subtle Spells58                                    |  |
-| Crusaders18                               | The Fall of Constantinople41                    |   | Public Spells58                                    |  |
-| Demon-Hunters and Exorcists19             | The Future, and the Antigones43                 |   | Wilderness Spells58                                |  |
-| Duelists and Champions19                  | Living Tastefully44                             |   | Ceremonial Magic58                                 |  |
-| Mercenaries and Adventurers19             | Seeking Beauty 44                               |   | Spell Mastery for Urban Characters60               |  |
-| Statesmen and Orators20                   | Avoiding Ugliness44                             |   | Arcane Connections60                               |  |
-| Hunters and Dragon-Slayers20              | Taste44                                         |   | The Creation of Beautiful Things60                 |  |
-| Outlaws and Rogues20                      | Art44                                           |   | Beautiful Objects and Detailed Illusions 60        |  |
-| Flambeau Tournaments20                    | Places of Beauty45                              |   | Creo Magic60                                       |  |
-| Certamen 21                               | Leisure 45                                      |   | Rego Magic60                                       |  |
-| Dimicatio 21                              | Sufficiency45                                   |   | Flourishes60                                       |  |
-| Wizards' Melee 21                         | Intrigue 45                                     |   | Perception and Deception61                         |  |
-| Special Challenges 22                     | Family45                                        |   | Species 61                                         |  |
-| Entertainment and Side Events 22          | Interference With the Mundanes46                |   | The Process of Perception63                        |  |
-| Wizard's War22                            | Travel 47                                       |   | Mimicry: Making Illusionary Objects 63             |  |
-| Wizard's War and the Order 22             | Fosterage47                                     |   | Traveling Species 63                               |  |
-| Reasons to Declare Wizard's War 23        | The Itinerarium47                               |   | Transparency63                                     |  |
-| Preparing for Wizard's War 24             | Paradoxography48                                |   | Striking the Organs of Perception 64               |  |
-| Waging Wizard's War 24                    | Display 48                                      |   | Macrotures: Illusions of Proximity to the Organ of |  |
-| Schools of Magical Combat25               | Dress48                                         |   | Perception64                                       |  |
-| Choosing a School 25                      | Animals48                                       |   | Synaesthesia: Switching Organs of                  |  |
-| Example Schools of Magical Combat 26      | Etiquette 48                                    |   | Perception64                                       |  |
-| The School of the Founder26               | Individual49                                    |   | Tricks of Interpretation 65                        |  |
-| The School of Apromor27                   | Competitive49                                   |   | Anamorphs65                                        |  |
-| The School of Boreas28                    | Collaborative49                                 |   | Created Emotional Bias66                           |  |
-| The School of Ramius28                    | Money and Good Manners50                        |   | Diminished Mental Capability66                     |  |
-| The Schools of Sebastian29                | Hermetic Courtesy and Hospitality51             |   | Miniatures: Tricks Using Perspective67             |  |
-| The School of Vilano29                    | Such Structure as the House Has51               |   | States of Consciousness67                          |  |
-| Rules for House Flambeau31                | The Primus 51                                   |   | Altering Thoughts68                                |  |
-|                                           |                                                 |   |                                                    |  |
+**Introduction: Societates**<br>
 
+**Chapter One: House Flambeau**<br>
+&emsp;History<br>
+&emsp;&emsp;Flambeau and the Early Order<br>
+&emsp;&emsp;The Controversy over Wizard's War<br>
+&emsp;&emsp;The Second Generation<br>
+&emsp;&emsp;The Founder's End<br>
+&emsp;&emsp;The House Under Apromor<br>
+&emsp;&emsp;The Schism War<br>
+&emsp;&emsp;The Rise of the Milites<br>
+&emsp;&emsp;The Normandy Crisis<br>
+&emsp;House Flambeau in 1220<br>
+&emsp;&emsp;House Culture<br>
+&emsp;&emsp;The Primus<br>
+&emsp;&emsp;Domus Magna<br>
+&emsp;&emsp;Joining House Flambeau<br>
+&emsp;&emsp;Societas Flambonis: The Milites<br>
+&emsp;&emsp;Societas Flambonis: The Cult of Mercury<br>
+&emsp;&emsp;Societas Flambonis: The Mithraians<br>
+&emsp;Flambeau Concepts<br>
+&emsp;&emsp;Hoplites<br>
+&emsp;&emsp;Crusaders<br>
+&emsp;&emsp;Demon-Hunters and Exorcists<br>
+&emsp;&emsp;Duelists and Champions<br>
+&emsp;&emsp;Mercenaries and Adventurers<br>
+&emsp;&emsp;Statesmen and Orators<br>
+&emsp;&emsp;Hunters and Dragon-Slayers<br>
+&emsp;&emsp;Outlaws and Rogues<br>
+&emsp;Flambeau Tournaments<br>
+&emsp;&emsp;Certamen<br>
+&emsp;&emsp;Dimicatio<br>
+&emsp;&emsp;Wizards' Melee<br>
+&emsp;&emsp;Special Challenges<br>
+&emsp;&emsp;Entertainment and Side Events<br>
+&emsp;Wizard's War<br>
+&emsp;&emsp;Wizard's War and the Order<br>
+&emsp;&emsp;Reasons to Declare Wizard's War<br>
+&emsp;&emsp;Preparing for Wizard's War<br>
+&emsp;&emsp;Waging Wizard's War<br>
+&emsp;Schools of Magical Combat<br>
+&emsp;&emsp;Choosing a School<br>
+&emsp;&emsp;Example Schools of Magical Combat<br>
+&emsp;&emsp;The School of the Founder<br>
+&emsp;&emsp;The School of Apromor<br>
+&emsp;&emsp;The School of Boreas<br>
+&emsp;&emsp;The School of Ramius<br>
+&emsp;&emsp;The Schools of Sebastian<br>
+&emsp;&emsp;The School of Vilano<br>
+&emsp;Rules for House Flambeau<br>
+&emsp;&emsp;House Acclaim<br>
+&emsp;&emsp;New Flaws<br>
+&emsp;&emsp;Miles<br>
+&emsp;&emsp;Rules for Magical Combat<br>
+&emsp;&emsp;&emsp;Fighting Invisibly<br>
+&emsp;&emsp;&emsp;Locating an Invisible Character<br>
+&emsp;&emsp;&emsp;Invisibility and Group Combat<br>
+&emsp;&emsp;New Magic Rules<br>
+&emsp;&emsp;&emsp;Effect Modification for Enchanted Items<br>
+&emsp;&emsp;&emsp;Spell Mastery Special Abilities<br>
+&emsp;&emsp;&emsp;New Spells<br>
 
-| Episodic Memories69                      |
-|------------------------------------------|
-| The Memorization of Created Knowledge 70 |
-| Other Tricks of Memory70                 |
-|                                          |
-|                                          |
-| House Tytalus<br>71                      |
-|                                          |
-| History71                                |
-| Tytalus the Sorcerer 71                  |
-| Tytalus the Magus 72                     |
-|                                          |
-| The House After Tytalus 73               |
-| The Betrayal 74                          |
-| The Schism War and its Aftermath 74      |
-| Primi at War75                           |
-| The Philosoph<br>y of Conflict75         |
-| The Antagonism Between Physis and        |
-| Nomos 76                                 |
-| Calliclean Ethics76                      |
-| Hippian Ethics77                         |
-| Growth Through Conflict77                |
-| Tools of Conflict 78                     |
-| Rivalry78                                |
-| Persuasion78                             |
-| Force78                                  |
-| Culture78                                |
-| Reverence for the Founder79              |
-| Equality79                               |
-| Pedagogy79                               |
-| Personality79                            |
-| Beloved Rivals80                         |
-| Eristic Moots81                          |
-| Apprenticeship 82                        |
-|                                          |
-| The Apprentice's Gauntlet83              |
-| Joining House Tytalus83                  |
-| Cabals 84                                |
-| Intrigue85                               |
-| Tytalan Agencies 86                      |
-| Spies86                                  |
-| Criminal Agents86                        |
-| Thugs86                                  |
-| Double Agents and Hostile Takeovers86    |
-| Disguises and Personae 87                |
-| Short-Term Disguises87                   |
-| Deep Cover Disguises87                   |
-| Personae90                               |
-| The Fine Art of Debate90                 |
-| Resolving Differences 90                 |
-| Winning Arguments 91                     |
-| Case Rulings92                           |
-| Characters93                             |
-| New Virtues 93                           |
-| Leper Magus93                            |
-| Persona94                                |
-| New Flaws 94                             |
-| Leprosy94                                |
-| Beloved Rival94                          |
-| Titanoi 94                               |
-| Leper Magi 95                            |
-| Magic96                                  |
-|                                          |
-| Magic for the Debating Arena96           |
-| The Magic of Impersonation97             |
-| The Magic of Intrigue98                  |
-| The Magic of the Titanoi99               |
-| The Magic of the Leper Magi100           |
+**Chapter Two: House Jerbiton**<br>
+&emsp;The History of House Jerbiton<br>
+&emsp;&emsp;Flavius of Jerbiton, the Founder<br>
+&emsp;&emsp;The League of Iconophiles, the Tradition of the Founder's Teacher<br>
+&emsp;&emsp;The Apprenticeship of the Founder<br>
+&emsp;&emsp;Valnastium Founded<br>
+&emsp;&emsp;The Order of Hermes Forms<br>
+&emsp;&emsp;Attitude to the Order<br>
+&emsp;&emsp;The House After the Founder<br>
+&emsp;&emsp;The Fall of Constantinople<br>
+&emsp;&emsp;The Future, and the Antigones<br>
+&emsp;Living Tastefully<br>
+&emsp;&emsp;Seeking Beauty<br>
+&emsp;&emsp;Avoiding Ugliness<br>
+&emsp;&emsp;Taste<br>
+&emsp;&emsp;Art<br>
+&emsp;&emsp;Places of Beauty<br>
+&emsp;&emsp;Leisure<br>
+&emsp;&emsp;Sufficiency<br>
+&emsp;&emsp;Intrigue<br>
+&emsp;&emsp;Family<br>
+&emsp;&emsp;Interference With the Mundanes<br>
+&emsp;&emsp;Travel<br>
+&emsp;&emsp;Fosterage<br>
+&emsp;&emsp;The Itinerarium<br>
+&emsp;Paradoxography<br>
+&emsp;&emsp;Display<br>
+&emsp;&emsp;Dress<br>
+&emsp;&emsp;Animals<br>
+&emsp;&emsp;Etiquette<br>
+&emsp;&emsp;Individual<br>
+&emsp;&emsp;Competitive<br>
+&emsp;&emsp;Collaborative<br>
+&emsp;&emsp;Money and Good Manners<br>
+&emsp;&emsp;Hermetic Courtesy and Hospitality<br>
+&emsp;Such Structure as the House Has<br>
+&emsp;&emsp;The Primus<br>
+&emsp;&emsp;&emsp;Electing the Primus<br>
+&emsp;&emsp;&emsp;The Current Primus and His Family<br>
+&emsp;&emsp;&emsp;The Primus's Policies<br>
+&emsp;&emsp;Valnastium<br>
+&emsp;&emsp;League Membership<br>
+&emsp;&emsp;&emsp;Designing a League<br>
+&emsp;&emsp;&emsp;Example Leagues<br>
+&emsp;Design Notes for Jerbiton Magi<br>
+&emsp;&emsp;Less Intelligent Magi?<br>
+&emsp;&emsp;Free Virtue<br>
+&emsp;&emsp;Favored Virtues and Flaws<br>
+&emsp;&emsp;New Virtues and Flaws<br>
+&emsp;&emsp;&emsp;New Virtues<br>
+&emsp;&emsp;&emsp;&emsp;Muse<br>
+&emsp;&emsp;&emsp;&emsp;Mystical Choreography<br>
+&emsp;&emsp;&emsp;&emsp;Supernatural Beauty<br>
+&emsp;&emsp;&emsp;New Flaws<br>
+&emsp;&emsp;&emsp;&emsp;Brutal Artist<br>
+&emsp;&emsp;&emsp;&emsp;Envied Beauty<br>
+&emsp;Urban Magic<br>
+&emsp;&emsp;Lacunae<br>
+&emsp;&emsp;Small Effects and High Penetration Bonuses<br>
+&emsp;&emsp;Subtle Spells<br>
+&emsp;&emsp;Public Spells<br>
+&emsp;&emsp;Wilderness Spells<br>
+&emsp;&emsp;Ceremonial Magic<br>
+&emsp;&emsp;Spell Mastery for Urban Characters<br>
+&emsp;&emsp;Arcane Connections<br>
+&emsp;The Creation of Beautiful Things<br>
+&emsp;&emsp;Beautiful Objects and Detailed Illusions<br>
+&emsp;&emsp;Creo Magic<br>
+&emsp;&emsp;Rego Magic<br>
+&emsp;&emsp;Flourishes<br>
+&emsp;Perception and Deception<br>
+&emsp;&emsp;Species<br>
+&emsp;&emsp;The Process of Perception<br>
+&emsp;&emsp;Mimicry: Making Illusionary Objects<br>
+&emsp;&emsp;Traveling Species<br>
+&emsp;&emsp;Transparency<br>
+&emsp;&emsp;Striking the Organs of Perception<br>
+&emsp;&emsp;Macrotures: Illusions of Proximity to the Organ of Perception<br>
+&emsp;&emsp;Synaesthesia: Switching Organs of Perception<br>
+&emsp;&emsp;Tricks of Interpretation<br>
+&emsp;&emsp;Anamorphs<br>
+&emsp;&emsp;Created Emotional Bias<br>
+&emsp;&emsp;Diminished Mental Capability<br>
+&emsp;&emsp;Miniatures: Tricks Using Perspective<br>
+&emsp;&emsp;States of Consciousness<br>
+&emsp;&emsp;Altering Thoughts<br>
+&emsp;Memory<br>
+&emsp;&emsp;Inscribed Memories<br>
+&emsp;&emsp;Procedural Memories<br>
+&emsp;&emsp;Episodic Memories<br>
+&emsp;&emsp;The Memorization of Created Knowledge<br>
+&emsp;&emsp;Other Tricks of Memory<br>
 
-**Memory..................................................68** *Inscribed Memories...................................69 Procedural Memories................................69*
+**Chapter Three: House Tytalus**<br>
+&emsp;History<br>
+&emsp;&emsp;Tytalus the Sorcerer<br>
+&emsp;&emsp;Tytalus the Magus<br>
+&emsp;&emsp;The House After Tytalus<br>
+&emsp;&emsp;The Betrayal<br>
+&emsp;&emsp;The Schism War and its Aftermath<br>
+&emsp;&emsp;Primi at War<br>
+&emsp;The Philosophy of Conflict<br>
+&emsp;&emsp;The Antagonism Between Physis and Nomos<br>
+&emsp;&emsp;Calliclean Ethics<br>
+&emsp;&emsp;Hippian Ethics<br>
+&emsp;&emsp;Growth Through Conflict<br>
+&emsp;&emsp;Tools of Conflict<br>
+&emsp;&emsp;&emsp;Rivalry<br>
+&emsp;&emsp;&emsp;Persuasion<br>
+&emsp;&emsp;&emsp;Force<br>
+&emsp;Culture<br>
+&emsp;&emsp;Reverence for the Founder<br>
+&emsp;&emsp;Equality<br>
+&emsp;&emsp;Pedagogy<br>
+&emsp;&emsp;Personality<br>
+&emsp;&emsp;Beloved Rivals<br>
+&emsp;&emsp;Eristic Moots<br>
+&emsp;&emsp;Apprenticeship<br>
+&emsp;&emsp;&emsp;The Apprentice's Gauntlet<br>
+&emsp;&emsp;&emsp;Joining House Tytalus<br>
+&emsp;&emsp;Cabals<br>
+&emsp;Intrigue<br>
+&emsp;&emsp;Tytalan Agencies<br>
+&emsp;&emsp;&emsp;Spies<br>
+&emsp;&emsp;&emsp;Criminal Agents<br>
+&emsp;&emsp;&emsp;Thugs<br>
+&emsp;&emsp;&emsp;Double Agents and Hostile Takeovers<br>
+&emsp;&emsp;Disguises and Personae<br>
+&emsp;&emsp;&emsp;Short-Term Disguises<br>
+&emsp;&emsp;&emsp;Deep Cover Disguises<br>
+&emsp;&emsp;&emsp;Personae<br>
+&emsp;The Fine Art of Debate<br>
+&emsp;&emsp;Resolving Differences<br>
+&emsp;&emsp;Winning Arguments<br>
+&emsp;&emsp;Case Rulings<br>
+&emsp;Characters<br>
+&emsp;&emsp;New Virtues<br>
+&emsp;&emsp;&emsp;Leper Magus<br>
+&emsp;&emsp;&emsp;Persona<br>
+&emsp;&emsp;New Flaws<br>
+&emsp;&emsp;&emsp;Leprosy<br>
+&emsp;&emsp;&emsp;Beloved Rival<br>
+&emsp;&emsp;&emsp;Titanoi<br>
+&emsp;&emsp;&emsp;Leper Magi<br>
+&emsp;Magic<br>
+&emsp;&emsp;Magic for the Debating Arena<br>
+&emsp;&emsp;The Magic of Impersonation<br>
+&emsp;&emsp;The Magic of Intrigue<br>
+&emsp;&emsp;The Magic of the Titanoi<br>
+&emsp;&emsp;The Magic of the Leper Magi<br>
 
-| House Ex Miscellanea                           | 101 |
-|------------------------------------------------|-----|
-| History101                                     |     |
-| Culture102                                     |     |
-| Governance of House Ex Miscellanea102          |     |
-| Magic103                                       |     |
-| Supernatural Abilities 103                     |     |
-| The Basics103                                  |     |
-| Designing a Supernatural Ability104            |     |
-| Example Supernatural Abilities 105             |     |
-| Summon Animals105                              |     |
-| Whistle Up the Wind105                         |     |
-| Control Fertility105                           |     |
-| Magi Ex Miscellanea Without a Major            |     |
-| Supernatural Ability 106                       |     |
-| Characters106                                  |     |
-| Magi Ex Miscellanea106                         |     |
-| Magi Orbi106                                   |     |
-| Gifted Companions107<br>New Virtue 107         |     |
-| Exotic Casting107                              |     |
-| New Flaws 107                                  |     |
-| Flawed Powers107                               |     |
-| Vulnerable to Folk Tradition107                |     |
-| Traditions of House Ex Miscellanea 108         |     |
-| Beast Masters108                               |     |
-| Damhadh-Duidsan108                             |     |
-| Hermetic Haruspexes108                         |     |
-| Karaites108                                    |     |
-| Malocchi108                                    |     |
-| Scinnfolk (Gifted Companions)109               |     |
-| Tempestaria (Weather Witch)109                 |     |
-| Witches of Thessaly109                         |     |
-| Columbae110                                    |     |
-| Key Facts 110                                  |     |
-| History 110                                    |     |
-| Culture 110                                    |     |
-| Characters 112                                 |     |
-| Major Supernatural Virtue: Warding112          |     |
-| Minor Hermetic Virtue: Ring/Circle Magic113    |     |
-| Major Hermetic Flaw: Necessary Condition115    |     |
-| The Donatores Requietis Aeternae115            |     |
-| Key Facts 115                                  |     |
-| History 115                                    |     |
-| Cult of the Dead115                            |     |
-| Founding the Tradition115                      |     |
-| Incorporation into the Order116<br>Culture 116 |     |
-| Quieting the Restless Dead116                  |     |
-| Traditions of the Donatores Requietis          |     |
-| Aeternae117                                    |     |
-| Organization117                                |     |
-| Surveillance by House Guernicus117             |     |
-| Characters 117                                 |     |
-| New Virtue: Banishing118                       |     |
-| Favored Virtues and Flaws119                   |     |
-| Preferred Spells120                            |     |
-| The Cult of Orph<br>eus120                     |     |
-| Key Facts 120                                  |     |
-| History 120                                    |     |
-| Culture 120                                    |     |
-| Characters 121                                 |     |
-| Major General Virtue, Sanguine Humor's         |     |
-| Blessing121                                    |     |
+**Chapter Four: House Ex Miscellanea**<br>
+&emsp;History<br>
+&emsp;Culture<br>
+&emsp;&emsp;Governance of House Ex Miscellanea<br>
+&emsp;Magic<br>
+&emsp;&emsp;Supernatural Abilities<br>
+&emsp;&emsp;&emsp;The Basics<br>
+&emsp;&emsp;&emsp;Designing a Supernatural Ability<br>
+&emsp;&emsp;&emsp;Example Supernatural Abilities<br>
+&emsp;&emsp;&emsp;Summon Animals<br>
+&emsp;&emsp;&emsp;Whistle Up the Wind<br>
+&emsp;&emsp;&emsp;Control Fertility<br>
+&emsp;&emsp;Magi Ex Miscellanea Without a Major Supernatural Ability<br>
+&emsp;Characters<br>
+&emsp;&emsp;Magi Ex Miscellanea<br>
+&emsp;&emsp;Magi Orbi<br>
+&emsp;&emsp;Gifted Companions<br>
+&emsp;&emsp;New Virtue<br>
+&emsp;&emsp;&emsp;Exotic Casting<br>
+&emsp;&emsp;New Flaws<br>
+&emsp;&emsp;&emsp;Flawed Powers<br>
+&emsp;&emsp;&emsp;Vulnerable to Folk Tradition<br>
+&emsp;Traditions of House Ex Miscellanea<br>
+&emsp;&emsp;Beast Masters<br>
+&emsp;&emsp;Damhadh-Duidsan<br>
+&emsp;&emsp;Hermetic Haruspexes<br>
+&emsp;&emsp;Karaites<br>
+&emsp;&emsp;Malocchi<br>
+&emsp;&emsp;Scinnfolk (Gifted Companions)<br>
+&emsp;&emsp;Tempestaria (Weather Witch)<br>
+&emsp;&emsp;Witches of Thessaly<br>
+&emsp;&emsp;Columbae<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;Major Supernatural Virtue: Warding<br>
+&emsp;&emsp;&emsp;Minor Hermetic Virtue: Ring/Circle Magic<br>
+&emsp;&emsp;&emsp;Major Hermetic Flaw: Necessary Condition<br>
+&emsp;&emsp;The Donatores Requietis Aeternae<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Cult of the Dead<br>
+&emsp;&emsp;&emsp;Founding the Tradition<br>
+&emsp;&emsp;&emsp;Incorporation into the Order<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Quieting the Restless Dead<br>
+&emsp;&emsp;&emsp;Traditions of the Donatores Requietis Aeternae<br>
+&emsp;&emsp;&emsp;Organization<br>
+&emsp;&emsp;&emsp;Surveillance by House Guernicus<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;New Virtue: Banishing<br>
+&emsp;&emsp;&emsp;Favored Virtues and Flaws<br>
+&emsp;&emsp;&emsp;Preferred Spells<br>
+&emsp;&emsp;The Cult of Orpheus<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;Major General Virtue: Sanguine Humor's Blessing<br>
+&emsp;&emsp;&emsp;Minor Hermetic Virtue: Orphic Magic<br>
+&emsp;&emsp;&emsp;Major Hermetic Flaw: Restriction (True Feeling)<br>
+&emsp;&emsp;&emsp;Orphic Spells<br>
+&emsp;&emsp;The Pharmacopoeians<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;Profession Apothecary<br>
+&emsp;&emsp;&emsp;Major Supernatural Virtue: Mythic Herbalism<br>
+&emsp;&emsp;&emsp;Minor Hermetic Virtue: Root-Cutter<br>
+&emsp;&emsp;The Lineage of Pralix<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Induction of Hedge Wizards into the Order<br>
+&emsp;&emsp;&emsp;Joint Training of Apprentices<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;New Major Supernatural Virtue: Comprehend Magic<br>
+&emsp;&emsp;&emsp;New Supernatural Ability: Comprehend Magic*<br>
+&emsp;&emsp;&emsp;Other Magical Interests<br>
+&emsp;&emsp;&emsp;New Spells<br>
+&emsp;&emsp;&emsp;New Mastery Special Ability: Unraveling<br>
+&emsp;&emsp;&emsp;New Mastery Special Ability: Rebuttal<br>
+&emsp;&emsp;Rustic Magi<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;Major Supernatural Virtue: Craft Magic<br>
+&emsp;&emsp;&emsp;Minor Hermetic Virtue: Spell Foci<br>
+&emsp;&emsp;&emsp;Major Hermetic Flaw: Weak Spontaneous Magic<br>
+&emsp;&emsp;Hermetic Sahirs<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Relationship with the Non-Hermetic Sahirs<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;Major Supernatural Virtue: Sihr<br>
+&emsp;&emsp;&emsp;Hermetic Magic<br>
+&emsp;&emsp;Seirenes<br>
+&emsp;&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;&emsp;History<br>
+&emsp;&emsp;&emsp;Culture<br>
+&emsp;&emsp;&emsp;Characters<br>
+&emsp;&emsp;&emsp;Siren Song<br>
+&emsp;&emsp;&emsp;Agents are Directly Controlled<br>
+&emsp;&emsp;&emsp;Agents Act as Intermediaries<br>
+&emsp;&emsp;&emsp;Designing Agents<br>
+&emsp;&emsp;&emsp;Recruiting Agents at Character Creation<br>
+&emsp;&emsp;&emsp;Recruited Agents as Story Rewards<br>
+&emsp;&emsp;&emsp;Using Agents<br>
+&emsp;&emsp;&emsp;Confounding Situations<br>
+&emsp;&emsp;&emsp;Maintaining Agents<br>
 
-| Orphic Spells123                             |  |
-|----------------------------------------------|--|
-| The Pharmacopoeians123                       |  |
-| Key Facts 123                                |  |
-| History 123                                  |  |
-| Culture 124                                  |  |
-| Characters 124                               |  |
-| Profession Apothecary125                     |  |
-| Major Supernatural Virtue: Mythic            |  |
-| Herbalism125                                 |  |
-| Minor Hermetic Virtue: Root-Cutter126        |  |
-| The Lineage of Pralix126                     |  |
-| Key Facts 126                                |  |
-| History 126                                  |  |
-| Culture 126                                  |  |
-| Induction of Hedge Wizards into the Order127 |  |
-|                                              |  |
-| Joint Training of Apprentices128             |  |
-| Characters 128                               |  |
-| New Major Supernatural Virtue: Comprehend    |  |
-| Magic128                                     |  |
-| New Supernatural Ability: Comprehend         |  |
-| Magic*128                                    |  |
-| Other Magical Interests 129                  |  |
-| New Spells129                                |  |
-| New Mastery Special Ability: Unraveling129   |  |
-| New Mastery Special Ability: Rebuttal 129    |  |
-| Rustic Magi130                               |  |
-| Key Facts 130                                |  |
-| History 130                                  |  |
-| Culture 130                                  |  |
-| Characters 131                               |  |
-| Major Supernatural Virtue: Craft Magic131    |  |
-| Minor Hermetic Virtue: Spell Foci132         |  |
-| Major Hermetic Flaw: Weak Spontaneous        |  |
-| Magic132                                     |  |
-| Hermetic Sahirs133                           |  |
-| Key Facts 133                                |  |
-| History 133                                  |  |
-| Culture 133                                  |  |
-| Relationship with the Non-Hermetic Sahirs134 |  |
-|                                              |  |
-| Characters 134                               |  |
-| Major Supernatural Virtue: Sihr135           |  |
-| Hermetic Magic137                            |  |
-| Seirenes137                                  |  |
-| Key Facts 137                                |  |
-| History 137                                  |  |
-| Culture 138                                  |  |
-| Characters 139                               |  |
-| Siren Song139                                |  |
-| Agents are Directly Controlled 140           |  |
-| Agents Act as Intermediaries 140             |  |
-| Designing Agents 140                         |  |
-| Recruiting Agents at Character Creation141   |  |
-| Recruited Agents as Story Rewards141         |  |
-| Using Agents 141                             |  |
-| Confounding Situations142                    |  |
-| Maintaining Agents142                        |  |
-|                                              |  |
-
-
-*Minor Hermetic Virtue: Orphic Magic..122 Major Hermetic Flaw: Restriction (True Feeling).................................................122*
-
-### Societates
-
-# Introduction
+# Introduction: Societates
 
 Welcome to *Houses of Hermes: Societates*, the final volume in the *Houses of Hermes* series, covering Houses Flambeau, Jerbiton, Tytalus, and Ex Miscellanea.
 
@@ -298,83 +383,73 @@ House Flambeau includes the champions and knights of the Order, individual warri
 
 House Jerbiton live lives in pursuit of beauty, and in pursuit of living beautifully. This requires interaction with the world beyond the Order of Hermes, both for the sake of the beauty found there and to avoid the stunted lives that result from living entirely within a covenant. Experts in the use of Mentem and Imaginem, followers of Jerbiton generally prefer to interact subtly with the world. The fall of Constantinople has, however, been a great shock to them, and has pushed the House onto a more active path.
 
-House Tytalus thrive on, and admire, conflict. The main conflict they see in the world is between an individual's nature and the rules imposed by society, but they believe this central conflict plays out in many, less abstract, contests. They are renowned for long-running rivalries with their Housemates, convoluted political schemes, and activities that skirt the edges of legality.
+House Tytalus thrives on, and admire, conflict. The main conflict they see in the world is between an individual's nature and the rules imposed by society, but they believe this central conflict plays out in many, less abstract, contests. They are renowned for long-running rivalries with their Housemates, convoluted political schemes, and activities that skirt the edges of legality.
 
 House Ex Miscellanea gathers together magi who do not fit into any other House, normally due to ties with a pre-Hermetic tradition. The House claims to embody unity in diversity, but the emphasis is definitely on the diversity. This book provides eight detailed examples of traditions within the House, complete with rules for their non-Hermetic abilities.
 
-### About the Authors
+> ## About the Authors
+> 
+> **Erik Dahl** is neither Welsh nor particularly crafty, but did experiment with drawing mystic symbols around his office for inspiration. He and his very patient wife live in Davis, California. Erik's work on this book is dedicated to his very columbine and mechanical friend Mark Thomas, who possesses all the best qualities of these two traditions, and who first introduced Erik to **Ars Magica** mumbleteen years ago.
+> 
+> **Andrew Gronosky** is a software engineer specializing in Intellego Aquam. Currently living in Massachusetts with his lovely wife Vesna, he commutes daily to Rhode Island in search of adventure and glory. This book constitutes his Wizard's Gauntlet as an **Ars Magica** author. He would like to thank the playtesters and his fellow authors for their support, particularly Erik Dahl for help with the Cult of Mercury.
+> 
+> *Dedication: To Matt Ryan, eternal thanks for introducing me to Vesna.*
+> 
+> **Timothy Ferguson** is a librarian who lives on the Gold Coast. He thinks cats are estimable animals. He'd like to dedicate his section of this book to Damelon Kimborough, for encouraging his first attempts at writing House Jerbiton.
+> 
+> **John Post** is an attorney who lives and works in San Francisco with his lovely wife. His city is filled with a wonderful variety of misfits, outcasts, and other nonconformists. Although none directly contributed to his Ex Miscellanea traditions, they did inspire him to look beyond the conventional depiction of members of the House. He hopes that his traditions will similarly inspire **Ars Magica** players. He owes a debt of gratitude to the playtesters and his fellow authors for making his traditions better.
+> 
+> **Mark Shirley** is an ecologist in the North East of England. His players have complained that he enjoyed writing the Tytalus chapter entirely too much, and now shake every apparently innocuous event vigorously, expecting a devious plot to fall out. Despite rumors, he is not planning a career change from badgerbotherer to back-bench parliamentarian. He would like to dedicate this book to the veritable miscellanea of family he has acquired throughout his life.
+> 
+> **Nick Simmonds** is a computer technician in Indianapolis, Indiana, and a daredevil adventurer in the confines of his own head. He splits his gaming time between running games and desperately trying to convince someone else to run so that he can play for once. Nick would like to dedicate his portion of this book to his dog Winifred, who may not have helped him write it by jumping on the keyboard, but who certainly thought she did.
 
-**Erik Dahl** is neither Welsh nor particularly crafty, but did experiment with drawing mystic symbols around his office for inspiration. He and his very patient wife live in Davis, California. Erik's work on this book is dedicated to his very columbine and mechanical friend Mark Thomas, who possesses all the best qualities of these two traditions, and who first introduced Erik to **Ars Magica** mumbleteen years ago.
-
-**Andrew Gronosky** is a software engineer specializing in Intellego Aquam. Currently living in Massachusetts with his lovely wife Vesna, he commutes daily to Rhode Island in search of adventure and glory. This book constitutes his Wizard's Gauntlet as an **Ars Magica** author. He would like to thank the playtesters and his fellow authors for their support, particularly Erik Dahl for help with the Cult of Mercury.
-
-*Dedication: To Matt Ryan, eternal thanks for introducing me to Vesna.*
-
-**Timothy Ferguson** is a librarian who lives on the Gold Coast. He thinks cats are estimable animals. He'd like to dedicate his section of this book to Damelon Kimborough, for encouraging his first attempts at writing House Jerbiton.
-
-**John Post** is an attorney who lives and works in San Francisco with his lovely wife. His city is filled with a wonderful variety of misfits, outcasts, and other nonconformists. Although none directly contributed to his Ex Miscellanea traditions, they did inspire him to look beyond the conventional depiction of members of the House. He hopes that his traditions will similarly inspire **Ars Magica** players. He owes a debt of gratitude to the playtesters and his fellow authors for making his traditions better.
-
-**Mark Shirley** is an ecologist in the North East of England. His players have complained that he enjoyed writing the Tytalus chapter entirely too much, and now shake every apparently innocuous event vigorously, expecting a devious plot to fall out. Despite rumors, he is not planning a career change from badgerbotherer to back-bench parliamentarian. He would like to dedicate this book to the veritable miscellanea of family he has acquired throughout his life.
-
-**Nick Simmonds** is a computer technician in Indianapolis, Indiana, and a daredevil adventurer in the confines of his own head. He splits his gaming time between running games and desperately trying to convince someone else to run so that he can play for once. Nick would like to dedicate his portion of this book to his dog Winifred, who may not have helped him write it by jumping on the keyboard, but who certainly thought she did.
-
-### Chapter One
-
-# House Flambeau
+# Chapter One: House Flambeau
 
 *Of.what.value.is.magic.if.we.do.not.use.it?.What. good. is. a. wizard. who. serves. only. himself?. Power,. itself,.is.nothing..The.true.measure.of.a.magus.is.not. how.much.power.he.wields,.but.the.worthiness.of.the. cause.in.which.he.wields.it.*
 
 — Flambeau
 
-House Flambeau is a loose fraternity of magi drawn together by their warlike tendencies and love of adventure. While other magi sometimes consider them an unruly, violent rabble who must be kept under control, House Flambeau's courage and fi ghting prowess have helped the Order of Hermes survive the worst crises in its history.
+House Flambeau is a loose fraternity of magi drawn together by their warlike tendencies and love of adventure. While other magi sometimes consider them an unruly, violent rabble who must be kept under control, House Flambeau's courage and fighting prowess have helped the Order of Hermes survive the worst crises in its history.
 
-Flambeau magi see themselves as magical warriors. Combat is not necessarily their *raison.d'être*, but they are prepared to fi ght when necessary. Some think of themselves as the Hermetic parallel of mundane knights: elite warriors charged with defending the weak and upholding justice. Like mundane knights, Flambeau magi tend toward bravado.
+Flambeau magi see themselves as magical warriors. Combat is not necessarily their *raison d'être*, but they are prepared to fight when necessary. Some think of themselves as the Hermetic parallel of mundane knights: elite warriors charged with defending the weak and upholding justice. Like mundane knights, Flambeau magi tend toward bravado.
 
-When most wizards think of House Flambeau, they think of fi re magic. Flambeau the Founder was the fi rst and most famous master of the Art of Ignem. While fi re magic remains popular within the House, it is by no means the only specialty practiced by its members. This chapter gives details of several additional "schools," or styles of fi ghting magic, which can be pursued by any magus with an interest in self-defense.
+When most wizards think of House Flambeau, they think of fire magic. Flambeau the Founder was the first and most famous master of the Art of Ignem. While fire magic remains popular within the House, it is by no means the only specialty practiced by its members. This chapter gives details of several additional "schools," or styles of fighting magic, which can be pursued by any magus with an interest in self-defense.
 
-In their hearts, followers of Flambeau believe that magic is meant to be used. They admire achievement above all else, though each maga within the House follows her own path to personal glory. This could be anything from fi ghting perceived enemies of the Order, to leading a
+In their hearts, followers of Flambeau believe that magic is meant to be used. They admire achievement above all else, though each maga within the House follows her own path to personal glory. This could be anything from fighting perceived enemies of the Order, to leading a Hermetic political movement, to writing great books to enlighten and inspire future generations of magi. Theirs is a vigorous and active House, deeply involved in all aspects of Hermetic society.
 
-### Key Facts
+> ## Key Facts
+> 
+> **Population:** 114 (19 in the Provençal Tribunal)
+> 
+> **Primus:** Garus, a former soldier-of-fortune and tournament champion, now advancing in years. He is a leading member of the milites, a Flambeau faction that promotes chivalry and service to the Order.
+> 
+> **Domus Magna:** Castra Solis, a modest castle in the Provençal Tribunal.
+> 
+> **Favored tribunals:** Traditionally Iberia, Provençal, and Normandy, but Flambeau magi travel widely in search of adventure. In recent decades, they have increasingly settled in the Novgorod, Thebes, and Levant Tribunals.
+> 
+> **Motto:** Ad mortem incurramus ("Unto death, let us charge"). This was adopted during the Schism War and has remained ever since.
+> 
+> **Symbol:** An hourglass. To House Flambeau, it symbolizes both the fleeting span of a mortal life and the timelessness of legendary deeds.
 
-**PoPulation:.** 114 (19 in the Provençal Tribunal)
+## History
 
-**Primus:.** Garus, a former soldierof-fortune and tournament champion, now advancing in years. He is a leading member of the milites, a Flambeau faction that promotes chivalry and service to the Order.
-
-**domus. magna:.** Castra Solis, a modest castle in the Provençal Tribunal.
-
-**Favored.tribunals:.**Traditionally Iberia, Provençal, and Normandy, but Flambeau magi travel widely in search of adventure. In recent decades, they have increasingly settled in the Novgorod, Thebes, and Levant Tribunals.
-
-**motto:.** Ad mortem incurramus ("Unto death, let us charge"). This was adopted during the Schism War and has remained ever since.
-
-**symbol:.** An hourglass. To House Flambeau, it symbolizes both the fl eeting span of a mortal life and the timelessness of legendary deeds.
-
-
-Hermetic political movement, to writing great books to enlighten and inspire future generations of magi. Theirs is a vigorous and active House, deeply involved in all aspects of Hermetic society.
-
-# History
-
-Flambeau the Founder is a rather obscure fi gure. He left few writings, partly because he learned letters late in his life and was never comfortable with a quill in his hand. What the Order knows about him comes from the memoirs of his fi lii, and the few surviving letters he dictated to them.
+Flambeau the Founder is a rather obscure figure. He left few writings, partly because he learned letters late in his life and was never comfortable with a quill in his hand. What the Order knows about him comes from the memoirs of his filii, and the few surviving letters he dictated to them.
 
 Details such as Flambeau's exact age, birthplace, and even his Christian name are lost to history. He was born to a family of petty nobles in Gascony (southwestern France), probably around 715 AD. His family estate was caught in the path of the invading Moorish army of Emir abd Al Raman, which crossed the Pyrenees and advanced through France in 732. The Frankish King Charles Martel repulsed the Moors at the Battle of Tours (October 10, 732), but before that battle the invaders cut a swath of destruction along their northward march. Moorish outriders attacked and burned the young Flambeau's family estate, slaying his kinsmen. Flambeau himself was shot with an arrow and left for dead. Surviving serfs found him and cared for him as best they could, but his wound festered and he languished with fever.
 
-The peasants brought the ailing youth to a local hermit who was known for his healing skills. This was Laberius, a wizard whose magic descended from the ancient
+The peasants brought the ailing youth to a local hermit who was known for his healing skills. This was Laberius, a wizard whose magic descended from the ancient Roman cult of Mithras. Laberius immediately recognized Flambeau's magical potential. He nursed the youth back to health and then began training him as his apprentice.
 
-
-#### Societates
-
-### Famous Figures
-
-**Apromor:** Flambeau's eldest apprentice and first Primus of the House. Apromor led House Flambeau's efforts to actively recruit pagan magicians. He eventually turned away from fire magic to focus instead on spells of destruction.
-
-**Elaine:** Flambeau's second apprentice. A Hoplite, Archmage, and noteworthy scholar and author, she trained four apprentices and firmly established the Founder's direct lineage.
-
-**Kaeso:** Founder of the Mithraic tradition within House Flambeau.
-
-**Entisimon:** Primus who rallied his House during the Schism War and was later disgraced in the Normandy Crisis.
-
-**Cindrallon:** A Flambeau apprentice who was deemed by House elders to have passed her Gauntlet by slaying a renounced magus in a Wizard's March; she had completed only seven years of apprenticeship.
-
-Roman cult of Mithras. Laberius immediately recognized Flambeau's magical potential. He nursed the youth back to health and then began training him as his apprentice.
+> ## Famous Figures
+> 
+> **Apromor:** Flambeau's eldest apprentice and first Primus of the House. Apromor led House Flambeau's efforts to actively recruit pagan magicians. He eventually turned away from fire magic to focus instead on spells of destruction.
+> 
+> **Elaine:** Flambeau's second apprentice. A Hoplite, Archmage, and noteworthy scholar and author, she trained four apprentices and firmly established the Founder's direct lineage.
+> 
+> **Kaeso:** Founder of the Mithraic tradition within House Flambeau.
+> 
+> **Entisimon:** Primus who rallied his House during the Schism War and was later disgraced in the Normandy Crisis.
+> 
+> **Cindrallon:** A Flambeau apprentice who was deemed by House elders to have passed her Gauntlet by slaying a renounced magus in a Wizard's March; she had completed only seven years of apprenticeship.
 
 Flambeau proved to be an apt pupil, but a willful one. He chafed at the pagan mysticism underlying his master's ritual spells and kept trying to modify the incantations so they would work without mentioning the pagan gods.
 
@@ -390,26 +465,21 @@ Flambeau managed to hunt down three of the sahirs who had slain Laberius, but th
 
 At first, Flambeau was skeptical about the idea of an order of magi. He had a deep distrust for wizards of all kinds, even members of his own tradition, and did not believe Trianoma's alliance of magi could last. After Trianoma demonstrated to him the efficacy of the Parma Magica against hostile spells, Flambeau realized he would be at a severe disadvantage if he did not learn its secret. He agreed to travel to Durenmar and listen to what Bonisagus and the other Founders had to say.
 
-Trianoma asked Flambeau's permission to extend her own Parma Magica over him
+Trianoma asked Flambeau's permission to extend her own Parma Magica over him before he met any wizards at Durenmar. She told him it would protect him against treachery, but it also protected him from the distrust and hostility engendered by the other magi's Gifts. To Flambeau's surprise, he found the other Founders to be trustworthy and likable. He came to believe in the Order as a league of honorable wizards who could bring an end to the treachery and petty rivalries so common among European wizards before the Founding. He hoped to build the Order into a military alliance that could destroy the putative Order of Suleiman (see Chapter 4: House Ex Miscellanea, Hermetic Sahirs).
 
+Like all of the Founders, Flambeau made some contributions to Hermetic theory. His accomplishment of having invented a single, original spell shows that he had more talent in the laboratory than his violent reputation might suggest. Still, his contributions were modest compared to those of some other Founders. Flambeau was more interested in applying Bonisagus's theory than in extending it. He soon invented many new spells, greatly expanding his personal repertoire. Later in his career, he spent years searching for ways to overcome the Parma Magica, in case the secret should ever fall into enemy hands. This work pioneered the study of Penetration as an Arcane Ability.
 
-before he met any wizards at Durenmar. She told him it would protect him against treachery, but it also protected him from the distrust and hostility engendered by the other magi's Gifts. To Flambeau's surprise, he found the other Founders to be trustworthy and likable. He came to believe in the Order as a league of honorable wizards who could bring an end to the treachery and petty rivalries so common among European wizards before the Founding. He hoped to build the Order into a military alliance that could destroy the putative Order of Suleiman (see Chapter 4: House Ex Miscellanea, Hermetic Sahirs).
-
-Like all of the Founders, Flambeau made some contributions to Hermetic theory. His accomplishment of having invented a single, original spell shows that he had more talent in the laboratory than his violent reputation might suggest. Still, his contributions were modest compared to those of some other Founders. Flambeau was more interested in applying Bonisagus's theory than in extending it. He soon invented many new spells, greatly expanding his personal repertoire. Later
-
-### Join or Die
-
-Flambeau advocated that all wizards in Christendom be brought into the Order – by force, if necessary. Not all of the Founders agreed: Guernicus insisted that membership in the Order should be strictly voluntary. Flambeau pointed out that a wizard who refused to swear the Oath was refusing to make peace with the Order and should be treated as an enemy.
-
-Guernicus did persuade the First Tribunal that wizards should be offered a chance to join the Order before being attacked. For the most part, Flambeau seems to have taken that directive to heart − except with regard to the sahirs, his sworn enemies. Flambeau firmly believed that all sahirs were diabolists and he repeatedly said he would rather be Marched than see one of them accepted into the Order.
-
-Flambeau personally recruited several wizards into the fledgling Order. Contrary to legend, he was usually diplomatic, not belligerent, toward non-Hermetic magicians (though he was candid about the potential consequences of refusing to join the Order). He did lose his temper and shout the famous words, "Join us or die!" on at least one occasion, but later generations of magi tend to exaggerate the frequency with which he used that ultimatum.
-
-The one documented case where Flambeau used his famous threat was in 771. He and three followers were confronting a wizard named Varstus who lived in the Italian Alps. Varstus was skilled in sympathetic magic, which could potentially be used as a form of attack. Furthermore, he was rumored to be organizing other wizards to resist Hermetic expansion into the area. Trianoma had previously approached Varstus with an offer of membership in the Order, but he had responded with scorn and threats. Bonisagus personally asked Flambeau to resolve the situation, hoping that Flambeau's reputation as a wizard-slayer would give Varstus pause. Varstus proved as ignorant as he was stubborn: Flambeau's name meant nothing to him, and he greeted the Founder with the same belligerence and arrogance he had shown Trianoma. Flambeau finally lost his temper and shouted, "Join us or die!," hurling a bolt of fire at a nearby tree to emphasize his words. He gave Varstus until sunset to decide. The Italian wizard withdrew, saying he would consider the offer, then immediately fled into the mountains. Flambeau waited until sunset as promised, then he and his followers gave chase. Varstus was dead before the next dawn; his allied hedge wizards capitulated and joined the Order.
-
-Even so, Flambeau believed that bringing new wizards into the Order should be a gradual, diplomatic process. Magi in 1220 – especially young magi – should be aware that demanding hedge wizards "join or die" is neither a common nor a recommended recruitment technique. Even in Mythic Europe, one can catch more flies with honey than with vinegar.
-
-in his career, he spent years searching for ways to overcome the Parma Magica, in case the secret should ever fall into enemy hands. This work pioneered the study of Penetration as an Arcane Ability.
+> ## Join or Die
+> 
+> Flambeau advocated that all wizards in Christendom be brought into the Order – by force, if necessary. Not all of the Founders agreed: Guernicus insisted that membership in the Order should be strictly voluntary. Flambeau pointed out that a wizard who refused to swear the Oath was refusing to make peace with the Order and should be treated as an enemy.
+> 
+> Guernicus did persuade the First Tribunal that wizards should be offered a chance to join the Order before being attacked. For the most part, Flambeau seems to have taken that directive to heart − except with regard to the sahirs, his sworn enemies. Flambeau firmly believed that all sahirs were diabolists and he repeatedly said he would rather be Marched than see one of them accepted into the Order.
+> 
+> Flambeau personally recruited several wizards into the fledgling Order. Contrary to legend, he was usually diplomatic, not belligerent, toward non-Hermetic magicians (though he was candid about the potential consequences of refusing to join the Order). He did lose his temper and shout the famous words, "Join us or die!" on at least one occasion, but later generations of magi tend to exaggerate the frequency with which he used that ultimatum.
+> 
+> The one documented case where Flambeau used his famous threat was in 771. He and three followers were confronting a wizard named Varstus who lived in the Italian Alps. Varstus was skilled in sympathetic magic, which could potentially be used as a form of attack. Furthermore, he was rumored to be organizing other wizards to resist Hermetic expansion into the area. Trianoma had previously approached Varstus with an offer of membership in the Order, but he had responded with scorn and threats. Bonisagus personally asked Flambeau to resolve the situation, hoping that Flambeau's reputation as a wizard-slayer would give Varstus pause. Varstus proved as ignorant as he was stubborn: Flambeau's name meant nothing to him, and he greeted the Founder with the same belligerence and arrogance he had shown Trianoma. Flambeau finally lost his temper and shouted, "Join us or die!," hurling a bolt of fire at a nearby tree to emphasize his words. He gave Varstus until sunset to decide. The Italian wizard withdrew, saying he would consider the offer, then immediately fled into the mountains. Flambeau waited until sunset as promised, then he and his followers gave chase. Varstus was dead before the next dawn; his allied hedge wizards capitulated and joined the Order.
+> 
+> Even so, Flambeau believed that bringing new wizards into the Order should be a gradual, diplomatic process. Magi in 1220 – especially young magi – should be aware that demanding hedge wizards "join or die" is neither a common nor a recommended recruitment technique. Even in Mythic Europe, one can catch more flies with honey than with vinegar.
 
 Flambeau's lasting contributions were in politics, not research. To expand the new alliance of magi, he traveled throughout what are now the Normandy and Provençal Tribunals, recruiting as many wizards as he could find. He proved to be a capable negotiator. The weight of his reputation was enough to make non-Hermetic wizards willing to talk to him rather than fight, and once he had their attention, he was charismatic and persuasive. His enthusiasm for the Order was contagious. Though he trained only two apprentices of his own, his House grew rapidly through recruitment.
 
@@ -429,11 +499,7 @@ At the time of the First Tribunal, it was unclear exactly how the Order would en
 
 Flambeau argued persuasively that wizards needed the right to use violence when necessary. He gave a number of hypothetical situations where one magus could bully, blackmail, or torment another without being in clear breach of the Code. He argued that if the law strictly forbade one magus from taking vengeance against another, wicked magi would flourish and honorable ones could be driven to outlawry.
 
-Several of the Founders opposed Flambeau's proposal: his most outspoken opponent was Guernicus, who feared that legalized Wizard's War would undermine the peace of the Order. The matter was finally settled in a famous debate. Flambeau pointed out that Guernicus himself had
-
-
-
-been forced to avenge his slain master. Without Wizard's War, Flambeau would be denied the same opportunity. Many of the Founders had first-hand experience of the atrocities wizards had committed against one another before the Founding, so finally they approved adding Wizard's War to the Code.
+Several of the Founders opposed Flambeau's proposal: his most outspoken opponent was Guernicus, who feared that legalized Wizard's War would undermine the peace of the Order. The matter was finally settled in a famous debate. Flambeau pointed out that Guernicus himself had been forced to avenge his slain master. Without Wizard's War, Flambeau would be denied the same opportunity. Many of the Founders had first-hand experience of the atrocities wizards had committed against one another before the Founding, so finally they approved adding Wizard's War to the Code.
 
 Flambeau envisioned Wizard's War as a kind of trial by combat; he expected wizards to simply meet on the field of honor to settle their differences in open battle. The legal concept of Wizard's War, however, evolved into something rather different than he would have expected, as will be explained later in this chapter.
 
@@ -445,25 +511,23 @@ Flambeau's eldest apprentice was a Basque boy he named Michel in honor of the ar
 
 Michel accompanied Flambeau throughout Mythic Europe and learned the art of diplomacy at his master's side. Flambeau had high hopes for his apprentice and groomed Michel to succeed him as leader of the House. But after Michel passed his Gauntlet, he changed his Hermetic name to Apromor. He and Flambeau grew apart, and had many disagreements. Though Michel did eventually become the first Primus of House Flambeau, he made many changes, few of which would have met with his pater's approval.
 
-The manner in which Flambeau trained his second apprentice seems to have been a reaction to the disappointment he felt about Apromor. She was a Frankish girl whom he named Elaine. Flambeau kept a tighter control over her education and training than he had with Apromor (though he did rely on tutors
+The manner in which Flambeau trained his second apprentice seems to have been a reaction to the disappointment he felt about Apromor. She was a Frankish girl whom he named Elaine. Flambeau kept a tighter control over her education and training than he had with Apromor (though he did rely on tutors to teach her Latin and writing). He made sure she was exposed to the Church's moral teachings. Flambeau trained Elaine primarily in fire magic, though he gave her plenty of time to read on outside topics. As a result, Elaine followed Flambeau's example more closely than did Apromor. Like her pater, she dedicated her career to serving the Order as a whole. Elaine was both a warrior and a scholar: she served with distinction as a Hoplite, and wrote several books that are still popular in 1220.
 
-### Elaine's Writings
+> ## Elaine's Writings
+> 
+> Elaine wrote several books that are widely read and copied throughout her House. The originals were kept at the library of Val-Negra, but have been lost since that covenant sank deep into Winter. There could still be undiscovered manuscripts of hers, moldering in some forgotten chest at Val-Negra. The Great Library at Durenmar has excellent copies of her surviving works:
+> 
+> **Ars Flambonis ("Flambeau's Art"):** Summa on Ignem, Level 14, Quality 12. Elaine wrote this book as a tribute to her pater, and the text is sprinkled with anecdotes about his teachings.
+> 
+> **Ultor ("The Avenger"):** Summa on Penetration, Level 5, Quality 11. While the principles in this book apply to defeating any type of Magic Resistance, Elaine's emphasis is specifically on penetrating the Parma Magica. This builds on Flambeau's early work and draws heavily on Elaine's practical experience as a Hoplite.
+> 
+> **Liber de Lumine ("Book of Light"):** Tractatus on Ignem, Quality 11. As the title suggests, this book concentrates on light as one aspect of the Form of Ignem.
+> 
+> **De Magia Sympathetica ("On Sympathetic Magic"):** Tractatus on Magic Theory, Quality 11. This book covers Arcane Connections and the related topic of sympathetic connections (which grant a Penetration bonus; see ArM5, page 84). While inspired by Elaine's research in Penetration, its content is purely theoretical and is applicable to all kinds of spellcasting. It is both insightful and rigorous.
+> 
+> **De Potestate et Obligatione ("On Power and Responsibility"):** Tractatus on Philosophiae, Quality 11. A discourse on the responsible and ethical practice of magic. Elaine advances the idea that The Gift is given by God to set magi apart, giving them both special powers and a special responsibility to serve his will. Her philosophy is evidently influenced by Saint Augustine's book, *City of God*.
 
-Elaine wrote several books that are widely read and copied throughout her House. The originals were kept at the library of Val-Negra, but have been lost since that covenant sank deep into Winter. There could still be undiscovered manuscripts of hers, moldering in some forgotten chest at Val-Negra. The Great Library at Durenmar has excellent copies of her surviving works:
-
-**Ars Flambonis ("Flambeau's Art"):** Summa on Ignem, Level 14, Quality 12. Elaine wrote this book as a tribute to her pater, and the text is sprinkled with anecdotes about his teachings.
-
-**Ultor ("The Avenger"):** Summa on Penetration, Level 5, Quality 11. While the principles in this book apply to defeating any type of Magic Resistance, Elaine's emphasis is specifically on penetrating the Parma Magica. This builds on Flambeau's early work and draws heavily on Elaine's practical experience as a Hoplite.
-
-**Liber de Lumine ("Book of Light"):** Tractatus on Ignem, Quality 11. As the title suggests, this book concentrates on light as one aspect of the Form of Ignem.
-
-**De Magia Sympathetica ("On Sympathetic Magic"):** Tractatus on Magic Theory, Quality 11. This book covers Arcane Connections and the related topic of sympathetic connections (which grant a Penetration bonus; see ArM5, page 84). While inspired by Elaine's research in Penetration, its content is purely theoretical and is applicable to all kinds of spellcasting. It is both insightful and rigorous.
-
-**De Potestate et Obligatione ("On Power and Responsibility"):** Tractatus on Philosophiae, Quality 11. A discourse on the responsible and ethical practice of magic. Elaine advances the idea that The Gift is given by God to set magi apart, giving them both special powers and a special responsibility to serve his will. Her philosophy is evidently influenced by Saint Augustine's book, *City of God*.
-
-to teach her Latin and writing). He made sure she was exposed to the Church's moral teachings. Flambeau trained Elaine primarily in fire magic, though he gave her plenty of time to read on outside topics. As a result, Elaine followed Flambeau's example more closely than did Apromor. Like her pater, she dedicated her career to serving the Order as a whole. Elaine was both a warrior and a scholar: she served with distinction as a Hoplite, and wrote several books that are still popular in 1220.
-
-Elaine trained four apprentices and eventually became an Archmage. She was never very active politically, but her influence on the House was nonetheless farreaching: she trained her apprentices to share Flambeau's sense of honor and his deep commitment to serving the Order. Elaine is also credited as the first intellectual leader within House Flambeau. Her insightful writings on magic theory and philosophy show that Flambeau magi can be interested in more than simply blasting things with fire spells.
+Elaine trained four apprentices and eventually became an Archmage. She was never very active politically, but her influence on the House was nonetheless far-reaching: she trained her apprentices to share Flambeau's sense of honor and his deep commitment to serving the Order. Elaine is also credited as the first intellectual leader within House Flambeau. Her insightful writings on magic theory and philosophy show that Flambeau magi can be interested in more than simply blasting things with fire spells.
 
 ### The Founder's End
 
@@ -471,10 +535,9 @@ Flambeau's Arts were never strong outside of his area of specialty. Due to a wea
 
 Some magi, including Apromor, believed Flambeau sought an encounter with the sahirs. Opinions are divided as to whether he wanted to die in battle against his lifelong enemies, or whether (as Apromor suspected) he was tired of fighting and was trying to offer peace. Whatever his intentions, Flambeau never returned, leading Apromor and others to conclude the sahirs had ambushed and killed him.
 
-Other magi believe that Flambeau retired from magic and joined a monastery to live out his final years in quiet devotion to the Lord. Flambeau was a Christian throughout his life: zealous in his youth, more pious and contemplative in his later years. Many
+Other magi believe that Flambeau retired from magic and joined a monastery to live out his final years in quiet devotion to the Lord. Flambeau was a Christian throughout his life: zealous in his youth, more pious and contemplative in his later years. Many who knew him, including his filia Elaine, believed this version of the story.
 
-
-### The Lost Talisman of the Founder
+## The Lost Talisman of the Founder
 
 Flambeau's talisman was called Fireheart: an oval-cut, flawless fire opal the size of a walnut. When he first enchanted it, he affixed it to the end of a staff, but in later years he had it re-set and wore it as a pendant. Whatever the fate of the Founder, his talisman has never been found.
 
@@ -484,13 +547,11 @@ Apart from its magical powers, Fireheart has significant historical value. As an
 
 Since Flambeau disappeared shortly after leaving Val-Negra, his talisman is thought to be somewhere in or near the Pyrenees (though it may have been found and moved to another location by some unknown party).
 
-who knew him, including his filia Elaine, believed this version of the story.
-
 ### The House Under Apromor
 
 Apromor led House Flambeau along a decidedly different course from that which his pater had set. Apromor was an astute diplomat and strategist. He believed that the Order of Hermes was already firmly established and the need to defend it from external threats was diminishing with time. On the other hand, he regarded the consolidation of power within Houses Tremere and Tytalus as a sign of internal rivalries emerging. He made strong moves to strengthen his own House against political competition within the Order.
 
-One of Apromor's major initiatives was to continue his pater's efforts to recruit non-Hermetic magi. Flambeau himself had observed the Christian religion throughout his life; while he had been willing to ally himself with wizards who revered the "old gods," he never really approved of paganism, and made efforts to convert his allies to his own faith. This led some new members of the Order to depart House Flambeau for other Houses they felt were more accepting of their beliefs. In an effort to increase the number of magi within his House, Apromor embarked on a longrunning, consistent campaign to ensure that pagan wizards recruited by House Flambeau remained there.
+One of Apromor's major initiatives was to continue his pater's efforts to recruit non-Hermetic magi. Flambeau himself had observed the Christian religion throughout his life; while he had been willing to ally himself with wizards who revered the "old gods," he never really approved of paganism, and made efforts to convert his allies to his own faith. This led some new members of the Order to depart House Flambeau for other Houses they felt were more accepting of their beliefs. In an effort to increase the number of magi within his House, Apromor embarked on a long-running, consistent campaign to ensure that pagan wizards recruited by House Flambeau remained there.
 
 A number of Flambeau magi traced their magical lineage back to the ancient Cult of Mercury. They worked with Priamitus of House Mercere to reconstruct the Roman cult (see *Houses of Hermes: True Lineages*, pages 95–96). Apromor encouraged these efforts and provided some resources, though he did not personally participate. As a result of House Flambeau's involvement in rebuilding the Cult of Mercury, a number of its members continue to practice Mercurian magic in 1220.
 
@@ -506,10 +567,7 @@ Following the corruption of House Tytalus, suspicions ran high within the Order.
 
 Of course, magi from other Houses were also involved in the conflict. When Primus Cercistum of House Tremere declared war on House Diedne and called for assistance from the rest of the Order, Primus Entisimon of House Flambeau was the first to answer. He rallied his House in a famous speech at Val-Negra.
 
-Until Entisimon threw his weight into the conflict, there had been voices within House Flambeau calling for restraint and peace. Some Flambeau magi spoke passionately at Tribunals, urging their sodales to preserve the Founders' vision of peaceful coexistence among the Houses. Others took more direct action, escorting Quaesitors into the lawless areas in an effort to restore order. But even the Flambeau magi most committed to peace stopped short of using force to curb the troublemakers within their own House. After Entisimon took
-
-
-a side in the conflict, the voices of reason within House Flambeau were shouted down. At least one magus who persisted too long in trying to soothe the conflict was slain in a Wizard's War by a fellow Flambeau magus who considered him an enemy collaborator.
+Until Entisimon threw his weight into the conflict, there had been voices within House Flambeau calling for restraint and peace. Some Flambeau magi spoke passionately at Tribunals, urging their sodales to preserve the Founders' vision of peaceful coexistence among the Houses. Others took more direct action, escorting Quaesitors into the lawless areas in an effort to restore order. But even the Flambeau magi most committed to peace stopped short of using force to curb the troublemakers within their own House. After Entisimon took a side in the conflict, the voices of reason within House Flambeau were shouted down. At least one magus who persisted too long in trying to soothe the conflict was slain in a Wizard's War by a fellow Flambeau magus who considered him an enemy collaborator.
 
 ### The Rise of the Milites
 
@@ -533,14 +591,13 @@ The Normandy Tribunal was unable to contain the conflict. The situation in Britt
 
 In the end, it was House Flambeau who brought an end to the conflict. Led by the milites, members of the House insisted on the restoration of law and order. They brought the violent members of their own House to heel and, at the Grand Tribunal of 1063, negotiated a truce. Special Tribunals were held to divide the disputed territory. The Flambeau Primus Entisimon, who had been encouraging the conflict, was forced to resign in disgrace.
 
-# House Flambeau in 1220
+## House Flambeau in 1220
 
 House Flambeau has a very loose internal organization. Although there is no formal hierarchy and there are no House offices other than that of Primus, there is a loose pecking order based on individual prestige. Flambeau magi place great esteem on practical ability: those who make significant achievements gain respect and status in the House. On the other hand, magi who accomplish little or display a reluctance to act can lose status. The most respected members of the House are usually middle-aged magi who have many victories and accomplishments to their credit, but remain active and involved in Hermetic affairs.
 
 To reflect the system of prestige within House Flambeau, the Rules section of this chapter provides mechanics for House Acclaim, a form of Reputation. It is similar, but not identical, to the House Acclaim system for House Bonisagus given in *Houses of Hermes: True Lineages* (page 21).
 
 House Flambeau tries to hold frequent meetings. It is held together mainly by *esprit de corps,* so meetings are considered important to the House's cohesiveness. Most House gatherings are social occasions. Flambeau magi are fond of telling tales over tankards of ale, debating about their favorite Arts or combat tactics, and holding the occasional friendly certamen. Increasingly often, Flambeau gatherings include some organized, combat-related activity such as a hunt or tournament, which further builds fellowship and helps the magi hone their fighting skills.
-
 
 ### House Culture
 
@@ -560,80 +617,67 @@ Another legacy of the Founder is a commitment to service. Flambeau spoke often o
 
 Whenever the position of Primus becomes vacant, members of House Flambeau from all across Mythic Europe gather at the domus magna to elect a new one. Magi who cannot attend are allowed to vote by proxy. The election process is tumultuous and disorganized, and is sometimes described by attendees as a "bragging tournament." Prominent Flambeau magi proclaim their candidacy and make blustering speeches about their magnificent accomplishments (which qualify them for leadership), and their glorious plans for the House's future. The House Quaesitor presides over the meeting and accepts motions from the floor. To maintain a minimum of order, the Quaesitor forbids certamen between candidates. House members may move for a vote to eliminate any candidate after all candidates have had a chance to speak, but such motions rarely pass on the first attempt. Speeches, debates, motions, and occasional voting continue, sometimes over several days, until a final winner emerges.
 
-The Prima nominally serves for life. In practice, there is a limited span of years during which a Prima's leadership can be effective. House Flambeau respects decisive action, not empty words. Not only does this place heavy expectations on the
-
+The Prima nominally serves for life. In practice, there is a limited span of years during which a Prima's leadership can be effective. House Flambeau respects decisive action, not empty words. Not only does this place heavy expectations on the Prima, it also puts her in a delicate political position. If her policies are too bold, she risks alienating members of her own House. If she is too reticent, she rapidly loses credibility and members of the House feel free to ignore her. The most common fate of a Flambeau Prima is to make a strong start, then gradually lose her authority until she becomes hopelessly ineffective and finally resigns. A few Primi have had the foresight to resign while they still had some of their authority left. The typical Flambeau Prima is a middle-aged to senior magus, who presides over the House for only two or three decades. 
 
 The direct powers of the Primus are relatively few; he rules more by influence and persuasion than by formal authority. He has the authority to preside over any Gauntlet for admission into House Flambeau. He is the nominal leader of the covenant of Castra Solis, though in practice there are other magi, long resident at the domus magna, who really control its resources. By tradition, the Primus organizes and presides over the grand tournament at Castra Solis.
 
-The current Primus, Garus, is an aging magus who was an adventurer and soldierof-fortune in his younger days. He fights according to the School of the Founder (see "Schools of Magical Combat" later in this chapter). His leadership is beginning to weaken because he has remained so long within the walls of the domus magna. He realizes that his days as leader of House Flambeau are numbered.
+The current Primus, Garus, is an aging magus who was an adventurer and soldier-of-fortune in his younger days. He fights according to the School of the Founder (see "Schools of Magical Combat" later in this chapter). His leadership is beginning to weaken because he has remained so long within the walls of the domus magna. He realizes that his days as leader of House Flambeau are numbered.
 
 The year 1220 represents a difficult time in House Flambeau's history, as it comes in a period of protracted peace. The Schism War has been over for two centuries; the majority of magi believe House Diedne will never be heard from again. With few overt threats looming before the Order, House Flambeau has no unified cause around which it can rally. Its members are divided, pursuing their own priorities and creating rival factions within the House. Recruitment grows increasingly difficult as the House seems to lack a collective purpose.
 
-Garus is one of the milites (see "The Milites" later in this chapter). He believes that the future of the House depends on finding a way to strengthen its members' common identity and shared values. His
-
-
-*12*
-
-vision is to organize the House into something resembling an order of knighthood, with a unified mission and a formal command structure. In this, he faces formidable opposition from within his own House.
+Garus is one of the milites (see "The Milites" later in this chapter). He believes that the future of the House depends on finding a way to strengthen its members' common identity and shared values. His vision is to organize the House into something resembling an order of knighthood, with a unified mission and a formal command structure. In this, he faces formidable opposition from within his own House.
 
 The Primus knows that reforming House Flambeau must be done gradually or the House's members will never accept it. He does not expect the work to be completed in his own time. He devotes considerable political energy to helping certain promising and like-minded magi gain prestige within the House. Evidently, he hopes that one of them will be chosen as his successor.
 
-Garus has implemented a number of reforms aimed at strengthening House unity. Before his tenure, the House tournament was held only during Tribunal years. Garus increased the frequency to every four years (there will be a tournament in 1220). The tournament helps build fellowship; additionally, the opening ceremonies provide with him a convenient bully pulpit from which to lecture about his vision of the House's future. Another of Garus's reforms has been to codify the milites' idea of chivalry in written form. Swearing to the milites' code of conduct is strictly voluntary, but Garus encourages young magi to do so. He has also introduced more formal bylaws for House meetings, which met with stiff opposition at first. Magi soon realized they made the meetings more streamlined and therefore shorter; after this, the new rules enjoyed widespread support.
+Garus has implemented a number of reforms aimed at strengthening House unity. Before his tenure, the House tournament was held only during Tribunal years. Garus increased the frequency to every four years (there will be a tournament in 1220). The tournament helps build fellowship; additionally, the opening ceremonies provide with him a convenient bully pulpit from which to lecture about his vision of the House’s future. Another of Garus’s reforms has been to codify the milites’ idea of chivalry in written form. Swearing to the milites’ code of conduct is strictly voluntary, but Garus encourages young magi to do so. He has also introduced more formal bylaws for House meetings, which met with stiff opposition at first. Magi soon realized they made the meetings more streamlined and therefore shorter; after this, the new rules enjoyed widespread support.
 
 ### Domus Magna
 
 The original domus magna of House Flambeau was Val-Negra, a covenant on the Spanish side of the Pyrenees mountains. During the Schism War, the Primus Entisimon found that Val-Negra's remote location made it unsuitable as a headquarters, so he moved his command to the covenant of Castra Solis. His successor officially moved the House's headquarters to the new site; there are rumors that neo-Roman elements within the House had a hand in the decision to move the domus magna.
 
-Castra Solis was founded by Kaeso, a member of the Roman Cult of Mithras
+Castra Solis was founded by Kaeso, a member of the Roman Cult of Mithras whom Apromor had recruited in 809. Kaeso built the covenant atop a subterranean cave that was once sacred to the cult: the covenant's name is a reference to Mithras's aspect as a sun god. Castra Solis is located in the Provençal Tribunal, several leagues south of Bordeaux.
 
-### The Horn of the Champions
-
-Castra Solis has a magical horn that can summon senior Flambeau magi from anywhere in Mythic Europe. The horn is kept by a magus known as the castellan. Magi who volunteer as defenders provide the castellan with a fixed Arcane Connection to themselves. As a gesture of trust and respect, the castellan gives each volunteer an Arcane Connection to himself in exchange. The Horn of Champions is an invested device with the following effects, each of which is activated by sounding a different note on the horn.
-
-#### Sounding the Alarm
-
-CrIm 50
-
-Pen +70, 1/day
-
-The horn is audible to everyone in the target Group regardless of distance, provided the user has an Arcane Connection to each person. This effect has a high Penetration to ensure it will be heard by the intended magi. At the sound of the horn, the magi who have volunteered to defend Castra Solis lower their Parmae Magicae and await the summoning effect.
-
-(Effect: Base 1, +4 Arcane Connection, +2 Group; +35 for Penetration)
-
-#### Summoning the Champions
-
-ReCo 65
-
-Pen 0, 1/day
-
-Each member of the target Group is instantly transported into the horn's pres-
-
-ence, provided the user has an Arcane Connection to him. This effect has no Penetration so magi can choose to resist the summons.
-
-(Effect: Base 35, +4 Arcane Connection, +2 Group)
-
-whom Apromor had recruited in 809. Kaeso built the covenant atop a subterranean cave that was once sacred to the cult: the covenant's name is a reference to Mithras's aspect as a sun god. Castra Solis is located in the Provençal Tribunal, several leagues south of Bordeaux.
+> ## The Horn of the Champions
+> 
+> Castra Solis has a magical horn that can summon senior Flambeau magi from anywhere in Mythic Europe. The horn is kept by a magus known as the castellan. Magi who volunteer as defenders provide the castellan with a fixed Arcane Connection to themselves. As a gesture of trust and respect, the castellan gives each volunteer an Arcane Connection to himself in exchange. The Horn of Champions is an invested device with the following effects, each of which is activated by sounding a different note on the horn.
+> 
+> ##### Sounding the Alarm
+> 
+> CrIm 50
+> 
+> Pen +70, 1/day
+> 
+> The horn is audible to everyone in the target Group regardless of distance, provided the user has an Arcane Connection to each person. This effect has a high Penetration to ensure it will be heard by the intended magi. At the sound of the horn, the magi who have volunteered to defend Castra Solis lower their Parmae Magicae and await the summoning effect.
+> 
+> (Effect: Base 1, +4 Arcane Connection, +2 Group; +35 for Penetration)
+> 
+> ##### Summoning the Champions
+> 
+> ReCo 65
+> 
+> Pen 0, 1/day
+> 
+> Each member of the target Group is instantly transported into the horn's presence, provided the user has an Arcane Connection to him. This effect has no Penetration so magi can choose to resist the summons.
+> 
+> (Effect: Base 35, +4 Arcane Connection, +2 Group)
 
 One might expect the domus magna of House Flambeau to be an imposing fortress, but in fact Castra Solis more closely resembles a large manor house. Kaeso realized that even the mightiest stone walls could be easily breached by magic, so he concentrated on building magical defenses rather than physical ones. The covenant has a number of enchanted items available for its defense.
 
 Castra Solis avoids building a large fortress for another reason: it is located within the territory of the Duke of Aquitaine and does not wish to antagonize him by building a strong castle on his lands. The covenant's turb is small for the same reason.
 
-The covenant has many guest rooms and there are a couple of guest houses in the nearby village. Even so, there is not enough space to accommodate all the magi in House Flambeau, let alone their apprentices, guards, and servants. A large, empty field near the covenant is used for tournaments and other House events. During major events, visitors pitch their tents in the field, which is large enough for
+The covenant has many guest rooms and there are a couple of guest houses in the nearby village. Even so, there is not enough space to accommodate all the magi in House Flambeau, let alone their apprentices, guards, and servants. A large, empty field near the covenant is used for tournaments and other House events. During major events, visitors pitch their tents in the field, which is large enough for both the encampments of the magi and the event itself.
 
-
-### The Grogs of Castra Solis
-
-Castra Solis keeps a small turb of grogs in order to maintain a low profile, but they are among the finest, best-trained, and best-led warriors in the Order. As a home to several senior Flambeau magi, the covenant takes pride in providing the best warriors to assist its members in their dangerous missions.
-
-The domus magna rarely hires raw recruits, instead preferring to handpick its grogs from the best they can find in other Flambeau covenants. Many Flambeau magi consider it a duty and an honor to transfer their servants to Castra Solis. Even those who are less community-spirited are willing to part with a few good men in exchange for the rewards the domus magna offers in exchange: vis, gold, lesser enchanted items, or the chance to spend seasons studying in its library.
-
-The grogs of Castra Solis are highly experienced. Even the cooks and stablehands are chosen for their loyalty and their excellence in their trades. All grogs receive combat training: they are taught that any male servant may be required to defend the covenant in an emergency. The shield grogs are among the finest warriors in the whole Order. The turb is small, perhaps only twenty shield grogs and as many servants, but their captain trains them daily to the peak of combat effectiveness. Most of the fighting grogs carry enchanted items.
-
-In exchange for their rigorous training and unremitting loyalty, the grogs of Castra Solis receive lavish rewards. Their pay is very high. They and their families live in comfortable, spacious quarters. When a grog dies or is forced into retirement, the covenant sees that his family is cared for. Officers and elite grogs may even be given a Longevity Ritual. Many grogs aspire to the honor of one day being chosen to guard the domus magna.
-
-If you are using the Legion of Mithras from *The Mysteries Revised Edition*, then some or all of Castra Solis's shield grogs may serve the Legion as Auxiliaries.
-
-both the encampments of the magi and the event itself.
+> ## The Grogs of Castra Solis
+> 
+> Castra Solis keeps a small turb of grogs in order to maintain a low profile, but they are among the finest, best-trained, and best-led warriors in the Order. As a home to several senior Flambeau magi, the covenant takes pride in providing the best warriors to assist its members in their dangerous missions.
+> 
+> The domus magna rarely hires raw recruits, instead preferring to handpick its grogs from the best they can find in other Flambeau covenants. Many Flambeau magi consider it a duty and an honor to transfer their servants to Castra Solis. Even those who are less community-spirited are willing to part with a few good men in exchange for the rewards the domus magna offers in exchange: vis, gold, lesser enchanted items, or the chance to spend seasons studying in its library.
+> 
+> The grogs of Castra Solis are highly experienced. Even the cooks and stablehands are chosen for their loyalty and their excellence in their trades. All grogs receive combat training: they are taught that any male servant may be required to defend the covenant in an emergency. The shield grogs are among the finest warriors in the whole Order. The turb is small, perhaps only twenty shield grogs and as many servants, but their captain trains them daily to the peak of combat effectiveness. Most of the fighting grogs carry enchanted items.
+> 
+> In exchange for their rigorous training and unremitting loyalty, the grogs of Castra Solis receive lavish rewards. Their pay is very high. They and their families live in comfortable, spacious quarters. When a grog dies or is forced into retirement, the covenant sees that his family is cared for. Officers and elite grogs may even be given a Longevity Ritual. Many grogs aspire to the honor of one day being chosen to guard the domus magna.
+> 
+> If you are using the Legion of Mithras from *The Mysteries Revised Edition*, then some or all of Castra Solis's shield grogs may serve the Legion as Auxiliaries.
 
 The library of Castra Solis has an impressive collection of books on combat magic, including lab texts for combat spells and tomes on Abilities such as Spell Mastery, Penetration, and Parma Magica. The library also includes many books about dragons and other fantastic beasts. The covenant does not allow visitors to copy any of the books, but members of House Flambeau are welcome to study from them — for a fee. (The fee is payable in money or vis; the amount should be about twice what would be necessary to sustain a maga at her home covenant.)
 
@@ -653,10 +697,7 @@ By the Peripheral Code, an apprentice who fails his Gauntlet three times is give
 
 In special circumstances, a magus or even an apprentice may be accepted directly into House Flambeau without the need for a Gauntlet. This is done for candidates who have already proved themselves in some dramatic way. For example, a Flambeau apprentice named Cindrallon was made a full maga of House Flambeau after only seven years of apprenticeship because she single-handedly killed a renounced magus in a Wizard's March. Though she had used a spear rather than a spell to slay the renegade, her master and the Primus agreed she had shown outstanding courage and fighting ability. Other, similar, battlefield promotions occurred during the Schism War.
 
-Since the days of the Founder, Flambeau magi have held a public initiation ceremony after the Gauntlet. The new Flambeau magus stands an all-night vigil (perhaps in a church, if his pater is a Christian, or perhaps in an ancient temple or magical site) and then appears in a plain white robe before an assembly of the
-
-
-House. The new magus swears or reaffirms the Hermetic Oath before an official (the Primus, a Quaesitor, or a highly-respected magus), who then taps him on the shoulder with a wand or staff and bestows his voting sigil. Sometimes the new magus's parens presents him with a gift at the conclusion of the ceremony.
+Since the days of the Founder, Flambeau magi have held a public initiation ceremony after the Gauntlet. The new Flambeau magus stands an all-night vigil (perhaps in a church, if his pater is a Christian, or perhaps in an ancient temple or magical site) and then appears in a plain white robe before an assembly of the House. The new magus swears or reaffirms the Hermetic Oath before an official (the Primus, a Quaesitor, or a highly-respected magus), who then taps him on the shoulder with a wand or staff and bestows his voting sigil. Sometimes the new magus's parens presents him with a gift at the conclusion of the ceremony.
 
 ### Societas Flambonis: The Milites
 
@@ -668,63 +709,59 @@ Personal honor is paramount to the milites. They subscribe to a code of conduct 
 
 The milites seek to use their power justly and to fight with honor. They tend to look down on magi who over-use their powers against mere mundanes: they usually regard only wizards and supernatural creatures as worthy opponents. Some go so far as to use a fighting style that favors hand-to-hand combat (see "The School of Ramius" under Schools of Magical Combat, later in this chapter), disdaining ranged spellcasting as ignoble.
 
-The milites pledge fealty to the Order as a whole, which is usually taken to mean the Grand Tribunal. While the Primus of Bonisagus is the overall leader of the Grand Tribunal and hence the Order, the milites see the Primus of their own House as their immediate superior. Thus, they regard their
+> ## The Code of Garus
+> 
+> The concept of chivalry has evolved throughout the history of Mythic Europe: knighthood in 1220 is not the same as it was in the days of Charlemagne. Mundanes in different lands have different ideas about what the ideal knight is like. So, too, have ideas of chivalry differed across House Flambeau. One of the achievements of the Primus Garus has been to bring the milites to a consensus on the code of conduct they should uphold. His code is loosely based on that put forth by Charlemagne for his knights. Already, magi are calling it the Code of Garus. It reads:
+> 
+> *As a magus in the Order of Hermes, of the honorable House of Flambeau, I now solemnly swear:*
+> 
+> *To serve the Order with constancy and faithfulness, even unto my own death;*
+> 
+> *To uphold and defend the Code of Hermes by word and by deed;*
+> 
+> *To obey the Primus of my House;
+>
+>To protect the weak and defend the innocent;*
+> 
+> *To always speak the truth and remain faithful to my pledged word;*
+> 
+> *To persevere in every task I shall undertake despite all hardship and opposition;*
+> 
+> *To display at all times courtesy and decorum, and uphold the good name of my House;*
+> 
+> *To respect the Holy Church;*
+> 
+> *To treat my servants justly;*
+> 
+> *To treat mundanes with dignity;*
+> 
+> *To be merciful to prisoners;*
+> 
+> *To guard and uphold the honor of my sodales;*
+> 
+> *To despise wickedness and deceit, Never to consent to wrongdoing; Never to refuse a challenge from an equal; Never to falter in the face of the enemy.*
+> 
+> Publicly swearing to this code grants a new Story Flaw (described later in this chapter). Actually taking it seriously may count as a (separate) Personality Flaw, such as Higher Purpose or Dutybound, depending on the character's attitude toward the oath.
 
-### The Code of Garus
+> ## Values of the Milites
+> 
+> The milites draw inspiration from mundane ideas of chivalry. Concepts of chivalry varied somewhat at different times and locations in historical Europe. Magi of House Flambeau have adapted early ideas of chivalry to fit Hermetic society, but they have not necessarily kept up with how chivalry has evolved in the mundane world.
+> 
+> The qualities which the milites believe describe the ideal Flambeau magus are:
+> 
+> **Prowess:** A Flambeau magus should be able to defend himself, his sodales, and the Order should the need arise. He should devote time and effort to maintaining and improving his fighting skills.
+> 
+> **Service:** In the words of Flambeau, "The true measure of a magus is not how much power he wields, but the worthiness of the cause in which he wields it."
+> 
+> **Courtesy:** Power without courtesy is brutality. A Flambeau magus should display at all times composure and decorum. He should always be gracious, whether in victory or defeat. A courteous magus does not intimidate or insult other magi.
+> 
+> **Generosity:** A Flambeau maga should be generous to subordinates, whether they are apprentices, grogs, or covenfolk. She should ensure that all who aid her in her endeavors receive a generous share of the rewards.
+> 
+> **Justice:** A magus should be ready to uphold and enforce Tribunal rulings, and cooperate with the Quaesitores. Wrongdoers are to be brought to trial, not summarily punished. A just magus treats his servants fairly.
+> 
+> **Citizenship:** A maga should participate in the deliberations at Tribunal and always vote her conscience. A good citizen knows when to be a leader and when to be a follower.
 
-The concept of chivalry has evolved throughout the history of Mythic Europe: knighthood in 1220 is not the same as it was in the days of Charlemagne. Mundanes in different lands have different ideas about what the ideal knight is like. So, too, have ideas of chivalry differed across House Flambeau. One of the achievements of the Primus Garus has been to bring the milites to a consensus on the code of conduct they should uphold. His code is loosely based on that put forth by Charlemagne for his knights. Already, magi are calling it the Code of Garus. It reads:
-
-*As a magus in the Order of Hermes, of the honorable House of Flambeau, I now solemnly swear:*
-
-*To serve the Order with constancy and faithfulness, even unto my own death;*
-
-*To uphold and defend the Code of Hermes by word and by deed;*
-
-> *To obey the Primus of my House; To protect the weak and defend the innocent;*
-
-*To always speak the truth and remain faithful to my pledged word;*
-
-*To persevere in every task I shall undertake despite all hardship and opposition;*
-
-*To display at all times courtesy and decorum, and uphold the good name of my House;*
-
-*To respect the Holy Church;*
-
-*To treat my servants justly;*
-
-*To treat mundanes with dignity;*
-
-*To be merciful to prisoners;*
-
-*To guard and uphold the honor of my sodales;*
-
-*To despise wickedness and deceit, Never to consent to wrongdoing; Never to refuse a challenge from an equal; Never to falter in the face of the enemy.*
-
-Publicly swearing to this code grants a new Story Flaw (described later in this chapter). Actually taking it seriously may count as a (separate) Personality Flaw, such as Higher Purpose or Dutybound, depending on the character's attitude toward the oath.
-
-### Values of the Milites
-
-The milites draw inspiration from mundane ideas of chivalry. Concepts of chivalry varied somewhat at different times and locations in historical Europe. Magi of House Flambeau have adapted early ideas of chivalry to fit Hermetic society, but they have not necessarily kept up with how chivalry has evolved in the mundane world.
-
-The qualities which the milites believe describe the ideal Flambeau magus are:
-
-**Prowess:** A Flambeau magus should be able to defend himself, his sodales, and the Order should the need arise. He should devote time and effort to maintaining and improving his fighting skills.
-
-**Service:** In the words of Flambeau, "The true measure of a magus is not how much power he wields, but the worthiness of the cause in which he wields it."
-
-**Courtesy:** Power without courtesy is brutality. A Flambeau magus should display at all times composure and decorum. He should always be gracious, whether in victory or defeat. A courteous magus does not intimidate or insult other magi.
-
-**Generosity:** A Flambeau maga should be generous to subordinates, whether they are apprentices, grogs, or covenfolk. She should ensure that all who aid her in her endeavors receive a generous share of the rewards.
-
-**Justice:** A magus should be ready to uphold and enforce Tribunal rulings, and cooperate with the Quaesitores. Wrongdoers are to be brought to trial, not summarily punished. A just magus treats his servants fairly.
-
-**Citrzenship:** A maga should participate in the deliberations at Tribunal and always vote her conscience. A good citizen knows when to be a leader and when to be a follower.
-
-Primus as their liege lord and the Primus of House Bonisagus as an overlord. They
-
-stand ready to assist the Quaesitores, their regional Tribunals, and even Redcaps. The
-
-
+The milites pledge fealty to the Order as a whole, which is usually taken to mean the Grand Tribunal. While the Primus of Bonisagus is the overall leader of the Grand Tribunal and hence the Order, the milites see the Primus of their own House as their immediate superior. Thus, they regard their Primus as their liege lord and the Primus of House Bonisagus as an overlord. They stand ready to assist the Quaesitores, their regional Tribunals, and even Redcaps. The Primus of Flambeau does call upon the milites to perform occasional errands, but the current Primus uses them only for official business of the Order and does not abuse their services.
 
 Unlike most members of House Flambeau, the milites are willing to work together. They consider other sworn members of the movement to be their brothers and sisters: they aid and support one another, and, if necessary, avenge one another.
 
@@ -736,17 +773,15 @@ Not everyone supports the milites' goals. Some magi are suspicious of the moveme
 
 When the Founders began to invite others to join the Order, Mercere's son Priamitus sought out hedge wizards who believed that their magic came from the Roman priests of the Cult of Mercury the same group from which the Order of Hermes took its name. These Mercurians (as they called themselves) still knew some of the secrets of Mercurian magic, including *Wizard's Communion*, but had lost all but a few of the ceremonial spells associated with their tradition. At Apromor's invitation, most of them joined House Flambeau, where they are still most represented. Through Priamitus they have always had very close ties to House Mercere, and they welcome any magi who wish to join their group.
 
-Mercurians believe that the gods of ancient Rome and Greece are mechanisms of nature with a magical aspect. When they speak of Venus's influence, they are
+Mercurians believe that the gods of ancient Rome and Greece are mechanisms of nature with a magical aspect. When they speak of Venus's influence, they are talking about the natural process of love given magical assistance — spells to inspire love might be described as blessings from Venus. Many also believe that there are magical spirits (daimons) associated with these processes that reside in the Magic realm, and with which, as magi, they can interact directly. When they speak of "the gods," they are sometimes referring to daimons, but more often they mean the anthropomorphized concepts that generally represent their magic.
 
-### Ancient Mercurians
-
-According to the stories that Priamitus collected from the wizards who became the Hermetic Cult of Mercury, there were temples to Mercury in ancient Rome, but unlike other priests, the Mercurians were never exclusively associated with the worship of their namesake. Mercury was seen as a symbol of commerce between the spirit world and the living world, and because of their connection to him, Mercurians were said to be able to communicate with the gods and other denizens of the spirit world more directly. In other words, they each had the power to work magic, and with it they could affect the aspects of nature that were represented by different gods or goddesses. Thus, a Mercurian priest would almost always be associated with another temple, and would use his magic to cause the will of his patron god, as he interpreted it, to become manifest.
-
-Individually the Mercurians held great influence in Roman culture, though they rarely acted as a united force. However, two centuries before Christ, the high priest Plentarch called together 38 Mercurians to meet with him in Pompeii, each of whom possessed one powerful ritual associated with their temple. Plentarch taught each priest a ritual he had discovered that would allow them to commune with their gods in concert, which made it possible for the priests to cast rituals associated with every temple as long as they worked together.
-
-The years that followed saw the Mercurians (and Rome) quickly reach the height of their power. Few of the barbarian cultures who opposed their expansion could stand against their combined might, and their tradition quickly spread throughout the Empire. In the later years, however, imperial regulations against sorcery and the rise of Christianity began to erode the cult's strength; their rituals began to fail even in the forums and temples as the Dominion gained supremacy. The cult fractured, and the priests were driven from the cities, each of them retaining only a fraction of the knowledge they had once possessed.
-
-talking about the natural process of love given magical assistance — spells to inspire love might be described as blessings from Venus. Many also believe that there are magical spirits (daimons) associated with these processes that reside in the Magic realm, and with which, as magi, they can interact directly. When they speak of "the gods," they are sometimes referring to daimons, but more often they mean the anthropomorphized concepts that generally represent their magic.
+> ## Ancient Mercurians
+> 
+> According to the stories that Priamitus collected from the wizards who became the Hermetic Cult of Mercury, there were temples to Mercury in ancient Rome, but unlike other priests, the Mercurians were never exclusively associated with the worship of their namesake. Mercury was seen as a symbol of commerce between the spirit world and the living world, and because of their connection to him, Mercurians were said to be able to communicate with the gods and other denizens of the spirit world more directly. In other words, they each had the power to work magic, and with it they could affect the aspects of nature that were represented by different gods or goddesses. Thus, a Mercurian priest would almost always be associated with another temple, and would use his magic to cause the will of his patron god, as he interpreted it, to become manifest.
+> 
+> Individually the Mercurians held great influence in Roman culture, though they rarely acted as a united force. However, two centuries before Christ, the high priest Plentarch called together 38 Mercurians to meet with him in Pompeii, each of whom possessed one powerful ritual associated with their temple. Plentarch taught each priest a ritual he had discovered that would allow them to commune with their gods in concert, which made it possible for the priests to cast rituals associated with every temple as long as they worked together.
+> 
+> The years that followed saw the Mercurians (and Rome) quickly reach the height of their power. Few of the barbarian cultures who opposed their expansion could stand against their combined might, and their tradition quickly spread throughout the Empire. In the later years, however, imperial regulations against sorcery and the rise of Christianity began to erode the cult's strength; their rituals began to fail even in the forums and temples as the Dominion gained supremacy. The cult fractured, and the priests were driven from the cities, each of them retaining only a fraction of the knowledge they had once possessed.
 
 Cult members generally have a strong appreciation of Roman culture. For many of them the society is simply an opportunity to dress up in anachronistic clothes and re-enact what they see as a more magical era. They organize festivals on important dates from the Roman calendar, such as Bona Dea in May, Consualia in August, or the Ides of March — a portentous day usually given to mystically preparing for the new year.
 
@@ -754,16 +789,15 @@ A Mercurian magus is called a **flamen** ("priest"). The activities of such magi
 
 Mercurian rites have had great influence on the customs of the Order of Hermes. For example, many covenants cast their *Aegis of the Hearth* on the eve of the winter solstice, when Mercurians celebrate the festival of Saturnalia, and so many of the traditions associated with it include Mercurian practices, such as everyone walking the boundary together. At Tribunal, the flamines often perform an invocation or a blessing before the event, and fulfill other duties such as leading Hermetic naming ceremonies, witnessing oaths, or conducting funereal rites.
 
-
-### Mercurian Characters
-
-The following Virtues and Flaws are suggested as especially appropriate for Mercurian characters, and players should feel free to choose as many or as few of them as they feel suit the character.
-
-**Suggested Virtues:** Flawless Magic, Mercurian Magic; Cyclic Magic, Mastered Spells, Method Caster, Premonitions, Student of Magic
-
-**Suggested Flaws:** Rigid Magic, Weak Spontaneous Magic, Pagan (see *Houses of Hermes: True Lineages*, page 109); Cyclic Magic, Difficult Spontaneous Magic, Slow Caster, Susceptibility to Divine Power, Visions
-
-Magi who belong to the cult also have access to any of the special Spell Mastery abilities listed in the rules section of this chapter.
+> ## Mercurian Characters
+> 
+> The following Virtues and Flaws are suggested as especially appropriate for Mercurian characters, and players should feel free to choose as many or as few of them as they feel suit the character.
+> 
+> **Suggested Virtues:** Flawless Magic, Mercurian Magic; Cyclic Magic, Mastered Spells, Method Caster, Premonitions, Student of Magic
+> 
+> **Suggested Flaws:** Rigid Magic, Weak Spontaneous Magic, Pagan (see *Houses of Hermes: True Lineages*, page 109); Cyclic Magic, Difficult Spontaneous Magic, Slow Caster, Susceptibility to Divine Power, Visions
+> 
+> Magi who belong to the cult also have access to any of the special Spell Mastery abilities listed in the rules section of this chapter.
 
 The pagan trappings of the cult are seen by many as foolish or even blasphemous conceits, but few Mercurians take them seriously. Just as most magi do not believe the name "Order of Hermes" is anything but symbolic, Mercurians use "gods," "blessings," and "offerings" as terms that evoke the grand history of magic, not sacrilegious practices. A good many cult members consider themselves Christian as well as Mercurian.
 
@@ -771,48 +805,39 @@ Within House Flambeau, the flamines and other Mercurians tend to emphasize gods 
 
 Other Hermetic groups are said to have an interest in Roman ceremonies and culture, such as the Mystery Cult called the Neo-Mercurians (see *The Mysteries*, page 114), or the holy societas Sol Invicti (see *The Divine*, page 71). Many believe that they are somehow related, so that a magus who proves himself in the Cult of Mercury might be invited to join one of the others.
 
-
 ### Societas Flambonis: The Mithraians
 
 Kaeso was a hedge wizard who belonged to Flambeau's ancestral tradition of Mithras priests. Apromor recruited him into the Order, so he was nominally Apromor's apprentice. He brought together three other magicians descended from the Cult of Mithras, all of whom eventually joined House Flambeau. In addition to sharing common magical powers, these magi shared a philosophy of promoting justice and harmony and of using their magic to battle the forces of evil in the world. They worked together to learn Hermetic magic, then helped one another teach Bonisagus's Arts to their apprentices. They founded the covenant of Castra Solis south of Bordeaux, over the site of a cave that had been sacred to the Cult of Mithras during Roman times. They then set about collecting the surviving fragments of the ancient cult.
 
-Reconstructing the Cult of Mithras was more difficult than Priamatus of Mercere's
+> ## Mithraic Characters
+> 
+> To create a character belonging to the Mithraic tradition within House Flambeau, choose some Virtues and Flaws from the list below. Since the ancient Cult of Mithras did not survive intact, not every character with Mithraic heritage possesses all, or even most, of these abilities. If you are using the Legion of Mithras from *The Mysteries Revised Edition* (or a similar group of your own invention) in your saga, then that Mystery Cult is open to characters from any magical lineage. Descent from the Mithraic lineage in House Flambeau does not imply the character is more likely to be accepted into the Legion than anyone else. Since it is a Mystery Cult, the Legion of Mithras can teach additional powers to characters who undergo Initiation.
+> 
+> **Suggested Virtues:** Cabal Legacy (see *The Mysteries Revised Edition,* page 20), Puissant Ignem (House Virtue), Gentle Gift, Affinity with Creo, Cyclic Magic (positive), Life Boost, Minor Magical Focus (soldiers), Inspirational, Self-Confident
+> 
+> **Suggested Flaws:** Deficient Technique (usually Perdo), Cyclic Magic (negative), Incompatible Arts (usually two Perdo combinations), Susceptibility to Infernal Power, Higher Purpose
 
-### Mithraic Characters
+Reconstructing the Cult of Mithras was more difficult than Priamatus of Mercere's job of re-discovering the Cult of Mercury. The Cult of Mercury was part of the Roman state religion and its rites and ceremonies were public. The Cult of Mithras, on the other hand, was more private, even secret. Many of its magical secrets were undoubtedly lost after the collapse of the Western Empire. While Kaeso was able to reconstruct some of the cult's beliefs and ceremonies, it is unclear whether he made any important magical discoveries. If he did, he did not share them with the Order at large. Even in 1220, four centuries after Kaeso began his work, there is much about the Cult of Mithras that remains unknown.
 
-To create a character belonging to the Mithraic tradition within House Flambeau, choose some Virtues and Flaws from the list below. Since the ancient Cult of Mithras did not survive intact, not every character with Mithraic heritage possesses all, or even most, of these abilities. If you are using the Legion of Mithras from *The Mysteries Revised Edition* (or a similar group of your own invention) in your saga, then that Mystery Cult is open to characters from any magical lineage. Descent from the Mithraic lineage in House Flambeau does not imply the character is more likely to be accepted into the Legion than anyone else. Since it is a Mystery Cult, the Legion of Mithras can teach additional powers to characters who undergo Initiation.
+> ## The Cult of Mithras
+> 
+> The Roman cult of Mithras was a mystery cult that was popular with the legions in the latter days of the pagan empire. Mithras was a god of Persian origin; his cult worshiped him as the savior of Creation.
+> 
+> According to myth, Mithras appeared spontaneously out of a rock. Evil forces were tormenting the world with drought; Mithras shot an arrow from his bow and where the arrow landed, a spring appeared. In order to relieve the wider drought, Mithras captured a divine bull and dragged it into a cave to sacrifice it. Vitality and abundance returned where its blood ran over the earth. Following this act of salvation, the Cult of Mithras believed their god assumed stewardship of Creation. Mithras continued his battle against the cosmic forces of evil, and it was prophesied that he would make steady progress and eventually prevail.
+> 
+> Mithras is a luminous god associated with the sun, frequently depicted being anointed by the sun's rays or receiving the sun's allegiance. He is a bringer of health, harmony, and abundance. He is a divine mediator, responsible for the rules of good conduct; he brings people together in concord. He is called the Bull-Slayer, and is most often portrayed in the act of sacrificing the bull. A few idols and carvings instead portray him as a lion-headed man holding a key.
+> 
+> Roman worshipers of Mithras met in underground caves, which could typically hold only about a dozen people. The cult was organized into seven levels of initiation, representing increasing levels of commitment to the god's service and, simultaneously, a spiritual journey toward some higher level of existence. By the time of Flambeau the Founder, the actual cult had apparently died out in Mythic Europe, but there remained certain magicians who possessed remnants of its knowledge and magic.
+> 
+> *The Mysteries Revised Edition* describes a mystery society called the Legion of Mithras, which is a 13th-century reconstruction of some of the ancient cult's practices. The Legion of Mithras certainly promotes the values of the ancient cult: loyalty, personal excellence, progress toward a higher level of spiritual existence, and a personal role in the cosmic struggle against evil. If you are using the Legion of Mithras in your saga, then the Mithraic wizards whom Kaeso recruited may have had a strong role in founding the Legion. The Mithraic wizards also helped to shape the philosophy and culture of House Flambeau with their martial and civic values.
+> 
+> In some ways, the Cult of Mithras resembles another late Roman cult, that of Sol Invictus (see *Realms of Power: the Divine*, page 70). Both cults worshiped sun gods and both were popular with the Roman legions. There seems to have been a relationship between the two deities. An important difference is that Sol Invictus held public rites, and indeed became the state religion of the Roman Empire under Aurelian. The Cult of Mithras met in private, perhaps in secret, and its spirituality seems to have been more personal.
 
-**Suggested Virtues:** Cabal Legacy (see *The Mysteries Revised Edition,* page 20), Puissant Ignem (House Virtue), Gentle Gift, Affinity with Creo, Cyclic Magic (positive), Life Boost, Minor Magical Focus (soldiers), Inspirational, Self-Confident
-
-**Suggested Flaws:** Deficient Technique (usually Perdo), Cyclic Magic (negative), Incompatible Arts (usually two Perdo combinations), Susceptibility to Infernal Power, Higher Purpose
-
-job of re-discovering the Cult of Mercury. The Cult of Mercury was part of the Roman state religion and its rites and ceremonies were public. The Cult of Mithras, on the other hand, was more private, even secret. Many of its magical secrets were undoubtedly lost after the collapse of the Western Empire. While Kaeso was able to reconstruct some of the cult's beliefs and ceremonies, it is unclear whether he made any important magical discoveries. If he did, he did not share them with the Order at large. Even in 1220, four centuries after Kaeso began his work, there is much about the Cult of Mithras that remains unknown.
-
-Magi descended from the ancient priesthood of Mithras do not always actually worship the pagan god (at least not publicly), but they do tend to share
-
-
-### The Cult of Mithras
-
-The Roman cult of Mithras was a mystery cult that was popular with the legions in the latter days of the pagan empire. Mithras was a god of Persian origin; his cult worshiped him as the savior of Creation.
-
-According to myth, Mithras appeared spontaneously out of a rock. Evil forces were tormenting the world with drought; Mithras shot an arrow from his bow and where the arrow landed, a spring appeared. In order to relieve the wider drought, Mithras captured a divine bull and dragged it into a cave to sacrifice it. Vitality and abundance returned where its blood ran over the earth. Following this act of salvation, the Cult of Mithras believed their god assumed stewardship of Creation. Mithras continued his battle against the cosmic forces of evil, and it was prophesied that he would make steady progress and eventually prevail.
-
-Mithras is a luminous god associated with the sun, frequently depicted being anointed by the sun's rays or receiving the sun's allegiance. He is a bringer of health, harmony, and abundance. He is a divine mediator, responsible for the rules of good conduct; he brings people together in concord. He is called the Bull-Slayer, and is most often portrayed in the act of sacrificing the bull. A few idols and carvings instead portray him as a lion-headed man holding a key.
-
-Roman worshipers of Mithras met in underground caves, which could typically hold only about a dozen people. The cult was organized into seven levels
-
-the ethos of the Mithras cult. They believe in building harmony and concord; in honesty and good conduct; and in personal excellence. Kaeso's followers believe that it was Flambeau's Mithraic heritage that made him such an active supporter of the Order, and seek to follow his example.
-
-of initiation, representing increasing levels of commitment to the god's service and, simultaneously, a spiritual journey toward some higher level of existence. By the time of Flambeau the Founder, the actual cult had apparently died out in Mythic Europe, but there remained certain magicians who possessed remnants of its knowledge and magic.
-
-*The Mysteries Revised Edition* describes a mystery society called the Legion of Mithras, which is a 13th-century reconstruction of some of the ancient cult's practices. The Legion of Mithras certainly promotes the values of the ancient cult: loyalty, personal excellence, progress toward a higher level of spiritual existence, and a personal role in the cosmic struggle against evil. If you are using the Legion of Mithras in your saga, then the Mithraic wizards whom Kaeso recruited may have had a strong role in founding the Legion. The Mithraic wizards also helped to shape the philosophy and culture of House Flambeau with their martial and civic values.
-
-In some ways, the Cult of Mithras resembles another late Roman cult, that of Sol Invictus (see *Realms of Power: the Divine*, page 70). Both cults worshiped sun gods and both were popular with the Roman legions. There seems to have been a relationship between the two deities. An important difference is that Sol Invictus held public rites, and indeed became the state religion of the Roman Empire under Aurelian. The Cult of Mithras met in private, perhaps in secret, and its spirituality seems to have been more personal.
+Magi descended from the ancient priesthood of Mithras do not always actually worship the pagan god (at least not publicly), but they do tend to share the ethos of the Mithras cult. They believe in building harmony and concord; in honesty and good conduct; and in personal excellence. Kaeso's followers believe that it was Flambeau's Mithraic heritage that made him such an active supporter of the Order, and seek to follow his example.
 
 ### Flambeau Concepts
 
 As the self-styled knights of the Order, magi of House Flambeau are active in all manner of Hermetic affairs. The following are some ideas for both player and nonplayer character concepts.
-
 
 #### Hoplites
 
@@ -830,11 +855,7 @@ A successful Hoplite needs strong combat ability to overwhelm his enemies, and e
 
 Some magi in House Flambeau believe the Order still faces significant threats from non-Hermetic wizards. In Iberia and the Holy Land, Saracen wizards still practice their arts, sometimes with the patronage of Muslim nobles. Paganism still prevails in parts of the Novgorod Tribunal. In Scandinavia, there are rumors of a secret society of magicians who get their power from the old Norse gods. Even within the heartland of the Order, the Rhine and Roman Tribunals, there are still hedge wizards who have escaped the Order's notice. Some of them are harmless, but others may be enemies of the Order, even diabolists.
 
-House Flambeau has a long history of fighting against the Order's enemies, both real and imagined. Members of the House are active in both the *Reconquista*
-
-#### Societates
-
-and the Crusades in the Holy Land. While the Code prohibits magi from interfering in mundane affairs, non-Hermetic wizards generally lack similar restrictions. Fighting against hostile wizards who happen to be accompanied by mundanes falls into a gray area of Hermetic Law. Flambeau magi who fight in such battles often claim that they were really fighting against enemy wizards, and any mundane casualties were simply the wizards' minions.
+House Flambeau has a long history of fighting against the Order's enemies, both real and imagined. Members of the House are active in both the *Reconquista* and the Crusades in the Holy Land. While the Code prohibits magi from interfering in mundane affairs, non-Hermetic wizards generally lack similar restrictions. Fighting against hostile wizards who happen to be accompanied by mundanes falls into a gray area of Hermetic Law. Flambeau magi who fight in such battles often claim that they were really fighting against enemy wizards, and any mundane casualties were simply the wizards' minions.
 
 Whether the Quaesitores are persuaded by such explanations, and how aggressively they pursue magi who fight in the Crusades or *Reconquista,* is a matter for your individual troupe or storyguide to decide. Even if your saga is one where the Order of Hermes strictly enforces the Code, there are likely to be some maverick Flambeau magi who think they can get away with fighting in the Crusades.
 
@@ -858,9 +879,7 @@ Flambeau magi who specialize in fighting demons usually prefer the School of Apr
 
 Sometimes a maga's best defense against becoming the target of Wizard's War is to have a senior magus of House Flambeau sworn to avenge her. The Peripheral Code does not prevent magi from waging Wizard's War to avenge slain friends and allies. Flambeau magi, especially those with a sense of chivalry, are often willing to make a public pledge of vengeance to deter other magi from declaring war. They swear to declare Wizard's War on any magus who first declares Wizard's War on their ally.
 
-The legal basis for this practice derives from the Normandy Tribunal of 898 AD, which exonerated Dominicus of House Jerbiton from wrongdoing when he used Wizard's War to avenge an amicus who had been killed in a separate Wizard's War (see *Houses of Hermes: True Lineages*, page 48). The presiding Quaesitor ruled that the Code's wording that "no retribution shall fall on the magus who slays me" means only that the Order will not punish the victor in a Wizard's War. Other magi who wish to avenge the loser of the Wizard's War remain free to do so, provided they declare
-
-and fight the war in accordance with the Peripheral Code.
+The legal basis for this practice derives from the Normandy Tribunal of 898 AD, which exonerated Dominicus of House Jerbiton from wrongdoing when he used Wizard's War to avenge an amicus who had been killed in a separate Wizard's War (see *Houses of Hermes: True Lineages*, page 48). The presiding Quaesitor ruled that the Code's wording that "no retribution shall fall on the magus who slays me" means only that the Order will not punish the victor in a Wizard's War. Other magi who wish to avenge the loser of the Wizard's War remain free to do so, provided they declare and fight the war in accordance with the Peripheral Code.
 
 Magi have several reasons why they might offer to become another wizard's avenger. They may be close friends (amici) of another magus and wish to protect him. Some Flambeau magi are simply a little bloodthirsty and pledge to avenge other magi in the hope they will get the chance to fight a Wizard's War. Others' sense of chivalry motivates them to defend weaker magi against bullying and aggression. Sometimes a magus seeking protection offers payment or favors in return for a pledge of vengeance.
 
@@ -873,7 +892,6 @@ Besides dueling in their House tournaments, some Flambeau magi travel Mythic Eur
 Magi of House Flambeau occasionally put their fighting skills to use as soldiers of fortune. Covenants sometimes need extra muscle to help protect them from the bullying of a larger covenant, or from hostile creatures like dark faeries or marauding dragons. Sometimes two or more Flambeau magi will form a small mercenary band and wander Mythic Europe looking for employment.
 
 Like mundane mercenaries, Flambeau soldiers of fortune are not renowned for their loyalty. They may back out of missions they consider too dangerous, or even switch sides if the opposition makes them a better offer.
-
 
 A variant of the mercenary concept is the magical knight-errant, who helps other wizards (or mundanes) out of generosity of spirit.
 
@@ -889,15 +907,13 @@ Regardless of the Primus's political objectives, House Flambeau generally favors
 
 Apart from a shared interest in leaving legal room for their various activities, members of the House have varying, sometimes conflicting, political goals. Individual Flambeau magi can be influential within their home Tribunals, but the House as a whole tends to lack political clout because of its lack of consensus. The political objectives of a Flambeau magus can be nearly anything; here are some possible examples:
 
-#### Houses of Hermes
-
-- Persuading the Order to take seriously a potential threat such as the rumored Order of Odin, or putative Order of Suleiman •
-- Trying to build military alliances or defensive pacts among covenants, especially in border Tribunals where threats appear more common •
-- Moving toward more harmonious relations with mundanes and the Church •
-- Preparing the Order to counter aggression from mundanes and the Church •
-- Supporting or opposing legal reform in the Order (see also Traditionalists/ Transitionalists in *Houses of Hermes: True Lineages*, pages 41–42) •
-- Ensuring enforcement of the Code in remote Tribunals •
-- Defending the right of magi to fight non-Hermetic wizards, for example, in the Crusades •
+- Persuading the Order to take seriously a potential threat such as the rumored Order of Odin, or putative Order of Suleiman
+- Trying to build military alliances or defensive pacts among covenants, especially in border Tribunals where threats appear more common
+- Moving toward more harmonious relations with mundanes and the Church
+- Preparing the Order to counter aggression from mundanes and the Church
+- Supporting or opposing legal reform in the Order (see also Traditionalists/ Transitionalists in *Houses of Hermes: True Lineages*, pages 41–42)
+- Ensuring enforcement of the Code in remote Tribunals
+- Defending the right of magi to fight non-Hermetic wizards, for example, in the Crusades
 
 #### Hunters and Dragon-Slayers
 
@@ -917,15 +933,9 @@ Some outlaw magi are villains who rob and bully those weaker than themselves. Ot
 
 Robber-magi usually prefer magic that is not readily apparent, so their victims can't identify them as wizards. They often fight according to the School of Ramius because its tactics are less obtrusive. Rather than using spells of attack, cunning outlaws prefer to use magic for reconnaissance, defense, and evasion.
 
-# Flambeau Tournaments
+## Flambeau Tournaments
 
-House Flambeau has held organized tournaments since the years following the Schism War. The major tournament is a regular competition held at Castra Solis, which lasts for five days surrounding the summer solstice of every leap year (the
-
-
-*20*
-
-
-most recent tournaments were in 1216 and 1220). Other tournaments are sometimes held at other Flambeau covenants, either at regular intervals (for example, every seven years), or to celebrate special occasions.
+House Flambeau has held organized tournaments since the years following the Schism War. The major tournament is a regular competition held at Castra Solis, which lasts for five days surrounding the summer solstice of every leap year (the most recent tournaments were in 1216 and 1220). Other tournaments are sometimes held at other Flambeau covenants, either at regular intervals (for example, every seven years), or to celebrate special occasions.
 
 House Flambeau's tournaments are not exclusive: any member of the Order is welcome to compete. Tournaments usually draw a number of competitors from Houses Tytalus and Tremere. Part of the way tournaments build fellowship is by giving Flambeau magi a chance to cheer for their own House.
 
@@ -935,15 +945,15 @@ The staple event of the wizards' tournament is certamen. The competition is usua
 
 The normal rules of certamen are altered for tournament purposes. The youngest magus chooses the Form, and the oldest the Technique (it is unusual for contestants to be exactly the same Hermetic age; such situations are decided by a coin toss). Competitors may veto their opponents' choice of Art as usual, but may not use a veto in both the first and the second duel of the match. This way, each contestant is guaranteed to get his first choice of Art at least once. Although the Peripheral Code allows the winner of a certamen to cast a spell on the loser, the rules of the tournament strictly forbid it.
 
-### Dimicatio
+> ## Forceless Casting
+> 
+> A magus can deliberately ensure the Penetration Total of a spell does not exceed 0. In essence, the magus casts the spell with no more effort than is required to avoid fatigue, and opts not to use his Penetration skill. As most magi have at least a Magic Resistance of 0, the casting magus can thereby ensure his spell will not affect a target who is also a magus, provided he does not botch.
+> 
+> Forceless casting requires no particular skill or effort. It is useful in magical tournaments, or when a magus casts a spell covering a large area and wants to avoid inadvertently affecting any magi who may be within the target area.
 
-Another popular tournament event is **dimicatio**, meaning "contest" or "battle."
+## Dimicatio
 
-### Forceless Casting
-
-A magus can deliberately ensure the Penetration Total of a spell does not exceed 0. In essence, the magus casts the spell with no more effort than is required to avoid fatigue, and opts not to use his Penetration skill. As most magi have at least a Magic Resistance of 0, the casting magus can thereby ensure his spell will not affect a target who is also a magus, provided he does not botch.
-
-Forceless casting requires no particular skill or effort. It is useful in magical tournaments, or when a magus casts a spell covering a large area and wants to avoid inadvertently affecting any magi who may be within the target area.
+Another popular tournament event is dimicatio, meaning “contest” or “battle.”
 
 It is unrelated to standard certamen. The competitors try to cast real spells at one another using the "forceless casting" option (see sidebar). Each magus uses a fast-cast defense (ArM5, page 83) to try to block the opposing spell. The first magus whose spell reaches his opponent's Parma is the winner.
 
@@ -951,13 +961,13 @@ Needless to say, this contest carries substantial dangers. Aimed spells that byp
 
 Because dimicatio has great potential for accidents or foul play, some Quaesitors want to outlaw the contest. This only increases its appeal to most Flambeau magi. The grand tournament at Castra Solis always includes a dimicatio event; any magus who wins at least two matches in the certamen event is qualified to enter, and the dimicatio event has a separate prize.
 
-### Dimicatio in Detail
-
-If you wish to play through a dimicatio, use the normal combat rules. Contestants start at Voice range from one another. The contest begins at the sound of a bell or other signal. Both competitors roll Initiative and the winner casts the first offensive spell. The defender must then fast-cast a defense. Rules for fast-cast defense are on page 83 of ArM5.
-
-The storyguide must apply some judgment in deciding whether a particular Form and Technique combination is effective as a defense against a particular spell, keeping in mind the rule of thumb that a fast-cast defense of one-half the level of the incoming spell is usually sufficient. For example, if one magus casts *Ball of Abysmal Flame* (CrIg 35), his opponent might defend using Creo Aquam (to quench the fire), Rego Ignem (to deflect the fireball), or even Creo Herbam (to create a wooden shield). Perdo Vim defenses can work, but they need to satisfy the normal rules for dispelling magic (ArM5, page 160). This becomes difficult if the defender fails to identify the Form.
-
-If the defense succeeds, the defender may cast an offensive spell on his own turn in the Initiative order. The cycle repeats according to the normal combat sequence. The rules of the contest allow magi to use vis if they wish.
+> ## Dimicatio in Detail
+> 
+> If you wish to play through a dimicatio, use the normal combat rules. Contestants start at Voice range from one another. The contest begins at the sound of a bell or other signal. Both competitors roll Initiative and the winner casts the first offensive spell. The defender must then fast-cast a defense. Rules for fast-cast defense are on page 83 of ArM5.
+> 
+> The storyguide must apply some judgment in deciding whether a particular Form and Technique combination is effective as a defense against a particular spell, keeping in mind the rule of thumb that a fast-cast defense of one-half the level of the incoming spell is usually sufficient. For example, if one magus casts *Ball of Abysmal Flame* (CrIg 35), his opponent might defend using Creo Aquam (to quench the fire), Rego Ignem (to deflect the fireball), or even Creo Herbam (to create a wooden shield). Perdo Vim defenses can work, but they need to satisfy the normal rules for dispelling magic (ArM5, page 160). This becomes difficult if the defender fails to identify the Form.
+> 
+> If the defense succeeds, the defender may cast an offensive spell on his own turn in the Initiative order. The cycle repeats according to the normal combat sequence. The rules of the contest allow magi to use vis if they wish.
 
 ### Wizards' Melee
 
@@ -965,22 +975,18 @@ Even more controversial than dimicatio is the wizards' melee, an uncommon and da
 
 Each team consists of one magus and five grogs. It is permissible, and expected, for a magus to extend his Parma Magica to cover some or all of his grogs.
 
-The wizards' melee is a tournament *au plaisance,* a contest for the pleasure of the
+The wizards' melee is a tournament *au plaisance,* a contest for the pleasure of the participants and spectators. Exact rules for the contest vary from one tournament to another (they are not yet standardized) but usually include:
 
+- Only Touch- and Personal-Range spells are usually permitted; this prevents magi from neutralizing the opposing grogs too easily. Some tournaments permit Voice-Range spells as long as they are used only on the caster's own grogs.
+- Grogs are typically armed with blunted weapons (–3 to Damage), and the selection of weapons may be restricted (warhammers are not safe tournament weapons!).
+- Damage-inflicting spells may be restricted to third magnitude and below, or banned altogether. (The tournament at Castra Solis bans damage-inflicting spells.)
+- Enchanted devices are allowed as long as they obey all the restrictions for spells. Magi are permitted to use vis during the wizards' melee.
 
-
-participants and spectators. Exact rules for the contest vary from one tournament to another (they are not yet standardized) but usually include:
-
-- Only Touch- and Personal-Range spells are usually permitted; this prevents magi from neutralizing the opposing grogs too easily. Some tournaments permit Voice-Range spells as long as they are used only on the caster's own grogs. •
-- Grogs are typically armed with blunted weapons (–3 to Damage), and the selection of weapons may be restricted (warhammers are not safe tournament weapons!). •
-- Damage-inflicting spells may be restricted to third magnitude and below, or banned altogether. (The tournament at Castra Solis bans damage-inflicting spells.) •
-- Enchanted devices are allowed as long as they obey all the restrictions for spells. Magi are permitted to use vis during the wizards' melee. •
-
-### Tournament Prizes
-
-Magi don't compete in tournaments merely for fame and prestige. The tournament host also offers prizes. These can be as simple as a purse of vis: a rook (ten pawns) is a moderate prize. Grander tournaments offer more lavish prizes: books, lesser enchanted items, even invested devices. Anything that most magi would value could be offered as a prize. The greater the prize, the more competitors are drawn to the tournament. Archmagi are usually content to let younger magi compete, but a truly compelling prize may even lure some of them off the sidelines.
-
-Even with these rules, the potential for accidental death or injury is so great that many Quaesitors are appalled the event even exists.
+> ## Tournament Prizes
+> 
+> Magi don't compete in tournaments merely for fame and prestige. The tournament host also offers prizes. These can be as simple as a purse of vis: a rook (ten pawns) is a moderate prize. Grander tournaments offer more lavish prizes: books, lesser enchanted items, even invested devices. Anything that most magi would value could be offered as a prize. The greater the prize, the more competitors are drawn to the tournament. Archmagi are usually content to let younger magi compete, but a truly compelling prize may even lure some of them off the sidelines.
+> 
+> Even with these rules, the potential for accidental death or injury is so great that many Quaesitors are appalled the event even exists.
 
 ### Special Challenges
 
@@ -988,11 +994,9 @@ Tournaments may also involve a special challenge devised by the tournament host.
 
 ### Entertainment and Side Events
 
-Large tournaments may also include minor events. Tests of accuracy using aimed spells, similar to mundane archery tournaments, are common. There may be separate contests for apprentices and
+Large tournaments may also include minor events. Tests of accuracy using aimed spells, similar to mundane archery tournaments, are common. There may be separate contests for apprentices and grogs. Alongside the competition there is music, entertainment, feasting, and plenty of alcohol.
 
-grogs. Alongside the competition there is music, entertainment, feasting, and plenty of alcohol.
-
-# Wizard's War
+## Wizard's War
 
 This section addresses the practical considerations of running a Wizard's War in your saga: how to be prepared for a Wizard's War, the social considerations of fighting a war, and tactics that can help a character win (or at least survive). This information is applicable to magi from any House, though Flambeau magi, with their fighting skills and their honor, are perhaps most likely to use it. Legal aspects of Wizard's War are covered in *Houses of Hermes: True Lineages* (pages 47–48).
 
@@ -1002,11 +1006,7 @@ Wizard's War was included in the Code of Hermes at the insistence of Flambeau th
 
 One of the key characteristics of Wizard's War is its limited duration. A Wizard's War must be declared on the night of a full moon. It then begins at the rise of the following full moon and lasts until the rise of the third full moon. Since it can be relatively easy for a magus to evade his adversary for one lunar month, Wizard's War does not always result in the death of either combatant.
 
-The Code defines Wizard's War as a conflict between exactly two wizards. Most wizards in 1220 belong to covenants, which offer protection in the event of Wizard's War. Although Wizard's War allows the combatants to step outside the protection of the Code, it does not grant the authority to violate the rights of other wizards. A combatant in Wizard's War may not lawfully destroy or steal property belonging to wizards other than his
-
-
-
-opponent, scry on non-combatant magi, or attack non-combatant magi who get in his way. This means a combatant in Wizard's War can often escape his adversary by hiding inside his covenant. Not only does he gain the protection of any *Aegis of the Hearth* the covenant may have, his sodales can deny his opponent entry to the covenant. If the enemy attempts to enter without permission, covenant members may use appropriate force to drive him out (and may be entitled to bring a complaint against him at Tribunal). While they should not simply kill the intruder out of hand, the Code does allow magi to defend their territory.
+The Code defines Wizard's War as a conflict between exactly two wizards. Most wizards in 1220 belong to covenants, which offer protection in the event of Wizard's War. Although Wizard's War allows the combatants to step outside the protection of the Code, it does not grant the authority to violate the rights of other wizards. A combatant in Wizard's War may not lawfully destroy or steal property belonging to wizards other than his opponent, scry on non-combatant magi, or attack non-combatant magi who get in his way. This means a combatant in Wizard's War can often escape his adversary by hiding inside his covenant. Not only does he gain the protection of any *Aegis of the Hearth* the covenant may have, his sodales can deny his opponent entry to the covenant. If the enemy attempts to enter without permission, covenant members may use appropriate force to drive him out (and may be entitled to bring a complaint against him at Tribunal). While they should not simply kill the intruder out of hand, the Code does allow magi to defend their territory.
 
 The Code also makes it difficult for a magus to scry on his opponent's covenant. Using magic that reveals information about other magi at the covenant, or even has the potential to accidentally reveal such information, is usually considered a breach of the Code.
 
@@ -1014,32 +1014,28 @@ When a combatant wants to hide inside a friendly covenant, his opponent has only
 
 Another option is to declare Wizard's War against the enemy's sodales or other allies. Each Wizard's War is legally defined as a conflict between two magi, but there is nothing to prevent a magus from being involved in multiple Wizard's Wars simultaneously. It is possible to declare separate Wizard's Wars against every member of a covenant. This allows one to attack the covenant with legal impunity. A lone magus can cause a great deal of trouble through hit-and-run raids, though of course there is a considerable risk his opponents will combine forces and slay him.
 
+> ## Declaration of War
+> 
+> The Order of Hermes recognizes that magi may not always be in their sancta. There is no guarantee that a magus will be at home on the day a declaration of Wizard's War arrives. How exactly the Peripheral Code applies to this situation is a matter for your troupe to decide for itself. The answer may vary from one Tribunal to another.
+> 
+> The whole point of requiring the declaration of war to arrive on a specific date (the night of the full moon) is to reduce the number of disputes over whether the declaration was properly made. Thus, simply hiding in one's sanctum and refusing to accept messages on the night of the full moon is unlikely to be effective. Most Tribunals hold a declaration of war to be duly served if the recipient was present at the covenant and the declaration was nailed to the door of his sanctum.
+> 
+> A more difficult situation is when the recipient is absent, or when it cannot be proved he is present. One possible solution is that the Tribunal requires magi on extended travel to leave a forwarding address with House Mercere; other Tribunals may require a magus to designate a representative who is authorized to receive official correspondence in his absence. If a Tribunal uses one of these procedures, then it probably holds each magus responsible for using them. A magus who is absent with no representative or forwarding address is treated as having willfully ignored the message.
+> 
+> Another alternative is that if the messenger fails to deliver the declaration to the intended recipient, he should immediately report to a Quaesitor, who conducts a cursory investigation (such as asking other members of the recipient's covenant where he is) and then rule on the declaration's validity within a fixed period of time. Part of the reason for the one-month waiting period before a Wizard's War begins is to allow official review of the war's legality.
+> 
+> The Peripheral Code of a Tribunal may require a declaration of war to be delivered by a Redcap. Even if the Tribunal does not require it, using a Redcap is highly advisable because of the official status and presumed neutrality of the messenger. Some Tribunals require that a copy of any declaration of Wizard's War be sent to a Quaesitor, or even that a declaration of war receive a Quaesitor's seal before being served to its recipient.
+
 Whenever a conflict escalates,, there is an increasingly greater risk that more and more magi and covenants may be drawn into the hostilities. For instance, a wizard might declare Wizard's War on an adversary who then takes shelter inside his covenant. The original aggressor might then declare war on the whole covenant
+ and raids its lands, burning buildings and slaying grogs. The enemy's covenant might then hound the aggressor back to his own covenant, which could easily draw this second covenant into the war. If there are any fatalities, the slain magi's friends and allies may seek vengeance, spreading the feud even wider.
 
-### Declaration of War
-
-The Order of Hermes recognizes that magi may not always be in their sancta. There is no guarantee that a magus will be at home on the day a declaration of Wizard's War arrives. How exactly the Peripheral Code applies to this situation is a matter for your troupe to decide for itself. The answer may vary from one Tribunal to another.
-
-The whole point of requiring the declaration of war to arrive on a specific date (the night of the full moon) is to reduce the number of disputes over whether the declaration was properly made. Thus, simply hiding in one's sanctum and refusing to accept messages on the night of the full moon is unlikely to be effective. Most Tribunals hold a declaration of war to be duly served if the recipient was present at the covenant and the declaration was nailed to the door of his sanctum.
-
-A more difficult situation is when the recipient is absent, or when it cannot be proved he is present. One possible solution is that the Tribunal requires magi on extended travel to leave a forwarding address with House Mercere; other Tribunals may require a magus to designate a representative who is authorized to receive official correspondence in his absence. If a Tribunal uses one of these procedures, then it probably holds each magus responsible for using them. A magus who is absent with no representative or forwarding address is treated as having willfully ignored the message.
-
-Another alternative is that if the messenger fails to deliver the declaration to the intended recipient, he should immediately report to a Quaesitor, who conducts a cursory investigation (such as asking other members of the recipient's covenant where he is) and then rule on the declaration's validity within a fixed period of time. Part of the reason for the one-month waiting period before a Wizard's War begins is to allow official review of the war's legality.
-
-The Peripheral Code of a Tribunal may require a declaration of war to be delivered by a Redcap. Even if the Tribunal does not require it, using a Redcap is highly advisable because of the official status and presumed neutrality of the messenger. Some Tribunals require that a copy of any declaration of Wizard's War be sent to a Quaesitor, or even that a declaration of war receive a Quaesitor's seal before being served to its recipient.
-
-and raids its lands, burning buildings and slaying grogs. The enemy's covenant might then hound the aggressor back to his own covenant, which could easily draw this second covenant into the war. If there are any fatalities, the slain magi's friends and allies may seek vengeance, spreading the feud even wider.
-
-Because of the potential for escalation, most covenants see little benefit in being drawn into a Wizard's War between two individuals. Although most covenants are usually willing to defend their magi from unprovoked aggression, if a magus antagonizes other wizards and then tries to hide behind his sodales, they look on the situation differently. Covenant charters sometimes include clauses that prohibit members from endangering the covenant through their actions.
+Because of the potential for escalation, most covenants see little benefit in being drawn into a Wizard’s War between two individuals. Although most covenants are usually willing to defend their magi from unprovoked aggression, if a magus antagonizes other wizards and then tries to hide behind his sodales, they look on the situation differently. Covenant charters sometimes include clauses that prohibit members from endangering the covenant through their actions.
 
 Covenants usually want to see Wizard's Wars resolved without their own members being killed. In order to prevent wars from escalating, the covenants to which the combatants belong may be willing to negotiate a resolution \_ perhaps without the combatants' knowledge. Terms may include restitution for the grievance that provoked the Wizard's War, arbitration by a Quaesitor or other neutral party, or even sending one or both magi into exile in another Tribunal.
 
 ### Reasons to Declare Wizard's War
 
-A declaration of Wizard's War does not always mean the aggressor actually intends to kill his opponent. The Code permits combatants to kill one another, but it doesn't require them to do so. Sometimes, the intent of a Wizard's War is
-
-
-simply to force one's opponent to negotiate. Wizard's War can also help persuade the opponent's covenant to get involved in resolving the dispute.
+A declaration of Wizard's War does not always mean the aggressor actually intends to kill his opponent. The Code permits combatants to kill one another, but it doesn't require them to do so. Sometimes, the intent of a Wizard's War is simply to force one's opponent to negotiate. Wizard's War can also help persuade the opponent's covenant to get involved in resolving the dispute.
 
 Wizard's War can be used to harass and intimidate another magus, especially a younger or weaker one. A tyrannical magus may simply declare Wizard's War occasionally to send the weaker magus scurrying into his sanctum. Such a strategy can backfire if the weaker magus has powerful friends, or if his covenant gets tired of the disruption. While Tribunals are generally reluctant to prosecute magi for liberal use of Wizard's War, extreme cases of abuse may lead to a charge of endangering the Order.
 
@@ -1069,12 +1065,7 @@ Most magi in Wizard's Wars do not simply stride boldly forth to meet their enemi
 
 Winning — or even surviving — Wizard's War is as much a matter of cunning as raw combat power. An enemy cannot attack what he cannot find. Flambeau the Founder was unable to track down all the sorcerers who had killed his master because he was weak in Intellego. The prudent magus remains hidden using such spells such as *Trackless Step*, *Disguise of the Transformed Image*, or *Veil of Invisibility*. Success in Wizard's War depends largely on having a combination of spells for offense, defense, stealth, and reconnaissance.
 
-The outcome of a Wizard's War can hinge on one magus obtaining an Arcane Connection to the other. The real value of an Arcane Connection is the bonus it provides to one's Penetration multiplier (see ArM5, page 84). In principle, it also allows one to cast spells on the enemy from a distance: *The Inexorable Search* to find his hiding place or *Opening the Intangible Tunnel* to attack him directly. In practice, such long-range
-
-
-#### Societates
-
-spells are ineffective unless the caster can achieve a high Penetration Total.
+The outcome of a Wizard's War can hinge on one magus obtaining an Arcane Connection to the other. The real value of an Arcane Connection is the bonus it provides to one's Penetration multiplier (see ArM5, page 84). In principle, it also allows one to cast spells on the enemy from a distance: *The Inexorable Search* to find his hiding place or *Opening the Intangible Tunnel* to attack him directly. In practice, such long-range spells are ineffective unless the caster can achieve a high Penetration Total.
 
 It is a basic principle of self-defense to avoid leaving an Arcane Connection to oneself for the enemy to find. This is easier said than done: a shed hair, a drop of perspiration, or even a robe thread snagged on a twig can all be Arcane Connections lasting hours or days. Intellego Corpus spells can find such connections as hair, blood, and shed skin. If a magus thinks to search for Arcane Connections to himself, he can then destroy them using Perdo Vim magic.
 
@@ -1084,12 +1075,9 @@ Magical disguises are easy to create. They can help one evade the enemy, discree
 
 Although young magi may feel very vulnerable in a Wizard's War, cunning, resourcefulness, and strategy are just as important as raw magical power. Some Wizard's Wars have been won by magi who never cast a spell at their opponents at all. A dagger in the back can be better than a *Pilum of Fire* from the front.
 
-# Schools of Magical Combat
+## Schools of Magical Combat
 
-When many magi think of House Flambeau, they think of fire magic. Flambeau the Founder was a master of the Art of Ignem and a large number of Flambeau magi follow in his footsteps. As a House of warriors and champions, Flambeau includes a wide variety of combative magi, not all of whom rely on fire
-
-
-magic. Apromor, Flambeau's first apprentice, concentrated instead on Perdo spells. Over time, subsequent magi have invented additional styles of fighting.
+When many magi think of House Flambeau, they think of fire magic. Flambeau the Founder was a master of the Art of Ignem and a large number of Flambeau magi follow in his footsteps. As a House of warriors and champions, Flambeau includes a wide variety of combative magi, not all of whom rely on fire magic. Apromor, Flambeau's first apprentice, concentrated instead on Perdo spells. Over time, subsequent magi have invented additional styles of fighting.
 
 Magi of House Flambeau refer to each fighting style as a "school" of magical combat. These schools are not formal lineages. They are simply groups of magi who have chosen a common approach to magical combat. Just as mundane scholars might describe a philosopher as belonging to the school of Aristotle, Flambeau magi speak of wizards belonging to the School of the Founder or the School of Apromor. Classifying wizards into schools is more precise than simply speaking of the Arts they prefer. Fighting with fire spells is fairly straightforward, but other Arts, like Rego, can be used in a number of different ways. Speaking in terms of schools gives Flambeau magi the terminology to discuss tactics and counter-measures \_ and to have long-winded debates about why their favorite school is better than everyone else's.
 
@@ -1099,20 +1087,19 @@ Flambeau magi name each school of magical combat after the pioneering magus who 
 
 Every magus who learns battle-worthy spells is preparing to use some school of magical combat, whether he realizes it or not. Flambeau magi tend to carefully choose their schools of combat, devoting a great deal of study and lab time to mastering them. There is a great difference between a magus who knows a few mismatched combat spells, and one who has dedicated many seasons of carefully planned study to the interconnected Arts, Abilities, and spells that make a school effective.
 
-Flambeau magi tend to gravitate toward whatever school of fighting is best suited to the individual strengths of their Gift — that is, their Hermetic Virtues (and
+Flambeau magi tend to gravitate toward whatever school of fighting is best suited to the individual strengths of their Gift — that is, their Hermetic Virtues (and Flaws). This is exactly how most of the schools were invented in the first place: some bygone magus developed a strategy that played to his individual strengths. There are other reasons to choose a particular school; for example, magi often choose a second school to compensate for any weaknesses their primary school may have, or they may select a school that is suited to fighting one particular kind of opponent.
 
 
-| Schools of Magical Combat at a Glance |                                                 |                                                        |  |  |  |
-|---------------------------------------|-------------------------------------------------|--------------------------------------------------------|--|--|--|
-| School                                | Description                                     | Recommended Virtue                                     |  |  |  |
-| The Founder                           | Attacks using fire                              | Puissant Ignem                                         |  |  |  |
-| Apromor                               | Damaging opponent directly<br>with Perdo        | Puissant Perdo                                         |  |  |  |
-| Boreas                                | Direct attacks using cold                       | Puissant Ignem or Puissant<br>Perdo                    |  |  |  |
-| Ramius                                | Mundane attacks, magical<br>defenses            | Warrior                                                |  |  |  |
-| Sebastian                             | Direct attacks using a Form<br>other than Ignem | Magical Focus                                          |  |  |  |
-| Vilano                                | Aimed spells that bypass<br>Magic Resistance    | Puissant Finesse or Cautious<br>With Ability (Finesse) |  |  |  |
+## Schools of Magical Combat at a Glance 
 
-Flaws). This is exactly how most of the schools were invented in the first place: some bygone magus developed a strategy that played to his individual strengths. There are other reasons to choose a particular school; for example, magi often choose a second school to compensate for any weaknesses their primary school may have, or they may select a school that is suited to fighting one particular kind of opponent.
+| School      | Description                                   | Recommended Virtue                               |
+|-------------|-----------------------------------------------|--------------------------------------------------|
+| The Founder | Attacks using fire                            | Puissant Ignem                                   |
+| Apromor     | Damaging opponent directly with Perdo         | Puissant Perdo                                   |
+| Boreas      | Direct attacks using cold                     | Puissant Ignem or Puissant Perdo                 |
+| Ramius      | Mundane attacks, magical defenses             | Warrior                                          |
+| Sebastian   | Direct attacks using a Form other than Ignem  | Magical Focus                                    |
+| Vilano      | Aimed spells that bypass Magic Resistance     | Puissant Finesse or Cautious With Ability (Finesse) |
 
 Magi who are trained within House Flambeau have their school chosen for them by their parentes. Usually, the parens simply trains the apprentice in whatever school the parens himself prefers, but there are exceptions. If an apprentice's Gift is obviously suited to a particular school, her parens may teach her that school for her benefit. Sometimes a parens chooses a different school for his apprentice because he wants to explore that school himself. In any case, the school assigned to a Flambeau apprentice may or may not be one she would have chosen for herself.
 
@@ -1124,7 +1111,7 @@ There are many possible schools of magical combat; the following is not meant to
 
 #### The School of the Founder
 
-#### Recommended Virtue: Puissant Ignem
+**Recommended Virtue: Puissant Ignem**
 
 Flambeau the Founder was a great master of fire magic. Incinerating opponents with Ignem spells remains the most popular school of magical combat within his House.
 
@@ -1142,12 +1129,11 @@ Another disadvantage of Ignem spells is that they are not subtle. When a magus b
 
 Fire is notoriously difficult to control; Ignem botches can be especially disastrous.
 
-
-### Option: Variant House Benefits
-
-Magi of House Flambeau gain a free Minor Virtue at character creation as their House benefit. This free Virtue must be either Puissant Art (Ignem) or Puissant Art (Perdo). These Virtues are very appropriate to three of the six schools of magical combat.
-
-If the storyguide wishes, he may permit player-magi who want to specialize in the Schools of Ramius, Sebastian, or Vilano to substitute one of the recommended Minor Virtues of their school in place of usual House Virtue.
+> ## Option: Variant House Benefits
+> 
+> Magi of House Flambeau gain a free Minor Virtue at character creation as their House benefit. This free Virtue must be either Puissant Art (Ignem) or Puissant Art (Perdo). These Virtues are very appropriate to three of the six schools of magical combat.
+> 
+> If the storyguide wishes, he may permit player-magi who want to specialize in the Schools of Ramius, Sebastian, or Vilano to substitute one of the recommended Minor Virtues of their school in place of usual House Virtue.
 
 Finally, magi who heavily specialize in the School of the Founder find their Arts are suitable for little else besides fighting. Many Flambeau magi don't care — they are perfectly content to be one-trick ponies when that trick is a high-Penetration *Ball of Abysmal Flame*. Adventuring magi, particularly those who work without other wizards, often need more breadth in their magical abilities. Narrowly specializing in one Form also makes a magus potentially weak in certamen.
 
@@ -1159,30 +1145,25 @@ The School of the Founder is a good choice for beginning players because it's st
 
 The School of Apromor emphasizes using Perdo magic to damage one's opponent directly. Apromor was Flambeau's first apprentice, who turned away from fire magic in the middle of his career.
 
-Compared with the School of the Founder, the School of Apromor has a number of advantages. While some creatures are immune to fire, none are immune to Perdo magic as such (though Perdo spells do need to penetrate Magic Resistance). The Art of Perdo can do nearly as much damage as
+Compared with the School of the Founder, the School of Apromor has a number of advantages. While some creatures are immune to fire, none are immune to Perdo magic as such (though Perdo spells do need to penetrate Magic Resistance). The Art of Perdo can do nearly as much damage as a Creo Ignem spell, yet is more versatile. Perdo spells may be used to disarm, blind, or otherwise incapacitate enemies instead of simply killing them. Perdo spells usually disregard the target's Soak, damaging fully armored knights or iron-scaled dragons as easily as more vulnerable opponents.
 
-### Enhancing Spell Penetration
+> ## Enhancing Spell Penetration
+> 
+> Many schools of fighting, and indeed many useful non-combat spells, require the caster to penetrate his opponent's Magic Resistance. This can be quite difficult, especially if the target is a Hermetic magus with a decent score in Parma Magica. The following practical advice can help player-magi overcome opponents who have high Magic Resistance.
+> 
+> **Favor Low-level Spells:** The Penetration of a spell is based on how much the casting total exceeds the spell level, so low-level spells are better against more magic-resistant opponents. A weak spell with high Penetration is better than a powerful spell that can't get through an opponent's Magic Resistance.
+> 
+> **Improve the Penetration Ability:** Improving Abilities is costly in terms of experience points and it may seem more effective to simply build up Arts instead. But Penetration is more powerful than it may appear. First, the Penetration Ability improves the Penetration of all spells, not just those of a single Art. Second, most bonuses that help Penetration act as a multiplier to the Penetration Ability. The higher one's Penetration Ability, the more benefit one gets from the bonuses.
+> 
+> **Take Advantage of Spell Mastery:** Consider the "penetration" special ability (ArM5, page 87). Spell Mastery also adds to the Casting Total of the spell, so it has a second (indirect) effect on Penetration.
+> 
+> **Get an Arcane Connection:** Get an Arcane Connection to the target if possible. Depending on the duration of the connection, it may grant a bonus to Penetration (ArM5, page 84).
+> 
+> **Use Sympathetic Connections:** If a magus has an Arcane Connection, he should try to use a sympathetic connection (ArM5, page 84) as well. With a little preparation, one can probably learn the target's nickname or birth name, which is good for a +1 increase to the Penetration multiplier (but remember, baptismal names cannot be used as sympathetic connections). With a bit more preparation, one can make a symbolic representation of the target (provided one has a good Craft skill) that grants another +2 to the multiplier. Those bonuses are cumulative, so if one has both a name and a picture of one's target, the multiplier would be x4 (x1 to start, +1 for the name, +2 for the symbolic representation).
 
-Many schools of fighting, and indeed many useful non-combat spells, require the caster to penetrate his opponent's Magic Resistance. This can be quite difficult, especially if the target is a Hermetic magus with a decent score in Parma Magica. The following practical advice can help player-magi overcome opponents who have high Magic Resistance.
-
-**Favor Low-level Spells:** The Penetration of a spell is based on how much the casting total exceeds the spell level, so low-level spells are better against more magic-resistant opponents. A weak spell with high Penetration is better than a powerful spell that can't get through an opponent's Magic Resistance.
-
-**Improve the Penetration Ability:** Improving Abilities is costly in terms of experience points and it may seem more effective to simply build up Arts instead. But Penetration is more powerful than it may appear. First, the Penetration Ability improves the Penetration of all spells, not just those of a single Art. Second, most bonuses that help Penetration act as a multiplier to the Penetration Ability. The higher one's Penetration Ability, the more benefit one gets from the bonuses.
-
-**Take Advantage of Spell Mastery:** Consider the "penetration" special ability (ArM5, page 87). Spell Mastery also adds to the Casting Total of the spell, so it has a second (indirect) effect on Penetration.
-
-**Get an Arcane Connection:** Get an Arcane Connection to the target if possible. Depending on the duration of the connection, it may grant a bonus to Penetration (ArM5, page 84).
-
-**Use Sympathetic Connections:** If a magus has an Arcane Connection, he should try to use a sympathetic connection (ArM5, page 84) as well. With a little preparation, one can probably learn the target's nickname or birth name, which is good for a +1 increase to the Penetration multiplier (but remember, baptismal names cannot be used as sympathetic connections). With a bit more preparation, one can make a symbolic representation of the target (provided one has a good Craft skill) that grants another +2 to the multiplier. Those bonuses are cumulative, so if one has both a name and a picture of one's target, the multiplier would be x4 (x1 to start, +1 for the name, +2 for the symbolic representation).
-
-a Creo Ignem spell, yet is more versatile. Perdo spells may be used to disarm, blind, or otherwise incapacitate enemies instead of simply killing them. Perdo spells usually disregard the target's Soak, damaging fully armored knights or iron-scaled dragons as easily as more vulnerable opponents.
-
-Perdo spells are less showy than hurling bolts of fire. Certainly, when opponents suddenly develop bleeding wounds or silently drop dead, onlookers can tell there is magic afoot, but they have a much harder time identifying the one who cast the spells. In the general confusion of battle, it can be difficult to even notice some Perdo effects: did the knight's sword break by accident, or because of magic? Apromor himself was fond of casting spells without gestures; many who follow his school take advantage of the Spell Mastery's "still casting" special ability (ArM5, page 87) to make their spells less
-
-obtrusive. This can be taken a step further to cast spells without voice, but most standard Perdo spells have Voice Range, and the caster would need to invent longer-Range (and higher-level) variants to fully benefit from such tactics.
+Perdo spells are less showy than hurling bolts of fire. Certainly, when opponents suddenly develop bleeding wounds or silently drop dead, onlookers can tell there is magic afoot, but they have a much harder time identifying the one who cast the spells. In the general confusion of battle, it can be difficult to even notice some Perdo effects: did the knight's sword break by accident, or because of magic? Apromor himself was fond of casting spells without gestures; many who follow his school take advantage of the Spell Mastery's "still casting" special ability (ArM5, page 87) to make their spells less obtrusive. This can be taken a step further to cast spells without voice, but most standard Perdo spells have Voice Range, and the caster would need to invent longer-Range (and higher-level) variants to fully benefit from such tactics.
 
 Perdo spells are not limited to offensive applications. Experts in the Technique of Perdo can learn spells of invisibility, for example, or Perdo Mentem spells that can help avoid a fight, such as *Calm the Motion of the Heart*. There are a number of Perdo spells that may be used to make indirect attacks, bypassing the opponent's Magic Resistance. *Pit of the Gaping* earth is one example, and it may also be used to create defensive trenches and the like. Dispelling magic is a Perdo effect. High-level Perdo effects can even remove properties of objects, making them behave in unusual but useful ways. For example, a high-level Perdo Corpus spell can make a person weightless.
-
 
 In spite of its greater versatility, the School of Apromor does have weaknesses. Most attacks in the School of Apromor need to penetrate Magic Resistance. Magi who follow the school must therefore devote scarce study time to the Penetration Ability and to Spell Mastery. This is somewhat offset by the greater variety of indirect attacks available in the School of Apromor: if one can't penetrate an enemy's Parma Magica, one can perhaps harm him by collapsing the building on top of him (*End of the Mighty Castle*, ArM5, page 155).
 
@@ -1208,15 +1189,9 @@ The main limitation of the School of Boreas is the very limited assortment of sp
 
 **Recommended Virtue: Warrior**
 
-The School of Ramius seeks to ignore an opponent's Magic Resistance altogether by relying on non-magical, physical attacks. The school uses magic to enhance the magus's own combat ability, usually emphasizing magical defense rather than offense. Ramius was a mid-rank member of House Tremere who defected to House Flambeau after the Sundering of Tremere in 848 AD. He was skilled in mundane arms as well as in magic. Ramius asserted that the emphasis on overcoming Magic Resistance led magi to over-specialize, which diminished their effectiveness both as wizards and as warriors. He went to Iberia and
-
-
-joined House Flambeau's struggle against the Moorish wizards, where he perfected his method of using mundane attacks supported by magical enhancements.
+The School of Ramius seeks to ignore an opponent's Magic Resistance altogether by relying on non-magical, physical attacks. The school uses magic to enhance the magus's own combat ability, usually emphasizing magical defense rather than offense. Ramius was a mid-rank member of House Tremere who defected to House Flambeau after the Sundering of Tremere in 848 AD. He was skilled in mundane arms as well as in magic. Ramius asserted that the emphasis on overcoming Magic Resistance led magi to over-specialize, which diminished their effectiveness both as wizards and as warriors. He went to Iberia and joined House Flambeau's struggle against the Moorish wizards, where he perfected his method of using mundane attacks supported by magical enhancements.
 
 The School of Ramius does not favor spells such as *Edge of the Razor* or *Blade of the Virulent Flame* to improve a magus's physical attacks. When a weapon is enchanted by such spells, Magic Resistance can stop it. Instead, followers of Ramius prefer mundane steel and use magic to improve their defenses or general fighting effectiveness. Some popular spells within the school are *Doublet of Impenetrable Silk* (ArM5, page 118), *Steed of Vengeance* (ArM5, page 119), *Gift of the Bear's Fortitude* (ArM5, page 131), *Endurance of the Berserkers* (ArM5 p. 134), *Shriek of the Impending Shafts* (ArM5 page 136), *Ward Against Heat and Flames* (ArM5, page 143), and *Veil of Invisibility* (ArM5, page 146). Personal wards (warding spells with parameters of Personal/Sun/Individual rather than Touch/Ring/Circle) are also very commonly used to protect either against weapons or against supernatural creatures.
-
-
-#### Societates
 
 One of the main advantages of the School of Ramius is that it does not require its followers to specialize in any particular Arts. With no need to develop high Penetration Totals, its followers can be more eclectic in their choice of Arts and spells. Followers of Ramius tend to prefer Arts that are not normally associated with spells of attack: Muto for improving their armor and defenses, Rego for personal wards, and Corpus for self-improvement and healing.
 
@@ -1242,25 +1217,23 @@ The Schools of Sebastian are a family of schools that rely on conjuring harmful 
 
 Most members of the Sebastian family of schools have a Magical Focus (either Major or Minor) and design their attacks to take advantage of that Focus. The schools are also attractive to magi who want to specialize in Arts other than Perdo or Ignem. Such Arts can have significant non-combat uses.
 
-Like the schools of the Founder and of Apromor, the Schools of Sebastian depend on the ability to penetrate Magic Resistance. They tend to offer spells that do less damage compared to Ignem spells
+Like the schools of the Founder and of Apromor, the Schools of Sebastian depend on the ability to penetrate Magic Resistance. They tend to offer spells that do less damage compared to Ignem spells of similar magnitude. The schools remain a good choice for magi who want to specialize in certain Forms (Animal, Aquam, Herbam, or Terram). They are commonly used outside House Flambeau by magi who think of themselves as specialists rather than combatants, but who want to be ready to defend themselves.
 
-### Magical Foci for the Schools of Sebastian
-
-The following are some examples of magical foci that may be useful to magi following one of the Schools of Sebastian. Except where noted, all of them would count as Minor Magical Foci. The Forms of Mentem, Imaginem, and Vim are unsuitable for conjuring harmful substances, and magi who favor the Form of Ignem are categorized in the School of the Founder or of Boreas.
-
-**Animal:** Birds (major), poisonous insects, snakes, canines, teeth
-
-**Aquam:** Acid, poison, boiling oil **Auram:** Weather (major), lightning, poisonous gases
-
-**Corpus:** Necromancy (major), animated corpses, human bones
-
-**Herbam:** Thorns, vines, plant toxins
-
-**Terram:** Blades, molten metal, stalagmites/stalactites
-
-See also the sample Major and Minor Magical Foci in ArM5, pages 45 and 46.
-
-of similar magnitude. The schools remain a good choice for magi who want to specialize in certain Forms (Animal, Aquam, Herbam, or Terram). They are commonly used outside House Flambeau by magi who think of themselves as specialists rather than combatants, but who want to be ready to defend themselves.
+> ## Magical Foci for the Schools of Sebastian
+> 
+> The following are some examples of magical foci that may be useful to magi following one of the Schools of Sebastian. Except where noted, all of them would count as Minor Magical Foci. The Forms of Mentem, Imaginem, and Vim are unsuitable for conjuring harmful substances, and magi who favor the Form of Ignem are categorized in the School of the Founder or of Boreas.
+> 
+> **Animal:** Birds (major), poisonous insects, snakes, canines, teeth
+> 
+> **Aquam:** Acid, poison, boiling oil **Auram:** Weather (major), lightning, poisonous gases
+> 
+> **Corpus:** Necromancy (major), animated corpses, human bones
+> 
+> **Herbam:** Thorns, vines, plant toxins
+> 
+> **Terram:** Blades, molten metal, stalagmites/stalactites
+> 
+> See also the sample Major and Minor Magical Foci in ArM5, pages 45 and 46.
 
 #### The School of Vilano
 
@@ -1268,10 +1241,7 @@ of similar magnitude. The schools remain a good choice for magi who want to spec
 
 The School of Vilano relies on indirect attacks that bypass Magic Resistance. An example of an indirect attack is using magic to levitate a rock over someone's head, then dropping the rock. Several examples of indirect attacks are given in ArM5, page 86.
 
-Vilano was a ninth-century Flambeau magus from Istria in the Transylvanian Tribunal. He suffered from the Hermetic Flaw Weak Magic but remained deter-
-
-
-mined to prove himself in battle. Vilano was the first member of House Flambeau to succeed using only indirect spells, most famously when he slew the Green Dragon of Labin by crushing it with two falling trees. His tactics have been widely emulated both within and outside his House.
+Vilano was a ninth-century Flambeau magus from Istria in the Transylvanian Tribunal. He suffered from the Hermetic Flaw Weak Magic but remained determined to prove himself in battle. Vilano was the first member of House Flambeau to succeed using only indirect spells, most famously when he slew the Green Dragon of Labin by crushing it with two falling trees. His tactics have been widely emulated both within and outside his House.
 
 Using indirect spells allows a follower of Vilano to attack any opponent regardless of how strong its Magic Resistance may be. Members of this school don't need to worry about using low-magnitude spells in order to get a better Penetration Total: they may bring their mightiest spells to bear against even the most powerful opponent. This makes the School of Vilano surprisingly effective.
 
@@ -1281,57 +1251,51 @@ Like all schools, the School of Vilano has its weaknesses. The selection of indi
 
 Indirect spells generally need to be aimed, and can miss. A good score in the Finesse Ability reduces but does not eliminate that risk. A less obvious consequence of aiming is that indirect spells require two stress rolls (one to cast the spell and another to aim it) and therefore have two chances to botch.
 
-Most indirect spells do fairly low damage. They are good for trapping or wounding opponents, but may have trouble ending a fight quickly (unless the caster is fortunate enough to bury his opponent
+Most indirect spells do fairly low damage. They are good for trapping or wounding opponents, but may have trouble ending a fight quickly (unless the caster is fortunate enough to bury his opponent under an avalanche). The great risk is that one's opponent might still be able to make effective counter-attacks. Some followers of Vilano develop strong magical defenses, perhaps combining their tactics with ideas from the School of Ramius. Others use invisibility when they fight, to make it difficult for the enemy to attack them. A third option is to rely on shield grogs to protect the magus long enough that he can fully neutralize the enemy.
 
-### Indirect Spells from ArM5
-
-The following spells from **Ars Magica Fifth Edition** can be at least partly effective without the need to penetrate Magic Resistance. Some additional indirect spells are given in the Rules section of this chapter.
-
-*Weaver's Trap of Webs* (CrAn 35, ArM5 page 117): While the webs do not touch the magus, they surround him and keep him in place.
-
-*Footsteps of Slippery Oil* (CrAq 5, ArM5 page 121): The maga can step in the magical oil, just as she can walk across a magically-created bridge.
-
-*Waves of Drowning and Smashing* (ReAq 30, ArM5 page 124): Although the wave can't directly harm the maga, it can capsize a boat in which she is riding or wash out a small bridge on which she is standing.
-
-*Neptune's Wrath* (ReAq 40, ArM5 page 125): Similar to *Waves of Drowning and Smashing*, but the wave is much more destructive.
-
-*Awaken the Slumbering Corpse* (ReCo 25, ArM5 page 134): If the corpse attacks in unarmed combat, it would be resisted because the whole corpse is under an active magical effect, but if it wields a non-magical weapon, the weapon would bypass Magic Resistance.
-
-*Strings of the Unwilling Marionette* (ReCo 25, ArM5 page 135): Similar to *Awaken the Slumbering Corpse*, above.
-
-*The Walking Corpse* (ReCo 35, ArM5 page 135): Similar to *Awaken the Slumbering Corpse*, above.
-
-*Trap of the Entwining Vines* (CrHe 15, ArM5 page 135): The vines do not completely immobilize the maga, but surround her and prevent her from moving about.
-
-*Tangle of Wood and Thorns* (ReHe 15, ArM5 page 138): This can be completely
-
-effective, as the wood does not have to touch a magus in order to immobilize him. The storyguide may choose to give a bonus to the Strength roll to escape.
-
-*Coils of the Entangling Plants* (ReHe 20, ArM5 page 138): Similar to *Weaver's Trap of Webs* or *Trap of the Entwining Vines*, above.
-
-*Tremulous Vault of the Torch's Flame* (ReIg 5, ArM5 page 142): The motion of the flame is magical but the flame itself is not; the flame stops as if it had gently touched the magus, but it still burns him.
-
-*Leap of the Fire* (ReIg 10, ArM5 page 143): Similar to *Tremulous Vault of the Torch's Flame*.
-
-*Pit of the Gaping Earth* (PeTe 15, ArM5 page 155): No one can resist having a pit open up under her feet.
-
-*Obliteration of the Metallic Barrier* (PeTe 20, ArM5 page 155): The shards of metal are thrown as projectiles and can bypass Magic Resistance.
-
-*End of the Mighty Castle* (PeTe 25, ArM5 page 155): Magic Resistance does not protect against non-magical stone falling due to gravity.
-
-*Cascade of Rocks* (PeTe 40, ArM5 page 155): Similar to *End of the Mighty Castle*, above.
-
-*The Earth Split Asunder* (ReTe 30, ArM5 page 156): Magic Resistance does not protect the magus from falling into the chasm, but it does protect him from being crushed when it closes. If the chasm closes slowly instead of violently (see the spell description), this would not be resisted, but the magus would probably be able to climb out during the process.
-
-*Creeping Chasm* (ReTe 35, ArM5 page 156): Similar to *Pit of the Gaping Earth*, above.
-
-under an avalanche). The great risk is that one's opponent might still be able to make effective counter-attacks. Some followers of Vilano develop strong magical defenses, perhaps combining their tactics with ideas from the School of Ramius. Others use invisibility when they fight, to make it difficult for the enemy to attack them. A third option is to rely on shield grogs to protect
-
-the magus long enough that he can fully neutralize the enemy.
+> ## Indirect Spells from ArM5
+> 
+> The following spells from **Ars Magica Fifth Edition** can be at least partly effective without the need to penetrate Magic Resistance. Some additional indirect spells are given in the Rules section of this chapter.
+> 
+> *Weaver's Trap of Webs* (CrAn 35, ArM5 page 117): While the webs do not touch the magus, they surround him and keep him in place.
+> 
+> *Footsteps of Slippery Oil* (CrAq 5, ArM5 page 121): The maga can step in the magical oil, just as she can walk across a magically-created bridge.
+> 
+> *Waves of Drowning and Smashing* (ReAq 30, ArM5 page 124): Although the wave can't directly harm the maga, it can capsize a boat in which she is riding or wash out a small bridge on which she is standing.
+> 
+> *Neptune's Wrath* (ReAq 40, ArM5 page 125): Similar to *Waves of Drowning and Smashing*, but the wave is much more destructive.
+> 
+> *Awaken the Slumbering Corpse* (ReCo 25, ArM5 page 134): If the corpse attacks in unarmed combat, it would be resisted because the whole corpse is under an active magical effect, but if it wields a non-magical weapon, the weapon would bypass Magic Resistance.
+> 
+> *Strings of the Unwilling Marionette* (ReCo 25, ArM5 page 135): Similar to *Awaken the Slumbering Corpse*, above.
+> 
+> *The Walking Corpse* (ReCo 35, ArM5 page 135): Similar to *Awaken the Slumbering Corpse*, above.
+> 
+> *Trap of the Entwining Vines* (CrHe 15, ArM5 page 135): The vines do not completely immobilize the maga, but surround her and prevent her from moving about.
+> 
+> *Tangle of Wood and Thorns* (ReHe 15, ArM5 page 138): This can be completely effective, as the wood does not have to touch a magus in order to immobilize him. The storyguide may choose to give a bonus to the Strength roll to escape.
+> 
+> *Coils of the Entangling Plants* (ReHe 20, ArM5 page 138): Similar to *Weaver's Trap of Webs* or *Trap of the Entwining Vines*, above.
+> 
+> *Tremulous Vault of the Torch's Flame* (ReIg 5, ArM5 page 142): The motion of the flame is magical but the flame itself is not; the flame stops as if it had gently touched the magus, but it still burns him.
+> 
+> *Leap of the Fire* (ReIg 10, ArM5 page 143): Similar to *Tremulous Vault of the Torch's Flame*.
+> 
+> *Pit of the Gaping Earth* (PeTe 15, ArM5 page 155): No one can resist having a pit open up under her feet.
+> 
+> *Obliteration of the Metallic Barrier* (PeTe 20, ArM5 page 155): The shards of metal are thrown as projectiles and can bypass Magic Resistance.
+> 
+> *End of the Mighty Castle* (PeTe 25, ArM5 page 155): Magic Resistance does not protect against non-magical stone falling due to gravity.
+> 
+> *Cascade of Rocks* (PeTe 40, ArM5 page 155): Similar to *End of the Mighty Castle*, above.
+> 
+> *The Earth Split Asunder* (ReTe 30, ArM5 page 156): Magic Resistance does not protect the magus from falling into the chasm, but it does protect him from being crushed when it closes. If the chasm closes slowly instead of violently (see the spell description), this would not be resisted, but the magus would probably be able to climb out during the process.
+> 
+> *Creeping Chasm* (ReTe 35, ArM5 page 156): Similar to *Pit of the Gaping Earth*, above.
 
 Many followers of Vilano make extensive use of enchanted items in addition to spells. One of the main limitations of enchanted items is their generally weak Penetration, but the tactics of this school circumvent that problem.
 
-
+## Rules for House Flambeau
 
 This section includes rules for House Acclaim, the system by which Flambeau magi measure their status relative to one another. Also included are new spells, some new laboratory and Spell Mastery options, and rules for integrating magical tactics into the combat system.
 
@@ -1343,32 +1307,33 @@ House Acclaim is a free Reputation that every Flambeau magus gains at the start 
 
 Noteworthy deeds of prowess, valor, and honor are rewarded with experience points in the House Acclaim Reputation. However, a member of House Flambeau may never rest on her laurels: unlike other Reputations, House Acclaim can diminish over time if the character fails to continue an illustrious career. Furthermore, ignoble acts can seriously damage a magus's House Acclaim. Loss of House Acclaim is handled by taking away experience points instead of adding them. It is not possible to have a negative House Acclaim, but if a magus with zero House Acclaim performs an ignoble act, he gains a bad Reputation according to the normal Reputation rules (ArM5, page 167).
 
+In order for a deed to grant experience points in House Acclaim, it must be done in front of witnesses. They need not be members of House Flambeau, as long as they are credible and are likely to tell of the magus's accomplishments.
+
 ### Example Acclaim Awards
 
 Flambeau magi can gain experience in House Acclaim just as they can in any other Reputation. Certain remarkable deeds can result in the gain or loss of more than one experience point at a time. The following are some example awards and penalties; the storyguide should feel free to make ad hoc awards for other glorious (or despicable) achievements.
 
-| Action                                            | Experience Points                  |
-|---------------------------------------------------|------------------------------------|
-| Exceptional Gauntlet*                             | 2–5                                |
-| Participating in a Wizard's March                 | 1                                  |
-| Winning certamen (outside a tournament)**         | 1                                  |
-| Winning certamen against a more senior<br>magus** | +1 (cumulative with winning)       |
-| Competing in magical tournament                   | 1                                  |
-| Fighting bravely in Wizard's War                  | 1–3                                |
-| Winning a Wizard's War                            | 2 x highest Reputation of opponent |
-| Finalist in magical tournament                    | +2 (cumulative with competing)     |
-| Champion in magical tournament                    | +2 (cumulative with finalist)      |
-| Slaying a renounced magus                         | 3 x highest Reputation of magus    |
-| Slaying a supernatural beast                      | Might of beast / 5                 |
-| Each year without gaining any Acclaim<br>points   | –1                                 |
-| Dismal tournament performance                     | –3 (still gain 1 for competing)    |
-| Appearance of dishonesty or cowardice             | –-1 (or more) per incident         |
-| Losing certamen (outside a tournament)**          | –1                                 |
-| Losing certamen against a more junior<br>magus**  | –1 (cumulative with losing)        |
+| Action                                             | Experience Points                   |
+|----------------------------------------------------|-------------------------------------|
+| Exceptional Gauntlet\*                             | 2–5                                 |
+| Participating in a Wizard's March                  | 1                                   |
+| Winning certamen (outside a tournament)\*\*        | 1                                   |
+| Winning certamen against a more senior magus\*\*   | +1 (cumulative with winning)        |
+| Competing in magical tournament                    | 1                                   |
+| Fighting bravely in Wizard's War                   | 1–3                                 |
+| Winning a Wizard's War                             | 2 x highest Reputation of opponent  |
+| Finalist in magical tournament                     | +2 (cumulative with competing)      |
+| Champion in magical tournament                     | +2 (cumulative with finalist)       |
+| Slaying a renounced magus                          | 3 x highest Reputation of magus     |
+| Slaying a supernatural beast                       | Might of beast / 5                  |
+| Each year without gaining any Acclaim points       | –1                                  |
+| Dismal tournament performance                      | –3 (still gain 1 for competing)     |
+| Appearance of dishonesty or cowardice              | –1 (or more) per incident           |
+| Losing certamen (outside a tournament)\*\*         | –1                                  |
+| Losing certamen against a more junior magus\*\*    | –1 (cumulative with losing)         |
 
-<sup>\*</sup> This award should only be granted if the troupe actually roleplays the Gauntlet.
-
-In order for a deed to grant experience points in House Acclaim, it must be done in front of witnesses. They need not be members of House Flambeau, as long as they are credible and are likely to tell of the magus's accomplishments.
+\* This award should only be granted if the troupe actually roleplays the Gauntlet.
+\*\* Magi only gain or lose House Acclaim for certamen when there is a meaningful dispute to settle. Simply dueling other magi for sport (or for no reason at all) does not add or remove House Acclaim points. 
 
 ### New Flaws
 
@@ -1379,9 +1344,6 @@ In order for a deed to grant experience points in House Acclaim, it must be done
 The character, who must be a member of House Flambeau, is a member of the milites (see "The Milites" earlier in this chapter). She has made a public oath to uphold the Code of Garus or some similar code of honor. This carries both benefits and obligations.
 
 The character gains 5 experience points in House Acclaim for House Flambeau. Other milites regard the character as a brother-in-arms and can be relied upon to provide support and assistance. However, the character may lose respect (represented by House Acclaim points) if he relies too heavily on their assistance and seems unable to accomplish tasks on his own.
-
-
-<sup>\*\*</sup> Magi only gain or lose House Acclaim for certamen when there is a meaningful dispute to settle. Simply dueling other magi for sport (or for no reason at all) does not add or remove House Acclaim points.
 
 Other milites may occasionally ask the character for assistance as well. The character has sworn an oath to obey the Primus of House Flambeau and may receive orders from the Primus at any time. (The Primus cannot give orders that affect how a magus uses his vote or what he says at Tribunal.) Successfully fulfilling a direct order from the Primus grants experience points in House Acclaim.
 
@@ -1399,18 +1361,14 @@ Invisibility can be powerful in combat, but it is not foolproof. An invisible ch
 
 A character who is invisible gains the following benefits:
 
-Opponents cannot engage the invisible character in melee unless they determine his location (see below); however, if the invisible character attacks in melee, the opponent(s) he •
+Opponents cannot engage the invisible character in melee unless they determine his location (see below); however, if the invisible character attacks in melee, the opponent(s) he has engaged remain engaged and can attack.
 
-#### Houses of Hermes
-
-has engaged remain engaged and can attack.
-
-- He cannot be hit by missile weapons unless his opponent is able to locate him first. Likewise, aimed spells can only hit him if the caster knows his location. •
-- He cannot be targeted by spells unless the caster either has an Arcane Connection to him, or is able to locate him. Area-affecting spells, such as *Arc of Fiery Ribbons*, work normally against invisible characters within the affected area. Aimed spells are treated like missile attacks (see the second point, above). •
-- He cannot be affected by spells with Range Eye, but neither can he cast them. Eye contact requires the two characters be able to see each other. •
-- An invisible character gains a large bonus to Stealth rolls related to hiding or remaining unseen. This bonus does not extend to rolls for moving quietly. •
-- Even if an opponent knows the invisible character's exact location and/or is engaged in melee with him, the invisible character gains bonuses to Attack and Defense rolls (see the "Effects of Invisibility" sidebar). •
-- An invisible character can make surprise attacks against opponents who have not precisely located her (see below). During the first round only, the invisible character automatically goes first and gains a +3 Attack bonus (this combines with the usual bonuses from the Effects of Invisibility table). After the first round, both combatants roll Initiative and combat proceeds as normal. An invisible character can make a surprise attack whenever her opponent does not know her exact location. It is possible to make a surprise attack, disengage, and then make another surprise attack in a later combat round. •
+- He cannot be hit by missile weapons unless his opponent is able to locate him first. Likewise, aimed spells can only hit him if the caster knows his location.
+- He cannot be targeted by spells unless the caster either has an Arcane Connection to him, or is able to locate him. Area-affecting spells, such as *Arc of Fiery Ribbons*, work normally against invisible characters within the affected area. Aimed spells are treated like missile attacks (see the second point, above).
+- He cannot be affected by spells with Range Eye, but neither can he cast them. Eye contact requires the two characters be able to see each other.
+- An invisible character gains a large bonus to Stealth rolls related to hiding or remaining unseen. This bonus does not extend to rolls for moving quietly.
+- Even if an opponent knows the invisible character's exact location and/or is engaged in melee with him, the invisible character gains bonuses to Attack and Defense rolls (see the "Effects of Invisibility" sidebar).
+- An invisible character can make surprise attacks against opponents who have not precisely located her (see below). During the first round only, the invisible character automatically goes first and gains a +3 Attack bonus (this combines with the usual bonuses from the Effects of Invisibility table). After the first round, both combatants roll Initiative and combat proceeds as normal. An invisible character can make a surprise attack whenever her opponent does not know her exact location. It is possible to make a surprise attack, disengage, and then make another surprise attack in a later combat round.
 
 One of the weaknesses of invisibility is that an invisible weapon is kept out by Magic Resistance (and an invisible character's touch is likewise kept out). It is possible to pick up a weapon after becoming invisible: the weapon then remains visible and non-magical. Of course, this approach sacrifices much of the advantage of invisibility. In particular, it makes surprise attacks impossible unless the character is able to strike from behind.
 
@@ -1424,41 +1382,37 @@ There is no need to make a roll to locate one's opponent if one is already engag
 
 Once an invisible character has been located, he may be attacked, but the bonus to Defense given in the Effects of Invisibility tables applies. If an invisible character has not been located, he cannot be attacked at all. Similarly, although an invisible opponent engaged in melee can be automatically located by his opponent, he still gets the appropriate bonus to Attack.
 
-It is not necessary to precisely locate an invisible character to know he is some-
+It is not necessary to precisely locate an invisible character to know he is somewhere nearby. Invisibility does not make a character any quieter than usual, so rolls to simply hear the character moving gain no bonus or penalty (use Perception + Awareness vs. Dexterity + Stealth – Encumbrance, with no Stealth bonus).
 
-
-
-The benefits of invisibility depend mostly on what visual clues betray the character's presence. The storyguide should decide what is the most obvious clue and assign bonuses according to the following table. Footprints and shadows are fairly easy to see in good light, but become much less obvious when visibility is poor.
-
-Trying to fight an invisible character using sound clues alone means the invisible character gains maximum benefits
-
-(from the "No signs" row of the table). If the character is especially noisy, the storyguide may choose to reduce his bonus.
-
-Invisibility grants a bonus to melee attack rolls, but not to missile attacks. The defense bonus due to invisibility applies to all incoming attacks, melee and missile alike. An attacker must know the invisible character's location (see Locating an Invisible Character in this section) in order to engage him in melee or to have any chance of hitting with missiles.
-
-| Clarity of<br>Signs | Examples                                                                        | Melee Attack<br>Bonus | Defense<br>Bonus | Stealth<br>Bonus |
-|---------------------|---------------------------------------------------------------------------------|-----------------------|------------------|------------------|
-| Obvious             | Invisible character with vis<br>ible sword                                      | +1                    | +3               | +3*              |
-|                     | Invisible character partly<br>covered in mud                                    |                       |                  |                  |
-|                     | Invisible character wading<br>through ankle-deep water,<br>mud, or snow         |                       |                  |                  |
-| Clear               | Invisible character casting<br>shadow in direct sunlight                        | +3                    | +3               | +3               |
-|                     | Invisible character leaving<br>footprints in tall grass, sand,<br>or light snow |                       |                  |                  |
-| Indistinct          | Invisible character casting<br>shadow on a cloudy day                           | +3                    | +6               | +6               |
-|                     | Invisible character leaving<br>footprints on packed earth<br>or gravel          |                       |                  |                  |
-| Faint               | Invisible character casting<br>shadow in moonlight                              | +6                    | +9               | +9               |
-|                     | Invisible character leaving<br>footprints on cobblestone                        |                       |                  |                  |
-| No signs            | Invisible character leaving<br>no visual cues                                   | +9                    | +9               | +12              |
-|                     | * Observers can automatically locate the character, but the Stealth bonus still |                       |                  |                  |
-
-applies to attempts to hide.
-
-where nearby. Invisibility does not make a character any quieter than usual, so rolls to simply hear the character moving gain no bonus or penalty (use Perception + Awareness vs. Dexterity + Stealth – Encumbrance, with no Stealth bonus).
+> ## Effects of Invisibility
+> 
+> The benefits of invisibility depend mostly on what visual clues betray the character's presence. The storyguide should decide what is the most obvious clue and assign bonuses according to the following table. Footprints and shadows are fairly easy to see in good light, but become much less obvious when visibility is poor.
+> 
+> Trying to fight an invisible character using sound clues alone means the invisible character gains maximum benefits (from the "No signs" row of the table). If the character is especially noisy, the storyguide may choose to reduce his bonus.
+> 
+> Invisibility grants a bonus to melee attack rolls, but not to missile attacks. The defense bonus due to invisibility applies to all incoming attacks, melee and missile alike. An attacker must know the invisible character's location (see Locating an Invisible Character in this section) in order to engage him in melee or to have any chance of hitting with missiles.
+> 
+> | Clarity of Signs | Examples | Melee Attack Bonus | Defense Bonus | Stealth Bonus |
+> |------------------|----------|--------------------|---------------|---------------|
+> | Obvious | Invisible character with visible sword | +1 | +3 | +3\* |
+> |  | Invisible character partly covered in mud |  |  |  |
+> |  | Invisible character wading through ankle-deep water, mud, or snow |  |  |  |
+> | Clear | Invisible character casting shadow in direct sunlight | +3 | +3 | +3 |
+> |  | Invisible character leaving footprints in tall grass, sand, or light snow |  |  |  |
+> | Indistinct | Invisible character casting shadow on a cloudy day | +3 | +6 | +6 |
+> |  | Invisible character leaving footprints on packed earth or gravel |  |  |  |
+> | Faint | Invisible character casting shadow in moonlight | +6 | +9 | +9 |
+> |  | Invisible character leaving footprints on cobblestone |  |  |  |
+> | No signs | Invisible character leaving no visual cues | +9 | +9 | +12\*\* |
+> 
+> \* Observers can automatically locate the character, but the Stealth bonus still applies to attempts to hide.
+> \*\* Visual detection is impossible.
 
 #### Invisibility and Group Combat
 
 Characters who are can't see one another may not fight as part of a trained group. Effective group tactics require the combatants to be aware of what the others are doing.
 
-An invisible character may serve as the vanguard of a group. If an untrained group contains some invisible members, everyone in the group gains an extra botch die per invisible character. On a botch, combatants may blunder into an invisible character or even accidentally strike him with their weapons.
+An invisible character may serve as the untrained group. If an untrained group contains some invisible members, everyone in the group gains an extra botch die per invisible character. On a botch, combatants may blunder into an invisible character or even accidentally strike him with their weapons.
 
 A group of allies cannot defend an invisible character (see ArM5, page 173) unless they have some means of knowing where he is.
 
@@ -1470,7 +1424,7 @@ The following magic rules are available to all magi, not just members of House F
 
 Magi of House Flambeau have developed a new way to make magic items more useful in combat. This has been disseminated throughout the Order and is available to all magi.
 
-#### Fast Trigger
+**Fast Trigger**
 
 The effect gains a +3 Initiative modifier. This adds +5 to the level of the effect.
 
@@ -1478,25 +1432,19 @@ The effect gains a +3 Initiative modifier. This adds +5 to the level of the effe
 
 The special abilities conferred by Spell Mastery are often useful in combat. Magi of House Flambeau are fond of all the Spell Mastery special abilities listed in **Ars Magica Fifth Edition** (page 87) and have developed some additional special abilities of their own. These are available to magi of any House, even though they originated within House Flambeau.
 
-#### Imperturbable Casting
+**Imperturbable Casting**
 
-Add the caster's Mastery score to all Concentration rolls related to the spell. This helps her maintain spells of Concentration Duration amid the chaos of
+Add the caster's Mastery score to all Concentration rolls related to the spell. This helps her maintain spells of Concentration Duration amid the chaos of battle, or while casting another spell (see the Concentration Table, ArM5, page 82).
 
-
-<sup>\*\*</sup> Visual detection is impossible.
-
-
-battle, or while casting another spell (see the Concentration Table, ArM5, page 82).
-
-#### Obfuscated Casting
+**Obfuscated Casting**
 
 Magi cannot automatically identify the Form of the spell as the magus casts it. This makes it difficult for them to use fastcast spells as a defense. They must always roll to determine the Form of the spell (see ArM5, page 83) and must add the caster's Mastery score to the Ease Factor.
 
-#### Precise Casting
+**Precise Casting**
 
 Add +1 to all Finesse rolls the caster makes with the spell, including aiming rolls. Subtract one botch die from any Finesse rolls she makes using the spell, to a minimum of one botch die. A maga may take this ability multiple times for the same spell.
 
-#### Quick Casting
+**Quick Casting**
 
 Add +1 to the caster's Initiative Total when he casts the Mastered spell. If he also has the Fast Casting special ability, add +1 to his Fast Casting Speed rolls (ArM5, page 83) when he fast-casts the spell. This ability cannot be used for Ritual spells. A magus may take this special ability multiple times for the same spell.
 
@@ -1506,7 +1454,7 @@ The following spells are available to any magus but are of particular interest t
 
 #### Creo Animal Spells
 
-**Summoning the Creeping Death**
+##### Summoning the Creeping Death
 
 Cr(Re)An 25
 
@@ -1514,31 +1462,31 @@ R: Touch, D: Diam, T: Ind
 
 Conjures an asp, which magically obeys the caster's mental commands. Use the statistics for an adder from the *Book of Mundane Beasts,* except that an asp's venom is much more deadly than an adder's. The effects of asp venom are given on page 180 of ArM5. The snake has no Might and hence no Magic Resistance of its own, but since it is a magically created creature, Magic Resistance does protect against its attack (use the caster's Penetration Total).
 
-### Mercurian Spell Mastery Abilities
-
-The Cult of Mercury teaches several exclusive Spell Mastery special abilities. These special abilities are not unique to House Flambeau, but are generally available to any member of the Cult (whose membership includes magi from many different Houses).
-
-The following special abilities were originally printed in *Houses of Hermes: True Lineages* (pages 99–100).
-
-**Adaptive Casting (Cult of Mercury):** This special ability may only be taken for General spells. The caster may use her Mastery score and all the special abilities associated with this spell when she casts the same spell at different levels.
-
-**Ceremonial Casting (Cult of Mercury):** The caster may use ceremonial methods when casting this spell, increasing the casting time and adding his Artes Liberales and Philosophiae to his Casting Total. This special ability cannot be taken for Ritual spells, which always require ceremonial casting.
-
-**Disguised Casting (Cult of Mercury):** When casting this spell, the caster may suppress or alter her sigil, to hide her identity or make the spell appear to have been cast by someone else. Since this actually changes her sigil, is it impossible for others to recognize her from it, though magi might be able to recognize that a fake sigil is not genuine. When the caster mimics the sigil of another magus, add her Spell Mastery score to the roll that determines how difficult it is to recognize.
-
-**Lab Mastery (Cult of Mercury):** The caster understands the theory of the spell so perfectly that he may add his Spell Mastery score to his Lab Total when designing effects that are similar to it (see Similar Spells, ArM5, page 101). This is in addition to the standard similar spell bonus.
-
-**Learn From Mistakes (Cult of Mercury):** The first time in a session that the caster botches a roll for this spell or fails the casting roll by exactly one point, she gains 5 experience points toward Mastery of this spell. The roll must come up naturally in the course of the story.
-
-**Stalwart Casting (Cult of Mercury):** The spell is less exhausting for the caster. If it is a Ritual, she loses normal Fatigue instead of Long-Term Fatigue when casting it, and half as many Fatigue levels, rounded up (but always at least one). If it is formulaic, she never loses Fatigue levels because of a low casting total, even if the spell doesn't succeed.
-
 This spell is sometimes used by magi who follow the School of Sebastian, but other Flambeau magi tend to disdain it as an ignoble form of attack.
 
 (Base 10, +1 Touch, +1 Diameter, +1 Rego requisite)
 
+> ## Mercurian Spell Mastery Abilities
+> 
+> The Cult of Mercury teaches several exclusive Spell Mastery special abilities. These special abilities are not unique to House Flambeau, but are generally available to any member of the Cult (whose membership includes magi from many different Houses).
+> 
+> The following special abilities were originally printed in *Houses of Hermes: True Lineages* (pages 99–100).
+> 
+> **Adaptive Casting (Cult of Mercury):** This special ability may only be taken for General spells. The caster may use her Mastery score and all the special abilities associated with this spell when she casts the same spell at different levels.
+> 
+> **Ceremonial Casting (Cult of Mercury):** The caster may use ceremonial methods when casting this spell, increasing the casting time and adding his Artes Liberales and Philosophiae to his Casting Total. This special ability cannot be taken for Ritual spells, which always require ceremonial casting.
+> 
+> **Disguised Casting (Cult of Mercury):** When casting this spell, the caster may suppress or alter her sigil, to hide her identity or make the spell appear to have been cast by someone else. Since this actually changes her sigil, is it impossible for others to recognize her from it, though magi might be able to recognize that a fake sigil is not genuine. When the caster mimics the sigil of another magus, add her Spell Mastery score to the roll that determines how difficult it is to recognize.
+> 
+> **Lab Mastery (Cult of Mercury):** The caster understands the theory of the spell so perfectly that he may add his Spell Mastery score to his Lab Total when designing effects that are similar to it (see Similar Spells, ArM5, page 101). This is in addition to the standard similar spell bonus.
+> 
+> **Learn From Mistakes (Cult of Mercury):** The first time in a session that the caster botches a roll for this spell or fails the casting roll by exactly one point, she gains 5 experience points toward Mastery of this spell. The roll must come up naturally in the course of the story.
+> 
+> **Stalwart Casting (Cult of Mercury):** The spell is less exhausting for the caster. If it is a Ritual, she loses normal Fatigue instead of Long-Term Fatigue when casting it, and half as many Fatigue levels, rounded up (but always at least one). If it is formulaic, she never loses Fatigue levels because of a low casting total, even if the spell doesn't succeed.
+
 #### Rego Animal Spells
 
-**Fury of the Charging Bull**
+##### Fury of the Charging Bull
 
 ReAn 20
 
@@ -1554,23 +1502,23 @@ Some magi who follow the School of Vilano use this spell to make animals attack 
 
 **Level 3:** Create ice in a natural shape, such as a floe or icicle.
 
-
-
-The laws of physics in Mythic Europe conform to medieval ideas, not modern ones. The differences are often unimportant, but they become significant when a magus uses Rego spells to throw projectiles or to drop heavy objects from a height. The physics (or "natural philosophy," as characters would call it) of Mythic Europe will be described in more detail in a future supplement for **Ars Magica Fifth Edition**. This book only addresses one narrow topic that is likely to interest magi from House Flambeau: how to use Rego spells as a form of attack.
-
-There are three different ways Rego magic may be used offensively.
-
-The first way is to use magic to propel the projectile all the way to the target. In this case, the motive force of the projectile is entirely due to magic. Magic Resistance protects against this form of attack, with projectiles stopping harmlessly at the edge of the target's Magic Resistance, as described under "The Functioning of Magic Resistance," on pages 85–86 of ArM5. This sort of spell does not need to be aimed. Nearly all Rego spells in the ArM5 rulebook work this way.
-
-The second form of attack is to exploit what philosophers call "natural motion:" the natural tendency of heavy objects to fall downward. A magus could use Rego magic to levitate a rock over someone's head and then cancel the spell. The rock would naturally fall and would bypass Magic Resistance. Such spells must be aimed to strike their targets.
-
-The third way is to use a brief jolt of magical force to hurl a projectile, as an arrow is thrown from a bow. There is a sentence in the first printing of ArM5 that appears to prohibit this (the final sentence of the first paragraph on page 86, beginning "Note that . . ."), but that sentence has been deleted by the official errata. Medieval natural philosophy did offer an explanation for how an arrow could continue moving after it leaves the bow. To over-simplify (in the interest of brevity), it involves the motion of air around the arrow. Magi can devise spells that hurl projectiles in this manner: new Rego guidelines are provided in the Rules section of this chapter. Only specially designed Rego spells can throw projectiles this way \_ the spell's description must explicitly state that it can throw projectiles (these spells are higher magnitude than generic Rego spells). Spells that throw a projectile release control of it immediately after launching it. The projectile then continues on a natural trajectory. In game terms, this means the spell must be aimed, but the projectile bypasses Magic Resistance. The Range of the spell need only be Touch (the magic only needs to act at the moment the projectile is thrown), but once launched, the projectile is subject to the natural laws of motion. The aiming roll suffers a range penalty just like a missile weapon does (ArM5, page 172) and the projectile can go no farther than it could be thrown by a very powerful mundane bow (or sling, catapult, or other device). Most projectiles thrown by spells have a range increment of 20 paces.
-
-The rule under "Aiming" on page 86 of ArM5 remains true: "If a spell is resisted . . . it need not be aimed. If it is not resisted, it must be aimed."
+> ## Projectiles and Rego Magic
+> 
+> The laws of physics in Mythic Europe conform to medieval ideas, not modern ones. The differences are often unimportant, but they become significant when a magus uses Rego spells to throw projectiles or to drop heavy objects from a height. The physics (or "natural philosophy," as characters would call it) of Mythic Europe will be described in more detail in a future supplement for **Ars Magica Fifth Edition**. This book only addresses one narrow topic that is likely to interest magi from House Flambeau: how to use Rego spells as a form of attack.
+> 
+> There are three different ways Rego magic may be used offensively.
+> 
+> The first way is to use magic to propel the projectile all the way to the target. In this case, the motive force of the projectile is entirely due to magic. Magic Resistance protects against this form of attack, with projectiles stopping harmlessly at the edge of the target's Magic Resistance, as described under "The Functioning of Magic Resistance," on pages 85–86 of ArM5. This sort of spell does not need to be aimed. Nearly all Rego spells in the ArM5 rulebook work this way.
+> 
+> The second form of attack is to exploit what philosophers call "natural motion:" the natural tendency of heavy objects to fall downward. A magus could use Rego magic to levitate a rock over someone's head and then cancel the spell. The rock would naturally fall and would bypass Magic Resistance. Such spells must be aimed to strike their targets.
+> 
+> The third way is to use a brief jolt of magical force to hurl a projectile, as an arrow is thrown from a bow. There is a sentence in the first printing of ArM5 that appears to prohibit this (the final sentence of the first paragraph on page 86, beginning "Note that . . ."), but that sentence has been deleted by the official errata. Medieval natural philosophy did offer an explanation for how an arrow could continue moving after it leaves the bow. To over-simplify (in the interest of brevity), it involves the motion of air around the arrow. Magi can devise spells that hurl projectiles in this manner: new Rego guidelines are provided in the Rules section of this chapter. Only specially designed Rego spells can throw projectiles this way \_ the spell's description must explicitly state that it can throw projectiles (these spells are higher magnitude than generic Rego spells). Spells that throw a projectile release control of it immediately after launching it. The projectile then continues on a natural trajectory. In game terms, this means the spell must be aimed, but the projectile bypasses Magic Resistance. The Range of the spell need only be Touch (the magic only needs to act at the moment the projectile is thrown), but once launched, the projectile is subject to the natural laws of motion. The aiming roll suffers a range penalty just like a missile weapon does (ArM5, page 172) and the projectile can go no farther than it could be thrown by a very powerful mundane bow (or sling, catapult, or other device). Most projectiles thrown by spells have a range increment of 20 paces.
+> 
+> The rule under "Aiming" on page 86 of ArM5 remains true: "If a spell is resisted . . . it need not be aimed. If it is not resisted, it must be aimed."
 
 #### Creo Aquam Spells
 
-**Dagger of Ice**
+##### Dagger of Ice
 
 Cr(Re)Aq 10
 
@@ -1580,7 +1528,7 @@ Creates a foot-long, sharp icicle and hurls it at a target. The icicle always hi
 
 (Base 3, +2 Voice, +1 Rego requisite)
 
-**Alchemist's Revenge**
+##### Alchemist's Revenge
 
 CrAq 25
 
@@ -1592,7 +1540,7 @@ Splashes a target with acid, inflicting +15 damage if it penetrates Magic Resist
 
 #### Rego Aquam Spells
 
-**Shackles of the Frozen Ice**
+##### Shackles of the Frozen Ice
 
 ReAq 10
 
@@ -1606,22 +1554,25 @@ A trapped character may break free of the ice by making a Strength roll. Charact
 
 takes time. Magic, including Perdo Aquam or Creo Ignem spells, may be able to free a character instantly.
 
-| Extent<br>of Ice<br>Coverage | Strength<br>Ease<br>Factor | Time to<br>Cut Free |
-|------------------------------|----------------------------|---------------------|
-| One foot                     | 6                          | 30 seconds          |
-| Both feet                    | 9                          | 1 minute            |
-| To knees                     | 12                         | 3 minutes           |
-| To waist                     | 15                         | 10 minutes          |
-| To chest                     | 18                         | 15 minutes          |
-| To neck                      | 21                         | 20 minutes          |
-| Completely<br>enclosed       | 21                         | depends on<br>depth |
+| Extent of Ice Coverage | Strength Ease Factor | Time to Cut Free |
+|------------------------|----------------------|------------------|
+| One foot               | 6                    | 30 seconds       |
+| Both feet              | 9                    | 1 minute         |
+| To knees               | 12                   | 3 minutes        |
+| To waist               | 15                   | 10 minutes       |
+| To chest               | 18                   | 15 minutes       |
+| To neck                | 21                   | 20 minutes       |
+| Completely enclosed    | 21                   | depends on depth |
 
 (Base 3, +2 Sun, +1 Part)
 
 #### Creo Auram Spells
 
-**Catapult of the Mighty Winds** Cr(Re)Au 30 R: Voice, D: Mom, T: Ind
+##### Catapult of the Mighty Winds
 
+Cr(Re)Au 30
+
+R: Voice, D: Mom, T: Ind
 
 Terrifically strong winds sweep up an object (such as a barrel, a piece of furniture, or an unfortunate human being) and hurl it on a high, arched trajectory toward any point within range. If the projectile has Magic Resistance, this spell must penetrate in order to affect it. However, once the projectile is airborne, its motion is natural and hence it bypasses the Magic Resistance of anything it hits.
 
@@ -1637,7 +1588,7 @@ You must succeed at an aiming roll to hit the intended target. Because this spel
 
 #### Muto Auram Spells
 
-**Curse of the Evil Humors**
+##### Curse of the Evil Humors
 
 MuAu 25
 
@@ -1651,7 +1602,7 @@ The foul humors dissipate when the spell Duration expires. A brisk breeze can di
 
 #### Rego Corpus Spells
 
-**Wizard's Leap**
+##### Wizard's Leap
 
 ReCo 15
 
@@ -1663,7 +1614,7 @@ The caster instantly transports himself up to 50 paces in any direction, provide
 
 #### Muto Herbam Spells
 
-**Aegis of Unbreakable Wood**
+##### Aegis of Unbreakable Wood
 
 MuHe 15
 
@@ -1675,7 +1626,7 @@ Makes a wooden shield (or object of comparable dimensions) as strong as iron, in
 
 #### Perdo Herbam Spells
 
-**Tree Falling in the Forest**
+##### Tree Falling in the Forest
 
 Pe(Re)He 35
 
@@ -1685,10 +1636,9 @@ Instantly cuts down a tree, making it fall in the direction the caster designate
 
 (Base 5, +3 Sight, +2 size, +1 Rego requisite)
 
-
 #### Creo Ignem Spells
 
-**Test of the Flames**
+##### Test of the Flames
 
 CrIg 15
 
@@ -1696,15 +1646,11 @@ R: Touch, D: Ring, T: Circle
 
 Waist-high flames fill the target circle. Everything inside the circle takes +5 damage each round.
 
-This spell is of ancient origin and is thought to have originated as a ritual ordeal within the Cult of Mithras. It was once used by Flambeau magi as a test of endurance, a kind of alternative to certamen. The people being tested (including, usually, the caster) would stand inside the circle, without using their Parmae Magicae, trying to withstand the flames as long as possible. The last person to leave the circle was considered the winner. Etiquette suggested that if anyone were to fall helpless due to burn damage, someone would break the Ring and end the spell to rescue the unfortunate. This test is little used in 1220 because most Flambeau magi prefer standard certamen; also, some members of House Flambeau (such as the example
-
-
-
-character page 25 of ArM5) possess a supernatural immunity to fire, giving them an unfair advantage in the test.
+This spell is of ancient origin and is thought to have originated as a ritual ordeal within the Cult of Mithras. It was once used by Flambeau magi as a test of endurance, a kind of alternative to certamen. The people being tested (including, usually, the caster) would stand inside the circle, without using their Parmae Magicae, trying to withstand the flames as long as possible. The last person to leave the circle was considered the winner. Etiquette suggested that if anyone were to fall helpless due to burn damage, someone would break the Ring and end the spell to rescue the unfortunate. This test is little used in 1220 because most Flambeau magi prefer standard certamen; also, some members of House Flambeau (such as the example character page 25 of ArM5) possess a supernatural immunity to fire, giving them an unfair advantage in the test.
 
 (Base 4, +1 Touch, +2 Ring)
 
-#### Last Flight of the Phoenix
+##### Last Flight of the Phoenix
 
 CrIg 50
 
@@ -1718,7 +1664,7 @@ An early version of this spell was found in the lab notes of Flambeau himself. S
 
 #### Perdo Ignem Spells
 
-#### Quench the Raging Conflagration
+##### Quench the Raging Conflagration
 
 PeIg 20
 
@@ -1730,23 +1676,19 @@ Extinguish any fire up to the size of a house fire. Many Flambeau magi learn thi
 
 #### Rego Ignem Spells
 
-**The Obedient Fire**
+##### The Obedient Fire**
 
 ReIg 20
 
 R: Voice, D: Conc, T: Ind
 
-Control the rate and direction in which a fire spreads. The caster may make the fire spread across combustible surfaces as fast as a man walks. It can leap most gaps as much as one pace across but cannot cross even the tiniest trickle of water. The caster can prevent the fire from spreading in certain directions but cannot actually
-
-#### Societates
-
-keep it from burning things it touches. He could, for instance, make a fire spread into the shape of a circle and then expand outward, or keep the fire away from himself while it follows his enemies around the room. If the fire surrounds a person, its heat is non-magical and so bypasses Magic Resistance. An aiming roll is required to get the fire close enough to do damage. If the fire grows larger than a basic Room Target, the caster loses control of it entirely.
+Control the rate and direction in which a fire spreads. The caster may make the fire spread across combustible surfaces as fast as a man walks. It can leap most gaps as much as one pace across but cannot cross even the tiniest trickle of water. The caster can prevent the fire from spreading in certain directions but cannot actually keep it from burning things it touches. He could, for instance, make a fire spread into the shape of a circle and then expand outward, or keep the fire away from himself while it follows his enemies around the room. If the fire surrounds a person, its heat is non-magical and so bypasses Magic Resistance. An aiming roll is required to get the fire close enough to do damage.
 
 (Base 4, +2 Voice, +1 Conc, +1 Size)
 
 #### Creo Mentem Spells
 
-**Heart of the Lion**
+##### Heart of the Lion
 
 CrMe 15
 
@@ -1758,7 +1700,7 @@ Instill a person with indomitable courage, increasing his Brave Personality Trai
 
 #### Creo Terram Spells
 
-#### Sword from the Unseen Scabbard
+##### Sword from the Unseen Scabbard
 
 CrTe 15
 
@@ -1768,7 +1710,7 @@ Conjure a steel longsword. The sword only lasts for two minutes — about 20 com
 
 (Base 5, +1 Touch, +1 Diameter)
 
-#### Silvery Scales of the Knight
+##### Silvery Scales of the Knight
 
 CrTe(An) 30
 
@@ -1780,7 +1722,7 @@ Conjure a suit of full chain mail armor. The Animal requisite is required to cre
 
 #### Muto Terram Spells
 
-**Hardness of Adamantine**
+##### Hardness of Adamantine**
 
 MuTe 25
 
@@ -1798,7 +1740,7 @@ If used on chain mail or metal scale armor, the Protection value of the armor is
 
 #### Perdo Terram Spells
 
-#### Undoing the Stonemason's Handiwork
+##### Undoing the Stonemason's Handiwork
 
 PeTe 15
 
@@ -1806,13 +1748,11 @@ R: Voice, D: Mom, T: Part
 
 This spell smashes a piece of masonry or pavement into its component bricks or stones. It has no effect on solid stone. The affected volume is one pace wide, one pace high, and up to one pace deep (depending on the thickness of the masonry), and can be a part of a larger piece of stonework.
 
-
-
 Followers of the School of Vilano sometimes use this spell to produce a large number of loose stones, which they can then use as ammunition. Magi with a knowledge of stonemasonry can use it to weaken or collapse stone structures by damaging load-bearing walls and arches, though solid pillars and the like are immune to its effects.
 
 (Base 3, +2 Voice, +1 Part, +1 destroy stone)
 
-#### Hauberk of Sublime Lightness
+##### Hauberk of Sublime Lightness
 
 PeTe 30
 
@@ -1834,7 +1774,7 @@ When Rego Terram spells are used to throw stones, the damage inflicted is limite
 
 #### Rego Terram Spells
 
-#### Ominous Levitation of the Weighty Stone
+##### Ominous Levitation of the Weighty Stone
 
 ReTe 15
 
@@ -1850,7 +1790,7 @@ The main limitation on this spell's combat effectiveness is the availability of 
 
 (Base 3, +2 Voice, +1 Concentration, +1 affect stone)
 
-#### Invisible Sling of Vilano
+##### Invisible Sling of Vilano
 
 ReTe 10
 
@@ -1861,74 +1801,65 @@ Hurl a stone (of a size that could be thrown with a mundane sling) at a target w
 (Base 5, +1 Touch)
 
 
-### Chapter Two
+# Chapter Two: House Jerbiton
 
-# House Jerbiton
+The Founder of House Jerbiton, and many of his successors, believed that a great artist designed and constructed the world. The world is beautiful, and contains obvious marks of his process of creation. Those sufficiently skilled in the creation of beauty can collaborate in this great work. Everyone else has the joy of being a member of his audience.
 
-The Founder of House Jerbiton, and many of his successors, believed that a great artist designed and constructed the world. The world is beautiful, and contains obvious marks of his process of creation. Those suffi ciently skilled in the creation of beauty can collaborate in this great work. Everyone else has the joy of being a member of his audience.
-
-House Jerbiton's founding members came from the cities of the Eastern Roman Empire. Its current members see their way of life as an echo of what would have been, had magicians not fl ed the Dominion. They are the custodians of a magical culture that, they hope, will blossom into a civilization.
+House Jerbiton's founding members came from the cities of the Eastern Roman Empire. Its current members see their way of life as an echo of what would have been, had magicians not fled the Dominion. They are the custodians of a magical culture that, they hope, will blossom into a civilization.
 
 Each member of House Jerbiton is free to seek or create beauty however she wishes. The role of Primus grants little political power, although the incumbent is skilled at ensuring his wishes are considered. Members of the House often form groups, called leagues, to collaborate.
 
-# The History of House Jerbiton
+## The History of House Jerbiton
 
-Jerbiton was born in a remote village in the Alps, but taken as an apprentice by a maga from the Imperial East. His tradition's ancestors are the cosmopolitan magi from the cities of Greece. Jerbiton was sent as an emissary to the forming Order, but for many years the other members of his tradition did not join it. House Jerbiton still feels that the Eastern Empire is its heartland, and has been stunned and angered by
+Jerbiton was born in a remote village in the Alps, but taken as an apprentice by a maga from the Imperial East. His tradition's ancestors are the cosmopolitan magi from the cities of Greece. Jerbiton was sent as an emissary to the forming Order, but for many years the other members of his tradition did not join it. House Jerbiton still feels that the Eastern Empire is its heartland, and has been stunned and angered by the fall of Constantinople in 1204. A new generation of apprentices, trained after the pillaging of the greatest of cities, is about to enter magushood. They represent a new way of being Jerbiton magi.
 
-### Key Facts
+> ## Key Facts
+> 
+> **Population:** Currently 102 magi, 26 of whom live in the Tribunal of the Greater Alps. A wave of apprentices will become magi in the next couple of years. This will increase the number of magi, and reduce their average age, substantially.
+> 
+> **domus magna:** Valnastium, a secluded valley in the Greater Alps Tribunal. This covenant currently has 21 members, although nine of them live in chapter houses the covenant owns in Vienna, Constance, Geneva, and outside Saint Gallen.
+> 
+> **Primus:** Andru filius Astrolabe, a charming, effective leader of middle age.
+> 
+> **Favored Tribunals:** The Greater Alps and Thebes, traditionally. In the last century, members of the House have dispersed across the Continent because of the rise of the great cities, the fall of Constantinople, and the fashion for magi reconnecting with their mundane families.
+> 
+> **Motto:** Quae pulchra, placent ("Beauty is all that pleases").
+> 
+> **Symbol:** A pennant flown from a tower. The pennant is often marked with the alchemical symbol for mercury.
 
-**PoPulation:.**Currently 102 magi, 26 of whom live in the Tribunal of the Greater Alps. A wave of apprentices will become magi in the next couple of years. This will increase the number of magi, and reduce their average age, substantially.
-
-**domus. magna:.** Valnastium, a secluded valley in the Greater Alps Tribunal. This covenant currently has 21 members, although nine of them live in chapter houses the covenant owns in Vienna, Constance, Geneva, and outside Saint Gallen.
-
-**Primus:.** Andru fi lius Astrolabe, a charming, effective leader of middle age.
-
-**Favored Tribunals:** The Greater Alps and Thebes, traditionally. In the last century, members of the House have dispersed across the Continent because of the rise of the great cities, the fall of Constantinople, and the fashion for magi reconnecting with their mundane families.
-
-**motto:.** Quae pulchra, placent ("Beauty is all that pleases").
-
-**symbol:.** A pennant fl own from a tower. The pennant is often marked with the alchemical symbol for mercury.
-
-the fall of Constantinople in 1204. A new generation of apprentices, trained after the pillaging of the greatest of cities, is about to enter magushood. They represent a new way of being Jerbiton magi.
-
-### Flavius oF.Jerbiton,. tHe.Founder
+### Flavius of Jerbiton, the Founder
 
 The Founder was born in a secluded Alpine valley in 729, and was named Flavius. He was a cheerful, pleasant child who particularly enjoyed horse riding. Nearby objects changed color to match his mood. Jerbiton was the son of the ruler of his valley, so he was raised as a minor nobleman.
 
 Jerbiton's family was of Rhaeto-Roman stock. They were descended from a Roman solider who was granted land in an isolated Alpine valley during the early Imperial period, and the remoteness of their home had preserved this community against the tides of invaders that had washed through the Alps. The Ierbi, as they now call themselves, live much as they have since Roman times, and speak a language that is a deformed descendant of Latin.
 
-Young men from Alpine villages often travel to surrounding countries to seek work as mercenaries, returning with their fortune to fi nd wives and settle as farmers. One such returnee, retired from service with a Thracian magus, recognized Jerbiton's Gift, and encouraged his parents to send the boy for training. The Thracian magus did not desire an apprentice, but mentioned the boy and his unusual community to his allies. One of them, Bernice of Thessalonica, traveled to the Alps to collect the young Jerbiton, and explore the Rhaeto-Roman culture.
+Young men from Alpine villages often travel to surrounding countries to seek work as mercenaries, returning with their fortune to find wives and settle as farmers. One such returnee, retired from service with a Thracian magus, recognized Jerbiton's Gift, and encouraged his parents to send the boy for training. The Thracian magus did not desire an apprentice, but mentioned the boy and his unusual community to his allies. One of them, Bernice of Thessalonica, traveled to the Alps to collect the young Jerbiton, and explore the Rhaeto-Roman culture.
 
+> ## This is Only the Beginning
+> 
+> The magi of House Jerbiton are fascinated by mundane people and institutions. This chapter does not grapple with the mortal institutions that serve as the crux of urban stories, because other books, particularly *Realms of Power: The Divine, City & Guild,* and *Art and Academe* deal with these ideas in greater detail than is possible here. This chapter explores the part of the House's lifestyle that is alien to mundane institutions, with the understanding that players will steal ideas from the rest of the line to integrate these magi into medieval society.
 
-### This is Only the Beginning
-
-The magi of House Jerbiton are fascinated by mundane people and institutions. This chapter does not grapple with the mortal institutions that serve as the crux of urban stories, because other books, particularly *Realms of Power: The Divine, City & Guild,* and *Art and Academe* deal with these ideas in greater detail than is possible here. This chapter explores the part of the House's lifestyle that is alien to mundane institutions, with the understanding that players will steal ideas from the rest of the line to integrate these magi into medieval society.
-
-### The League of Iconophiles, the Tradition of the Founder's Teacher
+#### The League of Iconophiles, the Tradition of the Founder's Teacher
 
 When the first Christian emperor, Constantine, moved his capital to Constantinople in 330 AD, the Church and Empire persecuted those in the region who had the magical air caused by The Gift. The surviving magi had the Gentle Gift, or sufficient wealth to interact with society through servants. Gently Gifted magi do not suffer the mutual distrust that The Gift causes, so they were able to form a loose society. These magi, involved with mundane culture and living in or near cities, are the ancestors of House Jerbiton.
 
 The magi of the eastern Empire formed alliances called leagues. Each league focused on a single charismatic figure, or a single issue, so they were transient. While the Order was forming, the most powerful was the League of Iconophiles, formed to oppose Emperor Leo III. In 729 Leo III declared that all images of Christ or the saints should be destroyed. He also forbade the display of crosses in places of worship. The Empire's magi worried that the violation of the sacred places of the Church would weaken the Dominion and give comfort to the Infernal.
 
-The League of Iconophiles opposed the Emperor in several ways. It aided non-
+The League of Iconophiles opposed the Emperor in several ways. It aided non-magi who were part of the broader movement of Iconophiles. It intrigued against the Emperor's supporters. It performed acts of sabotage against Imperial armies. Finally, its members transported icons to isolated monasteries for storage, waiting for a time when they could again be used in public.
 
-### Famous Figures
-
-Early figures of the House tend to have names that give the place from which they came.
-
-**Flavius of Jerbiton:** The Founder of the House. Believed that beauty is an expression of the love of the Divine, and that art brings the artist and his audience closer to the mind of the Creator. Saw the emerging Hermetic culture as a stunted, sickly thing.
-
-**Bernice of Thessalonica:** The Founder's teacher, who negotiated with Trianoma to bring some of the magi of the Eastern Empire into the Order of Hermes.
-
-**Petrus of Verdun:** A Primus from the tenth century, who advocated life within mundane communities. During his Primacy, Jerbiton magi abandoned multi-House covenants to live as wealthy citizens near, or in some cases within, major cities.
-
-**Mattieus of Cherson:** A Primus from the 12th century, who saw Jerbiton magi as ambassadors from the Order to mundane rulers. During his tenure, large Jerbiton covenants accepted members from many other Houses, so that almost all Jerbiton magi lived in multi-House covenants. The philosophies of Petrus and Mattieus continue to represent rival conceptions of the role of the House in 1220.
-
-#### magi who were part of the broader movement of Iconophiles. It intrigued against the Emperor's supporters. It performed acts of sabotage against Imperial armies. Finally, its members transported icons to isolated monasteries for storage, waiting for a time when they could again be used
+> ### Famous Figures
+> 
+> Early figures of the House tend to have names that give the place from which they came.
+> 
+> **Flavius of Jerbiton:** The Founder of the House. Believed that beauty is an expression of the love of the Divine, and that art brings the artist and his audience closer to the mind of the Creator. Saw the emerging Hermetic culture as a stunted, sickly thing.
+> 
+> **Bernice of Thessalonica:** The Founder's teacher, who negotiated with Trianoma to bring some of the magi of the Eastern Empire into the Order of Hermes.
+> 
+> **Petrus of Verdun:** A Primus from the tenth century, who advocated life within mundane communities. During his Primacy, Jerbiton magi abandoned multi-House covenants to live as wealthy citizens near, or in some cases within, major cities.
+> 
+> **Mattieus of Cherson:** A Primus from the 12th century, who saw Jerbiton magi as ambassadors from the Order to mundane rulers. During his tenure, large Jerbiton covenants accepted members from many other Houses, so that almost all Jerbiton magi lived in multi-House covenants. The philosophies of Petrus and Mattieus continue to represent rival conceptions of the role of the House in 1220.
 
 #### The Apprenticeship of the Founder
-
-in public.
 
 Bernice, the Founder's teacher, took her apprentice to Thessalonica, the second most important city in the Empire, to complete his schooling as a nobleman, and training as a magus. Bernice named her apprentice Flavius Ierbitonis, "the fair haired one of the town of yesterday." During Jerbiton's training, the fortunes of the Iconophiles waxed briefly when an iconophilic nobleman seized Constantinople, then waned dramatically when ruthless Imperial reprisals followed.
 
@@ -1942,10 +1873,7 @@ The Iconophiles dwelt in the villa that was Jerbiton's childhood home. Their app
 
 #### The Order of Hermes Forms
 
-Trianoma was unable to convince the Iconophiles to join her new league: they believed it was too geographically diffuse to be effective. Bernice of Thessalonica was unable to travel due to her injury, but was interested enough in the project instruct her protégé, by then usually called
-
-
-Jerbiton, to deliver some of her books to Bonisagus and answer his questions.
+Trianoma was unable to convince the Iconophiles to join her new league: they believed it was too geographically diffuse to be effective. Bernice of Thessalonica was unable to travel due to her injury, but was interested enough in the project instruct her protégé, by then usually called Jerbiton, to deliver some of her books to Bonisagus and answer his questions.
 
 Jerbiton assisted Bonisagus in refining the Arts of Imaginem and Mentem, and helped perfect the system of vocal and gestured guides to spellcasting. He also convinced Bonisagus to name his fields of study the "Arts," and the capacity to use magic "The Gift." Bernice of Thessalonica accepted membership in the Order, but died in 763, before the First Tribunal could be held.
 
@@ -1955,79 +1883,72 @@ At the time of the First Tribunal, the League of Iconophiles was still completel
 
 Jerbiton, and the other magi who were members of his household, participated in the Order only as a secondary concern. The Order was an interesting idea, and the Parma Magica was useful, but the future of civilization was being fought for in Constantinople, and none of Jerbiton's new "sodales" seemed interested. Indeed, the Code said that it was wrong to fight the emperor, aid the Church, or incite the wrath of the Infernal. Although Jerbiton's followers stayed within the wording of the Code, they continued to materially support their allies in the East. Eventually Jerbiton developed friendships with Bonisagus, Criamon, Mercere, and Tremere, although the youngest Founder betrayed his trust.
 
-In 775, House Tremere invaded the Empire, slaying magi, stealing their treasure, and claiming their vis sources. Conflict with the emperor, the Infernal, and House Tremere was too much for the magi in the north of the Empire. They formed a military alliance called the Theban League, and joined the Order of Hermes under Jerbiton's nominal leadership. Trained in the Parma Magica, these magi were able to reclaim territory from House Tremere. The
+In 775, House Tremere invaded the Empire, slaying magi, stealing their treasure, and claiming their vis sources. Conflict with the emperor, the Infernal, and House Tremere was too much for the magi in the north of the Empire. They formed a military alliance called the Theban League, and joined the Order of Hermes under Jerbiton's nominal leadership. Trained in the Parma Magica, these magi were able to reclaim territory from House Tremere. The Thebans eventually founded the Tribunal that bears their name. One of Jerbiton's allies, named Pelagius, traveled Europe seeking further recruits. Jerbiton's coterie became the leaders of a greatly expanded, but almost unstructured, House.
 
-### Ancient Ideas of Beauty
-
-Jerbiton's followers encountered pre-Christian aesthetic ideals retained in Valnastium's culture. This led to research into ancient forms of artistic expression, and the development of the House's philosophies of beauty. Valnastium, in 1220, is filled with delightful works of architecture and sculpture that appear completely alien to contemporary mundane artists. Many ancient ideas about what makes art beautiful, like realistic depiction of human models, are not followed in Mythic Europe. The House has tried to gently coax Europe back toward the great secular art of the past, but under the current Primus, this task has been seen as less important than maintaining good relations with the Church, which has unpredictable but often censorious views concerning novel art.
-
-Thebans eventually founded the Tribunal that bears their name. One of Jerbiton's allies, named Pelagius, traveled Europe seeking further recruits. Jerbiton's coterie became the leaders of a greatly expanded, but almost unstructured, House.
+> ## Ancient Ideas of Beauty
+> 
+> Jerbiton's followers encountered pre-Christian aesthetic ideals retained in Valnastium's culture. This led to research into ancient forms of artistic expression, and the development of the House's philosophies of beauty. Valnastium, in 1220, is filled with delightful works of architecture and sculpture that appear completely alien to contemporary mundane artists. Many ancient ideas about what makes art beautiful, like realistic depiction of human models, are not followed in Mythic Europe. The House has tried to gently coax Europe back toward the great secular art of the past, but under the current Primus, this task has been seen as less important than maintaining good relations with the Church, which has unpredictable but often censorious views concerning novel art.
 
 #### The House After the Founder
 
 Jerbiton died in his sleep, and is buried beside his wife under the Church of Saint Cyprian in Valnastium. In his later years Jerbiton had opposed the increasing influence of House Tremere, with mixed success. Jerbiton's death allowed the Domination to enter its final phase. Some Jerbiton claim a role in the Sundering. Others, in the Tribunals of Thebes, the Greater Alps, and Novgorod, continue to watch their neighbors in the Transylvanian Tribunal for signs of expansionism.
 
-During the Schism War, from the Primus of Jerbiton's perspective, a House filled with pagans was annihilated and a House dedicated to tyranny was shattered. House Jerbiton's members retreated to their strong places or cities and waited
+During the Schism War, from the Primus of Jerbiton's perspective, a House filled with pagans was annihilated and a House dedicated to tyranny was shattered. House Jerbiton's members retreated to their strong places or cities and waited for both sides to be too exhausted to fight any longer. House Jerbiton assisted with the period of reconstruction following the war, but privately, the leaders of House felt that it had turned out for the best. This attitude struck even some Jerbiton magi as callous.
 
-### The Diaries
-
-The Founder was a diarist, but his notes deliberately obscure many important matters. His descendants have studied many of these exclusions, but some have remained unexplained. Two unclear topics include:
-
-**Miriam, Jerbiton's Wife:** Her cultural group, history. and magical tradition, if any, are completely unclear. She did attend the first Tribunal, but her capacity is not described.
-
-**The Other "Apostles:"** A single line in the diaries indicates, if read a certain way, that the Iconophiles sent three teams of students to create archives like Valnastium. Most Jerbiton magi refuse to believe this, because they believe that the members of the other two groups would have made contact with the House after the final victory of the Iconophiles. Others contend that, lacking the Parma Magica, the other groups may have been destroyed. Some suggest that the other apostles went into Russia, Africa, or along the trade routes into Asia.
-
-for both sides to be too exhausted to fight any longer. House Jerbiton assisted with the period of reconstruction following the war, but privately, the leaders of House felt that it had turned out for the best. This attitude struck even some Jerbiton magi as callous.
+> ## The Diaries
+> 
+> The Founder was a diarist, but his notes deliberately obscure many important matters. His descendants have studied many of these exclusions, but some have remained unexplained. Two unclear topics include:
+> 
+> **Miriam, Jerbiton's Wife:** Her cultural group, history. and magical tradition, if any, are completely unclear. She did attend the first Tribunal, but her capacity is not described.
+> 
+> **The Other "Apostles:"** A single line in the diaries indicates, if read a certain way, that the Iconophiles sent three teams of students to create archives like Valnastium. Most Jerbiton magi refuse to believe this, because they believe that the members of the other two groups would have made contact with the House after the final victory of the Iconophiles. Others contend that, lacking the Parma Magica, the other groups may have been destroyed. Some suggest that the other apostles went into Russia, Africa, or along the trade routes into Asia.
 
 In the two centuries following the Schism, various fashions swept through the House. Most Jerbiton magi during this period did not study combat magic. As residents of multi-House covenants, they saw their role as ambassadorial and political, leaving violence to their servants and sodales. This focus on individual interests left the House incapable of concerted action, save during crisis.
 
 #### The Fall of Constantinople
 
-The fall of Constantinople was an appalling event, which shattered the certainties of educated people throughout Mythic Europe. It destroyed both the sense of destiny within the Empire, and
+The fall of Constantinople was an appalling event, which shattered the certainties of educated people throughout Mythic Europe. It destroyed both the sense of destiny within the Empire, and the credibility of the crusading movement. Similarly, the fall of the City as Jerbiton magi still call it, destroyed the House's arrogant certainty that its members were living in the best possible way. If the House could not prevent the fall of the City, then something was fundamentally wrong with the House.
 
-
-
-Players may have difficulty understanding why the fall of a single city had such powerful impact on European thinking, and on the beliefs of Jerbiton magi. There were three reasons for this.
-
-# THE DESTINY OF THE WORLD WAS KNOWN, WHICH PROVIDED EMOTIONAL SECURITY
-
-Mythic Europeans believe that the world's history is evolving as ordained by God, toward an outcome predicted in the Book of Revelations. As first enunciated by Eusebius, the Christianized Roman Empire is the tool of God, destined to prepare the world for the Kingdom of Peace, which Jesus will rule after Armageddon.
-
-When Rome fell different people adjusted their beliefs to suit local circumstances. In the West, the role of preparer of the world was given to the Church, and then to the Holy Roman Emperor. In the East, the fall of Rome did not matter, because, decades before, its role had been accepted by New Rome: Constantinople.
-
-### THERE IS NO BYZANTINE EMPIRE
-
-Players may be used to calling the Empire around Constantinople "Byzantium," but this is a modern convention. Mythic Europeans call the Empire some variant of "Romania," which means "land of the Romans." Most of the Empire's people are culturally Hellenic, but see themselves as politically *Rhomaioi*. The Roman Empire, centered on New Rome, is the heir to Augustus and Constantine, and the tool of God on Earth, destined to prepare the world for the Second Coming.
-
-The destruction of the City by crusaders stunned Europe. To Westerners, it demonstrated that something had gone terribly wrong in the crusading movement. To Easterners it was even more shocking: Providence no longer worked as they thought it should. Their unique role in the Divine plan seemed lost. The whole future of the world no longer made sense.
-
-### TIME HAS NOT HEALED THE CITY
-
-Constantinople had been controlled by non-Romans before, but these Emperors married into the local nobility, took their place in the elaborate rituals of the court, and defended the City. Constantinople healed, and its culture continued. This has not followed the sack of the City during 1204. The Latin Empire was instead created by crusaders who cared only for what they could take. The current Latin Emperor is more interested in the wellbeing of his home, Flanders, than in the City, because it is clear that his Empire is nominal, and that it is the weakest of the four powers feuding for control the Balkans (the other three being the Kingdom of Bulgaria, the Imperial court in exile at Nicea, and the Despotate of Epirus).
-
-the credibility of the crusading movement. Similarly, the fall of the City as Jerbiton magi still call it, destroyed the House's arrogant certainty that its members were living in the best possible way. If the House could not prevent the fall of the City, then something was fundamentally wrong with the House.
+> ## Why Is Constantinople So Important?
+> 
+> Players may have difficulty understanding why the fall of a single city had such powerful impact on European thinking, and on the beliefs of Jerbiton magi. There were three reasons for this.
+> 
+> ### The Destiny of the World Was Known, Which Provided Emotional Security
+> 
+> Mythic Europeans believe that the world's history is evolving as ordained by God, toward an outcome predicted in the Book of Revelations. As first enunciated by Eusebius, the Christianized Roman Empire is the tool of God, destined to prepare the world for the Kingdom of Peace, which Jesus will rule after Armageddon.
+> 
+> When Rome fell different people adjusted their beliefs to suit local circumstances. In the West, the role of preparer of the world was given to the Church, and then to the Holy Roman Emperor. In the East, the fall of Rome did not matter, because, decades before, its role had been accepted by New Rome: Constantinople.
+> 
+> ### There Is No Byzantine Empire
+> 
+> Players may be used to calling the Empire around Constantinople "Byzantium," but this is a modern convention. Mythic Europeans call the Empire some variant of "Romania," which means "land of the Romans." Most of the Empire's people are culturally Hellenic, but see themselves as politically *Rhomaioi*. The Roman Empire, centered on New Rome, is the heir to Augustus and Constantine, and the tool of God on Earth, destined to prepare the world for the Second Coming.
+> 
+> The destruction of the City by crusaders stunned Europe. To Westerners, it demonstrated that something had gone terribly wrong in the crusading movement. To Easterners it was even more shocking: Providence no longer worked as they thought it should. Their unique role in the Divine plan seemed lost. The whole future of the world no longer made sense.
+> 
+> ### Time Has Not Healed the City
+> 
+> Constantinople had been controlled by non-Romans before, but these Emperors married into the local nobility, took their place in the elaborate rituals of the court, and defended the City. Constantinople healed, and its culture continued. This has not followed the sack of the City during 1204. The Latin Empire was instead created by crusaders who cared only for what they could take. The current Latin Emperor is more interested in the wellbeing of his home, Flanders, than in the City, because it is clear that his Empire is nominal, and that it is the weakest of the four powers feuding for control the Balkans (the other three being the Kingdom of Bulgaria, the Imperial court in exile at Nicea, and the Despotate of Epirus).
 
 Andru, the House's Primus, has used the fall of the City to draw the House's members away from their personal contemplations. He has rallied the House around its ancient values, hiding precious works from vandals and covert interventionism. A new way of living as a Jerbiton magus is emerging.
 
-# Travel to Constantinople
+> ## Travel to Constantinople
+> 
+> Constantinople remains a dangerous environment for magi. It was sacked by an army of excommunicated crusaders, who practiced every depravity after they took the City, so it has many pockets of Infernal influence. Slightly after the conquest, to cover a retreat during civil unrest, some Venetian troops started a fire which they lost control of, burning down half the buildings and leaving thousands of anguished ghosts, many of whom still haunt the streets, killing foreigners. The crusaders' puppet emperor seized the treasures of the churches, melted down their reliquaries, and sold their relics, profaning many holy places. This has weakened the Dominion, but it is still a formidable obstacle to spellcasting.
+> 
+> Characters may still wish to visit the City for many reasons. Suggested stories include:
+> 
+> - A magus of their House died during the sack, and senior figures in the House now feel it is safe to attempt to recover his remains.
+> - A covenant is to be founded there, and characters wish to aid or oppose it.
+> - A cache of treasure, left by a magus during the sack, was not recovered, and indications of its whereabouts have come to light.
+> - The characters wish to deal with a nobleman involved in the court.
+>   This can involve people from a wide variety of countries, because the Empire's ruling class is extremely diverse.
+> - Covenants familiar with Venice, where many covenants maintain townhouses as informal embassies with each other, want to establish a similar system in Constantinople, and call a meeting of interested parties.
 
-Constantinople remains a dangerous environment for magi. It was sacked by an army of excommunicated crusaders, who practiced every depravity after they took the City, so it has many pockets of Infernal influence. Slightly after the conquest, to cover a retreat during civil unrest, some Venetian troops started a fire which they lost control of, burning down half the buildings and leaving thousands of anguished ghosts, many of whom still haunt the streets, killing foreigners. The crusaders' puppet emperor seized the treasures of the churches, melted down their reliquaries, and sold their relics, profaning many holy places. This has weakened the Dominion, but it is still a formidable obstacle to spellcasting.
-
-Characters may still wish to visit the City for many reasons. Suggested stories include:
-
-- A magus of their House died during the sack, and senior figures in the House now feel it is safe to attempt to recover his remains.
-- A covenant is to be founded there, and characters wish to aid or oppose it.
-- A cache of treasure, left by a magus during the sack, was not recovered, and indications of its whereabouts have come to light.
-- The characters wish to deal with a nobleman involved in the court.
-  This can involve people from a wide variety of countries, because the Empire's ruling class is extremely diverse.
-- Covenants familiar with Venice, where many covenants maintain townhouses as informal embassies with each other, want to establish a similar system in Constantinople, and call a meeting of interested parties.
-
-
-### Émigrés from Constantinople
-
-When the City fell many members of its ruling and merchant classes lost their positions. The Order of Hermes, particularly the members of House Jerbiton, has accepted many émigrés as companions. Emigration from Constantinople is a useful background for characters whose players want them to have rare capabilities, like knighthood or glassblowing , with none of the usual social constraints that come with these roles in intact societies.
-
-Characters seeking employees for Spring covenants can find emigrant communities in many Mediterranean ports. These communities, which were spread throughout Constantinople's trade network, have lost much of their wealth and influence since their trade was claimed by the Venetians after the invasion. Some maintain links with the Greek successor states, and because these have greater wealth, they have attracted displaced Constantinopolitans.
+> ## Émigrés from Constantinople
+> 
+> When the City fell many members of its ruling and merchant classes lost their positions. The Order of Hermes, particularly the members of House Jerbiton, has accepted many émigrés as companions. Emigration from Constantinople is a useful background for characters whose players want them to have rare capabilities, like knighthood or glassblowing , with none of the usual social constraints that come with these roles in intact societies.
+> 
+> Characters seeking employees for Spring covenants can find emigrant communities in many Mediterranean ports. These communities, which were spread throughout Constantinople's trade network, have lost much of their wealth and influence since their trade was claimed by the Venetians after the invasion. Some maintain links with the Greek successor states, and because these have greater wealth, they have attracted displaced Constantinopolitans.
 
 #### The Future, and the Antigones
 
@@ -2042,8 +1963,7 @@ Young magi from this group often bear symbols that express their allegiance to i
 
 The antigones are not formally organized, but many know each other, through the House's practices of tourism and fosterage. Some plan to form large House covenants, which are currently very rare. Others will live among magi from other Houses, but take a far more political role than their elders. One of the Primus's students, Constanta the Tessellatrix, is extremely active in the coordination of her age-mates.
 
-
-# Living Tastefully
+## Living Tastefully
 
 House Jerbiton is held together by its culture, rather than a political structure. Jerbiton magi live tastefully. Tasteful living usually embraces a series of ideas that have been popular among urban magi since before the beginning of the House. This section examines elements that most Jerbiton magi would agree contribute to tasteful living. Magi from other Houses may also live tastefully — the special interest that Jerbiton magi take in matters of taste is not preclusive.
 
@@ -2053,11 +1973,7 @@ Beauty has many definitions among Jerbiton magi, and these are often compatible.
 
 #### Avoiding Ugliness
 
-Jerbiton magi see ugliness as a mark of the wrongness of something, much like a putrid smell marks food as bad. The philosophy of the Church guides magi in their quest for beauty, by pointing out, as Bernard of Clairvaux does, that inner beauty is more precious than outer beauty. Modern players may have far more restrictive concepts of beauty than Mythic
-
-#### Houses of Hermes
-
-Europeans do. The Romans and Greeks, in whose aesthetic tradition this House continues, saw beauty in a wide range of things. People of other races were beautiful, because of their contrast to Europeans. Signs of aging could be beautiful, if they added character to the appearance. The crack in a gemstone could be beautiful, if it enhanced the luster of the stone. The ability to see the hidden beauty of things is a form of wisdom.
+Jerbiton magi see ugliness as a mark of the wrongness of something, much like a putrid smell marks food as bad. The philosophy of the Church guides magi in their quest for beauty, by pointing out, as Bernard of Clairvaux does, that inner beauty is more precious than outer beauty. Modern players may have far more restrictive concepts of beauty than Mythic Europeans do. The Romans and Greeks, in whose aesthetic tradition this House continues, saw beauty in a wide range of things. People of other races were beautiful, because of their contrast to Europeans. Signs of aging could be beautiful, if they added character to the appearance. The crack in a gemstone could be beautiful, if it enhanced the luster of the stone. The ability to see the hidden beauty of things is a form of wisdom.
 
 Jerbiton magi know that demons and faeries play with the appearance of beauty. This is because faeries and demons are ugly in essence, and must lie to appear beautiful.
 
@@ -2071,32 +1987,27 @@ That even people of good taste vary in their preferences is an important acknowl
 
 #### Art
 
-Jerbiton taught, and many of his descendants agree, that art requires skill, exercises creativity, and intends to express
-
-### Why Are Faeries Ugly?
-
-Members of House Jerbiton usually dislike faeries, despite their beauty and artistic prowess, because faeries lack souls. Their outward beauty is just a distraction from inner ugliness. Many faeries are cute and funny, but that's a deliberate, calculated manipulation of the viewer. They are parasitic animals, an affliction on the human race and an impediment to the spread of civilization. Faeries treat humans as prey, stealing creativity or blood, which is why the Church protects people from them.
-
-Demons frequently disguise themselves as faeries, because foolish people commit many sins with the aid of faeries that they would disdain if they suspected their helpers were Infernal. Sex with a faerie is a mortal sin — it is a type of bestiality — but sometimes the partner is really a succubus, which is worse.
-
-Most members of the House think useful faeries should be controlled and dangerous faeries should be rendered down for vis. Members of this House are some of the firmest advocates of the idea that it is only illegal to molest faeries if it brings down ruin on members of the Order. This does not endear them to House Merinita.
-
-beauty. This implies that art is something done best by people who have trained to be artists. Art draws on the gifts of the artist, and is therefore a method of associating with the Divine. It also implies that things done primarily for productive ends are not art.
+Jerbiton taught, and many of his descendants agree, that art requires skill, exercises creativity, and intends to express beauty. This implies that art is something done best by people who have trained to be artists. Art draws on the gifts of the artist, and is therefore a method of associating with the Divine. It also implies that things done primarily for productive ends are not art.
 
 Excellent art requires skill, which is learned, and creativity, which is a gift from God. Some artists are more skilled than other artists, much as some bakers are better than other bakers, and their art is therefore better or worse, at a level stronger than opinion. Many Jerbiton magi develop Finesse or other artistic Abilities. Those who lack talent extend patronage to mundane artists. A character is talented at the discretion of the player: this selection has no mechanical cost, but talent cannot be expressed without a suitable Ability.
-
-
-### Bad Taste? Why Do Many Other Magi Have Such
-
-Many magi who are not from House Jerbiton live in a way that is simply ugly, and thus wrong. Sinful acts are ugly, so violence is often in poor taste. Living a life separated from human interactions is ugly. Being cooped up in a laboratory for many years is, therefore, wrong. The way most Hermetic magi live, in wilderness castles and reviled by mundanes, is a pitiable existence for a person with the wonderful capacity for expression offered by The Gift, although it is rude to point this out. The ugliness prevalent in many other Houses occurs because many of the Founders were unpleasant people who
-
-lived in ugly ways, which have become traditional for their descendants.
-
-One element of the House's traditional attitude, that violence is something the rich pay the poor to do, is less popular with the rising generation of Jerbiton magi than their elders. The antigones see this belief, and the dependence it places on servants and magi from other Houses, as the greatest contributor to House Jerbiton's inability to defend Constantinople from the Fourth Crusade. These younger magi are not, usually, specialized magical warriors, but are far more interested in developing the capacity for aggression than their elders are. For them, indolent luxury is a form of ugliness.
 
 Creativity, the capacity to design unique art, cannot be learned. It is an innate gift, granted by God, that finds expression through the skill of the artist. A character creating beauty is acting as an artistic tool wielded by God. Jerbiton magi believe that even poor artists should continue to express their creativity, while developing their skill, because even poor art brings the artist into the hand of God.
 
 Craft, which is functional, is not art. A potter who makes a bowl to carry water, or a mason who builds a wall to hold up a roof, are engaged in craft, rather than art. Many crafters are, however, artists. The decoration of a pot may be artistic, because it is inessential to the function of a vessel. A wall may have decorative features that serve no function but to beautify it. Jerbiton magi similarly differentiate between the magical Arts and spellcraft. Each spell has a function, but each casting of a spell can be beautiful.
+
+> ## Why Are Faeries Ugly?
+> 
+> Members of House Jerbiton usually dislike faeries, despite their beauty and artistic prowess, because faeries lack souls. Their outward beauty is just a distraction from inner ugliness. Many faeries are cute and funny, but that's a deliberate, calculated manipulation of the viewer. They are parasitic animals, an affliction on the human race and an impediment to the spread of civilization. Faeries treat humans as prey, stealing creativity or blood, which is why the Church protects people from them.
+> 
+> Demons frequently disguise themselves as faeries, because foolish people commit many sins with the aid of faeries that they would disdain if they suspected their helpers were Infernal. Sex with a faerie is a mortal sin — it is a type of bestiality — but sometimes the partner is really a succubus, which is worse.
+> 
+> Most members of the House think useful faeries should be controlled and dangerous faeries should be rendered down for vis. Members of this House are some of the firmest advocates of the idea that it is only illegal to molest faeries if it brings down ruin on members of the Order. This does not endear them to House Merinita.
+
+> ## Why Do Many Other Magi Have Such Bad Taste?
+> 
+> Many magi who are not from House Jerbiton live in a way that is simply ugly, and thus wrong. Sinful acts are ugly, so violence is often in poor taste. Living a life separated from human interactions is ugly. Being cooped up in a laboratory for many years is, therefore, wrong. The way most Hermetic magi live, in wilderness castles and reviled by mundanes, is a pitiable existence for a person with the wonderful capacity for expression offered by The Gift, although it is rude to point this out. The ugliness prevalent in many other Houses occurs because many of the Founders were unpleasant people who lived in ugly ways, which have become traditional for their descendants.
+> 
+> One element of the House's traditional attitude, that violence is something the rich pay the poor to do, is less popular with the rising generation of Jerbiton magi than their elders. The antigones see this belief, and the dependence it places on servants and magi from other Houses, as the greatest contributor to House Jerbiton's inability to defend Constantinople from the Fourth Crusade. These younger magi are not, usually, specialized magical warriors, but are far more interested in developing the capacity for aggression than their elders are. For them, indolent luxury is a form of ugliness.
 
 #### Places of Beauty
 
@@ -2120,44 +2031,38 @@ Jerbiton magi use their leisure time to live as they like, and for many a favour
 
 #### Family
 
-The nurturance of a family and the simple pleasures of life in a community are important anchors for the life of a Jerbiton
-
-
-
-Jerbiton magi often use members of their own families as their agents, as described in the appendix. This allows the magus to use the incidental benefits of their adventures to enrich their family members. More powerful family members, in turn, are more powerful agents. A player engaged in nepotism finds ways of linking the wellbeing of one or more of the character's family members to the events in each story. This allows the magus to spend Bond Maintenance points, which equal the Adventure experience they receive for the story, on their family members.
-
-For the examples given below, imagine a Jerbiton magus from a noble family, with Close Family Ties. His father is a Landed Noble, and his brothers are a Gentleman, a Mercenary Captain, and a Priest. The player could control his brothers indirectly, simply by taking his father as an agent. He chooses instead to take all of them as agents, with a weak Bond representing the time he spent away as an apprentice. During each story, the player finds plausible ways to link the success of the story to the fortunes of his fathers or brothers. This allows them to become more powerful, and strengthens their Bond scores.
-
-Nepotism examples might include:
-
-The characters defeat a powerful faerie, and the magus arranges the •
-
-wood it dwelt in to be granted to his brother's church, hinting that the faerie might come back otherwise.
-
-- The covenant needs to defeat some bandits, to increase their Reputation with the ruling council of a local town. They destroy the bandits magically, and then hire the magus's brother's mercenary company to claim they killed the bandits. This avoids trouble with the Quaesitores (who may wonder if the bandits were hired by the town's noble rivals), gives a plum job to the mercenary company, increases the loyalty of the mercenaries to the magus's brother, and improves the Reputation of the covenant with the town council (who know the magi arranged it all) and of the mercenary company with potential employers. •
-- The characters meet an excellent minstrel in an inn. He lacks a patron, so the magus directs him to his father's court, with an introduction. This makes the father's court more glorious, and gives the father a skilled courtier to send on diplomatic missions. The troupe decides this is too tenuous a connection to the main story, to which the characters were simply traveling when the encounter took place, to allow more than 1 point to be spent on the father's Bond Strength. •
-
-magus. If a magus was rejected by his birth family, because of the taint of The Gift, he will have found an alternative one. Storyguides wanting to avoid many of the usual tales of lost sisters and troublesome nephews might wish to tuck this family safely among the covenfolk at Valnastium. Players may prefer to design their characters' families as agencies, as described in the appendix.
+The nurturance of a family and the simple pleasures of life in a community are important anchors for the life of a Jerbiton magus. If a magus was rejected by his birth family, because of the taint of The Gift, he will have found an alternative one. Storyguides wanting to avoid many of the usual tales of lost sisters and troublesome nephews might wish to tuck this family safely among the covenfolk at Valnastium. Players may prefer to design their characters' families as agencies, as described in the appendix.
 
 Jerbiton magi select apprentices from noble families more frequently than magi of other Houses. The Gentle Gift favors no social class, but lacking an apprentice with that most valued of Virtues, an apprentice from a noble family is preferred to similar apprentice from the peasantry. This can sometimes create confusing circumstances with regard to inheritance.
 
 Magi may not enter into feudal relationships, and so may not inherit land. They may, in some Tribunals, inherit other property, like rights or money, and their children may inherit land in some kingdoms. This system is identical to that used when noblemen enter monasteries, or the priesthood. Children who inherit in lieu of a living parent need a steward, approved by the parent and the child's liege, who acts as the child's agent until majority is reached. The Quaesitores are always concerned by these arrangements.
 
+> ## Nepotism
+> 
+> Jerbiton magi often use members of their own families as their agents, as described in the appendix. This allows the magus to use the incidental benefits of their adventures to enrich their family members. More powerful family members, in turn, are more powerful agents. A player engaged in nepotism finds ways of linking the wellbeing of one or more of the character's family members to the events in each story. This allows the magus to spend Bond Maintenance points, which equal the Adventure experience they receive for the story, on their family members.
+> 
+> For the examples given below, imagine a Jerbiton magus from a noble family, with Close Family Ties. His father is a Landed Noble, and his brothers are a Gentleman, a Mercenary Captain, and a Priest. The player could control his brothers indirectly, simply by taking his father as an agent. He chooses instead to take all of them as agents, with a weak Bond representing the time he spent away as an apprentice. During each story, the player finds plausible ways to link the success of the story to the fortunes of his fathers or brothers. This allows them to become more powerful, and strengthens their Bond scores.
+> 
+> Nepotism examples might include:
+> 
+> - The characters defeat a powerful faerie, and the magus arranges the wood it dwelt in to be granted to his brother's church, hinting that the faerie might come back otherwise.
+> - The covenant needs to defeat some bandits, to increase their Reputation with the ruling council of a local town. They destroy the bandits magically, and then hire the magus's brother's mercenary company to claim they killed the bandits. This avoids trouble with the Quaesitores (who may wonder if the bandits were hired by the town's noble rivals), gives a plum job to the mercenary company, increases the loyalty of the mercenaries to the magus's brother, and improves the Reputation of the covenant with the town council (who know the magi arranged it all) and of the mercenary company with potential employers.
+> - The characters meet an excellent minstrel in an inn. He lacks a patron, so the magus directs him to his father's court, with an introduction. This makes the father's court more glorious, and gives the father a skilled courtier to send on diplomatic missions. The troupe decides this is too tenuous a connection to the main story, to which the characters were simply traveling when the encounter took place, to allow more than 1 point to be spent on the father's Bond Strength.
 
-Families have reputations, similar to individuals, and characters engaged in nepotism often improve their family's Reputation. The actions of every character within the family modify the Reputation, and characters may use this Reputation instead of their own, among people who do not personally know the character. That is, people who know that a character is a liar will not be fooled by the family's Reputation for fair dealing. Characters besmirching family Reputations are dealt with by other members of the family. Characters who hide their family membership can avoid undesired Reputations.
+> ## Family Reputation
+> 
+> Families have reputations, similar to individuals, and characters engaged in nepotism often improve their family's Reputation. The actions of every character within the family modify the Reputation, and characters may use this Reputation instead of their own, among people who do not personally know the character. That is, people who know that a character is a liar will not be fooled by the family's Reputation for fair dealing. Characters besmirching family Reputations are dealt with by other members of the family. Characters who hide their family membership can avoid undesired Reputations.
 
 #### Interference With the Mundanes
 
 Jerbiton magi continually test the boundaries of the Order's prohibition against meddling with mundanes. The Code's provision against meddling is virtually unenforceable in the Greater Alps. It is weaker wherever Jerbiton magi are active, and in most Tribunals, it is not interfering with the mundanes to:
 
-- Defend oneself or one's servants from threatening mundanes, other than by forming alliances with the foe's enemies. Aiding their enemies anonymously is permitted, provided the magus's identity is never discovered, even by those assisted. •
-- Correspond or converse with mundanes, or tell them general information about the Order. •
-- Be identified as a magus, or cast spells before witnesses, provided this doesn't provoke the mundanes. •
-- Be involved in commerce, so long as the magical nature of the business is hidden by a mundane servant, who acts as its apparent leader. •
-- Offer goods or services to noblemen, provided that observers would be unable to tell that the magus was a supporter of that nobleman in his disputes. •
-- Kidnap Gifted children. •
-
-
+- Defend oneself or one's servants from threatening mundanes, other than by forming alliances with the foe's enemies. Aiding their enemies anonymously is permitted, provided the magus's identity is never discovered, even by those assisted.
+- Correspond or converse with mundanes, or tell them general information about the Order.
+- Be identified as a magus, or cast spells before witnesses, provided this doesn't provoke the mundanes.
+- Be involved in commerce, so long as the magical nature of the business is hidden by a mundane servant, who acts as its apparent leader.
+- Offer goods or services to noblemen, provided that observers would be unable to tell that the magus was a supporter of that nobleman in his disputes.
+- Kidnap Gifted children.
 
 ### Travel
 
@@ -2169,15 +2074,13 @@ Fosterage occurs when an apprentice is sent to live with a Jerbiton magus other 
 
 #### The Itinerarium
 
-Many Jerbiton magi enjoy travel, and spend a season every few years engaged in sightseeing. The apprentices of these magi accompany their masters, and benefit from this informal tourism. Tourism, particularly disguised as pilgrimage, is popular with the rich of Mythic Europe. The House also sponsors travel by apprentices near the completion of their training. The trip each takes is called the Itinerarium, and is meant to mirror the tour of Greece, Ephesus, Troy, and Egypt undertaken by many young Romans in the Imperial era,
+Many Jerbiton magi enjoy travel, and spend a season every few years engaged in sightseeing. The apprentices of these magi accompany their masters, and benefit from this informal tourism. Tourism, particularly disguised as pilgrimage, is popular with the rich of Mythic Europe. The House also sponsors travel by apprentices near the completion of their training. The trip each takes is called the Itinerarium, and is meant to mirror the tour of Greece, Ephesus, Troy, and Egypt undertaken by many young Romans in the Imperial era, providing young magi with a sense of their history and their potential.
 
-### Mappa Mundi
-
-In 5 BC, a new monument caused a sensation in Rome. It was a detailed map, 60 feet long and 30 feet high, surrounded by marble pillars on which were chiseled a geographic commentary. This led to the first wave of Roman tourism, the ancient ancestor of House Jerbiton's Itinerarium. The monument was destroyed, but its most valuable portion survives.
-
-When the monument was opened a smaller, but equally precise, version of the map was given to Augustus Caesar. It was cast in solid gold, with gemstones for provincial capitals. Many magi of 1220 would pay a fortune for the map. On a symbolic level, the gold map was given to the first Roman Emperor as the owner's deed to the Roman world, so House Tremere would like it simply for the sentiment. As a shape for enchantment as a magical device, the map would offer unequalled bonuses for many effects, so older members of House Verditius would compete for it. It may also act as an Arcane Connection to all of the places named, or marked with gemstones, making it very useful to House Mercere and Jerbiton, who travel so often. Some pagan magi, particularly from the Houses of Merinita and Ex Miscellanea, claim that the Dominion exists because the Pope has the Golden Map. This is false in the core setting, but that would not stop them from paying well for it.
-
-providing young magi with a sense of their history and their potential.
+> ## Mappa Mundi
+> 
+> In 5 BC, a new monument caused a sensation in Rome. It was a detailed map, 60 feet long and 30 feet high, surrounded by marble pillars on which were chiseled a geographic commentary. This led to the first wave of Roman tourism, the ancient ancestor of House Jerbiton's Itinerarium. The monument was destroyed, but its most valuable portion survives.
+> 
+> When the monument was opened a smaller, but equally precise, version of the map was given to Augustus Caesar. It was cast in solid gold, with gemstones for provincial capitals. Many magi of 1220 would pay a fortune for the map. On a symbolic level, the gold map was given to the first Roman Emperor as the owner's deed to the Roman world, so House Tremere would like it simply for the sentiment. As a shape for enchantment as a magical device, the map would offer unequalled bonuses for many effects, so older members of House Verditius would compete for it. It may also act as an Arcane Connection to all of the places named, or marked with gemstones, making it very useful to House Mercere and Jerbiton, who travel so often. Some pagan magi, particularly from the Houses of Merinita and Ex Miscellanea, claim that the Dominion exists because the Pope has the Golden Map. This is false in the core setting, but that would not stop them from paying well for it.
 
 The first Itinerarium was an accident. In the tenth century a Jerbiton Archmage named Anna of Naples sent a letter to her sodales. She indicated that her apprentice would be ready to join the House nine months before the annual Ceremony of Welcome. Rather than attend the Ceremony in another Tribunal, she had decided to take her student to Constantinople, and some neighboring sites, for a six-month immersion in the life of the City. The Archmage gave her itinerary of enticing places, and asked if any other magi would like to accompany her. Some attended, but six magi asked if their apprentices could accompany her on her travels instead. She accepted them, in exchange for remunerations and a promise that she would not be held responsible for their misbehavior.
 
@@ -2188,7 +2091,6 @@ Informal tours also occur. This splintering of the tourists is a result of the s
 The House favors the tour for many reasons. It broadens the minds of young magi, providing familiarity with a broad range of new objects. It provides them with a spiritual anchor, by showing them beauty before they enter the flowering of their Arts. It allows the younger members of the House to meet and form personal bonds that will prove significant in Hermetic politics. It allows the apprentices to perform many minor transgressions against tasteful living before they are considered magi, and thus entirely responsible for their actions. It gives practice in the art of traveling unsuspected in cities.
 
 Apprentices from other Houses sometimes attend the tour, which has led to the House sometimes dividing it into two parties, one Gently Gifted, the other not. Apprentices who lack the Gentle Gift mistrust each other. This can be overcome by each wearing a charm that suppresses the negative thoughts evoked by The Gift, or being accompanied by a magus who wraps the apprentice in his Parma Magica. These measures do not prevent negative mundane reactions to the group, so it is more challenging to guide this portion of the tour.
-
 
 #### Paradoxography
 
@@ -2204,9 +2106,10 @@ Jerbiton magi believe that it is the duty of magi to dress in a way that allows 
 
 Most Jerbiton magi who wish to display their status to mundanes wear robes of fine fabric and expensive colors. They avoid purple, because it has Imperial connotations, so woad blue is popular. The robes of each magus have a personal design, but it is these designs that lead to the common impression that magicians dress like scholars, but have stars on their robes. Jerbiton magi sometimes wear liberty caps (pointy wizard hats) because this symbol of magushood has been widely spread by House Mercere. They do not, however, wear red ones. Jerbiton magi like being asked to leave a worthless staff behind when negotiating with mundane potentates, so the idea that magi are weaker without their staffs is popular in Mythic Europe, while the existence of wands is little known.
 
-### Story Seed: Paradoxographia
+> ## Story Seed: Paradoxographia
+> 
+> A murder victim was recently found near a pilgrimage route. He was given Christian burial, but because he had the distinctive clothes of a magician, a knowledgeable merchant passed the story on to a Redcap, who has recovered the body under the pretext of being a family member. The Redcap was also able to recover the deceased's grave goods, and sewn into the hem of his shirt was a line of 28 small seeds that each contain vis. The magus was young, and the only clue concerning the location of this vis source, and perhaps his murderer, is a paradoxographic letter he sent to his teacher. Characters must find his vis source by following his route and trying to construct real places, people, and situations from the murder victim's parodies. When they find the vis source, they may also find clues to the murderer's identity.
 
-A murder victim was recently found near a pilgrimage route. He was given Christian burial, but because he had the distinctive clothes of a magician, a knowledgeable merchant passed the story on to a Redcap, who has recovered the body under the pretext of being a family member. The Redcap was also able to recover the deceased's grave goods, and sewn into the hem of his shirt was a line of 28 small seeds that each contain vis. The magus was young, and the only clue concerning the location of this vis source, and perhaps his murderer, is a paradoxographic letter he sent to his teacher. Characters must find his vis source by following his route and trying to construct real places, people, and situations from the murder victim's parodies. When they find the vis source, they may also find clues to the murderer's identity.
 
 Servants are an important part of the display required of the rich and powerful. A magus surrounded by grogs demonstrates both the wealth required to support a retinue and the possibility of violence as a method of ensuring his wishes are followed. Tatty equipment and unskilled grogs make a magus look weak and silly, so Jerbiton magi ensure that their servants are well equipped.
 
@@ -2216,18 +2119,13 @@ Animals are an important part of the display required by the rich. Horses, for e
 
 Every class of person in Mythic Europe has a particular raptor assigned to them, for the sport of falconry. The correct bird for magi, according to House Jerbiton, is the lammergeyer (bearded vulture). These birds usually have deep orange plumage, gained by rubbing themselves on ironrich rocks. Those living near covenants develop a wide variety of alternative colors. Lammergeyers prefer to eat the small bones of medium sized animals, which they swallow whole. The bones of lammergeyers are particularly good for making magical flutes.
 
-Jerbiton magi rarely have hounds, the other animal used to display wealth, because cats descended from the Founder's familiar often reside with them instead. Cats of the Black Lineage are intelligent and understand human language, although only a few can vocalize human sounds. Many have Second Sight. They live, on average, for 40 years. The cats have a parliament, and elect a monarch. Each cat adopts a family, and some young cats are selected for training as familiars. The cats are capable of a form of hedge magic, described in *Realms of Power: Magic*. The current Jerbiton Primus's familiar, Crucifixio, is not the King of the Cats, but may well become so when the current king, his mentor, dies.
+Jerbiton magi rarely have hounds, the other animal used to display wealth, because cats descended from the Founder's familiar often reside with them instead. Cats of the Black Lineage are intelligent and understand human language, although only a few can vocalize human sounds. Many have Second Sight. They live, on average, for 40 years. The cats have a parliament, and elect a monarch. Each cat adopts a family, and some young cats are selected for training as familiars. The cats are capable of a form of hedge magic, described in *Realms of Power: Magic*. The current Jerbiton Primus's familiar, Crucifixo, is not the King of the Cats, but may well become so when the current king, his mentor, dies.
 
 ### Etiquette
 
 The rules of etiquette are not arbitrary, although they can be obscure. They are designed to assist persons of quality to interact smoothly. Etiquette is also used to separate those who have been trained in proper behavior from those who merely aspire to it. Etiquette regulates, codifies and encourages communication between participants in events.
 
-Characters skilled in etiquette can use a bewildering variety of symbolic languages to convey messages to each other. Some of these languages have been codified, so that any Hermetic magus skilled in etiquette can explain the subtle messages that may be conveyed by the selection of different flowers given in a posy, or the serving of different dishes to various guests at a formal dinner. Other messages are conveyed by reference to adjoining symbols in famous works of art, or snatches from obscure poems. The challenge, which if met is considered admirable by Jerbiton magi, is for a person engaged in such com-
-
-
-#### Societates
-
-munication to merge the clarity of the message's expression with the beauty of its encapsulation.
+Characters skilled in etiquette can use a bewildering variety of symbolic languages to convey messages to each other. Some of these languages have been codified, so that any Hermetic magus skilled in etiquette can explain the subtle messages that may be conveyed by the selection of different flowers given in a posy, or the serving of different dishes to various guests at a formal dinner. Other messages are conveyed by reference to adjoining symbols in famous works of art, or snatches from obscure poems. The challenge, which if met is considered admirable by Jerbiton magi, is for a person engaged in such communication to merge the clarity of the message's expression with the beauty of its encapsulation.
 
 Characters who gather for an event are able to use their skill in Etiquette for three types of performance. They may attempt to claim central place in the memories others have of the event. They may use their skill to force rivals to make mistakes. Finally, they may work to ensure an evening goes smoothly. An observer watching a participant is able to determine which style of performance he is undertaking with an Intelligence + Etiquette roll against an Ease Factor of 3.
 
@@ -2243,16 +2141,7 @@ The sum of both selected penalties is subtracted from the standard Etiquette rol
 
 #### Collaborative
 
-Collaborative etiquette is used when several people attend an event with the intention that it should be a success, regardless of personal aggrandizement. In
-
-
-### The Great Feasts
-
-The Gastronomers, described below, hold great feasts under strict rules of collaborative etiquette. They have common feasts regularly, but they also hold occasional, exceptional meetings. The most frequent exceptional feasts are the Tribunicals, held at Durenmar every 33 years to accompany the Grand Tribunal. The next is due in 1228. The Seculars are held every 120 years: they take their name from a Roman measurement of time. A secular is the time it takes for all of the witnesses to an event, in this case the founding of the Order, to die. Among the Romans this was set at 90 years, but the Order uses a longer duration. The next is due in 1247, although there is some discussion of canceling it, because of the unprecedented feast that will follow in 1248.
-
-In 1248, the Order will celebrate the 2,000th anniversary of the founding of Rome. A feast of unprecedented opulence and size will be hosted by the magus who most impresses the other Gastronomers during an annual feast between 1218 and 1228, as decided at the tribunical feast in that year. During the 20 years that follow, the host, aided by all Gastronomers, will be expected to arrange the grandest celebration in the Order's history. Perhaps it will be held at the very dawn of the year, so that the secular and millennial feasts flow together. Others hope that a defeated rival for the millennial feast is offered the secular feast, so that the two enter a competitive etiquette duel for 20 years, trying to outshine each other to the benefit of all other magi.
-
-this case, the rolls of all participants are added together, to create a score that is compared to the scores for similar events given in the past. A person who botches during such an event reduces the score by 10, and may develop a poor Reputation. Hosting a successful event improves a character's Reputation, and attending allows a character to develop social contacts that may prove useful in later stories.
+Collaborative etiquette is used when several people attend an event with the intention that it should be a success, regardless of personal aggrandizement. In this case, the rolls of all participants are added together, to create a score that is compared to the scores for similar events given in the past. A person who botches during such an event reduces the score by 10, and may develop a poor Reputation. Hosting a successful event improves a character's Reputation, and attending allows a character to develop social contacts that may prove useful in later stories.
 
 The commonest large event, among magi, is the Tribunal Feast, sponsored by the League of Gastronomers, described below. It usually has around 50 participants. The average feast has a collaborative Etiquette score of 445. That is, the average Communication + Etiquette score of participants is 4, the average magus rolls a 5, and one person botches in an evening, so [50 x (4 + 5)] –10, with an additional +5 bonus for gifts, which are described below.
 
@@ -2260,12 +2149,17 @@ The appointment of a new Primus is rarely a purely collaborative event, but in s
 
 The average symposium, a sort of dinner and debate held by Jerbiton magi as a social event before Tribunals, has 12 participants, with an average Communication + Etiquette of 4. Assuming no attendee botches, all roll an average of 5, and the host gives two gifts as described below, this provides [12 x (4 + 5)] +2, for a total of 83. Excellent hosts find ways to give better gifts, or recruit guests with higher Communication + Etiquette totals, to improve this number toward 100, which is considered an excellent party. Having more than 11 guests, plus the host, is considered cheating.
 
+> ## The Great Feasts
+> 
+> The Gastronomers, described below, hold great feasts under strict rules of collaborative etiquette. They have common feasts regularly, but they also hold occasional, exceptional meetings. The most frequent exceptional feasts are the Tribunicals, held at Durenmar every 33 years to accompany the Grand Tribunal. The next is due in 1228. The Seculars are held every 120 years: they take their name from a Roman measurement of time. A secular is the time it takes for all of the witnesses to an event, in this case the founding of the Order, to die. Among the Romans this was set at 90 years, but the Order uses a longer duration. The next is due in 1247, although there is some discussion of canceling it, because of the unprecedented feast that will follow in 1248.
+> 
+> In 1248, the Order will celebrate the 2,000th anniversary of the founding of Rome. A feast of unprecedented opulence and size will be hosted by the magus who most impresses the other Gastronomers during an annual feast between 1218 and 1228, as decided at the tribunical feast in that year. During the 20 years that follow, the host, aided by all Gastronomers, will be expected to arrange the grandest celebration in the Order's history. Perhaps it will be held at the very dawn of the year, so that the secular and millennial feasts flow together. Others hope that a defeated rival for the millennial feast is offered the secular feast, so that the two enter a competitive etiquette duel for 20 years, trying to outshine each other to the benefit of all other magi.
+
 #### Money and Good Manners
 
 A mundane character making an Etiquette roll may add to the roll by spending money on materials given up as part of the Etiquette check. This represents gifts given to a host, donations made to causes to shame a rival, bets placed with spectators, sumptuous food offered, costumes purchased, rooms rented, and fine wines consumed. The bonus is equal to +1 for each time the character spends the weekly income of all of his guests. A character cannot gain a bonus higher than his Etiquette score by spending money.
 
-The loss of money represents the character purchasing particular items that
-
+The loss of money represents the character purchasing particular items that have been sanctified by time as suitable for this style of competition. The selection of costume, gifts, food, and location all have complex associated rules of appropriateness that the character must follow. Collecting suitable items for an Etiquette check takes time: a character living in a city can spend no more than one pound per day, while one living outside a city must travel to one, or send a skilled procurer.
 
 Magi cannot impress other magi with items that are mere expressions of wealth. Magi may find or procure rare and relevant items during stories. They frequently store items suitable for Etiquette check bonuses for many years, waiting for the perfect moment, and perfect recipient. Some Jerbiton magi barter these items with each other, or leave these items as gifts to their filii at death. A gift of this type grants a bonus of between +1 and +5 to the Etiquette check, with the highest score representing unique items that perfectly match the desires of the recipient.
 
@@ -2273,8 +2167,6 @@ An Intelligence + Order of Hermes Lore + Reputation (of the receiver) roll again
 
 - . . . **6** tells a magus what sorts of gifts are appropriate for another magus. For example, whether the magus is known to collect a certain type of art, or books by a certain author. Conversely, this result also tells a magus which magi are likely to want an unusual item found during a story.
 - . . . **9** refines the above information, telling the giver what items within that range of gifts are considered particularly common or precious by collectors of similar material. For example, a magus might learn that copies of the author Lucian's *True Story* are considered less precious than copies of his *Lovers of Lies* among Bonisagus magi, but that Jerbiton magi esteem the first higher than the second. This level of result also allows a magus to select a single magus most likely to value an exceptional item found during a story. For example, if the PC magi defeat a magical tortoise and take its shield-sized shell, this result tells them that Martial of Tytalus collects turtle shells inscribed with bellicose Latin quotations.
-
-
 
 . . . **12** refines the information yet further, so that a magus can define the perfect gift to give to a particular magus, or know that the item they are holding is the perfect gift for a particular magus, if such a magus is active in Hermetic society.
 
@@ -2284,28 +2176,28 @@ When giving gifts to mundane people, Intrigue may be used in lieu of Order of He
 
 Members of this House have a code of conduct for visiting those areas under the control of other Jerbiton magi. It is considered a serious offence to vary from this code, and such departure is sufficient for Jerbiton magi — although not others — to consider themselves deliberately insulted. Hospitality places obligations on the host and visitor. To comply with the code of conduct, guests must:
 
-- Announce their arrival •
-- Introduce themselves •
-- State the reason for their visit, and the things they intend to do •
-- Indicate when the visit will end •
-- Leave immediately, if asked •
-- Offer a small gift, which is not payment for hospitality •
-- Aid the host, if difficulty ensues during the stay •
-- Be amusing •
-- Not leave without informing the host •
+- Announce their arrival
+- Introduce themselves
+- State the reason for their visit, and the things they intend to do
+- Indicate when the visit will end
+- Leave immediately, if asked
+- Offer a small gift, which is not payment for hospitality
+- Aid the host, if difficulty ensues during the stay
+- Be amusing
+- Not leave without informing the host
 
 The host must:
 
-- Clearly either offer hospitality or decline it, so that the arrival knows if he is a guest •
-- Offer the guest good counsel, particularly of dangers in the region, taking particular note of the guest's intended activities •
-- Offer food and wine, and a place to sleep •
-- Offer a small gift, which is compared with the gift of the guest, imbalances creating debts of honor •
-- Be amusing •
-- Protect the guest from harm •
+- Clearly either offer hospitality or decline it, so that the arrival knows if he is a guest
+- Offer the guest good counsel, particularly of dangers in the region, taking particular note of the guest's intended activities
+- Offer food and wine, and a place to sleep
+- Offer a small gift, which is compared with the gift of the guest, imbalances creating debts of honor
+- Be amusing
+- Protect the guest from harm
 
 It is rude to refuse to offer hospitality, but it is also rude to demand it. Jerbiton magi intending to visit each other often send a Redcap ahead, to ensure they will be welcome.
 
-# Such Structure as the House Has
+## Such Structure as the House Has
 
 House Jerbiton is held together by a sense of difference from the magi of other Houses, mutual interest in each other's activities, and the charisma of its informal leaders. The Primus acts an ideological, rather than political, force within the House. Valnastium is the only large House covenant. Most Jerbiton magi are members of smaller organizations within the House, called leagues, which are clubs for magi sharing similar tastes or ambitions.
 
@@ -2324,7 +2216,6 @@ After all nominations have been made, and accepted or declined, a series of vote
 On the few occasions when there are many accepted nominations, much of the first day is spent weeding through unpopular candidates. Between votes magi may engage in politics. When it is clear that a wasteful day is inevitable, young magi who are performance artists arrange impromptu entertainment for their sodales and gain Reputations. Unpopular candidates usually prefer to decline nomination, rather than gain a handful of votes and be eliminated, so these wasted days rarely occur.
 
 Each Jerbiton magus has a single vote per ballot. Magi unwilling to attend the election may give their sigil, and written voting instructions, to any Hermetic magus, provided the proxy is witnessed by a Quaesitor. The House has a tradition, borrowed from the Papacy, that the Primus is not required to honor any promise made while campaigning for the position, although this would probably not be validated if a case came before a Tribunal.
-
 
 The Primus can be dismissed by one-third of the members of the House requesting that he resign. These petitions are presented at the Festival of Welcome held annually in the Greater Alps Tribunal to celebrate the graduation of apprentices for that year. Successful dismissals are extremely rare. Petitions on other matters are also presented at this time, and are more common. Popular petitions do not bind the Primus, but usually convince her to negotiate with the petition's sponsors.
 
@@ -2352,24 +2243,19 @@ Andru's policy toward the nobility of Europe has overt and covert elements. He f
 
 The Primus's policy toward the Church is straightforward, but mired in details. Andru is hoping to demonstrate that The Gift is a charism, a gift given by God and stamped upon the soul, like the others mentioned, in a non-exclusive list, in the Bible. House Jerbiton gives covert assistance to any research into the source of The Gift. The hostility between the Eastern and Western halves of the Church is so intense that a victory in one half might lead to condemnation in the other, unless the matter is handled carefully. Lacking proof of The Gift's Divine origin, Andru encourages churchmen to judge magi by their acts.
 
-
-#### Societates
-
 ### Valnastium
 
 Valnastium is a picturesque Alpine valley, made more beautiful by generations of tinkering by magi. Its weather is regulated with magic, and its entrance is hidden from those the covenant considers undesirable visitors. Powerful mystical defenses, dating from the Schism War, would give most assailants pause. The little villages of the valley, and the town that surrounds Jerbiton's villa, have almost 1,000 residents.
 
 During the early years of the House, each Primus built a palace in Valnastium's main town, about its central plaza. When Petrus of Verdun encouraged his sodales to leave the House covenants and embrace urban life, many palaces were given to the covenfolk. Most are now either the residences of extended families of favored servants, or used as public buildings, like the hospital, tavern, and bakery. The Primus lives in the little villa on the hill, as the Founder did. Most magi have rooms about the town, but have their laboratories in the covenant's extensive gardens. One section of the gardens also contains the graves of many Jerbiton magi. These elaborate, enchanted monuments commemorate significant events in each magus's life.
 
-Valnastium's library is a genuine Museum — a temple of the Muses — moved magically from Greece. The Founder carried it to his valley because he believed, correctly, that its presence would create a Magic aura in which he could build his laboratory. The aura of Valnastium is higher than it was in the Founder's lifetime, having a value of 3 in most areas, but the presence of the Church of Saint Cyprian has prevented it
-
-### Rhaetian
-
-Valnastium's mundane residents speak a Rhaetian dialect bought to the area by Roman settlers. A character with a score of 5 in Rhaetian can speak to a person who knows Latin as if he had a score of 2 in that language, and Latin speakers may converse with similar ease with Rhaetian speakers.
-
-from developing further, despite the age and size of the covenant. Much of the valley has a Divine aura of 2, rising to 6 at Saint Cyprian's.
+Valnastium's library is a genuine Museum — a temple of the Muses — moved magically from Greece. The Founder carried it to his valley because he believed, correctly, that its presence would create a Magic aura in which he could build his laboratory. The aura of Valnastium is higher than it was in the Founder's lifetime, having a value of 3 in most areas, but the presence of the Church of Saint Cyprian has prevented it from developing further, despite the age and size of the covenant. Much of the valley has a Divine aura of 2, rising to 6 at Saint Cyprian's.
 
 Valnastium's library is the finest in the Order for research into many mundane matters. It has a guesthouse, for the many visitors it attracts, and for the Redcap who carries the many letters requesting answers of the librarians. Failed apprentices, from all over Europe, are sometimes sent to the library for training.
+
+> ## Rhaetian
+> 
+> Valnastium's mundane residents speak a Rhaetian dialect bought to the area by Roman settlers. A character with a score of 5 in Rhaetian can speak to a person who knows Latin as if he had a score of 2 in that language, and Latin speakers may converse with similar ease with Rhaetian speakers.
 
 ### League Membership
 
@@ -2377,9 +2263,7 @@ Jerbiton magi form groups, called leagues, based on similarity of interest, driv
 
 The leagues also allow House Jerbiton to stretch its ethos to include magi from traditions that do not venerate beauty, who have joined the House for political or philosophical reasons. In other Houses, for example, an exile from House Criamon might found a lineage of successors. In House Jerbiton the exiled Criamon maga, and her students, would form the nucleus of a new league dedicated to seeking beauty in a certain way, or exploring a particular facet of the magical Arts. Interesting new leagues are rapidly joined by other Jerbiton magi, interested in collaboration. The new league will soon find a way to describe what it is doing it terms of the search for beauty, because beauty is a matter of taste.
 
-Jerbiton magi have such wide interests that players should not feel constrained to select a league from one of the examples given later. Players designing Jerbiton magi should discuss league membership with their troupes. Troupes may find it convenient to arrange their sagas so that a
-
-Jerbiton magus, regardless of the number of leagues he is involved in, only has a leaguerelated story about as often as characters from other houses are required to fulfill their obligations.
+Jerbiton magi have such wide interests that players should not feel constrained to select a league from one of the examples given later. Players designing Jerbiton magi should discuss league membership with their troupes. Troupes may find it convenient to arrange their sagas so that a Jerbiton magus, regardless of the number of leagues he is involved in, only has a leaguerelated story about as often as characters from other houses are required to fulfill their obligations.
 
 #### Designing a League
 
@@ -2392,7 +2276,6 @@ Players attach their characters to leagues so that they are involved in stories 
 **Headquarters:** Many leagues have property for use in common by the members. This can include a headquarters, library, workshop, laboratory, or many other things. Membership of the league lets the character access this resource, although there may be a waiting list, or seniority system that rations access. Troupes can also ration access by stating that the league's communal facilities are far from the troupe's covenant.
 
 **Reputation Bonus:** Two characters who are in the same league have probably heard of each other, and may be familiar with each others' work. All Reputations act as if they were 3 points higher, between colleagues. The character's higher Reputation with colleagues ensures he is a preferred recipient of invitations to events with limited numbers of participants. This is reflected by choosing members of the league as suppliers of information, materials, and influence in other stories.
-
 
 **Assistance:** The members of a league often collaborate on a single piece, or task. Members are expected to assist each other in the completion of such magnificent works. These works are often called "homages" and are dedicated to the memory of an influential member of the league who the others wish to honor.
 
@@ -2422,12 +2305,7 @@ The Keepers had their headquarters in Constantinople, but the crusaders sacked i
 
 **The Viticulturalists:** This group believes that peasant life has virtue, and engage in magically assisted manorial agriculture. Sabina of the Seine, a relatively young maga, leads them, but they lack a headquarters, meeting when Jerbiton magi gather for Tribunals or Ceremonies of Welcome. Sabina keeps the group's collection of casting tablets for rituals with agricultural uses, like improving soil, controlling weather, raising fences, and branding herds. Members of the Viticulturalists visit each other's estates very frequently, so they are suited to stories where the player character just happens to be in the area, and will move on afterward, for example, classic English murder mysteries.
 
-
-*54*
-
-#### Societates
-
-# Design Notes for Jerbiton Magi
+## Design Notes for Jerbiton Magi
 
 Members of House Jerbiton can live as they wish, and seek beauty as they desire. The culture of their House is, arguably, the least constraining of all of the Houses. The flexible structure of House Jerbiton can leave new players overwhelmed with choices when designing a new magus. This section gives advice, to assist storyguides and players to narrow their choices down into a single character concept.
 
@@ -2439,32 +2317,22 @@ Sagas vary concerning the prevalence of The Gift. In sagas where The Gift is rar
 
 Players of Jerbiton magi are allowed to select for themselves the Free Virtue their character acquires for being a member of the House. This choice is limited to Minor Virtues that relate to scholarship, art, or interacting with people. Suitable virtues from ArM5 include: Affinity with Ability, Apt Student, Book Learner, Cautious with Ability, Educated, Enchanting Music, Free Expression, Good Teacher, Gossip, Inspirational, Learn (Ability) From Mistakes, Light Touch, Long Winded, Piercing Gaze, Privileged Upbringing, Protection, Puissant (Ability), Social Contacts, Temporal Influence, Troupe Upbringing, True Love, Venus's Blessing, and Well-traveled.
 
-Many of these Virtues require the player to select an affected Ability. Suitable choices include (Area) Lore, Artes Liberales, Bargain, Carouse, Charm, Civil and Cannon Law, Common Law, Craft (any related to art), (Dead Language), Enchanting Music, Etiquette, Folk Ken, Guile, Infernal Lore, Intrigue, Leadership, Legerdemain, (Living Language), Magic Lore, Music, (Organization) Lore, Philosophae, Profession (any artistic), and
-
-Theology. If a character has a Virtue linked to an Ability, the magus does not lose this advantage when the Ability is used on non-mundane people, like grogs, magi, or companions
+Many of these Virtues require the player to select an affected Ability. Suitable choices include (Area) Lore, Artes Liberales, Bargain, Carouse, Charm, Civil and Cannon Law, Common Law, Craft (any related to art), (Dead Language), Enchanting Music, Etiquette, Folk Ken, Guile, Infernal Lore, Intrigue, Leadership, Legerdemain, (Living Language), Magic Lore, Music, (Organization) Lore, Philosophae, Profession (any artistic), and Theology. If a character has a Virtue linked to an Ability, the magus does not lose this advantage when the Ability is used on non-mundane people, like grogs, magi, or companions
 
 ### Favored Virtues and Flaws
 
-This section highlights groups of Virtues that suit lifestyles enjoyed by many
+This section highlights groups of Virtues that suit lifestyles enjoyed by many Jerbiton magi. In addition to those Virtues specifically mentioned, players should consider how the Ability-related Virtues might assist their characters. The Abilityrelated Virtues are: Affinity with Ability, Cautious with Ability, Learn (Ability) From Mistakes, and Puissant (Ability). Special Circumstances is also so general that it could prove useful for any lifestyle.
 
+- The Gentle Gift is the most prized Virtue in the House, and Jerbiton magi go to great effort and expense to find Gently Gifted apprentices.
+- Those Jerbiton magi who are artists prize the Free Expression Virtue. Performers often seek students with the Inspirational or Light Touch Virtues.
+- Characters who are interested in philosophy or scholarship might prefer to select Apt Student, Book Learner, Educated, or Good Teacher.
+- House Jerbiton's magi sometimes take apprentices from noble houses, and these students renew their connections following the culmination of their training. This relationship to the aristocracy can be expressed with Virtues like Privileged Upbringing, Protection, Social Contacts, or Temporal Influence, or Flaws such as Black Sheep, Close Family Ties, Dependent, Feud, or Heir.
+- The desire to cast spells inconspicuously in urban settings restricts many magi to low magnitude effects. These limitations can be loosened by the Deft Form Virtue, or the Quiet Magic and Subtle Magic Virtues. Flawless Magic and Mastered Spells allow the magus to compensate for the Dominion by increasing the Penetration of spells to be used in urban areas. Players planning to cast their magic ceremonially should choose Virtues that increase Philosophiae or Artes Liberales scores. Ways of the Town also offers a minor, broad bonus.
+- Supernatural Abilities, like Enchanting Music and Entrancement, can be used surreptitiously in cities, but the protection provided by the Dominion in most cities limits their effectiveness.
+- Jerbiton magi have the True Love Virtue and Lost Love Flaw far more often than other magi. They also often have children who may be represented as Dependents. Those players desiring characters with weaker emotional attachments might prefer the Venus's Blessing Virtue, or Curse of Venus Flaw.
 
-
-Jerbiton magi. In addition to those Virtues specifically mentioned, players should consider how the Ability-related Virtues might assist their characters. The Abilityrelated Virtues are: Affinity with Ability, Cautious with Ability, Learn (Ability) From Mistakes, and Puissant (Ability). Special Circumstances is also so general that it could prove useful for any lifestyle.
-
-- The Gentle Gift is the most prized Virtue in the House, and Jerbiton magi go to great effort and expense to find Gently Gifted apprentices. •
-- Those Jerbiton magi who are artists prize the Free Expression Virtue. Performers often seek students with the Inspirational or Light Touch Virtues. •
-- Characters who are interested in philosophy or scholarship might prefer to select Apt Student, Book Learner, Educated, or Good Teacher. •
-- House Jerbiton's magi sometimes take apprentices from noble houses, and these students renew their connections following the culmination of their training. This relationship to the aristocracy can be expressed with Virtues like Privileged Upbringing, Protection, Social Contacts, or Temporal Influence, or Flaws such as Black Sheep, Close Family Ties, Dependent, Feud, or Heir. •
-- The desire to cast spells inconspicuously in urban settings restricts many magi to low magnitude effects. These limitations can be loosened by the Deft Form Virtue, or the Quiet Magic and Subtle Magic Virtues. Flawless Magic and Mastered Spells allow the magus to compensate for the Dominion by increasing the Penetration of spells to be used in urban areas. Players planning to cast their magic ceremonially should choose Virtues that increase Philosophiae or Artes Liberales scores. Ways of the Town also offers a minor, broad bonus. •
-- Supernatural Abilities, like Enchanting Music and Entrancement, can be used surreptitiously in cities, but the protection provided by the Dominion in most cities limits their effectiveness. •
-- Jerbiton magi have the True Love Virtue and Lost Love Flaw far more often than other magi. They also •
-
-#### Houses of Hermes
-
-often have children who may be represented as Dependents. Those players desiring characters with weaker emotional attachments might prefer the Venus's Blessing Virtue, or Curse of Venus Flaw.
-
-- The Weakness Flaw is tolerated in Jerbiton magi to a degree not found in other Houses, provided it is for a particular form of beauty. Beauty is a subordinating force. •
-- Many Jerbiton magi are Well-traveled. •
+- The Weakness Flaw is tolerated in Jerbiton magi to a degree not found in other Houses, provided it is for a particular form of beauty. Beauty is a subordinating force.
+- Many Jerbiton magi are Well-traveled.
 
 ### New Virtues and Flaws
 
@@ -2509,15 +2377,11 @@ The magus creates and enjoys art that is ugly, according to his Housemates. He s
 
 The character's beauty draws revulsion and jealousy. This envy does not strike everyone, but vain persons of the character's gender are particularly susceptible to it.
 
-
-*56*
-
-
 Characters with this Flaw may avoid its penalties by refusing to reveal their beauty to the world, which creates its own complications.
 
 A character lacking a positive Presence score may not have this Flaw.
 
-# Urban Magic
+## Urban Magic
 
 Members of House Jerbiton are pioneers. They travel to, or even live within, towns and cities. The cities of Europe have grown rapidly in size, population, and Dominion for the last 50 years. Jerbiton magi believe these modern cities are something new to the West: magical wastelands completely unlike the ancient cities in which the Cult of Mercury thrived. Jerbiton magi have dwelt in similar places in the East, most notably Constantinople, and use the techniques developed by their ancestors to explore these new, beautiful, treasure-filled impotentators .
 
@@ -2527,36 +2391,31 @@ A lacuna, Latin for "hole" or "hollow," is a place within an urban environment w
 
 Every city has a unique array of lacunae, and knowledge of these spaces is vital to the lives of urban magi. Although Jerbiton magi are the most frequent users of lacunae, and discuss them at greatest length, other Houses also exploit them. House Mercere's members, for example, are adept at discovering new lacunae, and finding ways to use them.
 
-Most lacunae in large cities are small. In Paris, for example, there are several lacunae that are single rooms in larger buildings, one that fills the shadow of a particular tree, and one that can only be accessed from within
-
-### Finding New Lacunae
-
-Lacunae enter the saga in several ways.
-
-- A lacuna may be purchased during covenant creation, simply by selecting a resource and stating that it is in a lacuna in a certain location, accessed a certain way. •
-- A lacuna may be purchased in character creation, by selecting an appropriate Virtue, stating that it is in a lacuna. •
-- Lacunae may appear during stories. Characters may claim these sites, as a reward for skilled play, or may simply use them if an appropriate opportunity arises in a future story. •
-- Characters may search for lacunae. A character seeking lacunae spends a season, then rolls Intelligence + Area Lore against an Ease Factor of 9. The first time this is done, the character discovers all of the obvious lacunae, those in major public spaces that do not require obscure rituals or times to access. Characters raised in an area by a magus gain this knowledge as they develop their Area Lore, and do not need to spend a season acquiring foundational knowledge of lacunae. This list of lacunae is generated by •
-
-the player, under the supervision of the troupe. Characters who spend additional seasons searching for lacunae are engaged in Area Lore Practice, and may change the specialization of their Area Lore score to lacunae.
-
-A player whose character is familiar with local lacunae knows the locations of three small lacunae per level of Area Lore. Each lacuna should provides a place to cast magic unhindered by the Dominion. If the lacuna provides other resources, was not purchased at covenant creation, is not the result of a Virtue, and is not a reward for a completed story, then it must also include a limitation. This can include, for example, that it is unavailable during daylight hours, that it has inhabitants whom the magus must placate each time that it is used, that overuse may lead to mundane exposure, or that the lacuna has an Infernal aura.
-
-A character with extensive Area Lore may know many lacunae, and troupes may prefer to allow a player to make them up during stories, until they have their complete complement. The troupe should veto any new lacuna that seems too convenient a solution for the magus's current difficulties.
-
-an enclosed coach drawn along a particular road. Larger lacunae do occur, but there are rare, difficult to access, and likely to already be in the possession of powerful owners. Larger lacunae are often underground.
+Most lacunae in large cities are small. In Paris, for example, there are several lacunae that are single rooms in larger buildings, one that fills the shadow of a particular tree, and one that can only be accessed from within an enclosed coach drawn along a particular road. Larger lacunae do occur, but there are rare, difficult to access, and likely to already be in the possession of powerful owners. Larger lacunae are often underground.
 
 Magi do not really understand how lacunae form. The following theories might all be correct, in different cases:
 
-- Lacunae are the sites of ancient temples, or repeated magical rituals, or the lairs of potent monsters. Some appear around the laboratories of magi who practice the mystical Arts in the same place for an extended period. •
-- Lacunae occur in places of great natural or manufactured beauty. Some lacunae are the sites of places of beauty crafted by early Jerbiton magi that have been overwhelmed by expanding towns and forgotten. Some lacunae appear fol- •
+- Lacunae are the sites of ancient temples, or repeated magical rituals, or the lairs of potent monsters. Some appear around the laboratories of magi who practice the mystical Arts in the same place for an extended period.
+- Lacunae occur in places of great natural or manufactured beauty. Some lacunae are the sites of places of beauty crafted by early Jerbiton magi that have been overwhelmed by expanding towns and forgotten. Some lacunae appear fol-
 
 - lowing the completion of an exquisite artwork, theatrical performance, or musical rendition. These tend to vanish if the artwork is removed, or the performance not regularly repeated.
-- Lacunae occur when a single activity, of any type, occurs in an area so often that the spirit of the area becomes accustomed to it, and assists. This is why some bakeries, for example, seem to produce bread that is consistently (but non-magically) excellent, regardless of the skill level of the chief baker. •
-- Many lacunae are inexplicable: the reason for their existence is lost to history. Gifted children seem strangely attracted to such places. •
+- Lacunae occur when a single activity, of any type, occurs in an area so often that the spirit of the area becomes accustomed to it, and assists. This is why some bakeries, for example, seem to produce bread that is consistently (but non-magically) excellent, regardless of the skill level of the chief baker.
+- Many lacunae are inexplicable: the reason for their existence is lost to history. Gifted children seem strangely attracted to such places.
 
 *Realmsof Power: Magic* will include additional information on how magical spaces form.
 
+> ## Finding New Lacunae
+> 
+> Lacunae enter the saga in several ways.
+> 
+> - A lacuna may be purchased during covenant creation, simply by selecting a resource and stating that it is in a lacuna in a certain location, accessed a certain way.
+> - A lacuna may be purchased in character creation, by selecting an appropriate Virtue, stating that it is in a lacuna.
+> - Lacunae may appear during stories. Characters may claim these sites, as a reward for skilled play, or may simply use them if an appropriate opportunity arises in a future story.
+> - Characters may search for lacunae. A character seeking lacunae spends a season, then rolls Intelligence + Area Lore against an Ease Factor of 9. The first time this is done, the character discovers all of the obvious lacunae, those in major public spaces that do not require obscure rituals or times to access. Characters raised in an area by a magus gain this knowledge as they develop their Area Lore, and do not need to spend a season acquiring foundational knowledge of lacunae. This list of lacunae is generated by the player, under the supervision of the troupe. Characters who spend additional seasons searching for lacunae are engaged in Area Lore Practice, and may change the specialization of their Area Lore score to lacunae.
+> 
+> A player whose character is familiar with local lacunae knows the locations of three small lacunae per level of Area Lore. Each lacuna should provides a place to cast magic unhindered by the Dominion. If the lacuna provides other resources, was not purchased at covenant creation, is not the result of a Virtue, and is not a reward for a completed story, then it must also include a limitation. This can include, for example, that it is unavailable during daylight hours, that it has inhabitants whom the magus must placate each time that it is used, that overuse may lead to mundane exposure, or that the lacuna has an Infernal aura.
+> 
+> A character with extensive Area Lore may know many lacunae, and troupes may prefer to allow a player to make them up during stories, until they have their complete complement. The troupe should veto any new lacuna that seems too convenient a solution for the magus's current difficulties.
 
 ### Small Effects and High Penetration Bonuses
 
@@ -2570,58 +2429,48 @@ The low levels of these spells allow the magi to cast them, despite severe penal
 
 Examples include:
 
-- A Personal Range version of *Aura of Ennobled Presence* (ArM5, page 145) •
-- A Touch or Eye Range version of *The Call to Slumber* (ArM5, page 151) •
+- A Personal Range version of *Aura of Ennobled Presence* (ArM5, page 145)
+- A Touch or Eye Range version of *The Call to Slumber* (ArM5, page 151)
 - *Prying Eyes* (ArM5, page 144) *•*
 - *Recollection of Memories Never Quite Lived* (ArM5, page 149) *•*
 
 #### Public Spells
 
-These spells are used when the caster does not mind being recognized as a magus. These allow obviously supernatural travel or help the magus to tidy up mistakes, by killing people or changing their memories. The majority of spells of most
-
-### Performance Magic, In Brief
-
-Performance Magic is a Minor Hermetic Virtue that may be purchased at character creation, or learned through Initiation, following the rules given in *The Mysteries Revised Edition.* It is so useful for urban spellcasting — and of such great popularity in House Jerbiton — that its rules are presented here in abbreviated form.
-
-Many Hermetic magi have learned to disguise spellcasting with mundane activities. Each activity requires a separate Virtue linked to an Ability, for example Performance Magic (Music). The Ability nominated in the Virtue must be performed each time it is used to disguise the casting of a spell.
-
-Activities that include both verbal and physical aspects, such as singing while playing music, acting, and formal dining, are those prized by the House, since they replace both the words and gestures required by spellcasting. More limited activities are possible. Storytelling or bargaining, as examples, replace only the words, and athletics (for example dancing) replaces only the gestures.
-
-Abilities that allow the replacement of both gestures and words usually require props. A character who uses the Music Ability for Performance Magic, for example, must play an instrument if she wishes to replace her Hermetic gestures. She may also sing, unaccompanied by music, to replace only the words of her spell, or may play without singing, to replace only her gestures, if she wishes. The instrument also extends the Voice Range of her spells. Characters who are performing
-
-young Jerbiton magi fall into this group. They suffer only the casting penalty due to the Dominion, which is –9 in most parts of most cities.
+These spells are used when the caster does not mind being recognized as a magus. These allow obviously supernatural travel or help the magus to tidy up mistakes, by killing people or changing their memories. The majority of spells of most young Jerbiton magi fall into this group. They suffer only the casting penalty due to the Dominion, which is –9 in most parts of most cities.
 
 #### Wilderness Spells
 
-The final category, spells in which the magus has little surplus ability, are used in the wilderness, in lacunae, or cast ceremonially at targets within the Dominion. Many older Jerbiton magi dislike the idea may gain the normal bonuses for loud words or exaggerated gestures, although this may draw unwelcome attention.
+The final category, spells in which the magus has little surplus ability, are used in the wilderness, in lacunae, or cast ceremonially at targets within the Dominion. Many older Jerbiton magi dislike the idea of studying spells they rarely use, preferring to allow allies and servants to deal with difficult contingencies, like combat.
 
-It is difficult to recognize Performance Magic. Discerning the Form of a spell as it is being cast, so that a counter-spell may be fast cast, requires the following roll:
-
-**Recognize Form of Performance Magic Spell: stress die + Perception + Awareness + effect magnitude vs. Ease Factor 15**
-
-The Ease Factor is adjusted by:
-
-- –3 if Hermetic words can be heard
-- +0 if Hermetic gestures are seen
-- +3 if both words and gestures are mundane
-
-Characters with this Virtue may create spells with a new Duration, Performance, which is equivalent to the Concentration Duration. A spell with Performance Duration lasts while the caster performs. The caster automatically succeeds on all Concentration rolls required to maintain Performance spells. To cast a Performance Duration spell, the magus's player must make a roll, simple or stress as the situation dictates, of:
-
-**Cast a Performance Duration Spell: die roll + Ability's Characteristic + Ability vs. Ease Factor 3**
-
-If this roll fails or botches, so does the spell.
-
-of studying spells they rarely use, preferring to allow allies and servants to deal with difficult contingencies, like combat.
+> ## Performance Magic, In Brief
+> 
+> Performance Magic is a Minor Hermetic Virtue that may be purchased at character creation, or learned through Initiation, following the rules given in *The Mysteries Revised Edition.* It is so useful for urban spellcasting — and of such great popularity in House Jerbiton — that its rules are presented here in abbreviated form.
+> 
+> Many Hermetic magi have learned to disguise spellcasting with mundane activities. Each activity requires a separate Virtue linked to an Ability, for example Performance Magic (Music). The Ability nominated in the Virtue must be performed each time it is used to disguise the casting of a spell.
+> 
+> Activities that include both verbal and physical aspects, such as singing while playing music, acting, and formal dining, are those prized by the House, since they replace both the words and gestures required by spellcasting. More limited activities are possible. Storytelling or bargaining, as examples, replace only the words, and athletics (for example dancing) replaces only the gestures.
+> 
+> Abilities that allow the replacement of both gestures and words usually require props. A character who uses the Music Ability for Performance Magic, for example, must play an instrument if she wishes to replace her Hermetic gestures. She may also sing, unaccompanied by music, to replace only the words of her spell, or may play without singing, to replace only her gestures, if she wishes. The instrument also extends the Voice Range of her spells. Characters who are performing may gain the normal bonuses for loud words or exaggerated gestures, although this may draw unwelcome attention.
+> 
+> It is difficult to recognize Performance Magic. Discerning the Form of a spell as it is being cast, so that a counter-spell may be fast cast, requires the following roll:
+> 
+> **Recognize Form of Performance Magic Spell: stress die + Perception + Awareness + effect magnitude vs. Ease Factor 15**
+> 
+> The Ease Factor is adjusted by:
+> 
+> - –3 if Hermetic words can be heard
+> - +0 if Hermetic gestures are seen
+> - +3 if both words and gestures are mundane
+> 
+> Characters with this Virtue may create spells with a new Duration, Performance, which is equivalent to the Concentration Duration. A spell with Performance Duration lasts while the caster performs. The caster automatically succeeds on all Concentration rolls required to maintain Performance spells. To cast a Performance Duration spell, the magus's player must make a roll, simple or stress as the situation dictates, of:
+> 
+> **Cast a Performance Duration Spell: die roll + Ability's Characteristic + Ability vs. Ease Factor 3**
+> 
+> If this roll fails or botches, so does the spell.
 
 #### Ceremonial Magic
 
-Magi can use their understanding of the natural forces of the world, and their correspondence to mystical forces, to increase the power of their spellcasting. Rules for unprepared ceremonial casting are given on page 83 of ArM5. Characters
-
-
-#### Societates
-
-
-may also increase the effectiveness of ceremonial casting by using props, and by using a prepared spellcasting space.
+Magi can use their understanding of the natural forces of the world, and their correspondence to mystical forces, to increase the power of their spellcasting. Rules for unprepared ceremonial casting are given on page 83 of ArM5. Characters may also increase the effectiveness of ceremonial casting by using props, and by using a prepared spellcasting space.
 
 The use of props slows ceremonial casting, but provides a bonus based on the mystical significance of the items used. Large props are the most effective, but are very expensive, because master craftsmen must make them from rare materials. Large props are also difficult to transport. Medium-sized props are the ones magi can create or acquire most easily. Many evocative items that may found during stories are medium-sized props. Tiny props are expensive because they must be made from precious metals and gemstones that accord with the Arts. Props aid magic, but are not magical items. They may be constructed or repaired by a skilled craftsman (Ability of 5 or more) under the guidance of a magus, without distracting the magus from study.
 
@@ -2645,14 +2494,13 @@ Casting times when using ceremonial spaces, in minutes per magnitude, are:
 
 **Six Minutes per Magnitude:** A space that the magus has carefully designed to have suitable architectural features, lines of light and reflection, and appropriate placement of color.
 
-
-### Invocation of the Civic Patron
-
-As noted in *Realms of Power: The Divine,* it is possible for a character to ask a saint for a miracle. The formula and its modifiers are too detailed to repeat here. The usual miracle that Jerbiton magi ask for is the right to defend the City from harm. If the miracle is granted, the Dominion does not oppose virtuous use of the character's magic for one scene, or story, at the troupe's discretion. That is, the penalties the character suffers due to the Realm Interaction Chart are reduced to zero.
-
 **Three Minutes per Magnitude:** The magus's laboratory, or other place of magical contemplation.
 
 **One Minute per Magnitude:** A room designed solely for ceremonial casting, which contains props of the largest variety, and mystical choreographies permanently inscribed on the floor. Characters with the Mystical Choreography Virtue cast ceremonial magic at this speed regardless of how temporary their prepared space.
+
+> ## Invocation of the Civic Patron
+> 
+> As noted in *Realms of Power: The Divine,* it is possible for a character to ask a saint for a miracle. The formula and its modifiers are too detailed to repeat here. The usual miracle that Jerbiton magi ask for is the right to defend the City from harm. If the miracle is granted, the Dominion does not oppose virtuous use of the character's magic for one scene, or story, at the troupe's discretion. That is, the penalties the character suffers due to the Realm Interaction Chart are reduced to zero.
 
 #### Spell Mastery for Urban Characters
 
@@ -2660,13 +2508,9 @@ Many Spell Mastery special abilities, described on pages 86–87 of ArM5, are us
 
 #### Arcane Connections
 
-Arcane Connections make it far easier for magi to penetrate the magical protec-
+Arcane Connections make it far easier for magi to penetrate the magical protection provided by the Dominion. Magi have many methods of acquiring Arcane Connections, such as by making social contact, through magically-supported stealth, or by hiring servants.
 
-#### Houses of Hermes
-
-tion provided by the Dominion. Magi have many methods of acquiring Arcane Connections, such as by making social contact, through magically-supported stealth, or by hiring servants.
-
-# The Creation of Beautiful Things
+## The Creation of Beautiful Things
 
 Magic assists in the creation of things, by providing detail. A magus who wants to create a horse, for example, need only know that he wants a horse, and cast the appropriate spell, and a horse will appear. The magus does not need to know how a horse's heart works, or that horses do not have eyelashes on their lower lids. These additional details come from a place magi call the World of Forms.
 
@@ -2688,63 +2532,61 @@ Magi can use Rego magic to do anything a mundane artist could do with tools. The
 
 The Ease Factor is also modified by the length of time it would take a mundane artist to complete the work of art.
 
-- To do what a mundane artist could do in a day does not change the Ease Factor. •
-- To do what a mundane artist could do in a month adds +3 to the Ease Factor. •
-- To do what a mundane artist could do in a season adds +6 to the Ease Factor. •
-- To do what a mundane artist could do in a year adds +9 to the Ease Factor. •
+- To do what a mundane artist could do in a day does not change the Ease Factor.
+- To do what a mundane artist could do in a month adds +3 to the Ease Factor.
+- To do what a mundane artist could do in a season adds +6 to the Ease Factor.
+- To do what a mundane artist could do in a year adds +9 to the Ease Factor.
 
 #### Flourishes
 
-All magi incorporate their sigils into every spell effect, usually without considering it. A maga whose spells are accompanied by the scent of orange blossoms
-
-
-
-
-The table below is designed to assist players of magi to create spells that make items from raw materials, using the Art of Rego. These levels are correct for all spells that make items of Individual size, at Touch Range, with Momentary Duration. The beauty of these items depends on a Finesse roll, described in an adjoining section.
-
-| Raw<br>Material             | Level |
-|-----------------------------|-------|
-| Bone (animal)               | 3     |
-| Gemstone                    | 4     |
-| Glass                       | 3     |
-| Leather (tanned)            | 1     |
-| Metal                       | 4     |
-| Stone                       | 4     |
-| Timber (dried and prepared) | 1     |
-| Wood (unprepared timber)    | 5     |
-| Wool (prepared)             | 1     |
-| Wool (raw)                  | 3     |
-
-does not need to give her sigil any thought, because it is fixed, except in magnitude. The sigils of artistic magi are more flexible than this. An alternative expression of a sigil is called a **flourish**.
+All magi incorporate their sigils into every spell effect, usually without considering it. A maga whose spells are accompanied by the scent of orange blossoms does not need to give her sigil any thought, because it is fixed, except in magnitude. The sigils of artistic magi are more flexible than this. An alternative expression of a sigil is called a **flourish**.
 
 The sigils of artistic magi are a collection of related motifs. To follow the example given above, the maga's motif may be "orange." When she does not concentrate, her magic creates the scent of orange blossoms, but when she concentrates on changing her sigil, she can generate an alternative effect. Attempting to create a flourish adds 3 to the Ease Factor for the spell's Intelligence + Finesse roll.
 
 Flourishes are purely cosmetic effects, but make the maga's practice of the Arts more personal and aesthetically pleasant. Anyone familiar with a maga's sigil can easily identify flourishes as variations upon it. Flourishes for the theme of "oranges" could include could include:
 
-- The color of oranges •
-- The scent of orange juice, orange blossoms, or crushed citrus leaves •
-- The taste of oranges •
-- The smooth, but dimpled, texture of oranges, or the wood of orange trees •
+- The color of oranges
+- The scent of orange juice, orange blossoms, or crushed citrus leaves
+- The taste of oranges
+- The smooth, but dimpled, texture of oranges, or the wood of orange trees
 
-### Ease Factors for Creating and Crafting Objects
+> ## Crafting Items Using Rego Magic
+> 
+> The table below is designed to assist players of magi to create spells that make items from raw materials, using the Art of Rego. These levels are correct for all spells that make items of Individual size, at Touch Range, with Momentary Duration. The beauty of these items depends on a Finesse roll, described in an adjoining section.
+> 
+> | Raw Material                | Level |
+> |-----------------------------|:-----:|
+> | Bone (animal)               | 3     |
+> | Gemstone                    | 4     |
+> | Glass                       | 3     |
+> | Leather (tanned)            | 1     |
+> | Metal                       | 4     |
+> | Stone                       | 4     |
+> | Timber (dried and prepared) | 1     |
+> | Wood (unprepared timber)    | 5     |
+> | Wool (prepared)             | 1     |
+> | Wool (raw)                  | 3     |
+> 
 
-The Ease Factors in the table below include the +3 adjustment for magic use (see Rego Magic), assume the magus is familiar with the created thing (+0), and that a mundane artist would have to spend less than a day (+0) on the work.
-
-A character using Creo magic need not roll Finesse unless he desires the finished product to be of a quality higher than that represented by an Ease Factor of 9 on the following table.
-
-| Artistic Task        | Ease Factor | Notes                                                                                             |
-|----------------------|-------------|---------------------------------------------------------------------------------------------------|
-| Trivial              | 3           | Almost never worth rolling for                                                                    |
-| Simple               | 6           | Work regularly done by untrained people, like<br>whitewashing a house                             |
-| Easy                 | 9           | The daily work of semi-skilled artists                                                            |
-| Average              | 12          | The daily work of skilled artists                                                                 |
-| Hard                 | 15          | The daily work of highly skilled artists, or excep<br>tional work by average artists              |
-| Very Hard            | 18          | The daily work of exceptionally skilled artists, or<br>exceptional work by highly skilled artists |
-| Impressive           | 21          | Exceptional work done by grandmasters of an art                                                   |
-| Remarkable           | 24          | The finest work done by grandmasters of an art                                                    |
-| Almost<br>Impossible | 27          | The epitome of skill in an art                                                                    |
-
-# Perception and Deception
+> ## Ease Factors for Creating and Crafting Objects
+> 
+> The Ease Factors in the table below include the +3 adjustment for magic use (see Rego Magic), assume the magus is familiar with the created thing (+0), and that a mundane artist would have to spend less than a day (+0) on the work.
+> 
+> A character using Creo magic need not roll Finesse unless he desires the finished product to be of a quality higher than that represented by an Ease Factor of 9 on the following table.
+> 
+> | Artistic Task      | Ease Factor | Notes                                                                                              |
+> |--------------------|:-----------:|----------------------------------------------------------------------------------------------------|
+> | Trivial            |      3      | Almost never worth rolling for                                                                     |
+> | Simple             |      6      | Work regularly done by untrained people, like whitewashing a house                                 |
+> | Easy               |      9      | The daily work of semi-skilled artists                                                             |
+> | Average            |     12      | The daily work of skilled artists                                                                  |
+> | Hard               |     15      | The daily work of highly skilled artists, or exceptional work by average artists                   |
+> | Very Hard          |     18      | The daily work of exceptionally skilled artists, or exceptional work by highly skilled artists     |
+> | Impressive         |     21      | Exceptional work done by grandmasters of an art                                                    |
+> | Remarkable         |     24      | The finest work done by grandmasters of an art                                                     |
+> | Almost Impossible  |     27      | The epitome of skill in an art                                                                     |              
+                                                  |
+## Perception and Deception
 
 The Founder was skilled in magic that altered perception. His tradition continues, alongside those of many others who have joined the House since its beginnings. Perception is a complex process, which makes it fragile, and easily manipulated, at each of its stages, by magi. The process of distorting the perceptions of others is called deception, and members of House Jerbiton claim to be its masters, even though skilled practitioners of deception can be found in many Houses.
 
@@ -2752,101 +2594,98 @@ The Founder was skilled in magic that altered perception. His tradition continue
 
 Species are particles that are continuously emitted from objects, and that, when they strike the sense organs of the body, evoke a response. Humans regularly encounter four types of species:
 
-- Iconic species are carried in light, and are interpreted by the eye. •
-- Echoic species are carried in air and register with the ear. •
-- Haptic species pass only through direct contact, and are perceived by the skin. •
-- Olfactory and gustative species are sensed either in air (using smell) or water (using taste). These are the same species, just experienced by two different senses in two media. •
+- Iconic species are carried in light, and are interpreted by the eye.
+- Echoic species are carried in air and register with the ear.
+- Haptic species pass only through direct contact, and are perceived by the skin.
+- Olfactory and gustative species are sensed either in air (using smell) or water (using taste). These are the same species, just experienced by two different senses in two media.
 
 Mundane humans are unable to directly manipulate species, instead having to manipulate the objects that emit species, so that the pattern of emission is pleasant. Species do not themselves shed other species, and are weightless. This makes most species invisible and intangible. They are also limitlessly available, because all objects emit a continuing stream of species.
 
+> ## Level of Succes for Illusions
+> 
+> Magi may create illusions directly, or by transforming the appearance of existing objects. The magus makes either a Perception + Finesse roll to copy something, or an Intelligence + Finesse roll to create an image without a model, and uses the following scale to judge success.
+> 
+> - **3:** The character can choose how his sigil is incorporated into the creation. For example, the magus may determine that a created animal has eyes the color of the magus's sigil.
+> - **6:** The character can select one feature of a creation, so that it varies from the universal form of the image being created. This selection must still suit to the natural range of the creation. For example, the magus may select the precise color of an illusionary snake. This is also the level of Finesse required to create a copy of a particular person's appearance, so that it
+> 
+> fools casual acquaintances of the original person.
+> 
+> - **9:** The character may make several minor selections about the features of the image, so long as they remain within the natural range of similar objects. Alternately, the character may instead make a single cosmetic, unnatural selection. For example, a magus creating an illusory creature might determine that it has a pelt pattern never found in nature, or makes unusual sounds. This is also the level of Finesse required to create a copy of a particular person's appearance, so that it fools friends of the original person.
+> - **12:** The character may precisely tailor the appearance of the image, provided it stays within the natural range of objects of its type. Alternatively, the character may make a single, moderately unnatural selection. This is also the level of Finesse
+> 
+> required to create a copy of a particular person's appearance, so that it fools intimates of the original person.
+> 
+> - **15:** The character may precisely tailor the appearance of the created thing, provided it is unnatural only in cosmetic ways. This allows the creator to make the image unnaturally beautiful by incorporating mystical coloring, supernatural grace, and other attractive features.
+> - **18:** The character may perfectly express his artistic desire to the tiniest detail. This is the level required for exact duplication of an object, with all its tiny flaws and imperfections. It is also the level of Finesse required to create a duplicate that the original person believes reflects his appearance and mannerisms exactly.
+> - **21:** The character may create images that appear to be the epitome of the class of object represented.
 
+> ## Finesse Bonuses and Penalties for Familiarity
+> 
+> The pattern underlying the range of variance in the shape, color, and structure of a class of objects is called the "simile" of that class of objects. The simile differs from the form. The form of an apple allows a magus to make an idealized apple. The simile of apples allows a magus to make apples that look natural, and vary from the ideal within the natural range. The more familiar a character is with an object's simile, the easier it is to recreate the object convincingly.
+> 
+> The Finesse roll for using magic to create, craft, or simulate objects is adjusted by familiarity with the simile in the following ways.
+> 
+> - **Automatic Failure:** Characters automatically fail the Finesse roll if they attempt to create objects that they cannot imagine.
+> - **–3:** This penalty is appropriate when the character…
+>  - …can distinctly recall an example of the object, but has not seen it for more than a year.
+>  - …has not seen an example of the object, but has an Arcane Connection to one.
+>  - …has the Free Expression virtue, and has seen skilled art depicting the object.
+> - **+0:** General knowledge of the simile grants an adjustment of zero. All magi have this level of familiarity with the similes of things that…
+>    - …they encounter on a weekly basis.
+>    - …commonly occur in any area where they have an Area Lore of 1 or more.
+>    - …are uncommon, but occur, in any area where they have an Area Lore of 3 or more.
+>    - …are rare, but occur in any area where they have an Area Lore of 5 or more.
+>    - …are used to perform any Ability in which the character has a score of 1 or more.
+>    - …the troupe feels that they are likely to know, due to the character's history, Abilities, background, or Virtues.
+> 
+> - **+3:** Magi have deep familiarity with the similes of things that…
+>    - …they possess, and use as models.
+>    - …they encounter on a daily basis.
+>    - …commonly occur in any area where they have an Area Lore of 3 or more.
+>    - …are uncommon, but do occur, in any area where they have an Area Lore of 5 or more.
+>    - …are used to perform any Ability in which the character has a score of 5 or more.
+>    - …the troupe feels that they are likely to know intimately, due to the character's history, Abilities, background, or Virtues.
 
-Magi may create illusions directly, or by transforming the appearance of existing objects. The magus makes either a Perception + Finesse roll to copy something, or an Intelligence + Finesse roll to create an image without a model, and uses the following scale to judge success.
-
-- **3:** The character can choose how his sigil is incorporated into the creation. For example, the magus may determine that a created animal has eyes the color of the magus's sigil.
-- **6:** The character can select one feature of a creation, so that it varies from the universal form of the image being created. This selection must still suit to the natural range of the creation. For example, the magus may select the precise color of an illusionary snake. This is also the level of Finesse required to create a copy of a particular person's appearance, so that it
-
-fools casual acquaintances of the original person.
-
-- **9:** The character may make several minor selections about the features of the image, so long as they remain within the natural range of similar objects. Alternately, the character may instead make a single cosmetic, unnatural selection. For example, a magus creating an illusory creature might determine that it has a pelt pattern never found in nature, or makes unusual sounds. This is also the level of Finesse required to create a copy of a particular person's appearance, so that it fools friends of the original person.
-- **12:** The character may precisely tailor the appearance of the image, provided it stays within the natural range of objects of its type. Alternatively, the character may make a single, moderately unnatural selection. This is also the level of Finesse
-
-required to create a copy of a particular person's appearance, so that it fools intimates of the original person.
-
-- **15:** The character may precisely tailor the appearance of the created thing, provided it is unnatural only in cosmetic ways. This allows the creator to make the image unnaturally beautiful by incorporating mystical coloring, supernatural grace, and other attractive features.
-- **18:** The character may perfectly express his artistic desire to the tiniest detail. This is the level required for exact duplication of an object, with all its tiny flaws and imperfections. It is also the level of Finesse required to create a duplicate that the original person believes reflects his appearance and mannerisms exactly.
-- **21:** The character may create images that appear to be the epitome of the class of object represented.
-
-### Finesse Bonuses and Penalties for Familiarity
-
-The pattern underlying the range of variance in the shape, color, and structure of a class of objects is called the "simile" of that class of objects. The simile differs from the form. The form of an apple allows a magus to make an idealized apple. The simile of apples allows a magus to make apples that look natural, and vary from the ideal within the natural range. The more familiar a character is with an object's simile, the easier it is to recreate the object convincingly.
-
-The Finesse roll for using magic to create, craft, or simulate objects is adjusted by familiarity with the simile in the following ways.
-
-- **Automatic Failure:** Characters automatically fail the Finesse roll if they attempt to create objects that they cannot imagine.
-- **–3:** This penalty is appropriate when the character…
-  - …can distinctly recall an example of the object, but has not seen it for more than a year.
-
-- …has not seen an example of the object, but has an Arcane Connection to one.
-- …has the Free Expression virtue, and has seen skilled art depicting the object.
-- **+0:** General knowledge of the simile grants an adjustment of zero. All magi have this level of familiarity with the similes of things that…
-  - …they encounter on a weekly basis.
-  - …commonly occur in any area where they have an Area Lore of 1 or more.
-  - …are uncommon, but occur, in any area where they have an Area Lore of 3 or more.
-  - …are rare, but occur in any area where they have an Area Lore of 5 or more.
-  - …are used to perform any Ability in which the character has a score of 1 or more.
-  - …the troupe feels that they are likely to know, due to the character's
-
-history, Abilities, background, or Virtues.
-
-- **+3:** Magi have deep familiarity with the similes of things that…
-  - …they possess, and use as models.
-  - …they encounter on a daily basis.
-  - …commonly occur in any area where they have an Area Lore of 3 or more.
-  - …are uncommon, but do occur, in any area where they have an Area Lore of 5 or more.
-  - …are used to perform any Ability in which the character has a score of 5 or more.
-  - …the troupe feels that they are likely to know intimately, due to the character's history, Abilities, background, or Virtues.
-
-
-
-**Scattering Like Light** MuTe(Im) Level 30 R: Voice, D: Mom, T: Ind
-
-This spell changes the metal in an object, a sword for example, into iconic species. Passing light carries off these species, which are absorbed when they strike a non-reflective surface. This spell disintegrates objects, so it has obvious combat advantages, but it was originally created by an artist seeking an efficient method of plating objects in metal. He placed the metal and the object he wanted to plate, levitating, in a supernaturally lit box, mirrored on the inside, and used this spell to turn the metal first into species, then back again. This created a smooth coat of metal around the object, and the interior of the box.
-
-(Base 5, +2 Voice, +2 metal +1 Requisite)
+> ## Species Magic Example
+> 
+> **Scattering Like Light** MuTe(Im) Level 30 R: Voice, D: Mom, T: Ind
+> 
+> This spell changes the metal in an object, a sword for example, into iconic species. Passing light carries off these species, which are absorbed when they strike a non-reflective surface. This spell disintegrates objects, so it has obvious combat advantages, but it was originally created by an artist seeking an efficient method of plating objects in metal. He placed the metal and the object he wanted to plate, levitating, in a supernaturally lit box, mirrored on the inside, and used this spell to turn the metal first into species, then back again. This created a smooth coat of metal around the object, and the interior of the box.
+> 
+> (Base 5, +2 Voice, +2 metal +1 Requisite)
 
 Magi, using their Arts, may manipulate either the capacity of an object to make species, or the species directly. Muto spells transforming other Forms into species treat them as a slightly unnatural solid, liquid, or gas, and require an Imaginem requisite.
 
 The following Targets are used for species, supplementing those found in the core rulebook.
 
-- **Individual:** Sufficient species to create and maintain a life-sized illusion of a human being or smaller object, affecting all the senses. **•**
-- **Part:** Sufficient species to create and maintain a life-sized illusion of a human or smaller object, affecting one sense, or part of a human affecting all senses. **•**
-- **Group:** Sufficient species to create and maintain a life-sized illusion of a group of humans or smaller objects. **•**
+- **Individual:** Sufficient species to create and maintain a life-sized illusion of a human being or smaller object, affecting all the senses.
+- **Part:** Sufficient species to create and maintain a life-sized illusion of a human or smaller object, affecting one sense, or part of a human affecting all senses.
+- **Group:** Sufficient species to create and maintain a life-sized illusion of a group of humans or smaller objects.
 
 Hermetic magi have not yet found a way to make solid objects from species using Muto magic. There are several theories as to why this is the case, but many thinkers believe it is because of the difficulty in distinctly sensing a cluster of species to be transformed.
 
-### Additional, Minor Senses
-
-The body has internal senses that complement the five external senses. Like the five greater senses, the ability to interpret internal senses may be targeted with Mentem magic, and the organs these senses use may be attacked with Corpus spells. Internal senses are difficult to target with Imaginem magic of Range greater than Touch, because the species they use are haptic: that is, they travel only through the medium of direct contact on flesh, like the species of touch.
-
-**Proprioception** is the sense that the body uses to monitor the position and orientation of its parts. It is regulated by messages carried along the nerves. The body uses this sense to regulate movement. It is vital for coordination, because it tells the body's parts how far they need to move to work together adequately. There is no single organ of proprioception, but messages originate from the joints.
-
-**Balance** is a minor sense that the body uses to determine which way is down, and, by inference, which way is up. Hermetic magicians have not discovered the organ of balance, but they have never looked for it in a concentrated way.
-
-**Pain** is not, technically, a sense. It is the signal used by the body to report to the mind that the body is damaged. Corpus spells can heal the damage that the pain signal reflects, or create the sensation of pain, but the mind's ability to detect the signal can be inhibited, and false signals created, with Mentem magic.
-
-Pain, proprioception and balance are treated as mental capabilities with regard to base levels for spellcasting given in the core rulebook.
+> ## Additional, Minor Senses
+> 
+> The body has internal senses that complement the five external senses. Like the five greater senses, the ability to interpret internal senses may be targeted with Mentem magic, and the organs these senses use may be attacked with Corpus spells. Internal senses are difficult to target with Imaginem magic of Range greater than Touch, because the species they use are haptic: that is, they travel only through the medium of direct contact on flesh, like the species of touch.
+> 
+> **Proprioception** is the sense that the body uses to monitor the position and orientation of its parts. It is regulated by messages carried along the nerves. The body uses this sense to regulate movement. It is vital for coordination, because it tells the body's parts how far they need to move to work together adequately. There is no single organ of proprioception, but messages originate from the joints.
+> 
+> **Balance** is a minor sense that the body uses to determine which way is down, and, by inference, which way is up. Hermetic magicians have not discovered the organ of balance, but they have never looked for it in a concentrated way.
+> 
+> **Pain** is not, technically, a sense. It is the signal used by the body to report to the mind that the body is damaged. Corpus spells can heal the damage that the pain signal reflects, or create the sensation of pain, but the mind's ability to detect the signal can be inhibited, and false signals created, with Mentem magic.
+> 
+> Pain, proprioception and balance are treated as mental capabilities with regard to base levels for spellcasting given in the core rulebook.
 
 #### The Process of Perception
 
 Magi can deceive by interrupting the process of perception at any of its many stages. The stages of perception, and the points at which magi may disrupt the process, are:
 
-- An object exists, and sheds species. •
-- The species travel through a medium. •
-- The species strike an organ of perception. •
-- The organ signals the brain. This stage is not discussed further in this chapter, as it lies within the Corpus form. •
-- The mind interprets the signal, giving it meaning. •
-- The signal is remembered. •
+- An object exists, and sheds species.
+- The species travel through a medium.
+- The species strike an organ of perception.
+- The organ signals the brain. This stage is not discussed further in this chapter, as it lies within the Corpus form.
+- The mind interprets the signal, giving it meaning.
+- The signal is remembered.
 
 ### Mimicry: Making Illusionary Objects
 
@@ -2858,106 +2697,97 @@ Magi may manipulate the streams of species that pour from objects. The simplest 
 
 #### Transparency
 
-An illusion of transparency destroys the species of an object before they strike the eye, or sometimes the ear, of a particular viewer. Other people can still see the spe-
+An illusion of transparency destroys the species of an object before they strike the eye, or sometimes the ear, of a particular viewer. Other people can still see the species emitted by the object. Transparencies can only be maintained in relatively static environments, because the trick of perspective they employ is too difficult to maintain if attempted against multiple viewers moving in relation to the object and each other.
 
+A transparency has the same base level as the effect it emulates, as given on page 146 of ArM5. Transparencies use the Individual Target to represent the stream of species between the hidden object and observer. Casting an illusion of transparency requires a Perception + Finesse roll against an Ease Factor of 6. The Ease Factor is modified as follows:
 
-### Mimesis and Medieval Art
+| Mod. | Target                              |
+|------|-------------------------------------|
+| +3   | Objects of Room or Group size       |
+| +6   | Structures                          |
+| +9   | Spaces described by the Boundary Target |
 
-Medieval artists do not attempt mimesis, or mirror-like accuracy, in their art. As an example, a king portrayed in a medieval statue does not look like the actual king, but instead looks as a king should look, so as to impress the viewers of the statue with how regal the portrayed person is. If, while the statue is carved, a usurper replaces the king, then the usual practice is simply to change the name of the statue. Accuracy is not important in medieval art, influencing those who view the art is.
+> ### Mimesis and Medieval Art
+> 
+> Medieval artists do not attempt mimesis, or mirror-like accuracy, in their art. As an example, a king portrayed in a medieval statue does not look like the actual king, but instead looks as a king should look, so as to impress the viewers of the statue with how regal the portrayed person is. If, while the statue is carved, a usurper replaces the king, then the usual practice is simply to change the name of the statue. Accuracy is not important in medieval art, influencing those who view the art is.
+> 
+> Jerbiton magi have classical Greek examples of mimetic art available to them, but the philosophy of the arts in their own period sees mimesis as a flaw. The function of the artist is to render the simile, with subtle changes so that the differentiating features of the model are expressed. If the key features of the model and the simile conflict, then a skilled artist firmly adopts the features of simile, not the model. A magus who paints a sleeping king and does not include his crown has, by definition, painted badly, because he fails to include a compulsory feature.
+> 
+> This creates a dichotomy in the thought of the House. Magi of House Jerbiton are capable of perfectly mimetic art using magic — but for them it is effortless and thus not an expression of skill. Many magi are capable of both highly mimetic art, created with magic, and mundane art that depends on rendering idealized shapes.
 
-Jerbiton magi have classical Greek examples of mimetic art available to them, but the philosophy of the arts in their own period sees mimesis as a flaw. The function of the artist is to render the simile, with subtle changes so that the differentiating features of the model are expressed. If the key features of the model and the simile conflict, then a skilled artist firmly adopts the features of simile, not the model. A magus who paints a sleeping king and does not include his crown has, by definition, painted badly, because he fails to include a compulsory feature.
+> ## Transparency Examples
+> 
+> Transparencies are not resisted by the Parma Magica, because they involve destroying species before they strike the target.
+> 
+> ##### Ambush on the Deserted Road
+> 
+> PeIm 20
+> 
+> R: Touch, D: Ring, T: Circle
+> 
+> This spell destroys all of the species that the group of things within the Circle emit in a single direction. It can — for example — make a magus's traveling party invisible from the direction of another group they wish to ambush. The base level of this spell includes an adjustment that accounts for the magus's ability to gently move the direction of effect, so that as the enemy group passes by, they cannot spot the hidden party. Other people, for example the members of the magus's company, can still see each other, because the species reaching their eyes are unobstructed. The transparency requires a Perception + Finesse roll against an Ease Factor of 9 to be convincing.
+> 
+> (Base 5, +1 Touch, +2 Ring)
+> 
+> ##### Hiding in the Crowd
+> 
+> Pelm 10
+> 
+> R: Per, D: Sun, T: Ind
+> 
+> This spell makes the caster selectively invisible. It destroys a thin cone of the species the magus emits, so that a single person cannot see the caster. People around the magus, who are outside the cone, continue to see the caster. This is particularly useful in city crowds, because it stops the magus being buffeted by oblivious passersby. Note that this spell only works if the magus knows the location of the single viewer to be excluded, and if the viewer moves predictably. If the viewer moves rapidly out of the cone, the magus becomes visible to him.
+> 
+> The transparency requires a Perception + Finesse roll against an Ease Factor of 6 to be convincing, if the target remains stationary. If the target is moving slowly and predictably, as, for example, a sentry on a route or a pedestrian strolling to a gate, this increases to 9. It increases to 15 for a character moving very swiftly but predictably, for example, a horseman following a road.
+> 
+> (Base 4, +2 Sun)
 
-This creates a dichotomy in the thought of the House. Magi of House Jerbiton are capable of perfectly mimetic art using magic — but for them it is effortless and thus not an expression of skill. Many magi are capable of both highly mimetic art, created with magic, and mundane art that depends on rendering idealized shapes.
-
-cies emitted by the object. Transparencies can only be maintained in relatively static environments, because the trick of perspective they employ is too difficult to maintain if attempted against multiple viewers moving in relation to the object and each other.
-
-A transparency has the same base level as the effect it emulates, as given on page 146 of ArM5. Transparencies use the Individual Target to represent the stream of species between the hidden object and observer. Casting an illusion of transparency requires a Perception + Finesse roll
-
-### Transparency Examples
-
-Transparencies are not resisted by the Parma Magica, because they involve destroying species before they strike the target.
-
-#### AMBUSH ON THE DESERTED ROAD
-
-PeIm 20
-
-R: Touch, D: Ring, T: Circle
-
-This spell destroys all of the species that the group of things within the Circle emit in a single direction. It can — for example — make a magus's traveling party invisible from the direction of another group they wish to ambush. The base level of this spell includes an adjustment that accounts for the magus's ability to gently move the direction of effect, so that as the enemy group passes by, they cannot spot the hidden party. Other people, for example the members of the magus's company, can still see each other, because the species reaching their eyes are unobstructed. The transparency requires a Perception + Finesse roll against an Ease Factor of 9 to be convincing.
-
-(Base 5, +1 Touch, +2 Ring)
-
-This spell makes the caster selectively invisible. It destroys a thin cone of the species the magus emits, so that a single person cannot see the caster. People around the magus, who are outside the cone, continue to see the caster. This is particularly useful in city crowds, because it stops the magus being buffeted by oblivious passersby. Note that this spell only works if the magus knows the location of the single viewer to be excluded, and if the viewer moves predictably. If the viewer moves rapidly out of the cone, the magus becomes visible to him.
-
-HIDING IN THE CROWD
-
-R: Per, D: Sun, T: Ind
-
-Pelm 10
-
-The transparency requires a Perception + Finesse roll against an Ease Factor of 6 to be convincing, if the target remains stationary. If the target is moving slowly and predictably, as, for example, a sentry on a route or a pedestrian strolling to a gate, this increases to 9. It increases to 15 for a character moving very swiftly but predictably, for example, a horseman following a road.
-
-(Base 4, +2 Sun)
-
-against an Ease Factor of 6. The Ease Factor is modified as follows:
-
-MOD. TARGET
-
-- +3 Objects of Room or Group size
-- +6 Structures
-- +9 Spaces described by the Boundary Target
-
-# Striking the Organs of Perception
+## Striking the Organs of Perception
 
 Unusual effects can be achieved by modifying species slightly before they strike the senses of the target.
 
-#### MACROTURES: ILLUSIONS OF PROXIMITY TO THE ORGAN OF PERCEPTION
+#### Macrotures: Illusions of Proximity to the Organ of Perception
 
 A macroture is an image magnified beyond the possibility of the human eye,
 
 created by forcing the species of an object to strike the eye in a less concentrated way. These are already discussed in the Intellego Imaginem guidelines in ArM5 (base level 3). Jerbiton magi use macrotures to determine the method and technique of artifacts through the tiny marks left by the tools of the artisan. They also use macrotures to see artworks from angles inaccessible to mundane people, to see objects from great distances, and to determine the quality of precious materials they intend to purchase. Macrotures can also be used to correct vision impairments.
 
-### SYNAESTHESIA: SWITCHING ORGANS OF PERCEPTION
+#### Synaesthesia: Switching Organs of Perception
 
-Using synaesthetic illusions, the species of a weak sense are altered so that a stronger sense perceives them instead. In humans, sight is the most powerful sense, so most synaesthetic spells make species of less-detectable types visible. Species for
+Using synaesthetic illusions, the species of a weak sense are altered so that a stronger sense perceives them instead. In humans, sight is the most powerful sense, so most synaesthetic spells make species of less-detectable types visible. Species for external senses, like sight, if changed into those for internal senses, like pain, have no effect because they cannot reach the internal organs that detect them.
 
-
-### Synaesthesia Examples
-
-Spells that transform the species that trigger one sense into those that trigger another have a base level of 2.
-
-#### Glowing Footprints of the Thief
-
-MuIm 20
-
-R: Sight, D: Conc, T: Group
-
-This spell makes the traces of sweat left by a person visible, by transforming the stream of olfactory species of the person's scent into a stream of iconic species. The way this light appears is dependent on the sigil and Finesse of the magus. This spell is mimetic, so all nearby people can see the scent traces. Note that to cast this spell, the magus must be distinctly aware of the scent of the thief, so that there is a valid target for the spell.
-
-(Base 2, +3 Sight, +1 Conc, +2 Group)
-
-#### Sight of the Warm Surface
-
-MuIm 15
-
-R: Touch, D: Conc, T: Vision
-
-Although Imaginem magic cannot create heat, warm surfaces emit species, which humans can sense through touch. This spell transforms those into species that the eye responds to. How the warmth is seen varies by magus.
-
-(Base 2, +1 Touch, +1 Concentration, +4 Vision)
-
-#### A Visible Demand for Repair
-
-MuIm 5
-
-R: Touch, D: Ring, T: Circ
-
-This spell transforms the groans and squeaks of damaged pieces of equipment into iconic species reminiscent of the magus's sigil. This makes it easier for magi to find the flaws in damaged parts, granting a +3 bonus to Craft or Profession rolls.
-
-(Base 2, +1 Touch, +2 Ring)
-
-
-external senses, like sight, if changed into those for internal senses, like pain, have no effect because they cannot reach the internal organs that detect them.
+> ### Synaesthesia Examples
+> 
+> Spells that transform the species that trigger one sense into those that trigger another have a base level of 2.
+> 
+> ##### Glowing Footprints of the Thief
+> 
+> MuIm 20
+> 
+> R: Sight, D: Conc, T: Group
+> 
+> This spell makes the traces of sweat left by a person visible, by transforming the stream of olfactory species of the person's scent into a stream of iconic species. The way this light appears is dependent on the sigil and Finesse of the magus. This spell is mimetic, so all nearby people can see the scent traces. Note that to cast this spell, the magus must be distinctly aware of the scent of the thief, so that there is a valid target for the spell.
+> 
+> (Base 2, +3 Sight, +1 Conc, +2 Group)
+> 
+> ##### Sight of the Warm Surface
+> 
+> MuIm 20
+> 
+> R: Sight, D: Conc, T: Group
+> 
+> Although Imaginem magic cannot create heat, warm surfaces emit species, which humans can sense through touch. This spell transforms those into species that the eye responds to. How the warmth is seen varies by magus.
+> 
+> (Base 2, +1 Sight, +1 Concentration, +4 Group)
+> 
+> ##### A Visible Demand for Repair
+> 
+> MuIm 5
+> 
+> R: Touch, D: Ring, T: Circ
+> 
+> This spell transforms the groans and squeaks of damaged pieces of equipment into iconic species reminiscent of the magus's sigil. This makes it easier for magi to find the flaws in damaged parts, granting a +3 bonus to Craft or Profession rolls.
+> 
+> (Base 2, +1 Touch, +2 Ring)
 
 ### Tricks of Interpretation
 
@@ -2971,92 +2801,88 @@ The Ease Factor of the victim's Perception roll is the sum of a die roll, the vi
 
 **Victim's Perception Ease Factor: die + value of dominant, active Personality Trait + caster's Perception + caster's Finesse**
 
-### The Brushstrokes Revealed
+> ## The Brushstrokes Revealed
+> 
+> InIm 10
+> 
+> R: Touch, D: Ring, T: Circle
+> 
+> This spell makes the species cast by an object within the circle more vivid, so that the magus can see tiny details that are otherwise invisible. This spell has traditionally been used to investigate the physical construction of artworks, but nature-oriented Jerbiton magi have recently begun using it to investigate the handiwork of God, by examining the tiny structures of creation.
+> 
+> (Base 3, +1 Touch, +2 Ring)
 
-InIm 10
-
-R: Touch, D: Ring, T: Circle
-
-This spell makes the species cast by an object within the circle more vivid, so that the magus can see tiny details that are otherwise invisible. This spell has traditionally been used to investigate the physical construction of artworks, but nature-oriented Jerbiton magi have recently begun using it to investigate the handiwork of God, by examining the tiny structures of creation.
-
-(Base 3, +1 Touch, +2 Ring)
-
-
-- If the victim's total exceeds the Ease Factor by 6, he sees the anamorph as it truly is: a shapeless, supernatural thing. •
-- If the victim's total exceeds the Ease Factor by 3, he sees the anamorph as a false thing, with a mundane explanation. •
-- If the victim's total exceeds the Ease Factor by less than 3, he barely registers the anamorph's existence. He knows that something is there, but it's not important enough for his mind to classify without prompting. If forced to consider the anamorph by his situation, he investigates it further. •
-- If the Ease Factor exceeds the target's total, he sees the anamorph as a thing that suits his current emotional state, but is not sufficiently important to investigate. •
-- If the Ease Factor exceeds the victim's total by 3, the target sees the anamorph as characteristic of his mental state. For example, a frightened person may see a menacing figure, or a happy person might see a carnival performer. •
-- If the Ease Factor exceeds the victim's total by 6, the anamorph appears to do what the character assumes it should do. A menacing figure may seem to slink toward the target, while a performer may seem to juggle. •
-- If the Ease Factor exceeds the victim's total by 9, the character constructs a very detailed memory of his interaction with the anamorph. In threatening situations, this may include minor scuffles, and in a happy situations it may include brief, uninformative conversation. •
+- If the victim's total exceeds the Ease Factor by 6, he sees the anamorph as it truly is: a shapeless, supernatural thing.
+- If the victim's total exceeds the Ease Factor by 3, he sees the anamorph as a false thing, with a mundane explanation.
+- If the victim's total exceeds the Ease Factor by less than 3, he barely registers the anamorph's existence. He knows that something is there, but it's not important enough for his mind to classify without prompting. If forced to consider the anamorph by his situation, he investigates it further.
+- If the Ease Factor exceeds the target's total, he sees the anamorph as a thing that suits his current emotional state, but is not sufficiently important to investigate.
+- If the Ease Factor exceeds the victim's total by 3, the target sees the anamorph as characteristic of his mental state. For example, a frightened person may see a menacing figure, or a happy person might see a carnival performer.
+- If the Ease Factor exceeds the victim's total by 6, the anamorph appears to do what the character assumes it should do. A menacing figure may seem to slink toward the target, while a performer may seem to juggle.
+- If the Ease Factor exceeds the victim's total by 9, the character constructs a very detailed memory of his interaction with the anamorph. In threatening situations, this may include minor scuffles, and in a happy situations it may include brief, uninformative conversation.
 
 Anamorphs usually fool only a single sense, by sending out vague visual clues that the target misconstrues. As images that affect a single sense, they have a base level of 1. Some magi prefer to create anamorphs that affect multiple senses. For each additional sense the magus includes, and that the victim experiences, reduce the victim's Perception total by 3. Anamorphs do not require a Mentem requisite, because they do not magically influence the mind, they merely subvert the human reflex to classify sensations.
 
-### Anamorph Example
-
-A maga wants a guard to mistake her servant for the Duke of Rothesay, but she has no idea what the Duke looks like. She casts an anamorphic illusion on her servant's face, so that people tend to see what they expect to see. Then, to aid the illusion, she arranges for him to arrive at night, on a horse with the Duke's badge on its blankets, carrying a shield with the Duke's coat of arms, while another servant yells, "Open the gates for the Duke of Rothesay!"
-
-The trappings of the Duke and the suggestion by the other servant that this person is the Duke have prepared the guard's emotional state. The guard's roll has an Ease Factor of a die roll (5, in this case), plus the guard's Loyalty score (+2), the caster's Perception (+1), and her Finesse (4), for a total of 12. If the guard makes a Perception + Awareness roll of…
-
-- …18 or more, he sees the face of the Duke as a shifting, supernatural thing.
-- …15–17, he sees a face that is similar to the Duke's, but clearly not the Duke's.
-- …12–14, he knows there is something wrong with the face, sufficient to investigate further.
-- …11 or less, he is taken in by the illusion, with more complicated misperceptions for lower rolls.
+> ## Anamorph Example
+> 
+> A maga wants a guard to mistake her servant for the Duke of Rothesay, but she has no idea what the Duke looks like. She casts an anamorphic illusion on her servant's face, so that people tend to see what they expect to see. Then, to aid the illusion, she arranges for him to arrive at night, on a horse with the Duke's badge on its blankets, carrying a shield with the Duke's coat of arms, while another servant yells, "Open the gates for the Duke of Rothesay!"
+> 
+> The trappings of the Duke and the suggestion by the other servant that this person is the Duke have prepared the guard's emotional state. The guard's roll has an Ease Factor of a die roll (5, in this case), plus the guard's Loyalty score (+2), the caster's Perception (+1), and her Finesse (4), for a total of 12. If the guard makes a Perception + Awareness roll of…
+> 
+> - …18 or more, he sees the face of the Duke as a shifting, supernatural thing.
+> - …15–17, he sees a face that is similar to the Duke's, but clearly not the Duke's.
+> - …12–14, he knows there is something wrong with the face, sufficient to investigate further.
+> - …11 or less, he is taken in by the illusion, with more complicated misperceptions for lower rolls.
 
 #### Created Emotional Bias
 
 Magi may attack the decision-making abilities of their enemies by clouding their minds with emotions, which provide artificial +5 Personality Traits. Spells that create extreme emotions can be resisted with a roll of any opposed Personality Trait against an Ease Factor of 9. Spells that create milder emotions are resisted by a roll against an Ease Factor of (4 + the score of the artificial Personality Trait), but have the same level as more powerful spells. Base level guidelines are as follows:
 
-- Creo Mentem spells that create emotion directed at a particular person or object have a base level of 4. *Panic of the Trembling Heart* and *Rising Ire* (both ArM5, page148) are examples of this spell type. •
-- Spells that generate an undirected tendency toward a particular emotion have a base level of 5. Examples effects include a spell that makes its victim furious at all the people around him, or makes him find anything said uproariously amusing. •
-- Spells that generate an emotion directed toward a general class of people or things have a base level of 5. Examples include spells that direct hatred toward people wearing a particular badge, or from a particular place. •
+- Creo Mentem spells that create emotion directed at a particular person or object have a base level of 4. *Panic of the Trembling Heart* and *Rising Ire* (both ArM5, page148) are examples of this spell type.
+- Spells that generate an undirected tendency toward a particular emotion have a base level of 5. Examples effects include a spell that makes its victim furious at all the people around him, or makes him find anything said uproariously amusing.
+- Spells that generate an emotion directed toward a general class of people or things have a base level of 5. Examples include spells that direct hatred toward people wearing a particular badge, or from a particular place.
 
 #### Diminished Mental Capability
 
 Perdo Mentem spells allow magi to diminish the mental capacity of their targets. This has a base level of 4, noted on page 150 of ArM5. The example given is *Trust of Childlike Faith*, which destroys adult judgment regarding truth and falsity. Hermetic magic can create many similar spells, which diminish the target's mental capacity in a host of other ways. Using *Trust of Childlike Faith* as a template, characters skilled in Perdo Mentem may inhibit a target's ability to do any of the following:
 
-- Ignore irrelevant detail to find the core properties of a thing •
-- Articulate words •
-- Assess details without emotional bias •
-- Command muscles to complete learned movements •
-- Concentrate •
-- Deduce facts from observations •
-- Estimate the passage of time •
-- Form memories or learn •
-- Infer the properties of a thing from previous experience with similar things •
-- Integrate sensory information (which makes the character appear clumsy, as if inebriated) •
-- Read facial expressions •
-- Recover from nervous shock •
-- Write •
-- Understand and form words •
+- Ignore irrelevant detail to find the core properties of a thing
+- Articulate words
+- Assess details without emotional bias
+- Command muscles to complete learned movements
+- Concentrate
+- Deduce facts from observations
+- Estimate the passage of time
+- Form memories or learn
+- Infer the properties of a thing from previous experience with similar things
+- Integrate sensory information (which makes the character appear clumsy, as if inebriated)
+- Read facial expressions
+- Recover from nervous shock
+- Write
+- Understand and form words
+- Understand simple mathematical concepts
+- Understand speech
 
-
-
-Characters creating emotions have many options, which are subtly different from each other. The following list gives a small sample of the range of emotions magi may evoke: absorption, amazement, anger, annoyance, anxiety, arrogance, apathy, awe, benevolence, bitterness, boredom, callousness, calm, cheerfulness, compassion, confidence, courage, cynicism, delight, depression, despair, disappointment, embarrassment, enmity, enthusiasm, excitement, friendliness, gallantry, fortitude, fulfillment, fury, generosity, gloom, grief, hatred, hope, horror, infatuation, indifference, joy, love, modesty, offense, optimism, placidity, passion, patience, pity, resent-
-
-- Understand simple mathematical concepts •
-- Understand speech •
+> ## A List of Emotions
+> 
+> Characters creating emotions have many options, which are subtly different from each other. The following list gives a small sample of the range of emotions magi may evoke: absorption, amazement, anger, annoyance, anxiety, arrogance, apathy, awe, benevolence, bitterness, boredom, callousness, calm, cheerfulness, compassion, confidence, courage, cynicism, delight, depression, despair, disappointment, embarrassment, enmity, enthusiasm, excitement, friendliness, gallantry, fortitude, fulfillment, fury, generosity, gloom, grief, hatred, hope, horror, infatuation, indifference, joy, love, modesty, offense, optimism, placidity, passion, patience, pity, resentment, resolution, restlessness, reverence, sentimentality, shyness, sorrow, startledness, surprise, tantilizedness, terror, unctuousness, vexation, vindictiveness, and wonder.
+> 
+> Most characters don't speak English, and players may also wish to identify terms for emotional states described best in other cultures. Examples include the German *schadenfreude*, the gladness that a terrible thing is happening to someone else; the Italian *magari,* which might be translated as the emotion giving rise to resigned, spontaneous cries of "Oh, if only!;" and the Portuguese *saudade,* the feeling that nothing important ever happens here, at least not anymore.
 
 #### Miniatures: Tricks Using Perspective
 
 A miniature is a small illusion that sends species only in a single direction. It is designed to fool the viewer using a trick of perspective: that small, close objects look just like larger, distant objects. Miniatures are convenient in cities because they are inconspicuous. They require more Finesse than normal illusions, but this does not hinder Jerbiton magi.
 
-Urban magi often use miniatures because, within buildings, the lines of sight of targets are restricted. A miniature on a window or doorway, which are Individual Targets, can appear to show an entire panorama, which requires a Boundary Target if performed with mimetic illusions. The doorway or window lowers the magnitude of the spell by providing a surface on which to trace a Circle and Ring. Even unframed miniatures can make images that seem, to the viewer, to have Room, Structure, or Boundary Targets. The miniature retains its Individual Target, and instead requires increased Finesse. These miniatures affect all viewers on the active side of the illusion, so they do not require the Part Target ment, resolution, restlessness, reverence, sentimentality, shyness, sorrow, startledness, surprise, tantilizedness, terror, unctuousness, vexation, vindictiveness, and wonder.
-
-Most characters don't speak English, and players may also wish to identify terms for emotional states described best in other cultures. Examples include the German *schadenfreude*, the gladness that a terrible thing is happening to someone else; the Italian *magari,* which might be translated as the emotion giving rise to resigned, spontaneous cries of "Oh, if only!;" and the Portuguese *saudade,* the feeling that nothing important ever happens here, at least not anymore.
-
-that must be used by miniatures that are targeted at the head of a single victim.
+Urban magi often use miniatures because, within buildings, the lines of sight of targets are restricted. A miniature on a window or doorway, which are Individual Targets, can appear to show an entire panorama, which requires a Boundary Target if performed with mimetic illusions. The doorway or window lowers the magnitude of the spell by providing a surface on which to trace a Circle and Ring. Even unframed miniatures can make images that seem, to the viewer, to have Room, Structure, or Boundary Targets. The miniature retains its Individual Target, and instead requires increased Finesse. These miniatures affect all viewers on the active side of the illusion, so they do not require the Part Target that must be used by miniatures that are targeted at the head of a single victim.
 
 Miniatures may also be used to create illusions that only a single victim can sense. A conventional illusion of a snake on a bed can be seen by all the people in a room. A tiny illusion of a snake placed just in front of the eyes of a victim, that sheds species only in the direction of his eyes, is invisible to the other people in the room. Similar tricks can create illusions of sound, producing music or voices that only the target can hear.
 
 Most miniatures are one magnitude higher than the base level given by the table on page 144 of ArM5. The added magnitude allows the miniature to move slightly, so that the movements of a single viewer's head do not ruin the trick of perspective vital to the miniature's success. A miniature's caster must make a Perception + Finesse roll against an Ease Factor of 9 to successfully create the illusion. The Ease Factor is modified as follows:
 
-#### Modifier Circumstance
-
-- +3 Miniatures mimicking Room Targets
-- +6 Miniatures mimicking Structure Targets
-- +9 Miniatures mimicking Boundary Targets
-- –1 to –3 The viewer's range of movement, or lines of observation, are restricted
+| Modifier | Circumstance                                              |
+|----------|-----------------------------------------------------------|
+| +3       | Miniatures mimicking Room Targets                         |
+| +6       | Miniatures mimicking Structure Targets                    |
+| +9       | Miniatures mimicking Boundary Targets                     |
+| –1 to –3 | The viewer's range of movement, or lines of observation, are restricted |
 
 #### States of Consciousness
 
@@ -3066,64 +2892,65 @@ A mental state is defined by the target's perception of his relationship with hi
 
 Other possible mental states include the following:
 
-- **Animalist**, where a person, for example a Bjornaer maga, sees her environment through the sensory apparatus of, and with the sense of time of, an animal. This may require an Animal requisite. **•**
-- **Anaesthetic**, where the person is ignorant of the existence of his body, but engaged in the environment. A person captivated completely by an artistic performance is in this state. **•**
-- **Daydreaming**, where the person is contemplating some thought to the exclusion of the environment. **•**
-- **Dreaming**, where the person is contemplating the realm of dreams, described in *The Mysteries Revised Edition,* rather than the waking world. **•**
-- **Self-aware**, where the person is contemplating her own reactions or sensations, rather than her environment. Pain makes people intensely self-aware. **•**
-- **Somnambulistic**, typical of sleepwalkers, where the perception of the real world is filtered through dreams. **•**
-- , the more general category, of which "asleep" is used as an example in the core rulebook. An unconscious person is aware of neither himself nor his environment. There are several forms of unconsciousness, for example asleep, comatose, and fainted. •
+- **Animalist**, where a person, for example a Bjornaer maga, sees her environment through the sensory apparatus of, and with the sense of time of, an animal. This may require an Animal requisite.
+- **Anaesthetic**, where the person is ignorant of the existence of his body, but engaged in the environment. A person captivated completely by an artistic performance is in this state.
+- **Daydreaming**, where the person is contemplating some thought to the exclusion of the environment.
+- **Dreaming**, where the person is contemplating the realm of dreams, described in *The Mysteries Revised Edition,* rather than the waking world.
+- **Self-aware**, where the person is contemplating her own reactions or sensations, rather than her environment. Pain makes people intensely self-aware.
+- **Somnambulistic**, typical of sleepwalkers, where the perception of the real world is filtered through dreams.
+- , the more general category, of which "asleep" is used as an example in the core rulebook. An unconscious person is aware of neither himself nor his environment. There are several forms of unconsciousness, for example asleep, comatose, and fainted.
 
 
-### Miniature Examples
+> ## Miniature Examples
+> 
+> Many of the following spells have a Part Target. This means the magus is creating a stream of species aimed at the head of a single viewer. A magus doing this is targeting a victim with a magical medium, so these spells are resisted by the Parma Magica.
+> 
+> ##### An Enemy Awash in the Pure Sigil of the Magus
+> 
+> CrIm 15
+> 
+> R: Sight, D: Conc, T: Part
+> 
+> This spell washes the target with concentrated visible species, overloading the eyes. It requires no Finesse roll, because the species do not construct an image. In this case, the sheer number of species is being used to overload the capacity of the eye, so that the target is unable to see anything else. The spell's name comes from its appearance, which is always based strongly on the sigil of the caster. The victim's eyes recover two minutes after the spell is complete, or in only a round if the victim thinks to close his overburdened eyes when first struck by the spell.
+> 
+> Spells similar to this one can create detailed images, but that requires Finesse rolls.
+> 
+> (Base 2, +3 Sight, +1 Concentration, +1 Part)
+> 
+> ##### False Window
+> 
+> CrIm 5
+> 
+> R: Touch, D: Sun (some versions use Ring), T: Ind
+> 
+> This spell allows the magus to trace the frame of a door or window and create a miniature that seems to show something that lies beyond the frame. A Perception + Finesse roll is required to craft a convincing illusion. The Ease Factor is 9 if the image seems to show a room, 12 if it seems to show a structure, or 15 if it seems to run to the horizon. These numbers already include the reduction for limiting the viewer's line of sight, but could be reduced or increased by familiarity with the depicted scene.
+> 
+> Many casters of *False Window* add an additional magnitude, so that figures within the image appear to move, and the pattern of light changes to suit the time of day, but this simpler version creates only a static image. This spell also models similar spells for the other senses: a mirror that plays a tune, provided its face is not turned toward a wall, is an example. Directly created species like these are resisted by the Parma Magica.
+> 
+> (Base 2, +2 Sun or Ring, +1 Individual)
+> 
+> ##### Silent Shout
+> 
+> CrIm 10
+> 
+> R: Sight, D: Mom, T: Part
+> 
+> This spell creates a burst of species, matching the caster's voice, which strike the target in the head. This spell requires a Perception + Finesse roll against an Ease Factor of 6 to make the voice sound convincingly like that of the magus (the base Ease Factor is 9, with a –3 modifier for deep familiarity), but even if the roll fails, the target still hears the message. This spell is used on battlefields, or to instruct apprentices in the Tribunal chamber. It takes advantage of the directional nature of miniatures to prevent others from overhearing its contents.
+> 
+> (Base 2, +3 Sight, +1 Part)
+> 
+> ##### Fooling the Eye
+> 
+> CrIm 10
+> 
+> R: Sight, D: Mom, T: Part
+> 
+> A magus using this spell creates the correct species for the swift movement of a small bright object, and casts them at the head of the target. Virtually all humans have in involuntary reflex that makes their eyes track the paths of moving objects, particularly those that might strike them. The magus uses this reflex against the victim, because when she looks where the object should be, she makes eye contact with the magus. This allows the magus to cast spells with Eye Range on the victim.
+> 
+> This spell does not require a Finesse roll, because it does not simulate a particular object.
+> 
+> (Base 2, +3 Sight, +1 Part)
 
-Many of the following spells have a Part Target. This means the magus is creating a stream of species aimed at the head of a single viewer. A magus doing this is targeting a victim with a magical medium, so these spells are resisted by the Parma Magica.
-
-#### An Enemy Awash in the Pure Sigil of the Magus
-
-CrIm 15
-
-R: Sight, D: Conc, T: Part
-
-This spell washes the target with concentrated visible species, overloading the eyes. It requires no Finesse roll, because the species do not construct an image. In this case, the sheer number of species is being used to overload the capacity of the eye, so that the target is unable to see anything else. The spell's name comes from its appearance, which is always based strongly on the sigil of the caster. The victim's eyes recover two minutes after the spell is complete, or in only a round if the victim thinks to close his overburdened eyes when first struck by the spell.
-
-Spells similar to this one can create detailed images, but that requires Finesse rolls.
-
-(Base 2, +3 Sight, +1 Concentration, +1 Part)
-
-#### False Window
-
-CrIm 5
-
-R: Touch, D: Sun (some versions use Ring), T: Ind
-
-This spell allows the magus to trace the frame of a door or window and create a miniature that seems to show something that lies beyond the frame. A Perception + Finesse roll is required to craft a convincing illusion. The Ease Factor is 9 if the image seems to show a room, 12 if it seems to show a structure, or 15 if it seems to run to the horizon. These numbers already include the reduction for limiting the viewer's line of sight, but could be reduced or increased by familiarity with the depicted scene.
-
-Many casters of *False Window* add an additional magnitude, so that figures within the image appear to move, and the pattern of light changes to suit the time of day, but this simpler version creates only a static image. This spell also models similar spells for the other senses: a mirror that plays a tune, provided its face is not turned toward a wall, is an example. Directly created species like these are resisted by the Parma Magica.
-
-(Base 2, +2 Sun or Ring, +1 Individual)
-
-#### Silent Shout
-
-CrIm 10
-
-R: Sight, D: Mom, T: Part
-
-This spell creates a burst of species, matching the caster's voice, which strike the target in the head. This spell requires a Perception + Finesse roll against an Ease Factor of 6 to make the voice sound convincingly like that of the magus (the base Ease Factor is 9, with a –3 modifier for deep familiarity), but even if the roll fails, the target still hears the message. This spell is used on battlefields, or to instruct apprentices in the Tribunal chamber. It takes advantage of the directional nature of miniatures to prevent others from overhearing its contents.
-
-(Base 2, +3 Sight, +1 Part)
-
-#### Fooling the Eye
-
-CrIm 10
-
-R: Sight, D: Mom, T: Part
-
-A magus using this spell creates the correct species for the swift movement of a small bright object, and casts them at the head of the target. Virtually all humans have in involuntary reflex that makes their eyes track the paths of moving objects, particularly those that might strike them. The magus uses this reflex against the victim, because when she looks where the object should be, she makes eye contact with the magus. This allows the magus to cast spells with Eye Range on the victim.
-
-This spell does not require a Finesse roll, because it does not simulate a particular object.
-
-(Base 2, +3 Sight, +1 Part)
 
 #### Altering Thoughts
 
@@ -3131,18 +2958,15 @@ Mentem magic can target thoughts. A thought is the expression of an idea, curren
 
 The core rulebook contains base spell levels for creating, understanding, and controlling thoughts. It is also possible to change and destroy thoughts, using the same base levels as for memories. Examples of spells that impair thought are found in the core rulebook. *Tip of the Tongue* (ArM5, page 150), for example, affects the capacity to think a word, rather than the memory of the word, because the capacity returns when the spell expires.
 
-# Memory
+## Memory
 
 There are many types of memory. The three classes of greatest interest to Hermetic magi are the following:
 
-- **Inscribed memories,** which are etched into the mind by study and experience. **•**
-- **Procedural memories,** which are sequences in which actions are performed to complete a greater task. **•**
-- **Episodic memories,** which recollect particular events. Autobiographical memories are episodic memories. **•**
+- **Inscribed memories,** which are etched into the mind by study and experience.
+- **Procedural memories,** which are sequences in which actions are performed to complete a greater task.
+- **Episodic memories,** which recollect particular events. Autobiographical memories are episodic memories.
 
 Hermetic magic should, in theory, be able to duplicate procedural and inscribed memories from a donor to a target, allowing the transfer of Abilities. At the present time, no magus has accomplished this using conventional spellcraft. Inscribed and procedural memories remain valid targets for other magical manipulations, but the creation of Abilities using magic is currently beyond the limit of Hermetic understanding.
-
-
-#### Societates
 
 Hermetic magic can create episodic memories, as detailed in the core rulebook and expanded below. Hermetic scholars suggest this is because the process of remembering an episodic memory creates a fresh episode, and thus a fresh memory, not sustained by magic. Episodic memories do not grant Abilities, although they may grant individual facts. Memory of a particular event may, at the troupe's discretion, provide automatic success on a particular Lore check. The core rulebook assigns a base level of 5 to spells that create a single memory.
 
@@ -3164,89 +2988,84 @@ The loss of episodic memories does not prevent the use of other abilities. An am
 
 The level of detail in an episodic memory is dependent on an Intelligence + Finesse roll against an Ease Factor of 6.
 
-- **Botch:** The character has created an element in the memory so obviously false that the target notices it as soon as the memory is examined. **•**
-- **Fail:** The character has created a memory so unconvincing that the target dismisses it as whimsy. **•**
-- **Success:** The caster creates a memory, but the details are entirely drawn from the experiences and expectations of the victim. For example, a victim from London who has been given a memory of a visit to Venice may remember its muddy streets, because he does not know that he should remember canals instead. **•**
-- **Success by 3 or More:** The magus may incorporate a few details that he knows into the memory. If the person seeks to confirm the memory, he is sure that he could not have known these details except from the experience of the remembered event. This can include, as an example, an accurate view of a significant building, or the layout of a room's furniture. **•**
-- **Success by 6 or More:** The magus may include many small details, known to him, which make it easy to confuse a person attempting to confirm the veracity of the memory. **•**
-- **Success by 9 or More:** The magus may include extremely detailed information in the memory. If the target **•**
+- **Botch:** The character has created an element in the memory so obviously false that the target notices it as soon as the memory is examined.
+- **Fail:** The character has created a memory so unconvincing that the target dismisses it as whimsy.
+- **Success:** The caster creates a memory, but the details are entirely drawn from the experiences and expectations of the victim. For example, a victim from London who has been given a memory of a visit to Venice may remember its muddy streets, because he does not know that he should remember canals instead.
+- **Success by 3 or More:** The magus may incorporate a few details that he knows into the memory. If the person seeks to confirm the memory, he is sure that he could not have known these details except from the experience of the remembered event. This can include, as an example, an accurate view of a significant building, or the layout of a room's furniture.
+- **Success by 6 or More:** The magus may include many small details, known to him, which make it easy to confuse a person attempting to confirm the veracity of the memory.
+- **Success by 9 or More:** The magus may include extremely detailed information in the memory. If the target attempts to verify the memory, this detail will make it appear sound.
 
-### Inscribed Memory Spell Examples
+> ## Inscribed Memory Spell Examples
+> 
+> ##### Creation of the Simile
+> 
+> CrMe 20
+> 
+> R: Eye, D: Sun, T: Ind
+> 
+> This spell creates a new category of thing in the mind of the viewer, granting unconscious familiarity with a broad range of instances of that thing. Alternatively, the spell may be used to grant a broad knowledge of a category of thing of which the target is already aware. A magus deeply familiar with a simile, as described earlier, may make the target deeply familiar with the simile, while a magus only broadly familiar with a simile may only create broad familiarity in the target.
+> 
+> This spell is usually created with a long Range and Duration, because it allows the magus to create unreal similes in the minds of hostile targets. This is most effective when the target does not already have a ready category for the thing the magus wishes to hide. As an example, a magus carting odd spell components into a city may convince the guards that they are "geegaws," or some other meaningless category, and thus unimportant. This will not work if the guard already has a simile that includes things that look like spell components, for example "tools of the Devil."
+> 
+> (Base 5, +1 Eye, +2 Sun)
+> 
+> ##### Agnosia
+> 
+> PeMe 10
+> 
+> R: Eye, D: Sun T: Ind
+> 
+> This spell destroys familiarity with a category of object represented by a single noun. The victim of this spell cannot recognize instances of the thing, although she is that aware such things exist. If confronted with a representative object, the victim cannot identify or use it. This spell does not destroy Abilities, so if the character is placed in a position where she uses an object without conscious monitoring, her Abilities return. This can be alarming for the spell's target, since she cannot consciously use the tool to repeat her inadvertent actions.
+> 
+> (Base 3, +1 Eye, +2 Sun)
 
-**Creation of the Simile**
-
-CrMe 20
-
-R: Eye, D: Sun, T: Ind
-
-This spell creates a new category of thing in the mind of the viewer, granting unconscious familiarity with a broad range of instances of that thing. Alternatively, the spell may be used to grant a broad knowledge of a category of thing of which the target is already aware. A magus deeply familiar with a simile, as described earlier, may make the target deeply familiar with the simile, while a magus only broadly familiar with a simile may only create broad familiarity in the target.
-
-This spell is usually created with a long Range and Duration, because it allows the magus to create unreal similes in the minds of hostile targets. This is most effective when the target does not already have a ready category for the thing the magus wishes to hide. As an example, a magus carting odd spell components into a city may convince the guards that they are "geegaws," or some other meaningless category, and thus unimportant. This will not work if the guard already has a simile that includes things that look like spell components, for example "tools of the Devil."
-
-(Base 5, +1 Eye, +2 Sun)
-
-#### Agnosia
-
-PeMe 10
-
-R: Eye, D: Sun T: Ind
-
-This spell destroys familiarity with a category of object represented by a single noun. The victim of this spell cannot recognize instances of the thing, although she is that aware such things exist. If confronted with a representative object, the victim cannot identify or use it. This spell does not destroy Abilities, so if the character is placed in a position where she uses an object without conscious monitoring, her Abilities return. This can be alarming for the spell's target, since she cannot consciously use the tool to repeat her inadvertent actions.
-
-(Base 3, +1 Eye, +2 Sun)
-
-
-### Procedural Memory Spell Example
-
-**Dissolving the Wall of Shields**
-
-PeMe 20
-
-R: Voice, D: Mom, T: Group
-
-This spell removes the memories that allow a group of soldiers to fight as a unit. This spell can be used to destroy other simple skills, too small to be encompassed by an Ability. For example, a magus might cast it on a group of courtiers so that all of them forget the steps of a particular dance. These memories do not return when the spell concludes, but may be regained with simple demonstration and practice, requiring time but not experience points.
-
-This spell does not damage autobiographical memory, so it is obvious to the victims that he has lost a skill he previously possessed. The spell does not impair judgment, so the victim may infer that the magus is responsible. A version of this spell with Sight Range (level 25) is less conspicuous.
-
-(Base 4, +2 Voice, +2 Group)
-
-attempts to verify the memory, this detail will make it appear sound.
+> ## Procedural Memory Spell Example
+> 
+> ##### Dissolving the Wall of Shields
+> 
+> PeMe 20
+> 
+> R: Voice, D: Mom, T: Group
+> 
+> This spell removes the memories that allow a group of soldiers to fight as a unit. This spell can be used to destroy other simple skills, too small to be encompassed by an Ability. For example, a magus might cast it on a group of courtiers so that all of them forget the steps of a particular dance. These memories do not return when the spell concludes, but may be regained with simple demonstration and practice, requiring time but not experience points.
+> 
+> This spell does not damage autobiographical memory, so it is obvious to the victims that he has lost a skill he previously possessed. The spell does not impair judgment, so the victim may infer that the magus is responsible. A version of this spell with Sight Range (level 25) is less conspicuous.
+> 
+> (Base 4, +2 Voice, +2 Group)
 
 #### The Memorization of Created Knowledge
 
 Created thoughts and memories fade from the target's mind when the spell that generates them expires. Some characters may wish to retain these thoughts. Using the thought or memory, so that the mind creates episodic memories around it, allows the mind to reconstruct the memory once the magic has faded away.
 
-This is not an effective teaching aid, because it requires an hour of work for each image or significant cluster of facts to fix itself in memory. For example, if a magus creates the image of a map in the mind of a servant, the servant can fix that memory by drawing the details of the map for an hour, before the spell expires. Reconstructed memories are also imprecise copies of the original memory. This does
+This is not an effective teaching aid, because it requires an hour of work for each image or significant cluster of facts to fix itself in memory. For example, if a magus creates the image of a map in the mind of a servant, the servant can fix that memory by drawing the details of the map for an hour, before the spell expires. Reconstructed memories are also imprecise copies of the original memory. This does not inhibit the use of simple, reconstructed facts, but for complex information, these errors accumulate.
 
-### Episodic Memory Spell Examples
-
-The spells given in the core rulebook tend to suit this style of memory. Examples include *Recollection of Memories Never Quite Lived*, *Past of Another,* and *Loss of But a Moment's Memory,* each of which relate to memories as records of events.
-
-#### Creation of an Undeserved Reputation
-
-CrMe 20
-
-R: Eye, D: Sun, T: Ind
-
-This spell creates the memory that a certain person has confessed to having an extremely enjoyable evening of intercourse with another person. The second person may be named, if the magus wishes, or, with a penalty of 3 on the Finesse roll, merely suggested so that the target of the spell draws his own conclusions.
-
-When the Duration expires, the details of the episode vanish, but the character remembers recalling them. This means the character may not be able to remember where or when the confession was made, but remembers that it was. If pressed, the character starts to infer the context of the memory, which then becomes more solid with each recollection.
-
-(Base 5, +1 Eye, +2 Sun)
-
-**The Unbidden Task**
-
-MuMe 25
-
-R: Eye, D: Moon, T: Ind
-
-This spell creates a simple prospective memory in the target, which repeats itself so often that the target infers a reason for the memory. Simple memories, like, "I need to leave the back door unlocked tomorrow night" draw out reasonable inferences like, "because his lordship is sneaking out for a night on the town after her ladyship falls asleep." The magus takes advantage of the action the prospective memory guides, so in the example above the magus could send a servant to rob the house, knowing the door would be unlocked.
-
-If there is no possible reasonable inference, the spell fails, so it cannot force most characters to commit suicide or do things that are abominable. Characters cannot be convinced to do things that are dangerous unless the character regularly faces that sort of danger as part of his profession. A shepherd might fight off a wolf, or a town watchman arrest a violent drunk, but neither would reasonably infer that they should perform the task better suited to the other.
-
-(Base 5, +1 Eye, +3 Moon)
-
-not inhibit the use of simple, reconstructed facts, but for complex information, these errors accumulate.
+> ## Episodic Memory Spell Examples
+> 
+> The spells given in the core rulebook tend to suit this style of memory. Examples include *Recollection of Memories Never Quite Lived*, *Past of Another,* and *Loss of But a Moment's Memory,* each of which relate to memories as records of events.
+> 
+> ##### Creation of an Undeserved Reputation
+> 
+> CrMe 20
+> 
+> R: Eye, D: Sun, T: Ind
+> 
+> This spell creates the memory that a certain person has confessed to having an extremely enjoyable evening of intercourse with another person. The second person may be named, if the magus wishes, or, with a penalty of 3 on the Finesse roll, merely suggested so that the target of the spell draws his own conclusions.
+> 
+> When the Duration expires, the details of the episode vanish, but the character remembers recalling them. This means the character may not be able to remember where or when the confession was made, but remembers that it was. If pressed, the character starts to infer the context of the memory, which then becomes more solid with each recollection.
+> 
+> (Base 5, +1 Eye, +2 Sun)
+> 
+> ##### The Unbidden Task
+> 
+> MuMe 25
+> 
+> R: Eye, D: Moon, T: Ind
+> 
+> This spell creates a simple prospective memory in the target, which repeats itself so often that the target infers a reason for the memory. Simple memories, like, "I need to leave the back door unlocked tomorrow night" draw out reasonable inferences like, "because his lordship is sneaking out for a night on the town after her ladyship falls asleep." The magus takes advantage of the action the prospective memory guides, so in the example above the magus could send a servant to rob the house, knowing the door would be unlocked.
+> 
+> If there is no possible reasonable inference, the spell fails, so it cannot force most characters to commit suicide or do things that are abominable. Characters cannot be convinced to do things that are dangerous unless the character regularly faces that sort of danger as part of his profession. A shepherd might fight off a wolf, or a town watchman arrest a violent drunk, but neither would reasonably infer that they should perform the task better suited to the other.
+> 
+> (Base 5, +1 Eye, +3 Moon)
 
 #### Other Tricks of Memory
 
@@ -3256,112 +3075,101 @@ not inhibit the use of simple, reconstructed facts, but for complex information,
 
 Mentem base effect of level 5 (ArM5, page 151). One of the most important inclinations, from the perspective of Jerbiton magi, lies toward belief. That is, spells of this type are used to make targets more gullible, so that other illusions and hallucinations have a greater possibility of success. A second inclination, lack of interest, is also useful. Rego Mentem spells cannot be used to destroy memories, but a character who simply does not care about what she sees is far less likely to remember it.
 
-### Chapter Three
-
-# House Tytalus
+# Chapter Three: House Tytalus
 
 *Dullards.and.idiots.created.laws.to.punish.success. and.enslave.violence,.yet.it.took.someone.of.wisdom. and.perspicacity.to.invent.fear.of.the.gods;.so.introducing.the.most.pleasant.of.teachings,.the.hiding.of. truth. within. a. false. account.. Still,. the. truly. wise. and.acute.of.mind.cannot.be.limited.by.any.laws.of. human.invention.*
 
 *—.*Tytalus the Founder
 
-House Tytalus is most famously known for their never-ending quest for confl ict. They are perceived as troublemakers, cunning politicians, and perpetrators of clandestine plots. They are all these things and much more. For a player interested in characters of House Tytalus, this chapter describes the history, philosophy, and culture of the House, and details the motivations of these strife-seeking magi. For the storyguide, there is a toolkit of rules for running Tytalus-based stories or sagas, including rules for the resolution of public debates, and ideas for stories based on intrigue and nefarious schemes.
+House Tytalus is most famously known for their never-ending quest for conflict. They are perceived as troublemakers, cunning politicians, and perpetrators of clandestine plots. They are all these things and much more. For a player interested in characters of House Tytalus, this chapter describes the history, philosophy, and culture of the House, and details the motivations of these strife-seeking magi. For the storyguide, there is a toolkit of rules for running Tytalus-based stories or sagas, including rules for the resolution of public debates, and ideas for stories based on intrigue and nefarious schemes.
 
-# History
+## History
 
-Some have said that the history of House Tytalus can be divided into eras based on pairs of prominent magi in contention with each other. The early years were dominated by Tytalus's fi ghts with his mater, with Tremere, and then with his fi lii, who subsequently continued the tradition by feuding with each other. The middle period of history consisted of the corruption of the House, which set the fourth, fi fth, and sixth Primi at each other's throats. Finally, in the current day, the House is still at war, with two magi
+Some have said that the history of House Tytalus can be divided into eras based on pairs of prominent magi in contention with each other. The early years were dominated by Tytalus's fights with his mater, with Tremere, and then with his filii, who subsequently continued the tradition by feuding with each other. The middle period of history consisted of the corruption of the House, which set the fourth, fifth, and sixth Primi at each other's throats. Finally, in the current day, the House is still at war, with two magi claiming a right to the leadership of the House.
 
-### Key facts
-
-**PoPulation:.**96
-
-**Primus:.** Either Buliste or Harpax (see Primi at War, below)
-
-**domus. magna:.** Fudarus, located on a the Isle of Ushant, just off the coast of Brittany. This fl at-topped island rises with almost vertical cliffs 180' above sea level, and is infamous for its treacherous reefs and violent storms. Fudarus is a sprawling fortress atop the landward cliffs, impossibly draped down the face of the cliff like petrifi ed ivy. The covenant is hidden from mortal view by sea mists and spirits of deception.
-
-**Favored.tribunals:.**none
-
-**motto:.** Auctus ex dimicatione ("from confl ict, growth")
-
-**symbol:.**A spiral. Tytalan heraldry is a complex matter, consisting of many variants of this basic symbol (see Spiral Symbolism). The symbol of the House as a whole is the type of spiral called a spira, consisting of four full turns; this symbol turns clockwise currently, but this has not always been so. In recent years, supporters of Buliste or Harpax color the symbol either violet or green respectively (see History for more details of the quarrel between Buliste and Harpax).
-
-claiming a right to the leadership of the House.
+> ## Key facts
+> 
+> **Population:** 96
+> 
+> **Primus:** Either Buliste or Harpax (see Primi at War, below)
+> 
+> **Domus Magna:** Fudarus, located on a the Isle of Ushant, just off the coast of Brittany. This flat-topped island rises with almost vertical cliffs 180' above sea level, and is infamous for its treacherous reefs and violent storms. Fudarus is a sprawling fortress atop the landward cliffs, impossibly draped down the face of the cliff like petrified ivy. The covenant is hidden from mortal view by sea mists and spirits of deception.
+> 
+> **Favored Tribunals:** none
+> 
+> **Motto:** Auctus ex dimicatione ("from conflict, growth")
+> 
+> **Symbol:** A spiral. Tytalan heraldry is a complex matter, consisting of many variants of this basic symbol (see Spiral Symbolism). The symbol of the House as a whole is the type of spiral called a spira, consisting of four full turns; this symbol turns clockwise currently, but this has not always been so. In recent years, supporters of Buliste or Harpax color the symbol either violet or green respectively (see History for more details of the quarrel between Buliste and Harpax).
 
 ### Tytalus the Sorcerer
 
-In her search for wizards to form an Order united by Hermetic magic and the Parma Magica, Trianoma visited the catacombs of Naples. There she found Guorna the Fetid, perhaps the greatest necromancer who ever lived, and heir to the secrets of death and the dead (see *Houses.of. Hermes:. True. Lineages*, page 112). Trianoma, with great trepidation, invited the hideous necromancer to Durenmar to study under Bonisagus, in order that her powerful magic could be integrated into Hermetic Theory. Unknown to Trianoma, Guorna's three pupils — Tytalus, Tremere, and an as-yetuntrained girl called Pralix — had recently fl ed across the Adriatic Sea to Dacia after discovering her horrifi c plot to transfer her soul from her pus-fi lled, leprosy-riddled body into one of theirs.
+In her search for wizards to form an Order united by Hermetic magic and the Parma Magica, Trianoma visited the catacombs of Naples. There she found Guorna the Fetid, perhaps the greatest necromancer who ever lived, and heir to the secrets of death and the dead (see *Houses.of. Hermes:. True. Lineages*, page 112). Trianoma, with great trepidation, invited the hideous necromancer to Durenmar to study under Bonisagus, in order that her powerful magic could be integrated into Hermetic Theory. Unknown to Trianoma, Guorna's three pupils — Tytalus, Tremere, and an as-yetuntrained girl called Pralix — had recently fled across the Adriatic Sea to Dacia after discovering her horrific plot to transfer her soul from her pus-filled, leprosy-riddled body into one of theirs.
 
-The three apprentices marshaled forces to kill their former teacher and tormentor. Tytalus took charge; he was the eldest of the three, and had studied under the witch for nearly three decades. He ordered Tremere to fi nd wizards to aid them, while he himself sought out magical assistance to oppose Guorna's own magic. Her power derived from the gods of the dead (despite the secularization of their religion), so Tytalus sought out those spirits imprisoned in the Underworld by those gods, spirits fi lled with resentment, rebellion, hatred, and vast power — the titans. He forged numerous pacts with these fearful spirits, and, bolstered by the necromantic wizards recruited by
+The three apprentices marshaled forces to kill their former teacher and tormentor. Tytalus took charge; he was the eldest of the three, and had studied under the witch for nearly three decades. He ordered Tremere to find wizards to aid them, while he himself sought out magical assistance to oppose Guorna's own magic. Her power derived from the gods of the dead (despite the secularization of their religion), so Tytalus sought out those spirits imprisoned in the Underworld by those gods, spirits filled with resentment, rebellion, hatred, and vast power — the titans. He forged numerous pacts with these fearful spirits, and, bolstered by the necromantic wizards recruited by Tremere, the two destroyed the remnants of Guorna's tradition in Naples, and then waited for the witch herself to return from the Black Forest. The trap set by the two brothers was too well-planned for Guorna to survive, despite even her new Hermetic teaching. Tytalus claimed to have inflicting the killing blow against his mater, ripping her heart from her pus-filled chest. Guorna, however, had her revenge: with her dying breath she cursed her matricidal pupil with her own affliction of leprosy.
 
-
-
-**Tytalus:** The Founder of the House.
-
-**Pralix:** The first apprentice of Tytalus, and the Founder of House Ex Miscellanea.
-
-**Hariste:** A beloved pupil of Tytalus, collator of the *Analects,* and first of the lineage of Leper Magi.
-
-**Tasgillia:** A Prima executed for diabolism in 961 AD.
-
-**Kalliste the Accursed:** The Prima who succeeded Tasgillia.
-
-Tremere, the two destroyed the remnants of Guorna's tradition in Naples, and then waited for the witch herself to return from the Black Forest. The trap set by the two brothers was too well-planned for Guorna to survive, despite even her new Hermetic teaching. Tytalus claimed to have inflicting the killing blow against his mater, ripping her heart from her pus-filled chest. Guorna, however, had her revenge: with her dying breath she cursed her matricidal pupil with her own affliction of leprosy.
+> ## Famous Figures
+> 
+> **Tytalus:** The Founder of the House.
+> 
+> **Pralix:** The first apprentice of Tytalus, and the Founder of House Ex Miscellanea.
+> 
+> **Hariste:** A beloved pupil of Tytalus, collator of the *Analects,* and first of the lineage of Leper Magi.
+> 
+> **Tasgillia:** A Prima executed for diabolism in 961 AD.
+> 
+> **Kalliste the Accursed:** The Prima who succeeded Tasgillia.
 
 ### Tytalus the Magus
 
-After the defeat of Guorna, Tytalus and Tremere (and Pralix) marched on Durenmar, intent on eliminating the wizards they considered her allies and co-conspirators. However, the diplomacy of Trianoma forestalled their wrath, and the brothers were convinced of their innocence; indeed, they were persuaded to accept tutelage under Bonisagus instead. Tytalus found the adoption of Hermetic magic very difficult because of his extensive training and substantial power in his native tradition, although he was able to learn the Parma Magica. Pralix became the joint apprentice of Tytalus and Bonisagus, and she received a full understanding of both sorcery and Hermetic magic from her two masters. When the wizards whom Trianoma had gathered at Durenmar started to formulate the structure of the Order, Tytalus assumed that Tremere would become a member of his House, for his magical training was inferior to all of the other prospec-
+After the defeat of Guorna, Tytalus and Tremere (and Pralix) marched on Durenmar, intent on eliminating the wizards they considered her allies and co-conspirators. However, the diplomacy of Trianoma forestalled their wrath, and the brothers were convinced of their innocence; indeed, they were persuaded to accept tutelage under Bonisagus instead. Tytalus found the adoption of Hermetic magic very difficult because of his extensive training and substantial power in his native tradition, although he was able to learn the Parma Magica. Pralix became the joint apprentice of Tytalus and Bonisagus, and she received a full understanding of both sorcery and Hermetic magic from her two masters. When the wizards whom Trianoma had gathered at Durenmar started to formulate the structure of the Order, Tytalus assumed that Tremere would become a member of his House, for his magical training was inferior to all of the other prospective Founders. However, Tremere had long chafed under the dominating yoke of his brother, and, with the support of several other Founders and his cadre of Dacian necromancers, found sufficient political force to form his own House. This was the beginning of the rift between Tytalus and Tremere, which grew wider as time went on.
 
-Each type of spiral employed by House Tytalus has a particular symbolism associated with it. No Tytalan symbol contains intersecting lines; they are all spirals, not knots.
-
-A **spira** has equally spaced lines as they radiate from the center of the symbol. This represents the self and human nature.
-
-A **concha** ("shell") has turns which progressively increase in distance from the previous. This represents news and reputation.
-
-A **vertex** ("whirlpool") has turns that get closer and closer until the spiral appears to be trapped within a circle. This represents privacy and secrets.
-
-A **clavicula** ("little key") is a spiral trapped within a geometric shape other than a circle or oval. This represents tradition.
-
-A **swirl** consists of arcs that double back on each other. This represents rivalry and confusion.
-
-tive Founders. However, Tremere had long chafed under the dominating yoke of his brother, and, with the support of several other Founders and his cadre of Dacian necromancers, found sufficient political force to form his own House. This was the beginning of the rift between Tytalus and Tremere, which grew wider as time went on.
+> ## Spiral Symbolism
+> 
+> Each type of spiral employed by House Tytalus has a particular symbolism associated with it. No Tytalan symbol contains intersecting lines; they are all spirals, not knots.
+> 
+> A **spira** has equally spaced lines as they radiate from the center of the symbol. This represents the self and human nature.
+> 
+> A **concha** ("shell") has turns which progressively increase in distance from the previous. This represents news and reputation.
+> 
+> A **vertex** ("whirlpool") has turns that get closer and closer until the spiral appears to be trapped within a circle. This represents privacy and secrets.
+> 
+> A **clavicula** ("little key") is a spiral trapped within a geometric shape other than a circle or oval. This represents tradition.
+> 
+> A **swirl** consists of arcs that double back on each other. This represents rivalry and confusion.
+> 
+> A **labyrinth** is made of one or more spirals on the same continuous line, usually twisting first in one direction and then in another. This represents the combination of two disparate qualities.
+> 
+> A **turbo** ("whirl") consists of multiple lines which spiral together. This represents combined effort.
+> 
+> A **helix** ("snail") is a spiral wound around a cone. This represents decline or ascension.
+> 
+> A **hedera** ("ivy") is a spiral wound around a cylinder. This represents continuance.
+> 
+> **Clockwise** turning (from the center out, also called right or dexter) indicates growth and perception, and the Calliclean ethical viewpoint (see Philosophy of Conflict, below).
+> 
+> **Anticlockwise** turning (from the center out, also called left or sinister) represents introspection, and the Hippian ethical viewpoint (see Philosophy of Conflict, below).
 
 Tytalus was a skilled politician as well as a powerful wizard. He spent a great deal of effort and time haranguing the other Founders, particularly Guernicus, over the structure and governance of the Order of Hermes. Tytalus became a proponent of a democratic structure for the Order, and much of the early Code of Hermes was framed as a result of public debates between Guernicus and Tytalus. It is largely believed nowadays by his followers that Tytalus maneuvered the Order down a democratic path purely to cut the power base from under Tremere's feet rather than for any nobler purpose. He felt that giving the governance of the Order to the plebeian class was a better alternative to one where a power-hungry upstart could rule the Order single-handedly.
 
-A **labyrinth** is made of one or more spirals on the same continuous line, usually twisting first in one direction and then in another. This represents the combination of two disparate qualities.
-
-A **turbo** ("whirl") consists of multiple lines which spiral together. This represents combined effort.
-
-A **helix** ("snail") is a spiral wound around a cone. This represents decline or ascension.
-
-A **hedera** ("ivy") is a spiral wound around a cylinder. This represents continuance.
-
-**Clockwise** turning (from the center out, also called right or dexter) indicates growth and perception, and the Calliclean ethical viewpoint (see Philosophy of Conflict, below).
-
-**Anticlockwise** turning (from the center out, also called left or sinister) represents introspection, and the Hippian ethical viewpoint (see Philosophy of Conflict, below).
-
 The writings of Tytalus reveal his numerous schemes in the mundane world. He was at least partially responsible for the establishment of a protectorate over the Slavs on the eastern border of the Duchy of Bavaria, with the intent to drive a wedge between the Bulgars (the allies of Tremere) and their northern kin. There are rumors that he was also active in the Byzantine Empire, assisting Jerbiton in defeating Tremere's empire-building ambitions. He was likely responsible for the annexation of Brittany (where he had made his home) by the Frankish Empire, for he believed it to be more stable than the fractured Saxon kingdoms of the British Isles. However, House legend also places Tytalus in Britain meddling with the succession of its kings. All the stories told about Tytalus cannot be true because some of them place him in different places at the same time. No accusations of Code-breaking were ever brought against him, but at that time the Order was small, and a skilled intriguer such as Tytalus could easily escape the watchful eyes of the Quaesitores.
 
-In 798 AD Pralix, now a powerful maga in her own right, introduced her
+In 798 AD Pralix, now a powerful maga in her own right, introduced her master to a young maiden whom she had intended to take as her apprentice. The girl, whose name was Hariste, was enchantingly beautiful, and Tytalus immediately became besotted with her. Overcome with this unfamiliar emotion, Tytalus stole Hariste from Pralix, and retreated to his home at Fudarus to train her. The furious Pralix was left to take his place as acting leader of the House, though she never claimed the title of Prima.
 
+Tytalus's relationship with Hariste bordered on the obsessive; his leprosy made her forever unattainable, and although he received no rejection from Hariste, he refused to sully her perfection. In frustration, she became determined to punish her master for his reticence, thus giving rise to a tradition of rivalry between master and pupil that persists to this day in House Tytalus.
 
-### Tytalus
+> ## Tytalus
+> 
+> Tytalus was both a tragic and a terrifying figure. It was largely because of the threat posed by powerful sorcerers such as Tytalus that the Order was formed in the first place. He was the true heir to Guorna's powerful spiritmagic as well as her curse of leprosy, and he shared with her an apparent lack of social compunction. Once convinced to join the Order, he turned his energy towards ensuring that it would stand as a testament to the Founders long after their eventual demise. Tytalus was a powerful politician in the Tribunals of the Order, but not because he was truthful, earnest, or correct. Instead, he answered any question on any subject instantly and without consideration. He sought to entangle, entrap, and confuse his opponents, dazzling them with strange or flowery metaphors — and if this didn't work, by violence and noise.
+> 
+> He genuinely believed that adversity brought growth, and felt that if the Order did not have enemies, it would stagnate. Tytalus was a social chameleon; he had the ability to adapt to nearly any human situation, and pass himself off as a genuine member of the community. He had a spirit familiar with the material form of a huge black dog, who Tytalus claimed was a son of Hekate and brother to Kerberos. Out of humor or spite (or both), he named this dog "Tremere."
 
-Tytalus was both a tragic and a terrifying figure. It was largely because of the threat posed by powerful sorcerers such as Tytalus that the Order was formed in the first place. He was the true heir to Guorna's powerful spiritmagic as well as her curse of leprosy, and he shared with her an apparent lack of social compunction. Once convinced to join the Order, he turned his energy towards ensuring that it would stand as a testament to the Founders long after their eventual demise. Tytalus was a powerful politician in the Tribunals of the Order, but not because he was truthful, earnest, or correct. Instead, he answered any question on any subject instantly and without consideration. He sought to entangle, entrap, and confuse his opponents, dazzling them with strange or flowery metaphors — and if this didn't work, by violence and noise.
-
-He genuinely believed that adversity brought growth, and felt that if the Order did not have enemies, it would stagnate. Tytalus was a social chameleon; he had the ability to adapt to nearly any human situation, and pass himself off as a genuine member of the community. He had a spirit familiar with the material form of a huge black dog, who Tytalus claimed was a son of Hekate and brother to Kerberos. Out of humor or spite (or both), he named this dog "Tremere."
-
-master to a young maiden whom she had intended to take as her apprentice. The girl, whose name was Hariste, was enchantingly beautiful, and Tytalus immediately became besotted with her. Overcome with this unfamiliar emotion, Tytalus stole Hariste from Pralix, and retreated to his home at Fudarus to train her. The furious Pralix was left to take his place as acting leader of the House, though she never claimed the title of Prima.
-
-Tytalus's relationship with Hariste bordered on the obsessive; his leprosy made her forever unattainable, and although he received no rejection from Hariste, he refused to sully her perfection. In frustration, she became determined to punish her
-
-### Tytalus and Tremere
-
-*It is dreadful when one who is not wise believes himself to be so.*
-
-— Critias
-
-Tytalus never forgave Tremere for his betrayal before the other Founders. He devoted considerable effort to thwarting the plans of his "little brother" (as he styled him, although the two were not related by blood), and had he not met his end when he did, may well have succeeded in putting him in his place as he had always intended. In his writings, Tytalus often refers to Tremere and his followers as "wolves," due to their self-adopted symbol, but always in a negative way, emphasizing their savage nature, unpleasant disposition, habit for feasting on the corpses of the slain, and inability to be domesticated. His writings also preserve a number of other unpleasant names for Tremere, which are still used for members of House Tremere by Tytalan magi: Fratrilis ("little brother"), Tremulus ("quiverer"), and Vagitus ("whiner," "puppy").
-
-master for his reticence, thus giving rise to a tradition of rivalry between master and pupil that persists to this day in House Tytalus.
+> ## Tytalus and Tremere
+> 
+> *It is dreadful when one who is not wise believes himself to be so.*
+> 
+> — Critias
+> 
+> Tytalus never forgave Tremere for his betrayal before the other Founders. He devoted considerable effort to thwarting the plans of his "little brother" (as he styled him, although the two were not related by blood), and had he not met his end when he did, may well have succeeded in putting him in his place as he had always intended. In his writings, Tytalus often refers to Tremere and his followers as "wolves," due to their self-adopted symbol, but always in a negative way, emphasizing their savage nature, unpleasant disposition, habit for feasting on the corpses of the slain, and inability to be domesticated. His writings also preserve a number of other unpleasant names for Tremere, which are still used for members of House Tremere by Tytalan magi: Fratrilis ("little brother"), Tremulus ("quiverer"), and Vagitus ("whiner," "puppy").
 
 ### The House After Tytalus
 
@@ -3373,10 +3181,7 @@ Hariste's influence on the House was subtle but pervasive. Tytalus was a creatur
 
 Pralix never fully accepted Hariste. To her, Tytalus was a harsh but beloved father figure, which cast Hariste in the role of a gold-digging strumpet, and one nearly half her own age. Yet the younger, prettier maga had gained the support of the House through virtue of swift action and a compelling oratory style that made Pralix seem positively flat-footed. With her skills more suited to the battlefield than the Tribunal arena, Pralix aborted her attempt to win control of the House, and instead bent her efforts towards recruiting more wizards into the fold of the Order.
 
-Pralix and Hariste are considered the first pair of "beloved rivals" for which the house is famous. Their rivalry is legendary, and in the beginning was based on envy. Hariste was jealous of Pralix because the older maga had known Tytalus for all her life. Pralix resented Hariste for not being her own apprentice. When Hariste manipulated the Order into sending Pralix to battle Damhan-Allaidh, it was a masterstroke worthy of Tytalus himself. It was only when Pralix had foresworn the Order that Hariste realized how much she missed
-
-
-
+Pralix and Hariste are considered the first pair of "beloved rivals" for which the house is famous. Their rivalry is legendary, and in the beginning was based on envy. Hariste was jealous of Pralix because the older maga had known Tytalus for all her life. Pralix resented Hariste for not being her own apprentice. When Hariste manipulated the Order into sending Pralix to battle Damhan-Allaidh, it was a masterstroke worthy of Tytalus himself. It was only when Pralix had foresworn the Order that Hariste realized how much she missed her “elder sister,” and how much of their antagonism hid true affection. She consequently did everything she could to protect Pralix when the rest of the Houses demanded she be executed for her temerity (see Chapter 4: House Ex Miscellanea, History).
 
 ### The Betrayal
 
@@ -3384,52 +3189,42 @@ Pralix and Hariste are considered the first pair of "beloved rivals" for which t
 
 > — Tasgillia, to the Tribunal that executed her for diabolism
 
-The fourth Prima of House Tytalus was Tasgillia. She was despised by her House for possessing a thoroughly unpleasant personality and extremely selfi sh view of the world; this, and her puissance in spirit magic, made her oft-likened to Guorna. Nevertheless, she won the right to lead House Tytalus, which none could deny her. Her feud with her fi lia Kalliste was the most acrimonious and vindictive quarrel in the history of the House. Kalliste believed that Oath provided a culture superior to the lawless chaos that had existed before its foundation, when every magus had pursued his own selfi sh nature. The immoral Tasgillia had no such altruistic tendencies, and let nothing impede her selfi sh nature. The two opposed each other at every turn, and fought no less than four Wizard's Wars against each other, until the Tribunal threatened to March them both.
+The fourth Prima of House Tytalus was Tasgillia. She was despised by her House for possessing a thoroughly unpleasant personality and extremely selfish view of the world; this, and her puissance in spirit magic, made her oft-likened to Guorna. Nevertheless, she won the right to lead House Tytalus, which none could deny her. Her feud with her filia Kalliste was the most acrimonious and vindictive quarrel in the history of the House. Kalliste believed that Oath provided a culture superior to the lawless chaos that had existed before its foundation, when every magus had pursued his own selfish nature. The immoral Tasgillia had no such altruistic tendencies, and let nothing impede her selfish nature. The two opposed each other at every turn, and fought no less than four Wizard's Wars against each other, until the Tribunal threatened to March them both.
 
-The feud ended abruptly in 961 AD when Kalliste brought evidence to the Quaesitores that her mater was amassing power through diabolism, using Guorna's own lore to summon demons to attend to her sybaritic desires. Tasgillia was executed for diabolism by Archmage Erythravis of House Guernicus later that year. Her whole tradition, the Titanoi (see Characters, below) fell under suspicion, and the subsequent investigation resulted in the executions of 14 additional Titanoi, and three other Tytali, at the hands of the Order's
-
-### The Analects of Tytalus
-
-- Summa on House Tytalus Lore, Level 4, Quality 11 •
-- Summa on Philosophiae, Level 3, Quality 11 •
-- Tractatus on Order of Hermes Lore, Quality 8 •
-
-hoplites. Of the lineage of the Titanoi, only Kalliste and her fi lii survived. With the endorsement and support of House Guernicus, Kalliste replaced Tasgillia, becoming the fi fth Prima of House Tytalus, despite never winning that privilege in the time-honored manner of the house.
+The feud ended abruptly in 961 AD when Kalliste brought evidence to the Quaesitores that her mater was amassing power through diabolism, using Guorna's own lore to summon demons to attend to her sybaritic desires. Tasgillia was executed for diabolism by Archmage Erythravis of House Guernicus later that year. Her whole tradition, the Titanoi (see Characters, below) fell under suspicion, and the subsequent investigation resulted in the executions of 14 additional Titanoi, and three other Tytali, at the hands of the Order's hoplites. Of the lineage of the Titanoi, only Kalliste and her filii survived. With the endorsement and support of House Guernicus, Kalliste replaced Tasgillia, becoming the fifth Prima of House Tytalus, despite never winning that privilege in the time-honored manner of the house.
 
 This event came to be known as the Betrayal to Tytali, although the Order more commonly calls it the Corruption; it is viewed as a dark period in history by modern Tytali but not for the reason that other Houses think. They freely admit that Tasgillia was guilty of the crimes of which she was accused, yet fault *Kalliste* for betraying the principles of Tytalus by putting custom before nature, which is completely antithetical to the Founder's philosophy. Further, the Tytalan way would have been to settle the matter behind closed doors; instead the proud House was publicly shamed before the Order, and to this day has not recovered its former reputation. It is Kalliste to whom Tytali refer when they speak of the Betrayal, and her memory is ritually cursed every midwinter at Fudarus.
 
+> ## The Analects of Tytalus
+> 
+> - Summa on House Tytalus Lore, Level 4, Quality 11
+> - Summa on Philosophiae, Level 3, Quality 11
+> - Tractatus on Order of Hermes Lore, Quality 8
+
 ### The Schism War and its Aftermath
 
-Following the Betrayal, House Tytalus underwent a period of relative quiet, concentrating on rebuilding their numbers, as well as their reputation in the Order. The spirit mages, with their command over spirits of confl ict and victory, had been the most combat-worthy members of the House, and with their loss the Tytali turned away from physical confl ict — leaving it to the Flambeau and Tremere — and re-embraced the fi ne art of debate
-
-
-#### Societates
-
-
-In 1228 the Grand Tribunal will be held. Both Primi will want to represent the House at this prestigious event, and it is likely that the rivalry between the two factions will escalate. A player character who has declared for one side will find himself the target of numerous plots by the other side to reduce the number of opposing supporters; likewise, he will be expected to instigate plots to do the same to his rivals. What started in friendly competition (for the members of House Tytalus, if not the Primi) might become a matter of deadly earnest as the Grand Tribunal approaches.
-
-favored by their Founder. As a result they amassed political power, particularly in the Normandy Tribunal. Kalliste led the broken House during the Schism War, and it became little more than a tool of House Guernicus. On the day of the final battle between House Diedne and the rest of the Order, Prima Kalliste met her demise at the end of a poisoned knife wielded by a member of her own House. The perpetrator of this crime was Marched by his own pater, Klynoites, who became the next Primus of House Tytalus. It is generally believed that Klynoites's filius committed his crime on behalf of the House and his pater.
+Following the Betrayal, House Tytalus underwent a period of relative quiet, concentrating on rebuilding their numbers, as well as their reputation in the Order. The spirit mages, with their command over spirits of conflict and victory, had been the most combat-worthy members of the House, and with their loss the Tytali turned away from physical conflict — leaving it to the Flambeau and Tremere — and re-embraced the fine art of debate favored by their Founder. As a result they amassed political power, particularly in the Normandy Tribunal. Kalliste led the broken House during the Schism War, and it became little more than a tool of House Guernicus. On the day of the final battle between House Diedne and the rest of the Order, Prima Kalliste met her demise at the end of a poisoned knife wielded by a member of her own House. The perpetrator of this crime was Marched by his own pater, Klynoites, who became the next Primus of House Tytalus. It is generally believed that Klynoites's filius committed his crime on behalf of the House and his pater.
 
 In the years that followed the Schism War and the demise of House Diedne, there were rich pickings of vis sources and magical sites all over Mythic Europe, nowhere moreso than in Brittany. The veterans of the Schism War in the Normandy Tribunal, predominantly members of House Flambeau, claimed these vis sources by right of conquest, despite their location within territory traditionally claimed by members of House Tytalus. This tension between individuals intensified as each side was joined by sodales in their respective Houses. It became as much about ideology as resources. House Tytalus accused House Flambeau of demanding to be rewarded for carrying out their self-appointed duties in slaying members of House Diedne. Scorn was poured on the Flambeaus' self-righteous protestations of justice and honor; there was nothing honorable, the Tytali claimed, about grabbing resources from other Houses and claiming they were spoils of war. At Tribunal, Primus Klynoites referred to the Flambeau as narrow-minded fools who suborned their magic to the dictates of the Quaesitores rather than reveling in the power of their Gifts.
 
 The inter-House conflict threatened to return the Order to the pre-Schism lawlessness. Certamens over resources and territory escalated into cycles of vengeancedriven Wizard's Wars until the original disputes were nearly forgotten, at least by the Tytali. It was the Flambeau who ended the conflict at the Grand Tribunal of 1063; in a show of solidarity they refused to fight the Tytali any more. For the Tytali involved, the conflict had become less about issues and more about the struggle itself. By removing themselves as opponents, the Flambeau effected a truce. In Normandy, legal institutions were put in place to distribute all magical resources acquired during the Schism War. Across Europe, the Grand Tribunal sponsored covenants containing followers of Flambeau and Tytalus, often with Bonisagi of Trianoma's lineage to mediate; and an *entente cordiale* was eventually established between the two Houses, at least on the surface.
 
+> ## Story Seed: Uncivil War
+> 
+> In 1228 the Grand Tribunal will be held. Both Primi will want to represent the House at this prestigious event, and it is likely that the rivalry between the two factions will escalate. A player character who has declared for one side will find himself the target of numerous plots by the other side to reduce the number of opposing supporters; likewise, he will be expected to instigate plots to do the same to his rivals. What started in friendly competition (for the members of House Tytalus, if not the Primi) might become a matter of deadly earnest as the Grand Tribunal approaches.
+> 
+
 #### Primi at War
 
-Twenty-five years ago, Prima Buliste entered a protracted Twilight, and she was declared dead by her younger Hermetic brother Harpax, who had previously been defeated by her for the leadership of the House. Harpax subsequently won the privilege of serving as the tenth Primus. However, three years later, in 1198, Buliste recovered from her temporary Twilight (as some suspected she would), and tried to resume her former position at the head of the House. Characteristically, Harpax refused to relinquish control of House Tytalus to his rival. The House held its breath while the two powerful siblings fought a protracted battle, but no victor emerged. Today, in 1220, the matter has still not been resolved. Both magi have won the right to serve the House as Primus, and neither seems able to gain the upper
+Twenty-five years ago, Prima Buliste entered a protracted Twilight, and she was declared dead by her younger Hermetic brother Harpax, who had previously been defeated by her for the leadership of the House. Harpax subsequently won the privilege of serving as the tenth Primus. However, three years later, in 1198, Buliste recovered from her temporary Twilight (as some suspected she would), and tried to resume her former position at the head of the House. Characteristically, Harpax refused to relinquish control of House Tytalus to his rival. The House held its breath while the two powerful siblings fought a protracted battle, but no victor emerged. Today, in 1220, the matter has still not been resolved. Both magi have won the right to serve the House as Primus, and neither seems able to gain the upper hand over the other. Consequentially, each House-member's decision whether to become a **Decimus** (supporter of the tenth Primus) or a **Fidelus** (loyalist of the ninth Prima) is based on personal choice and/or whim rather than legal merit; only refusing to choose a side invites scorn. Should Tytali from opposite sides encounter one another, they likely as not dispute vociferously about the relative merits of their chosen champion. The domus magna of Fudarus is occupied by both Primi, and has effectively become two covenants under a single roof. While they share the same rooms, barracks, and resources the magi, covenfolk, and grogs loyal to each Primus live separate lives, refusing to acknowledge the existence of the other side. They wear swatches of colored material to distinguish themselves from each other, royal purple for Buliste, and revolutionary green for Harpax, colors which have been adopted as badges by the Fideli and Decimi respectively. Outsiders are perturbed by the seriousness of Tytalan magi in pursuing this conflict, and puzzled that it has been over 20 years and the dispute has still not been resolved. The truth of the matter is that House Tytalus finds the whole business far too enjoyable to be done with it just yet.
 
-hand over the other. Consequentially, each House-member's decision whether to become a **Decimus** (supporter of the tenth Primus) or a **Fidelus** (loyalist of the ninth Prima) is based on personal choice and/or whim rather than legal merit; only refusing to choose a side invites scorn. Should Tytali from opposite sides encounter one another, they likely as not dispute vociferously about the relative merits of their chosen champion. The domus magna of Fudarus is occupied by both Primi, and has effectively become two covenants under a single roof. While they share the same rooms, barracks, and resources the magi, covenfolk, and grogs loyal to each Primus live separate lives, refusing to acknowledge the existence of the other side. They wear swatches of colored material to distinguish themselves from each other, royal purple for Buliste, and revolutionary green for Harpax, colors which have been adopted as badges by the Fideli and Decimi respectively. Outsiders are perturbed by the seriousness of Tytalan magi in pursuing this conflict, and puzzled that it has been over 20 years and the dispute has still not been resolved. The truth of the matter is that House Tytalus finds the whole business far too enjoyable to be done with it just yet.
-
-# The Philosophy of Conflict
+## The Philosophy of Conflict
 
 *A person would make most advantage of justice for himself if he treated the laws as important in the presence of witnesses, and treated the decrees of nature as important when alone.*
 
 — Antiphon
 
-House Tytalus seek to emulate its Founder, considering him to have been the finest magus to have ever existed. They dote on the *Analects of Tytalus*, which describe the route to his power. Philosophers from other Houses have denigrated Tytalus as a true philosopher, claiming he was more a "magpie of wisdom," collecting only those fragments of philosophy which glittered attractively to him. At this point, the Tytali involved in such debates nod their heads
-
-
-vigorously in agreement — finally, someone who understands the Master!
+House Tytalus seek to emulate its Founder, considering him to have been the finest magus to have ever existed. They dote on the *Analects of Tytalus*, which describe the route to his power. Philosophers from other Houses have denigrated Tytalus as a true philosopher, claiming he was more a "magpie of wisdom," collecting only those fragments of philosophy which glittered attractively to him. At this point, the Tytali involved in such debates nod their heads vigorously in agreement — finally, someone who understands the Master!
 
 Of the many schools of ancient Greece which taught philosophy, Tytalus drew most heavily from the teachings of the Sophists; and it is true to say that much of the corpus of Sophistic teaching holds resonance with the members of House Tytalus today. The Sophists were an antagonistic group of scholars who used underhanded tactics to defeat their opponents, and were almost unanimously reviled by later writers. It is clear why their philosophy is so attractive to House Tytalus, for it is based on an underlying conflict — the rivalry between nature and custom.
 
@@ -3447,36 +3242,32 @@ The followers of Tytalus believe that custom is directly antagonistic to what is
 
 #### Calliclean Ethics
 
-*Our unnatural laws mould our best men from their youth up, teaching them that equality is fine and just, but if a character naturally strong enough were to arise, like a young lion he would shake off these fetters, break his cage, and turn master instead*
-
-
-*of slave. Then nature's justice would shine forth in all its glory.*
+*Our unnatural laws mould our best men from their youth up, teaching them that equality is fine and just, but if a character naturally strong enough were to arise, like a young lion he would shake off these fetters, break his cage, and turn master instead of slave. Then nature's justice would shine forth in all its glory.*
 
 — Callicles
 
 Laws and justice are merely devices of the majority of weaklings to keep the strong man (who, by *physis*, is a just man) from his rightful place. It is human nature to behave selfishly, whether as an individual or as a nation, and to be a tyrant who enforces his will on others is both an inescapable consequence of pursuing one's *physis* and an ideal state in which to exist. Luxury, wantonness, and freedom from restraint, if backed by strength, constitutes excellence and happiness; all else is worthless nonsense. The downfall of Tasgillia was that this excellence was all she sought, and that her vanity was superior to her prudence.
 
-### The Philosophers
-
-The following Sophists were often quoted in the *Analects of Tytalus*:
-
-**Antiphon** proposed that man is better off escaping from the constraints of convention. He believed that a man cannot be self-controlled if he has never been tempted, and taught a life of refined and intellectual hedonism, planning the maximum pleasure and the minimum suffering from a brief and imperfect existence.
-
-**Critias** was a leading member of the Thirty Tyrants who ruled Athens following its defeat by the Spartans. He believed that laws were neither inherent in human nature nor a gift from the gods, and that virtue could be imposed by force. Religion was a purely human invention aimed at controlling the masses, and he was a strong opponent of democracy, stating that acceptance of convention was no way to run a nation. He was killed in a civil war against the democrats.
-
-**Gorgias** was a pupil of Empedocles, and taught his pupils to master the arts of persuasion and deceit. He illustrated the
-
 The Calliclean holds that *nomoi* are established by the ruling powers to benefit themselves, not those they rule. As a consequence, the man who acts justly always comes off worse than the unjust man. It is therefore right to seem to be good (i.e., to obey *nomos*), if it brings genuine social advantage, but there is no point in actually being good when no one is looking. It is always better to seize any opportunities to act unfairly if it results in the betterment of the self, but often the self can be served by playing nicely with others and following the dictates of society.
 
-On the face of it, this philosophy seems to suggest that a man should always act selfishly, and always to the detriment of society. However, Callicleans hold that while self-interest is what every *physis* naturally pursues as good, *nomos* constrains it to diverge into respect for equality. Justice depends solely on the equality of power, for without equality, the strong will do what they want, and the weak will submit. Thus, among the Callicleans one can find the root of the belief that from conflict can corrupting power of words by writing a speech in defense of the salacious Helen of Troy. He alerted the listener to the insidious effects of exposure to rhetoric by using those effects on the listener himself. In another work he propounds through logic that a) nothing exists, b) even if there was something, knowledge of it was impossible, and c) even if we could know about it, we could never communicate it to anyone else.
-
-**Hippias** believed in the fundamental unity of mankind through unwritten laws of divine provenance. He suggested that laws which derive from human agreement and custom build barriers between people, and can equally be a tyrant or a peacemaker.
-
-**Protagoras** achieved a reputation as a political and moral thinker without becoming involved in politics or seeking power for himself. He taught that humans are the yardstick for deciding what counts and what doesn't count as real. The world is as we make it out to be; there is no independent truth.
-
-come growth; a weak man can be taught to be strong by hardship and strife, and thus challenge the limitations of his nature.
+On the face of it, this philosophy seems to suggest that a man should always act selfishly, and always to the detriment of society. However, Callicleans hold that while self-interest is what every *physis* naturally pursues as good, *nomos* constrains it to diverge into respect for equality. Justice depends solely on the equality of power, for without equality, the strong will do what they want, and the weak will submit. Thus, among the Callicleans one can find the root of the belief that from conflict can come growth; a weak man can be taught to be strong by hardship and strife, and thus challenge the limitations of his nature.
 
 Callicleans are driven to force the world to accommodate their selfish aims. They usually show no compunction in breaking rules that do not suit them, although they recognize the need to sometimes do so in secret. Typical roles for these magi are hedonists, bullies, tyrants, duelists, thrill-seekers, and *agents provocateurs*.
+
+> ## The Philosophers
+> 
+> The following Sophists were often quoted in the *Analects of Tytalus*:
+> 
+> **Antiphon** proposed that man is better off escaping from the constraints of convention. He believed that a man cannot be self-controlled if he has never been tempted, and taught a life of refined and intellectual hedonism, planning the maximum pleasure and the minimum suffering from a brief and imperfect existence.
+> 
+> **Critias** was a leading member of the Thirty Tyrants who ruled Athens following its defeat by the Spartans. He believed that laws were neither inherent in human nature nor a gift from the gods, and that virtue could be imposed by force. Religion was a purely human invention aimed at controlling the masses, and he was a strong opponent of democracy, stating that acceptance of convention was no way to run a nation. He was killed in a civil war against the democrats.
+> 
+> **Gorgias** was a pupil of Empedocles, and taught his pupils to master the arts of persuasion and deceit. He illustrated the corrupting power of words by writing a speech in defense of the salacious Helen of Troy. He alerted the listener to the insidious effects of exposure to rhetoric by using those effects on the listener himself. In another work he propounds through logic that a) nothing exists, b) even if there was something, knowledge of it was impossible, and c) even if we could know about it, we could never communicate it to anyone else.
+> 
+> **Hippias** believed in the fundamental unity of mankind through unwritten laws of divine provenance. He suggested that laws which derive from human agreement and custom build barriers between people, and can equally be a tyrant or a peacemaker.
+> 
+> **Protagoras** achieved a reputation as a political and moral thinker without becoming involved in politics or seeking power for himself. He taught that humans are the yardstick for deciding what counts and what doesn't count as real. The world is as we make it out to be; there is no independent truth.
+> 
 
 #### Hippian Ethics
 
@@ -3490,10 +3281,7 @@ Hippians seek to reform those laws and customs that are (in their opinion) contr
 
 #### Growth Through Conflict
 
-Tytalus adopted the motto of the House for a reason; he believed that adversity brings positive change. A Hippian magus sees this as the purpose of his conflicts and intrigues, whereas one with a Calliclean ethic considers this to be a side effect, albeit a beneficial one. The war with Damhan-Allaidh led to the creation of House Ex Miscellanea. The Schism War ended decades of contention and ushered in an era of peace to the Order as a whole. House Tytalus's conflict with House Flambeau (see History) precipitated the rise in power of the milites within that House. On a more personal level, a magus who tries to exploit a loophole in the Code of Hermes only serves to promote rulings that eliminate those inconsistencies. A magus who struggles against his rival
-
-
-amasses personal power in an attempt to overcome that foe. A magus who hoodwinks another in an intrigue makes his victim more cautious, and less likely to be fooled again. This drive towards constant growth also allows Tytali to snatch victory from the jaws of defeat by claiming selfimprovement when a plan fails.
+Tytalus adopted the motto of the House for a reason; he believed that adversity brings positive change. A Hippian magus sees this as the purpose of his conflicts and intrigues, whereas one with a Calliclean ethic considers this to be a side effect, albeit a beneficial one. The war with Damhan-Allaidh led to the creation of House Ex Miscellanea. The Schism War ended decades of contention and ushered in an era of peace to the Order as a whole. House Tytalus's conflict with House Flambeau (see History) precipitated the rise in power of the milites within that House. On a more personal level, a magus who tries to exploit a loophole in the Code of Hermes only serves to promote rulings that eliminate those inconsistencies. A magus who struggles against his rival amasses personal power in an attempt to overcome that foe. A magus who hoodwinks another in an intrigue makes his victim more cautious, and less likely to be fooled again. This drive towards constant growth also allows Tytali to snatch victory from the jaws of defeat by claiming selfimprovement when a plan fails.
 
 ### Tools of Conflict
 
@@ -3527,7 +3315,7 @@ The strength of a Tytalus is a full understanding of his own *physis*, and the r
 
 Crushed by defeat again and again, an apprentice to a Tytalus magus must learn to strive against injustice to fulfill his nature. This struggle builds the necessary mental armor to survive almost anything that life throws at him. The strength of will that drives every Tytalan magus though life is perhaps their most distinctive feature. Some members of House Tytalus turn this philosophy against others, supplying the hardship and denying the pleasure so as to forge steel from crude iron. Most subjects of this treatment do not appreciate the attention.
 
-# Culture
+## Culture
 
 *Remember me for this, if nothing else — I can forge your weapons, I can strap you into your armor, I can even choose the battlefield; but only you can win the fight.*
 
@@ -3537,17 +3325,14 @@ For a House that teaches that there is nothing morally repugnant in acting selfi
 
 While rivalry plays a major role in the life of a Tytalan magus, there are other things that bind the house together.
 
-
-#### Societates
-
-### Rumors
-
-The following is a small selection of the current rumors surrounding the Founder. There are many more, on all kinds of topics:
-
-- Tytalus resigned from the world to become a god, and he can now be summoned by powerful theurgists. •
-- Tytalus still lives; one day he will win free from the Queen of the Faeries and return to the world. On that day, there will be a queue of Tytali waiting to discover whether their Founder is as good as his legends claim. •
-- Pralix and Hariste were two personae of the same magus, perhaps even Tytalus himself. That's why they disappeared in the same month. •
-- Tytalus discovered that Bonisagus was really a faerie called Alberich; yes, the same one as in the *Nibelungenlied*. •
+> ## Rumors
+> 
+> The following is a small selection of the current rumors surrounding the Founder. There are many more, on all kinds of topics:
+> 
+> - Tytalus resigned from the world to become a god, and he can now be summoned by powerful theurgists.
+> - Tytalus still lives; one day he will win free from the Queen of the Faeries and return to the world. On that day, there will be a queue of Tytali waiting to discover whether their Founder is as good as his legends claim.
+> - Pralix and Hariste were two personae of the same magus, perhaps even Tytalus himself. That's why they disappeared in the same month.
+> - Tytalus discovered that Bonisagus was really a faerie called Alberich; yes, the same one as in the *Nibelungenlied*.
 
 #### Reverence for the Founder
 
@@ -3577,11 +3362,7 @@ A Tytalus gives his instruction either to small circles of pupils (which may inc
 
 > *—* Cercistum, Primus of House Tremere during the Schism War
 
-Members of House Tyalus are clearly a contentious bunch, but this does not make them unpleasant. When meeting in public they usually appear to be friendly to each other; only when they are excruciatingly polite to each other can an undercurrent of a rivalry be detected. By no means are all Tytali cut from the same cloth as the argumentative and unpleasant stereotype. However, because of their love of intrigue, many Tytalan magi are inveterate gossips who love nothing better than to discuss with each other the foibles of a third party. As well as besmirching the reputations of others, they are keen to enhance their own, and a magus may often be boastful and prone to self-aggrandization when in the company
-
-
-
-of others of his House. This combination of gossip and intrigue also makes them purveyors of conspiracy, and they tend to see the hand of a clandestine cabal in the hand of every major event in society, both Hermetic and mundane.
+Members of House Tyalus are clearly a contentious bunch, but this does not make them unpleasant. When meeting in public they usually appear to be friendly to each other; only when they are excruciatingly polite to each other can an undercurrent of a rivalry be detected. By no means are all Tytali cut from the same cloth as the argumentative and unpleasant stereotype. However, because of their love of intrigue, many Tytalan magi are inveterate gossips who love nothing better than to discuss with each other the foibles of a third party. As well as besmirching the reputations of others, they are keen to enhance their own, and a magus may often be boastful and prone to self-aggrandization when in the company of others of his House. This combination of gossip and intrigue also makes them purveyors of conspiracy, and they tend to see the hand of a clandestine cabal in the hand of every major event in society, both Hermetic and mundane.
 
 Magi of House Tytalus are also prone to obsession, occasionally to the point of psychosis. In the pursuit of his rivalry a magus can become excessively focused on the target of his intentions, and develop a deep emotional bond disturbing for outsiders to behold. Taken to extremes, a maga might begin to stalk her target, obsessively collecting his refuse and even sneaking into his sanctum when she knows her rival is not there. She may severely threaten his life by arranging dangerous challenges so that she can derive vicarious pleasure from his triumph. This darker side of Tytalan rivalry is mercifully rare in its most extreme form, but every Tytalus who undertakes a rivalry shares in it to some extent.
 
@@ -3589,55 +3370,45 @@ It is rare for a member of this House to fall for the same trick twice; a vanqui
 
 A follower of Tytalus is rarely gracious in victory. It is important to his ego and his reputation in the House that a defeated opponent fully recognizes the winner's superiority, and the more public the defeat, the better. To other Houses, crowing over a victory often appears to be unnecessarily arrogant, but Tytalan magi cannot feel shame over such a thing. As Tytalus said, "To be forgotten is a crime, to be recognized for a crime is a victory; but to be recognized for great victory is to touch godhood."
 
-### Tytalan Names
-
-When Tytalus adopted wizards into his House, he gifted each with a Hermetic name for everyday use, using the names and titles of the Titans as his inspiration. Clearly, this list was limited in size, and Tytalus was not above creating false names with fabricated meanings. The Primi of House Tytalus still reserve the right to confer a magus's name upon his initiation into the Order, but in modern times the magus is permitted to choose the name himself; the written endorsement from the Primus is merely a formality. Many Tytali still choose for themselves a name styled after the Titans of ancient time; alternatively, magi might manufacture names for themselves by combining a prefix with a gender-specific suffix.
-
-| Prefixes | Female<br>suff<br>ixes | Male<br>suff<br>ixes |
-|----------|------------------------|----------------------|
-| Okean-   | -ia                    | -noites              |
-| Kron-    | -is                    | -nos                 |
-| Aster-   | -ome                   | -petos               |
-| At-      | -ibe                   | -lios                |
-| Hel-     | -emis                  | -las                 |
-| Pho-     | -ione                  | -ses                 |
-| Per-     | -ene                   | -theus               |
-| Kly-     | -etis                  | -rion                |
-|          |                        |                      |
-
-|  | Prefixes | Female       | Male         |
-|--|----------|--------------|--------------|
-|  |          | suff<br>ixes | suff<br>ixes |
-|  | Har-     | -illia       | -lus         |
-|  | Bul-     | -iste        | -cus         |
-|  | Kal-     | -ix          | -butes       |
-|  | Tas(g)-  | -egis        | -pax         |
-|  | Hyp-     | -eppo        | -das         |
-|  | Iap-     | -atia        | -rates       |
-|  | Men-     | -ine         | -krax        |
-
-For female names, the last consonant of the prefix is often doubled. Example names: Perrene, Iapatia, Hypeppo, Okeanibe, Helletis, Klyome.
-
-For male names, the last consonant of the prefix is often deleted if it clashes with the initial consonant of the male suffix. Example names: Perion, Iaprax, Hydas, Okealas, Hertheus, Klyses.
-
-**Female Titan Names:** Ankhiale, Asteria, Dione, Eos, Eurynome, Klymene, Kybele, Metis, Mnemosyne, Phoibe, Rhea, Selene, Tethys, Theia, Themis
-
-**Male Titan Names:** Adanos, Astraios, Atlas, Epimetheus, Helios, Hyperion, Iapetos, Koios, Krios, Kronos, Menoites, Okeanos, Pallas, Perses, Prometheus
+> ## Tytalan Names
+> 
+> When Tytalus adopted wizards into his House, he gifted each with a Hermetic name for everyday use, using the names and titles of the Titans as his inspiration. Clearly, this list was limited in size, and Tytalus was not above creating false names with fabricated meanings. The Primi of House Tytalus still reserve the right to confer a magus's name upon his initiation into the Order, but in modern times the magus is permitted to choose the name himself; the written endorsement from the Primus is merely a formality. Many Tytali still choose for themselves a name styled after the Titans of ancient time; alternatively, magi might manufacture names for themselves by combining a prefix with a gender-specific suffix.
+> 
+> | Prefixes | Female suffixes | Male suffixes |
+> |----------|------------------|---------------|
+> | Okean-   | -ia              | -noites       |
+> | Kron-    | -is              | -nos          |
+> | Aster-   | -ome             | -petos        |
+> | At-      | -ibe             | -lios         |
+> | Hel-     | -emis            | -las          |
+> | Pho-     | -ione            | -ses          |
+> | Per-     | -ene             | -theus        |
+> | Kly-     | -etis            | -rion         |
+> | Har-     | -illia           | -lus          |
+> | Bul-     | -iste            | -cus          |
+> | Kal-     | -ix              | -butes        |
+> | Tas(g)-  | -egis            | -pax          |
+> | Hyp-     | -eppo            | -das          |
+> | Iap-     | -atia            | -rates        |
+> | Men-     | -ine             | -krax         |
+> 
+> For female names, the last consonant of the prefix is often doubled. Example names: Perrene, Iapatia, Hypeppo, Okeanibe, Helletis, Klyome.
+> 
+> For male names, the last consonant of the prefix is often deleted if it clashes with the initial consonant of the male suffix. Example names: Perion, Iaprax, Hydas, Okealas, Hertheus, Klyses.
+> 
+> **Female Titan Names:** Ankhiale, Asteria, Dione, Eos, Eurynome, Klymene, Kybele, Metis, Mnemosyne, Phoibe, Rhea, Selene, Tethys, Theia, Themis
+> 
+> **Male Titan Names:** Adanos, Astraios, Atlas, Epimetheus, Helios, Hyperion, Iapetos, Koios, Krios, Kronos, Menoites, Okeanos, Pallas, Perses, Prometheus
 
 #### Beloved Rivals
 
 *Hate is as powerful as Love. Who is to judge which is the most noble?*
 
-*—* Analects of Tytalus
+— Analects of Tytalus
 
 A Tytalan apprenticeship is not a pleasant experience (see below), and the competition that develops between master and pupil is often the most intense relationship of a magus's career. The resentment built up over a 15-year apprenticeship is not easy to shed, even if the magus realizes why he had to suffer at the hands of his master. Resentment (and even hatred) often matures into rivalry, as the former apprentice uses his newfound freedom to lash out at his tormentor. That spark of contention never subsides, even if (or perhaps because) the magus grows to respect his master, and it is not unusual for a Tytalus to have a protector and a foe who are the same person!
 
-Should this hostility not resolve itself naturally, then a magus can make an official declaration of rivalry by declaring that they are Beloved Rivals. This is not a thing to be entered into lightly, for once declared — usually ceremonially, with the issuance to the rival of a spiral drawn in the magus's own blood — the rivalry will persist until the death of one or other of the opponents. Formally declared rivalries extend throughout one's life; at every turn, the rival is there, waiting for signs of weakness. The two magi do everything they can to hinder each other, even putting each other's lives in danger. However, when they meet in person, they are often inseparable, like a
-
-
-#### Societates
-
-doting father with his beloved son. Beloved Rivals most commonly exist between master and pupil, but could potentially exist between any pair of Tytali who have sufficient cause.
+Should this hostility not resolve itself naturally, then a magus can make an official declaration of rivalry by declaring that they are Beloved Rivals. This is not a thing to be entered into lightly, for once declared — usually ceremonially, with the issuance to the rival of a spiral drawn in the magus's own blood — the rivalry will persist until the death of one or other of the opponents. Formally declared rivalries extend throughout one's life; at every turn, the rival is there, waiting for signs of weakness. The two magi do everything they can to hinder each other, even putting each other's lives in danger. However, when they meet in person, they are often inseparable, like a doting father with his beloved son. Beloved Rivals most commonly exist between master and pupil, but could potentially exist between any pair of Tytali who have sufficient cause.
 
 Beloved Rivals use formal modes of address to signify this relationship, and to warn spectators not to get in the way. Between members of the same Hermetic "family" — master to pupil, or between filii of the same master — Tytali use the adjective **carus** (feminine cara, "beloved") to indicate a rival. Thus a maga and her former pupil might refer to each other as mater cara ("beloved mother") and filius carus ("beloved son"). Between unrelated magi, the terms used are cognatus praeclarus or cognata praeclara (for men and women, respectively), meaning "honored kinsman/woman." When these terms are used, other Tytali know not to interfere in their rivalries. The comparatives (praeclarior, "more honored"; and carior "more beloved") and superlatives (praeclarissimus/ a, "most honored"; and carissimus/a, "most beloved") of these adjectives are used to ironic effect.
 
@@ -3657,7 +3428,7 @@ House Tytalus is seen by its members as a large family, with the Primus at the h
 
 *May deeds illustrious thy protection claim, and find, led on by thee, immortal fame.*
 
-*—* Orphic Hymn to Nike
+— Orphic Hymn to Nike
 
 House Tytalus does not hold regular meetings of the House. Whereas other Houses feel the need for periodic meetings to share knowledge, determine political agendas, and reinforce bonds with other members of the House, Tytalan magi eschew all of these things, and thus have no need for meetings. This is not to say that members of House Tytalus never hold meetings; it is just that these meetings are never regular, and rarely include even a substantial fraction of the House. Occasionally, two Tytali feel the need to publicly resolve their differences, and they call for an **eristic moot**.
 
@@ -3665,22 +3436,17 @@ These moots are public disputes between competing speakers. Announcement of the 
 
 Most commonly there are two participants, and up to a dozen observers, but participants might form teams to defeat powerful rivals, or each magus might find himself facing multiple individual opponents. Further, it is not unknown for the observers to become participants over the course of the dispute. By convention, the minimum attendance for an eristic moot is five — two participants and three witnesses.
 
-As the name might suggest (deriving from *eris*, Greek for "strife"), these moots are not places where disputes are settled peacefully. Each participant in the moot does his utmost to defeat his opponent through any means necessary. The "weapons" allowed in a moot must be decided in advance; battles of words are the most common, and rules for adjudicating debates are
+As the name might suggest (deriving from *eris*, Greek for "strife"), these moots are not places where disputes are settled peacefully. Each participant in the moot does his utmost to defeat his opponent through any means necessary. The "weapons" allowed in a moot must be decided in advance; battles of words are the most common, and rules for adjudicating debates are given later on in this chapter. Occasionally opponents agree to physical or magical combat, although the latter is disallowed in a subtle contest. If magic is employed in the moot, then certamen is frequently used, although some opponents find this overly constraining. In front of the witnesses, both opponents may publicly declare that their intent is not to threaten the life of their counterpart with their spells, and permit each other to use whatever scrying magic is at their command. With these declarations in place, the opponents are free to use any magic against each other that they see fit, and only the death of an opponent results in a prosecution under the Code of Hermes.
 
-### Stories Arising from Eristic Moots
+There are two special kinds of eristic moot practiced by the House. The first is an Apprentice's Gauntlet, where an apprentice uses the formal procedure of the moot, in front of witnesses of the House, to force his master to accept his status as a full member of the Order. The other specific moot is held one year after the death or Final Twilight of the Primus of House Tytalus. This moot is always hosted by the covenant of Fudarus, and all Tytalan magi do their very best to attend; all other witnesses are excluded. Everyone who considers himself worthy of the position of Primus is an opponent, and it is a "sudden-death" tournament that lasts until there is one contestant left — the new Primus. In such a high-powered expression of the eristic moot, the most skilled members of the House have eliminated some of their competitors even before setting foot in Fudarus, already outmaneuvering their opponent on a social level through blackmail, rumor, and other dirty tricks.
 
-Moots are a great place to further one's own ambitions within the House, even if just as an observer. Whether one of the participants in a moot is an ally or an enemy, a player character might discover something about that participant that he would rather had been kept hidden.
-
-A subtle contest of arms presents an interesting legal issue: does this count as "attempting to slay another magus" under the Code, or is preserving the ignorance of the mundane witnesses more important?
-
-A rival allows himself to be defeated at a moot; his contrite admission of weakness inflicts more damage to his opponent than his victory ever could.
-
-given later on in this chapter. Occasionally opponents agree to physical or magical combat, although the latter is disallowed in a subtle contest. If magic is employed in the moot, then certamen is frequently used, although some opponents find this overly constraining. In front of the witnesses, both opponents may publicly declare that their intent is not to threaten the life of their counterpart with their spells, and permit each other to use whatever scrying magic is at their command. With these declarations in place, the opponents are free to use any magic against each other that they see fit, and only the death of an opponent results in a prosecution under the Code of Hermes.
-
-There are two special kinds of eristic moot practiced by the House. The first is an Apprentice's Gauntlet, where an apprentice uses the formal procedure of the moot, in front of witnesses of the House, to force his master to accept his status as a full member of the Order. The other specific moot is held one year after the death or Final Twilight of the Primus of House Tytalus. This moot is always hosted by the covenant of Fudarus, and all Tytalan magi do their very best to attend; all other witnesses are excluded. Everyone who considers himself worthy of the position of Primus is an opponent, and it is a
-
-
-"sudden-death" tournament that lasts until there is one contestant left — the new Primus. In such a high-powered expression of the eristic moot, the most skilled members of the House have eliminated some of their competitors even before setting foot in Fudarus, already outmaneuvering their opponent on a social level through blackmail, rumor, and other dirty tricks.
+> ## Stories Arising from Eristic Moots
+> 
+> Moots are a great place to further one's own ambitions within the House, even if just as an observer. Whether one of the participants in a moot is an ally or an enemy, a player character might discover something about that participant that he would rather had been kept hidden.
+> 
+> A subtle contest of arms presents an interesting legal issue: does this count as "attempting to slay another magus" under the Code, or is preserving the ignorance of the mundane witnesses more important?
+> 
+> A rival allows himself to be defeated at a moot; his contrite admission of weakness inflicts more damage to his opponent than his victory ever could.
 
 ### Apprenticeship
 
@@ -3692,44 +3458,37 @@ House Tytalus is infamous in the Order of Hermes for its treatment of its appren
 
 Tytalus suffered greatly during his training under Guorna the Fetid — perhaps more so than is acceptable in the modern Order — and he hints that he tried to end his suffering more than once. After the fact, Tytalus reasoned that through his suffering he was able to reach deeper into himself and find reserves of magic and strength that would have remained untapped. Tytalus believed that he did an injustice to Tremere by mitigating Guorna's cruelty, leaving him "half-baked" — more than a man, but less than a magus.
 
-Tytalan magi usually choose older children than other Houses, and ensure that they are well-schooled in Latin, Artes Liberales, and Athletics (the subjects favored by the Sophists) before apprenticeship begins. This education usually comes from enrollment in a good cathedral school, or else employs private tutors, perhaps even the magus himself, under the disguise of a persona (see below). The child is kept oblivious of the magical destiny ahead of him. After at least four years of this schooling, the student is retrieved from his tutors and informed of his true path. The
-
-### Excerpts from the Book of Instruction
-
-An apprentice in his first two years of training must keep his head below the level of his shoulders while cleaning laboratory equipment. An apprentice who has passed his sixth year of instruction must hold an object of wood between his teeth when performing this task.
-
-Making eye contact with a magus other than the master before the sun has set is to be punished by having to carry a pig's head on his back for a month, unless there has been thunder that morn, in which case the head will be from a goat, and the period will last one season.
-
-An apprentice is allowed a halfhour's rest every four hours, except on Thursdays, when he will receive five minutes every hour. In the months where the Ides fall on the 15th day, these rest periods are reversed.
-
-Touching the fur or scales of a familiar is to be punished by having three clay marbles inserted into the shoe of the left foot until they have been ground into powder through the action of walking.
-
-Surliness is to be punished by holding two bowls of water at arm's length following every meal, for a total time of one day, divided up into as many periods as it takes to complete this penalty.
-
-Obduracy is to be punished by the collection of 144 pinecones.
-
-Intransigence is to be punished by wearing clothes soaked in vinegar for one week.
-
-### Eschewing the Book of Instruction
-
-The *Book of Instruction* is the most hated object of a Tytalan apprentice, and having suffered for 15 years under its dictates, a newly-Gauntleted magus often swears to never use it on his own apprentices. Almost invariably, however, when the time comes to begin such training, he procures a copy and sticks to it rigidly, now convinced of its true utility in producing apprentices of the highest caliber. A maga deciding not to use the book should employ a similarly harsh regime designed to build self-confidence and harden the spirit, for her apprentice must learn the value of choosing *physis* over *nomos*, else he cannot call himself a follower of Tytalus.
-
-master then opens the apprentice's Arts, and begins his Hermetic training.
+Tytalan magi usually choose older children than other Houses, and ensure that they are well-schooled in Latin, Artes Liberales, and Athletics (the subjects favored by the Sophists) before apprenticeship begins. This education usually comes from enrollment in a good cathedral school, or else employs private tutors, perhaps even the magus himself, under the disguise of a persona (see below). The child is kept oblivious of the magical destiny ahead of him. After at least four years of this schooling, the student is retrieved from his tutors and informed of his true path. The master then opens the apprentice's Arts, and begins his Hermetic training.
 
 During the next 15 years, the apprentice's life is exceptionally hard. No luxury is afforded the apprentice; he enters a life of virtual slavery from his hitherto privileged schooling. Only meager provisions and squalid conditions are supplied, and when not receiving direct instruction or providing assistance, the tasks assigned to him vary from the monotonously tedious to the downright dangerous. While many of the practices employed by a Tytalan master seem cruel, the purpose is not cruelty for its own sake. Rather, the master seeks to reveal the injustices of the laws (*nomoi*) imposed by an arbitrary society, and make the apprentice rebel against custom and embrace his *physis*. To this end, a master often employs the *Book of Instruction*, a text written by Tytalus himself,
 
 which lays down explicit rules as to the correct behavior of an apprentice, and the punishments applied to infractions of these rules. The penalties are both arbitrary and seemingly random, and have absolutely no instructional value: the *Book of Instruction* does not legislate upon how to train an apprentice, but rather how to treat him. A master often pretends to sympathize with her pupil, appealing to the iron law of the *Book of Instruction* as her excuse: "I don't want to do this to you, really I don't. But the *Book of Instruction* dictates that washing on a Thursday is prohibited. I have no choice."
 
-In the latter years of the apprenticeship, the master deliberately exposes her pupil to the culture of the House through the eristic moots, stressing the huge inequality between his current situation and the rule-flouting attitude of the House, while continuing to punish any
-
-
-#### Societates
-
-sign of complaint or dissatisfaction. Many apprentices run away at least once during apprenticeship, others take out their frustration on other children in the covenant through bullying. Some harbor fantasies of murder, although few act on these urges. Nevertheless, it is a foolish master who does not take precautions against harm from the person who stands at her back, cooks her food, and shares her sanctum when she is sleeping.
+In the latter years of the apprenticeship, the master deliberately exposes her pupil to the culture of the House through the eristic moots, stressing the huge inequality between his current situation and the rule-flouting attitude of the House, while continuing to punish any sign of complaint or dissatisfaction. Many apprentices run away at least once during apprenticeship, others take out their frustration on other children in the covenant through bullying. Some harbor fantasies of murder, although few act on these urges. Nevertheless, it is a foolish master who does not take precautions against harm from the person who stands at her back, cooks her food, and shares her sanctum when she is sleeping.
 
 The point of this treatment is not to crush the apprentice's ego but to forge it into an iron will. That spark of rebellion, a surliness or disobedience which is the first sign of an emerging will, is be fanned into a raging turmoil of emotion in the adolescent's mind, and then honed by resentment into a dangerous weapon. A Calliclean master tries to provoke that rebellious streak into active conflict, whereas a Hippian master guides her apprentice towards avoiding penalty on technicalities, and flagrantly disregarding the rules when he thinks his master is not watching. Both types of master exhibit public disapproval of her apprentice's actions while privately reveling in them.
 
 If the teaching methods of Tytalus fail to produce the right caliber of student, the master does not continue his education. A failure to react against the harsh training leads to a life outside House Tytalus; such an unfortunate is passed off to another House, or abandoned altogether (resulting in the Failed Apprentice Social Virtue).
+
+> ## Excerpts from the Book of Instruction
+> 
+> An apprentice in his first two years of training must keep his head below the level of his shoulders while cleaning laboratory equipment. An apprentice who has passed his sixth year of instruction must hold an object of wood between his teeth when performing this task.
+> 
+> Making eye contact with a magus other than the master before the sun has set is to be punished by having to carry a pig's head on his back for a month, unless there has been thunder that morn, in which case the head will be from a goat, and the period will last one season.
+> 
+> An apprentice is allowed a halfhour's rest every four hours, except on Thursdays, when he will receive five minutes every hour. In the months where the Ides fall on the 15th day, these rest periods are reversed.
+> 
+> Touching the fur or scales of a familiar is to be punished by having three clay marbles inserted into the shoe of the left foot until they have been ground into powder through the action of walking.
+> 
+> Surliness is to be punished by holding two bowls of water at arm's length following every meal, for a total time of one day, divided up into as many periods as it takes to complete this penalty.
+> 
+> Obduracy is to be punished by the collection of 144 pinecones.
+> 
+> Intransigence is to be punished by wearing clothes soaked in vinegar for one week.
+
+> ## Eschewing the Book of Instruction
+> 
+> The *Book of Instruction* is the most hated object of a Tytalan apprentice, and having suffered for 15 years under its dictates, a newly-Gauntleted magus often swears to never use it on his own apprentices. Almost invariably, however, when the time comes to begin such training, he procures a copy and sticks to it rigidly, now convinced of its true utility in producing apprentices of the highest caliber. A maga deciding not to use the book should employ a similarly harsh regime designed to build self-confidence and harden the spirit, for her apprentice must learn the value of choosing *physis* over *nomos*, else he cannot call himself a follower of Tytalus.
 
 #### The Apprentice's Gauntlet
 
@@ -3739,29 +3498,23 @@ An apprentice who succeeds in killing his master at any point in his apprentices
 
 #### Joining House Tytalus
 
-Any member of another House, or a hedge wizard, can join House Tytalus if he can accept the philosophy of the Founder expounded in the *Analects of Tytalus*, and succeed in forcing a Tytalan magus (of a similar or greater age) to accept him as worthy, as in an Apprentice's Gauntlet. However, a general lack of wizards seeking to join the Order of Hermes in the 13th
-
-### Story Seed: The Unwilling King
-
-A non-Tytalus character makes an enemy of a Tytalus. She fights him for years in all arenas. Finally, when the non-Tytalus manages to inflict the final blow that lays her opponent low for good, he welcomes her to House Tytalus. By defeating him, she has passed the Gauntlet of the House. From then on, all Tytali of the Tribunal refer to the maga as a member of their House, much to her embarrassment.
-
-century, and the difficulty in passing the Gauntlet, means that most modern Tytalan magi have been raised within the House.
+Any member of another House, or a hedge wizard, can join House Tytalus if he can accept the philosophy of the Founder expounded in the *Analects of Tytalus*, and succeed in forcing a Tytalan magus (of a similar or greater age) to accept him as worthy, as in an Apprentice's Gauntlet. However, a general lack of wizards seeking to join the Order of Hermes in the 13th century, and the difficulty in passing the Gauntlet, means that most modern Tytalan magi have been raised within the House.
 
 It is not even necessary for a magus to renounce membership of his former House to join House Tytalus; anyone who has proved himself worthy is entitled to call himself a Tytalus, regardless of what others call him (or even what he calls himself). Of course, since House Tytalus is the only one of the 12 Houses that permit dual membership, the Order of Hermes does not look kindly on such magi, and they are rare.
 
 Winning recognition as a member of House Tytalus is considered to be the highest accolade afforded to non-Tytali, for they consider themselves to be the best among magi. Because of the somewhat loose definition of "a member of House Tytalus," a magus may find that he has earned that status unwittingly, having unequivocally defeated a Tytalus administering the Gauntlet of the House to him. Henceforth, members of House Tytalus persist in referring to that magus as being of House Tytalus, often to the frustration and embarrassment of the magus involved. Of course, forcing the House to rescind the honor of membership only convinces the Tytali more strongly that the unwilling member of the House is deserving of that status!
 
-From this attitude it also follows that a magus ceases to be a member of House Tytalus if he becomes disillusioned with its philosophy. It is virtually unheard-of for a Tytalan magus to be cast out of the House without his consent, but a magus occasionally requests that the Primus of
+From this attitude it also follows that a magus ceases to be a member of House Tytalus if he becomes disillusioned with its philosophy. It is virtually unheard-of for a Tytalan magus to be cast out of the House without his consent, but a magus occasionally requests that the Primus of Tytalus allows him to relinquish his status as a member of the House. The magus then has a year to join a new House before he is punished for vagrancy (see *Houses of Hermes: True Lineages*, House Guernicus). Many Houses do not trust a magus who renounces House Tytalus, assuming it is all part of some grander plot.
 
-
-
-Tytalus allows him to relinquish his status as a member of the House. The magus then has a year to join a new House before he is punished for vagrancy (see *Houses of Hermes: True Lineages*, House Guernicus). Many Houses do not trust a magus who renounces House Tytalus, assuming it is all part of some grander plot.
+> ## Story Seed: The Unwilling King
+> 
+> A non-Tytalus character makes an enemy of a Tytalus. She fights him for years in all arenas. Finally, when the non-Tytalus manages to inflict the final blow that lays her opponent low for good, he welcomes her to House Tytalus. By defeating him, she has passed the Gauntlet of the House. From then on, all Tytali of the Tribunal refer to the maga as a member of their House, much to her embarrassment.
 
 ### Cabals
 
 *Tragedy creates a deception in which the deceiver is more just than the nondeceiver, and the deceived is wiser than the undeceived.*
 
-*—* Gorgias
+— Gorgias
 
 Tytalan magi clearly maintain a culture within their House that is focused on clever schemes and plots, to advance both their own power and, through their conflict, advance the power of the House and perhaps even the Order of Hermes. However, few followers of Tytalus pursue their more lofty schemes without assistance. When a group of followers of Tytalus seek to change society in a coordinated manner, they form a **cabal**. A magus's personal rivalry — with "family" or otherwise — is his own business, but a magus need not stand alone when his schemes could benefit others.
 
@@ -3773,27 +3526,25 @@ This next meeting is the inaugural meeting of the new cabal. Only those who are 
 
 Once formed, cabals usually have a closed membership, but a magus who publicly displays adherence to a goal pursued by a cabal may receive one or more invitations to join from current members; of course, he might be a member already! A magus typically receives an invitation to form a new cabal once every few years, or more frequently if the local area has a substantial Tytalan presence. A typical cabal consists of 3–6 members, and meets once every few years. Many followers of House Tytalus are active members of one or two cabals, and less active members of several others; these cabals may even have conflicting goals, with those who are members of each deliberately manipulating both to eventually face each other to determine which one is the stronger. Most Tytali find such political games highly entertaining.
 
+> ## Current Cabals
+> 
+> Detailed below are some examples of cabals that are currently active or soon to form. Note that the goals of these cabals vary enormously, from the straightforward to the ambitious, and some might have aims that exceed the limits prescribed by the Code of Hermes. The names of cabals are usually somewhat esoteric and mysterioussounding, and they employ a symbol with which to identify anonymous communiqués from cabal members.
+> 
+> **The Cabal of the Broken Ocean** (Symbol: A clockwise turbo of four lines, making one quarter-turn each). Provides covert support to the pagans of Lithuania against the Teutonic Knights.
+> 
+> **The Cabal of Erigone** (Symbol: a triangular clavicula). Determined to prevent Caecilius of Durenmar from becoming praeco of the Rhine Tribunal (see *Guardians of the Forests*, page 27), although only half of its membership are members of that Tribunal.
+> 
+> **The Cabal of the Lance** (Symbol: a helix made from chain). Covertly shielding a newly formed covenant from the intrigue of its tribunal, though to what purpose is unclear. The covenant protected by this cabal are unaware of their guardians.
+> 
+> **The Cabal of the Shining Eye** (Symbol: A concha with an eagle at the center). Dedicated to maneuvering the Roman Tribunal into colonization of North Africa.
+> 
+> **The Unnamed Cabal** (Symbol: a counterclockwise swirl of five lines, which double back on one another and create a vertex). Spoken of in hushed tones, the Unnamed Cabal's goal is to ensure that the other cabals are kept in conflict with each other. It is supposedly composed of the most powerful Tytalus Archmagi, and, some claim, Tytalus himself! There may even be more than one cabal with this goal. . . .
 
-### Current Cabals
-
-Detailed below are some examples of cabals that are currently active or soon to form. Note that the goals of these cabals vary enormously, from the straightforward to the ambitious, and some might have aims that exceed the limits prescribed by the Code of Hermes. The names of cabals are usually somewhat esoteric and mysterioussounding, and they employ a symbol with which to identify anonymous communiqués from cabal members.
-
-**The Cabal of the Broken Ocean** (Symbol: A clockwise turbo of four lines, making one quarter-turn each). Provides covert support to the pagans of Lithuania against the Teutonic Knights.
-
-**The Cabal of Erigone** (Symbol: a triangular clavicula). Determined to prevent Caecilius of Durenmar from becoming praeco of the Rhine Tribunal (see *Guardians of the Forests*, page 27), although only half of its membership are members of that Tribunal.
-
-**The Cabal of the Lance** (Symbol: a helix made from chain). Covertly shielding a newly formed covenant from the intrigue of its tribunal, though to what purpose is unclear. The covenant protected by this cabal are unaware of their guardians.
-
-**The Cabal of the Shining Eye** (Symbol: A concha with an eagle at the center). Dedicated to maneuvering the Roman Tribunal into colonization of North Africa.
-
-**The Unnamed Cabal** (Symbol: a counterclockwise swirl of five lines, which double back on one another and create a vertex). Spoken of in hushed tones, the Unknown Cabal's goal is to ensure that the other cabals are kept in conflict with each other. It is supposedly composed of the most powerful Tytalus Archmagi, and, some claim, Tytalus himself! There may even be more than one cabal with this goal. . . .
-
-
-# Intrigue
+## Intrigue
 
 *As gold is tried in the fire, so acceptable men are tried in the furnace of adversity.*
 
-*—* Wisdom of Jesus Son of Sirach, 2:5
+— Wisdom of Jesus Son of Sirach, 2:5
 
 The natural environment of a Tytalus magus is in the midst of an intrigue, whether of her own making, or another's. In **Ars Magica Fifth Edition**, these stories present different challenges to the storyguide in design and execution than do most stories, but to neglect intrigue stories in a saga which contains one or more Tytalan player characters is to deny them their strengths. Conflict can be (and is) found in other arenas too — in combat or in certamen
 
@@ -3801,44 +3552,37 @@ The natural environment of a Tytalus magus is in the midst of an intrigue, wheth
 
 The sections below provide a toolkit of elements that play a part in pursuing intrigue, including rules for deep-cover disguises called **personae**, which are used by Tytalan magi, and rules for the cut-andthrust of political debate. Rules for running agencies of spies, thieves, and other useful lackeys are provided in the Appendix to this book, as members of House Jerbiton also use such agents.
 
-Intrigue-based adventures are difficult to frame, because player actions can be so variable under different stimuli. It is usually best to present an overall picture describing the situation, with a number of different resolutions, each with its own
+Intrigue-based adventures are difficult to frame, because player actions can be so variable under different stimuli. It is usually best to present an overall picture describing the situation, with a number of different resolutions, each with its own consequences. It is far more important to know the goals of the antagonists rather than the intricacies of a plot. As long as the storyguide has a good conception of the designer of an intrigue, and knows his motivations and intent, then as long as he acts consistently in the pursuit of his goal, a good story will result even if the player characters throw him a curveball. A good trick, but one which must not be overused, is to use hindsight as a surrogate for a well-formed plot. The instigator of an intrigue is potentially more intelligent and devious than the storyguide himself, but a way around this is to change the actions of the antagonist as a result of the player characters' actions. In reality, you retroactively decide, the intriguer had planned these actions from the very beginning, and thus the ability to predict character actions is simulated. However, it is important not to thwart the actions of the characters too many times with this trick, nor to deny them a hard-won victory.
 
-### Stories of Intrigue
-
-Presented below are examples of typical Tytalan intrigues. In common with the fables told in House Tytalus, they feature Tytalus as the protagonist, and other founders fill other iconic roles: Guernicus as the co-conspirator, Tremere as the dupe, and Flambeau as the dupe's ally. These are fables, not history, but should be used to provide inspiration for intrigue-based stories.
-
-**Deliverance:** Tytalus rescues Tremere from danger. Tremere later discovers that Tytalus put him in danger to begin with. Is it too transparent to assume that Tytalus merely wanted Tremere to owe him a boon?
-
-**Crime Pursued by Vengeance:** The dishonor of Guernicus by Tremere provokes a furious reaction from Tytalus. But wasn't it Tytalus that gave Tremere the evidence against Guernicus?
-
-**Disaster:** Tytalus appears to be constantly suffering defeat, but it is secretly self-inflicted. Why would he want others to see him as a victim?
-
-**Murderous Adultery:** Tytalus persecutes Guernicus after he supports Tremere, treating him to worse than he's ever inflicted on Tremere. Is this a true split between the former allies?
-
-**Madness:** After a Twilight, Tytalus muddles up his intrigues by employing the wrong agents in the wrong plots. Or does he just want to appear to be weak?
-
-**Involuntary Crimes of Love:** Tremere's new filius turns out to be Tytalus in disguise.
-
-**Self-Sacrifice for Kindred:**Tytalus appears to commit all his resources in a hopeless effort to protect Guernicus. This is possible, but very unlikely to be the real story.
-
-**Adultery:** Tytalus abandons Guernicus in favor of Flambeau. Is this a true change of heart?
-
-**Discovery of the Dishonor of a Loved One:** What is the reaction of Tremere's mortal family when Tytalus shows them what their child has become? More importantly, how does this affect Tremere?
-
-**Mistaken Jealousy:** Tytalus tells Tremere that the latter's ally Flambeau is actually allied to Guernicus. Is Tytalus seeking an alliance with Flambeau, Guernicus, or Tremere?
-
-**Remorse:** Tytalus confesses his crimes to Tremere in uncharacteristic contrition. In doing so he implicates Flambeau in treachery.
-
-**Loss of Loved Ones:** After the disappearance of Tremere, Tytalus frantically seeks to reveal the crime. Using zeal to hide guilt is too transparent for Tytalus. However, the alternative is that his grief is real.
-
-
-consequences. It is far more important to know the goals of the antagonists rather than the intricacies of a plot. As long as the storyguide has a good conception of the designer of an intrigue, and knows his motivations and intent, then as long as he acts consistently in the pursuit of his goal, a good story will result even if the player characters throw him a curveball. A good trick, but one which must not be overused, is to use hindsight as a surrogate for a well-formed plot. The instigator of an intrigue is potentially more intelligent and devious than the storyguide himself, but a
-
-way around this is to change the actions of the antagonist as a result of the player characters' actions. In reality, you retroactively decide, the intriguer had planned these actions from the very beginning, and thus the ability to predict character actions is simulated. However, it is important not to thwart the actions of the characters too many times with this trick, nor to deny
+> ## Stories of Intrigue
+> 
+> Presented below are examples of typical Tytalan intrigues. In common with the fables told in House Tytalus, they feature Tytalus as the protagonist, and other founders fill other iconic roles: Guernicus as the co-conspirator, Tremere as the dupe, and Flambeau as the dupe's ally. These are fables, not history, but should be used to provide inspiration for intrigue-based stories.
+> 
+> **Deliverance:** Tytalus rescues Tremere from danger. Tremere later discovers that Tytalus put him in danger to begin with. Is it too transparent to assume that Tytalus merely wanted Tremere to owe him a boon?
+> 
+> **Crime Pursued by Vengeance:** The dishonor of Guernicus by Tremere provokes a furious reaction from Tytalus. But wasn't it Tytalus that gave Tremere the evidence against Guernicus?
+> 
+> **Disaster:** Tytalus appears to be constantly suffering defeat, but it is secretly self-inflicted. Why would he want others to see him as a victim?
+> 
+> **Murderous Adultery:** Tytalus persecutes Guernicus after he supports Tremere, treating him to worse than he's ever inflicted on Tremere. Is this a true split between the former allies?
+> 
+> **Madness:** After a Twilight, Tytalus muddles up his intrigues by employing the wrong agents in the wrong plots. Or does he just want to appear to be weak?
+> 
+> **Involuntary Crimes of Love:** Tremere's new filius turns out to be Tytalus in disguise.
+> 
+> **Self-Sacrifice for Kindred:**Tytalus appears to commit all his resources in a hopeless effort to protect Guernicus. This is possible, but very unlikely to be the real story.
+> 
+> **Adultery:** Tytalus abandons Guernicus in favor of Flambeau. Is this a true change of heart?
+> 
+> **Discovery of the Dishonor of a Loved One:** What is the reaction of Tremere's mortal family when Tytalus shows them what their child has become? More importantly, how does this affect Tremere?
+> 
+> **Mistaken Jealousy:** Tytalus tells Tremere that the latter's ally Flambeau is actually allied to Guernicus. Is Tytalus seeking an alliance with Flambeau, Guernicus, or Tremere?
+> 
+> **Remorse:** Tytalus confesses his crimes to Tremere in uncharacteristic contrition. In doing so he implicates Flambeau in treachery.
+> 
+> **Loss of Loved Ones:** After the disappearance of Tremere, Tytalus frantically seeks to reveal the crime. Using zeal to hide guilt is too transparent for Tytalus. However, the alternative is that his grief is real.
 
 ### Tytalan Agencies
-
-them a hard-won victory.
 
 *A human being is the measure of all things — of things that are, that they are, and of things that are not, that they are not.*
 
@@ -3848,21 +3592,19 @@ The Appendix presents rules for recruiting and maintaining agents, mundanes who 
 
 #### Spies
 
-Perhaps the most common use for agents among House Tytalus is as spies. Simply having a source of information in the local town or church can provide an early warning of any potential problems directed at a covenant, which a Tytalus can use to his personal advantage. A more dangerous game is placing a spy among
+Perhaps the most common use for agents among House Tytalus is as spies. Simply having a source of information in the local town or church can provide an early warning of any potential problems directed at a covenant, which a Tytalus can use to his personal advantage. A more dangerous game is placing a spy among the covenfolk of a rival covenant; only if the agent acquires his information with magic is this prosecutable under the Code of Hermes.
 
-### Example Agencies with Tytalan Principals
-
-Fudarus maintains an immense spy network. The covenant directly controls a number of agents, who themselves maintain their own agencies, and so on through several layers of interaction. These agents are spies, largely petty criminals, who keep a close eye on the mundane interests of the covenant, although the Primus sometimes uses them on behalf of the House. It is unclear to what extent the members of this network are secretly agents of Tytali other than the Primus.
-
-A Tytalan magus operates a network of merchants on the Mediterranean Sea. All the merchants have access to ships, and the magus can often arrange passage on these ships on behalf of other magi, for a price.
-
-A solitary member of House Tytalus maintains several mercenary captains and outlaw leaders as agents instead of having grogs, and he can call upon them at short notice, should his plans against his rival come to fruition.
-
-A Tytalan maga maintains several scholars in Rome, Bologna, Salerno, and Paris as agents. She has never met these agents; all communication is written, and they believe she is another scholar (and a man). The maga seeks to subtly introduce Tytalan philosophy into the ethics, law, and theology these scholars write about.
-
-Several of the employees of a brothel are agents of a Tytalus. They not only serve his needs, but also supply a ready source of blackmail material with which to recruit further agents within the local community.
-
-the covenfolk of a rival covenant; only if the agent acquires his information with magic is this prosecutable under the Code of Hermes.
+> ### Example Agencies with Tytalan Principals
+> 
+> Fudarus maintains an immense spy network. The covenant directly controls a number of agents, who themselves maintain their own agencies, and so on through several layers of interaction. These agents are spies, largely petty criminals, who keep a close eye on the mundane interests of the covenant, although the Primus sometimes uses them on behalf of the House. It is unclear to what extent the members of this network are secretly agents of Tytali other than the Primus.
+> 
+> A Tytalan magus operates a network of merchants on the Mediterranean Sea. All the merchants have access to ships, and the magus can often arrange passage on these ships on behalf of other magi, for a price.
+> 
+> A solitary member of House Tytalus maintains several mercenary captains and outlaw leaders as agents instead of having grogs, and he can call upon them at short notice, should his plans against his rival come to fruition.
+> 
+> A Tytalan maga maintains several scholars in Rome, Bologna, Salerno, and Paris as agents. She has never met these agents; all communication is written, and they believe she is another scholar (and a man). The maga seeks to subtly introduce Tytalan philosophy into the ethics, law, and theology these scholars write about.
+> 
+> Several of the employees of a brothel are agents of a Tytalus. They not only serve his needs, but also supply a ready source of blackmail material with which to recruit further agents within the local community.
 
 #### Criminal Agents
 
@@ -3874,22 +3616,19 @@ If working subtly, it is often inconvenient to maintain a turb of grogs. Having 
 
 #### Double Agents and Hostile Takeovers
 
-Occasionally, a Tytalan magus will come across (or seek out) an agent in the employ of a rival. This agent might be courted by the magus so that he has a mole inside the rival agency. Recruiting the agent follows the usual rules (see Appendix); as soon as the Bond Strength of the agent reaches zero, he becomes a double agent, working for both agencies, but most loyal to the principal with the highest Bond Strength. Should the original principal become aware of the subordination of his agent, he can maintain him as a triple agent, feeding back false information.
+Occasionally, a Tytalan magus will come across (or seek out) an agent in the employ of a rival. This agent might be courted by the magus so that he has a mole inside the rival agency. Recruiting the agent follows the usual rules (see Appendix); as soon as the Resistance of the agent reaches zero, he becomes a double agent, working for both agencies, but most loyal to the principal with the highest Bond Strength. Should the original principal become aware of the subordination of his agent, he can maintain him as a triple agent, feeding back false information.
 
-Conducting a hostile takeover of another's agency can be done one agent at a time, but there are quicker methods available to magi. Using appropriate magics, a Tytalan can disguise himself as the principal and establish a persona (see below) among the agents as the original principal. The interloper can then use the Bond Strength of any agent built by the principal as if it were his own. The agent believes that he
+Conducting a hostile takeover of another's agency can be done one agent at a time, but there are quicker methods available to magi. Using appropriate magics, a Tytalan can disguise himself as the principal and establish a persona (see below) among the agents as the original principal. The interloper can then use the Bond Strength of any agent built by the principal as if it were his own. The agent believes that he is still working for the same person, and is often relocated to keep him away from his former principal. This process only works if the original principal does not have regular contact with his agents, else the deception is too easily discovered.
 
-
-
-
-Rather than increasing an agent's Bond Strength with favors, a magus, using a classic Tytalan ploy, makes him more indebted to the magus. The more convoluted and involved the plot, the greater the reward in experience, and therefore the bigger the gain to the Bond Strength of the agent.
-
-An agent comes to his principal with a story that another has tried to recruit him as a double agent; further investigation reveals that the recruiter never existed.
-
-A magus's rival becomes one of his agents, either by impersonating a current agent (who has been disposed of), or by possessing a persona who is newly recruited.
-
-Someone is targeting a magus's agents, eliminating the source of their Bonds, or simply eliminating the agents altogether. The enemy must have inside knowledge as to the identities of these agents — so who is the snitch?
-
-is still working for the same person, and is often relocated to keep him away from his former principal. This process only works if the original principal does not have regular contact with his agents, else the deception is too easily discovered.
+> ## Story Seeds for Tytalan Agencies
+> 
+> Rather than increasing an agent's Bond Strength with favors, a magus, using a classic Tytalan ploy, makes him more indebted to the magus. The more convoluted and involved the plot, the greater the reward in experience, and therefore the bigger the gain to the Bond Strength of the agent.
+> 
+> An agent comes to his principal with a story that another has tried to recruit him as a double agent; further investigation reveals that the recruiter never existed.
+> 
+> A magus's rival becomes one of his agents, either by impersonating a current agent (who has been disposed of), or by possessing a persona who is newly recruited.
+> 
+> Someone is targeting a magus's agents, eliminating the source of their Bonds, or simply eliminating the agents altogether. The enemy must have inside knowledge as to the identities of these agents — so who is the snitch?
 
 ### Disguises and Personae
 
@@ -3909,60 +3648,53 @@ The storyguide should make the roll on behalf of the character, so that the play
 
 #### Deep Cover Disguises
 
-Occasionally, a magus needs to establish a long-term presence in a specific community to pull off one of his intrigues. He might be spying on a rival covenant, gathering gossip in a bishop's palace, or even hiding from his enemies. In such situations, a physical disguise is often insufficient; over the long term they tend to be uncovered. Instead, a character can disguise himself by adopting a totally different identity among the target group. He chooses a role
+Occasionally, a magus needs to establish a long-term presence in a specific community to pull off one of his intrigues. He might be spying on a rival covenant, gathering gossip in a bishop's palace, or even hiding from his enemies. In such situations, a physical disguise is often insufficient; over the long term they tend to be uncovered. Instead, a character can disguise himself by adopting a totally different identity among the target group. He chooses a role to play, complete with personality, history, and quirks, and then establishes this new identity among his chosen community.
 
-| Disguise Roll Modifiers                    |          |                                                                                 |
-|--------------------------------------------|----------|---------------------------------------------------------------------------------|
-| Circumstance<br>(use all that app<br>ly)   | Modifier | Example                                                                         |
-| Change social status                       | +3       | magus disguising himself as a peasant                                           |
-| Minor alteration in physical<br>appearance | +1       | changing hair color with dye                                                    |
-| Major alteration in physical<br>appearance | +3       | becoming obese, or an inch taller                                               |
-| Change sex                                 | +6       | male magus becoming female maga                                                 |
-| Minimal preparation                        | +3       | less than five minutes to make the dis<br>guise, or limited costume available   |
-| No preparation                             | +6       | less than five rounds to make the dis<br>guise, or very basic costume available |
+> ## Disguise Roll Modifiers
+> 
+> | Circumstance (use all that apply)   | Modifier | Example                                               |
+> |-------------------------------------|----------|-------------------------------------------------------|
+> | Change social status                | +3       | magus disguising himself as a peasant                 |
+> | Minor alteration in physical appearance | +1   | changing hair color with dye                          |
+> | Major alteration in physical appearance | +3   | becoming obese, or an inch taller                     |
+> | Change sex                          | +6       | male magus becoming female maga                       |
+> | Minimal preparation                 | +3       | less than five minutes to make the disguise, or limited costume available |
+> | No preparation                      | +6       | less than five rounds to make the disguise, or very basic costume available |
+> 
 
-
-
-to play, complete with personality, history, and quirks, and then establishes this new identity among his chosen community.
-
-Deep cover disguises have names, jobs, and personalities that are separate from those of their creator. Once the personality has been developed, the magus gets into an appropriate costume, enters the community where the cover is to persist, and performs a noteworthy act in front of witnesses, which establishes the character in the minds of the residents. This act grants a new Reputation as the disguised individual, at a score of 1 (see ArM5, page 167). Establishing the Reputation in the fi rst place often requires a Disguise roll to be successful, but once established the Reputation replaces the need to make further Disguise rolls. However, if it is ever necessary for the magus to convince others of the validity of the cover — if he is questioned by a suspicious priest, or tries to cover up the slip of a comrade — then the Ease Factor of the Disguise roll is reduced by the value of the Reputation.
+Deep cover disguises have names, jobs, and personalities that are separate from those of their creator. Once the personality has been developed, the magus gets into an appropriate costume, enters the community where the cover is to persist, and performs a noteworthy act in front of witnesses, which establishes the character in the minds of the residents. This act grants a new Reputation as the disguised individual, at a score of 1 (see ArM5, page 167). Establishing the Reputation in the first place often requires a Disguise roll to be successful, but once established the Reputation replaces the need to make further Disguise rolls. However, if it is ever necessary for the magus to convince others of the validity of the cover — if he is questioned by a suspicious priest, or tries to cover up the slip of a comrade — then the Ease Factor of the Disguise roll is reduced by the value of the Reputation.
 
 *Example:. Carolus. Furax. decides. to. develop. the. persona. of. a. mercenary.. He. fi.gures. that. this. job. gives. him. suffi.cient. reason. to. be. absent. from. his. home. village. for. long. periods. of. time,. but. also. gives.him.the.opportunity.to.swap.war.stories.with. the. town. guard. and. —. more. importantly. for. his. current. schemes. —. with. the. soldiers. of. the. baron. who.frequent.a.certain.tavern.in.town..He.therefore. chooses. the. name. "Reynard,". procures. some. arms. and. armor,. and. after. spending. some. time. studying. his. covenant's. grogs,. swaggers. into. the. tavern. and. orders. himself. a. drink.. He. has. arranged. for. some. "robbers".(actually.his.grogs).to.attack,.who.allow. him. to. beat. them. back. in. defense. of. the. townsfolk.. Once.this.is.accomplished,.Carolus.has.acquired.a. Local.Reputation.of.Reynard.the.Mercenary,.at.an. initial.score.of.1.*
 
-The only limit to the disguise's role in society is the ability of the magus to get himself into a situation where he can convincingly establish the desired role. If a magus is capable of convincing the local clergy and townsfolk that he is a priest, then he could potentially lay claim to that parish, but most Tytali opt for less conspicuous roles. In general, a deep cover disguise that normally requires a Minor Social Status Virtue (such as Priest) incurs the effects of acquiring a Minor Story Flaw, as the character has to pursue the obligations of his role, but also enjoys some minor benefi ts. A disguise that normally incurs a Major Social Status Virtue (such as Landed Noble) requires the attention that a Major Story Flaw normally requires to maintain that disguise, and even then, the disguise is not tenable in the long term. A deep cover disguise that needs Virtues other than Social Status Virtue to support it, such as Temporal Infl uence or Wealthy, is impossible to develop.
+The only limit to the disguise's role in society is the ability of the magus to get himself into a situation where he can convincingly establish the desired role. If a magus is capable of convincing the local clergy and townsfolk that he is a priest, then he could potentially lay claim to that parish, but most Tytali opt for less conspicuous roles. In general, a deep cover disguise that normally requires a Minor Social Status Virtue (such as Priest) incurs the effects of acquiring a Minor Story Flaw, as the character has to pursue the obligations of his role, but also enjoys some minor benefits. A disguise that normally incurs a Major Social Status Virtue (such as Landed Noble) requires the attention that a Major Story Flaw normally requires to maintain that disguise, and even then, the disguise is not tenable in the long term. A deep cover disguise that needs Virtues other than Social Status Virtue to support it, such as Temporal Influence or Wealthy, is impossible to develop.
 
-Every time a character performs an action that confi rms the role he is playing in society, he gains 1 experience point in the Reputation, which increases as if it was an Ability. Actually living in a community for a season and having regular contact with its members is usually suffi cient to earn 2 experience points in the Reputation, whereas regular visits throughout a season earn only 1 experience point. A magus who makes a brief visit every season (avoid-
+Every time a character performs an action that confirms the role he is playing in society, he gains 1 experience point in the Reputation, which increases as if it was an Ability. Actually living in a community for a season and having regular contact with its members is usually sufficient to earn 2 experience points in the Reputation, whereas regular visits throughout a season earn only 1 experience point. A magus who makes a brief visit every season (avoiding penalties to lab work, for example) gains only 2 experience points per year. A magus can speed the process of establishing the Reputation by staging noteworthy events for the benefit of those he is fooling (1 experience point per event), but he must display the appropriate Abilities (or be able to hide his lack with subterfuge or magic) or else his efforts are wasted. Events that enmesh him closer in the community — such as getting married, having children, or taking on a role such as reeve — are also worth 1 experience point in the Reputation. In any case, a Reputation increased by more than 2 experience points per season is likely to arouse suspicion because the magus is trying too hard.
 
-### New Supernatural Ability: Persona\
+> ## New Supernatural Ability: Persona\*
+> 
+> The character with this Ability (and the appropriate Virtue, see New Virtues) can alter his appearance to adopt a different identity. He can alter any aspect of his appearance: hair and eye color, complexion, shape of nose, build and height (within the limits of his Size), apparent age, and even gender. These changes are total, proof even to the most intimate mundane scrutiny, but do not change the character's essential nature. Consequently, all Characteristic scores remain unchanged, Virtues and Flaws are transferred to all new forms, and a male character cannot become pregnant when adopting the persona of a woman.
+> 
+> Adopting a different identity requires one round of concentration and a roll of Stamina + Persona against an Ease Factor of 9. Changing back to the character's natural form requires the same concentration and the same roll. Each identity has its own Personality Traits and behavioral quirks, and no Disguise roll is necessary to convince others of the role; this is not a disguise but a whole different person.
+> 
+> The character gains one identity for every point he has in the Persona Ability. Every time the Ability increases by one point, the character must design a new identity.
+> 
+> **Specialties**: priests, peasants, magi
 
-The character with this Ability (and the appropriate Virtue, see New Virtues) can alter his appearance to adopt a different identity. He can alter any aspect of his appearance: hair and eye color, complexion, shape of nose, build and height (within the limits of his Size), apparent age, and even gender. These changes are total, proof even to the most intimate mundane scrutiny, but do not change the character's essential nature. Consequently, all Characteristic scores remain unchanged, Virtues and Flaws are transferred to all new forms, and a male character cannot become pregnant when adopting the persona of a woman.
-
-Adopting a different identity requires one round of concentration and a roll of Stamina + Persona against an Ease Factor of 9. Changing back to the character's natural form requires the same concentration and the same roll. Each identity has its own Personality Traits and behavioral quirks, and no Disguise roll is necessary to convince others of the role; this is not a disguise but a whole different person.
-
-The character gains one identity for every point he has in the Persona Ability. Every time the Ability increases by one point, the character must design a new identity.
-
-**Specialties**: priests, peasants, magi
-
-ing penalties to lab work, for example) gains only 2 experience points per year. A magus can speed the process of establishing the Reputation by staging noteworthy events for the benefit of those he is fooling (1 experience point per event), but he must display the appropriate Abilities (or be able to hide his lack with subterfuge or magic) or else his efforts are wasted. Events that enmesh him closer in the community — such as getting married, having children, or taking on a role such as reeve — are also worth 1 experience point in the Reputation. In any case, a Reputation increased by more than 2 experience points per season is likely to arouse suspicion because the magus is trying too hard.
-
-### Hermetic Disguises and Personae
-
-It is entirely feasible for a Tytalan magus to maintain a deep cover disguise or persona in another covenant, if he divides his time between the two covenants and has a plausible explanation for his absences. He also needs to ensure that his identities could never meet each other, and that his two sets of sodales never come into contact. Unless a covenant's charter explicitly forbids a magus from being a member of more than one covenant, there is nothing contrary to the Code in such an action, although once discovered it might raise a few questions regarding the motives of the Tytalan magus who perpetrated this double life.
-
-No Tytalus has been caught impersonating a Quaesitor, but if one was, then every decision that the "Quaesitor" had made would have to be reconsidered, and it is unlikely that the Tytalus would escape censure from the Tribunal. A case was brought to the Normandy Tribunal of a magus who impersonated a Redcap, thus gaining access to private communications between his rivals. This magus was successfully prosecuted for scrying, because he used magic to take the appearance of the Redcap, but had he not done this, there is no provision in the Code that would make this a Hermetic crime.
+> ## Hermetic Disguises and Personae
+> 
+> It is entirely feasible for a Tytalan magus to maintain a deep cover disguise or persona in another covenant, if he divides his time between the two covenants and has a plausible explanation for his absences. He also needs to ensure that his identities could never meet each other, and that his two sets of sodales never come into contact. Unless a covenant's charter explicitly forbids a magus from being a member of more than one covenant, there is nothing contrary to the Code in such an action, although once discovered it might raise a few questions regarding the motives of the Tytalan magus who perpetrated this double life.
+> 
+> No Tytalus has been caught impersonating a Quaesitor, but if one was, then every decision that the "Quaesitor" had made would have to be reconsidered, and it is unlikely that the Tytalus would escape censure from the Tribunal. A case was brought to the Normandy Tribunal of a magus who impersonated a Redcap, thus gaining access to private communications between his rivals. This magus was successfully prosecuted for scrying, because he used magic to take the appearance of the Redcap, but had he not done this, there is no provision in the Code that would make this a Hermetic crime.
 
 The Gift is the biggest impediment to a magus wanting to run a deep cover disguise; however, as the fake identity becomes wellknown in a society, the effects of the distrust and envy engendered by The Gift diminish (assuming that the character does nothing to confirm them), as people around him become used to him. A character therefore subtracts his Reputation from the penalty to social rolls caused by The Gift, but only when dealing with those with whom he has regular contact. This diminishing effect of The Gift does not apply to strangers, only to those that come to know the magus well; this is a formalization of the effect seen normally over prolonged contact with the Gifted (ArM5, page 75).
 
-### Story Seed: The Reborn Identity
-
-A Tytalan magus enters a protracted Twilight and becomes one of his personae. All memories of his life as a magus are lost, and he cannot use the magic to which he is unaware he has access. Perhaps the magus was privy to a particularly important piece of information that the player characters need. Should the player characters — unaware of his condition — reveal to him the existence of the Order, the persona might react badly to this knowledge and start telling the world their secrets.
+> ## Story Seed: The Reborn Identity
+> 
+> A Tytalan magus enters a protracted Twilight and becomes one of his personae. All memories of his life as a magus are lost, and he cannot use the magic to which he is unaware he has access. Perhaps the magus was privy to a particularly important piece of information that the player characters need. Should the player characters — unaware of his condition — reveal to him the existence of the Order, the persona might react badly to this knowledge and start telling the world their secrets.
 
 *Example: Carolus becomes a regular visitor to the village (particularly its tavern), regaling the patrons with stories of all the battles he's fought in while he's been away (although in reality he's been back at the covenant studying magic). After two years, and another demonstration of his martial abilities, the persona of Reynard has a Reputation of 2. In this village, he suffers only a –1 penalty to social interactions from The Gift.*
 
-Because deep cover disguises involve such a total change in the mannerisms and personality of the magus, those who know him as a magus may not recognize him when he is in his disguise, because recognition is based so much on context. Should a magus enter the locality in which his cover lives without first adopting the disguise, he may be recognized by the townsfolk, but it is amazing how situation can make one blind to the obvious. Without the mannerisms and distinctive costume of the disguise, the magus appears to be a different person, even if he shares the same facial features. However, the effects of the Mistaken Identity Flaw could temporarily apply to a magus in this situation. Naturally, the chances of being recognized depend very much on the level of interaction he has, how well he is known by the observer, and so forth. There is little chance that any mundane who is familiar with his cover will ever encounter the same individual in Hermetic circles; the reverse is a little more likely, but a magus is granted the right of privacy by the Code of Hermes, and need not explain to another magus why he is pretending to be
-
-
-a mundane. As long as interaction between the magus and characters who know him in his other life is kept to a minimum, it is unlikely that the disguise will be uncovered, although if conversations ensue, the player of the undercover character must make a Disguise roll, as detailed above.
+Because deep cover disguises involve such a total change in the mannerisms and personality of the magus, those who know him as a magus may not recognize him when he is in his disguise, because recognition is based so much on context. Should a magus enter the locality in which his cover lives without first adopting the disguise, he may be recognized by the townsfolk, but it is amazing how situation can make one blind to the obvious. Without the mannerisms and distinctive costume of the disguise, the magus appears to be a different person, even if he shares the same facial features. However, the effects of the Mistaken Identity Flaw could temporarily apply to a magus in this situation. Naturally, the chances of being recognized depend very much on the level of interaction he has, how well he is known by the observer, and so forth. There is little chance that any mundane who is familiar with his cover will ever encounter the same individual in Hermetic circles; the reverse is a little more likely, but a magus is granted the right of privacy by the Code of Hermes, and need not explain to another magus why he is pretending to be a mundane. As long as interaction between the magus and characters who know him in his other life is kept to a minimum, it is unlikely that the disguise will be uncovered, although if conversations ensue, the player of the undercover character must make a Disguise roll, as detailed above.
 
 Deep cover disguises have a limited life span. If a magus ceases to expose the community to his disguised identity, then it forgets about him and the Reputation dwindles. After being dormant for a number of years equal to the Reputation score, the Reputation loses one point per year. Further, the negative Reputation of The Gift becomes re-established at its original strength if the magus tries to use the persona again after this dormancy period.
 
@@ -3970,11 +3702,11 @@ Deep cover disguises have a limited life span. If a magus ceases to expose the c
 
 A magus with the Persona Minor Supernatural Virtue has a Supernatural Ability of the same name (see insert), which grants the power to create a small number of flawless disguises. Every one of these personae automatically gains a Reputation of 1 when it is first created, and any experience points applied to the Persona Ability also apply the same number of experience points to the Reputations of all of the magus's personae. A persona is more than just a physical disguise; every persona has its own distinct speech patterns, personality, and quirks. A persona cannot impersonate a specific individual — a magus cannot become Duke Tybol, for example — but he can develop a persona who has sufficient physical and behavioral mannerisms of Duke Tybol to convince others that he is his illegitimate son. Although magical, the Persona Supernatural Ability involves a very subtle form of magic; at the moment of transformation it can be detected as if it were a Muto Corpus spell of 10th level, but for every sunset or sunrise that passes after adopting the persona, the magnitude drops by one. Negative magnitudes of spells can only be detected with powerful Intellego Vim magic (see *Houses of Hermes: True Lineages*, page 71). If an equivalent spell level is needed for other purposes (such as for *Sight of the True Form*, or *Wind of Mundane Silence*, for example) the equivalent spell level is equal to five times the score in the Ability.
 
-# The Fine Art of Debate
+## The Fine Art of Debate
 
 *One should destroy the seriousness of one's opponent with laughter, and his laughter with seriousness.*
 
-*—* Gorgias
+— Gorgias
 
 The rules given below present a mechanic for settling an argument through debate. They are broken down into two sections: the testing of the strength of each other's positions in a debate, and the consequences of winning the debate on the opinions of the observers. Naturally, if there are no observers, or the issue is one of little consequence, then the second step is unnecessary. However, they become of vital importance to a magus who is prosecuting or defending a case at Tribunal.
 
@@ -3988,6 +3720,7 @@ In each round of the debate choose which of the three Attack Abilities (Folk Ken
 
 **Attack Total: Communication + Attack Ability + attack modifier + stress die**
 
+**Defense Total: Intelligence + Defense Ability + stress die** 
 
 **Attack Advantage: Attack Total – Defense Total (if Attack Total is higher)**
 
@@ -4001,35 +3734,29 @@ The Ability chosen for the Attack Total determines the style of the debater's or
 
 **Folk Ken** relies on the understanding of human behavior and motivation to secure an advantage.
 
-- **Charm**: You offer a compromise or a disarming compliment. **•**
-- **Guile**: You support your point with a complete fabrication of the truth. **•**
-- **Leadership**: You issue a personal threat or insult against your opponent. **•**
+- **Charm**: You offer a compromise or a disarming compliment.
+- **Guile**: You support your point with a complete fabrication of the truth.
+- **Leadership**: You issue a personal threat or insult against your opponent.
 
 **Intrigue** represents the ability of the debater to manipulate his opponent into traps, and to employ dirty tricks.
 
-**Charm**: You misdirect your opponent, or baffle him with an obtuse comment. **•**
-
-
-
-- **Guile**: You hint that you know things that your opponent would not want publicly known, or cite false authority. **•**
-- **Leadership**: You scare-monger over your opponent's points, or hint at friends in high places. **•**
+- **Charm**: You misdirect your opponent, or baffle him with an obtuse comment.
+- **Guile**: You hint that you know things that your opponent would not want publicly known, or cite false authority.
+- **Leadership**: You scare-monger over your opponent's points, or hint at friends in high places.
 
 **Artes Liberales**, particularly the specialty of Rhetoric, determines the debater's ability to use sophisticated verbal techniques against their opponents.
 
-- **Charm**: You employ hyperbole and rhetoric to confuse your opponent with erudition, distracting him from the matter at hand. **•**
-- **Guile**: You tease your opponent with wit, or play to the crowd by using premises based on popularity rather than fairness. **•**
-- **Leadership**: You forcibly interrogate your opponent, or question whether he has followed proper procedure. **•**
+- **Charm**: You employ hyperbole and rhetoric to confuse your opponent with erudition, distracting him from the matter at hand.
+- **Guile**: You tease your opponent with wit, or play to the crowd by using premises based on popularity rather than fairness.
+- **Leadership**: You forcibly interrogate your opponent, or question whether he has followed proper procedure.
 
 Particular styles of debating are more effective against some tactics than others, and a debater is often required to adapt his debating style several times during the debate to try to secure the biggest advantage. For each Attack Total, the attacker gains an **Attack Modifier** based on the Defense Ability used by his opponent. Refer to the following table:
 
-| Charm | Guile | Leadership |
-|-------|-------|------------|
-|-------|-------|------------|
-
-| Folk<br>Ken        | +3 | –3 | 0  |
-|--------------------|----|----|----|
-| Intrigue           | 0  | +3 | –3 |
-| Artes<br>Liberales | –3 | 0  | +3 |
+|                | Charm | Guile | Leadership |
+|----------------|:-----:|:-----:|:----------:|
+| Folk Ken       |  +3   |  –3   |     0      |
+| Intrigue       |   0   |  +3   |    –3      |
+| Artes Liberales|  –3   |   0   |    +3      |
 
 *Example: In this round of a debate at Tribunal, Moratamis is trying to interrogate Carolus regarding his activities, whereas Carolus is infuriating her (and pleasing the crowd) with disarming words. Moratamis is attacking with Artes Liberales and defending with Leadership. Carolus is attacking with Folk Ken and defending with Charm.*
 
@@ -4041,88 +3768,77 @@ Particular styles of debating are more effective against some tactics than other
 
 The debate rules can be placed in a wider context, if the outcome of the debate may convince onlookers of the merits of the opinions of the debaters. The debate tests the strengths and weaknesses of each opponent's position over the issue, but it is down to any outside observers as to which opponent truly won the argument. At a Tribunal, this distinction becomes even clearer, because decisions are made by voting, and the way an observer votes on a case is not solely due to who won the argument, but also determined by alliances and enmities.
 
-If a debate ends because one opponent's argument loses 5 or more Fatigue Levels, then the winner is clear. Otherwise, the opponent whose argument has the smallest Fatigue penalty is deemed to be the technical victor. To convert winning an argument into winning a vote, the storyguide must first divide the observers of the debate into factions, depending upon whether they were initially inclined towards the defense principle, the prosecution principle, or neither. Where there are more than two opponents in a debate, this
+> ## The Power of Truth
+> 
+> A character who wishes to debate a patently flawed thesis, or one held in overwhelming contempt by the audience, might begin the debate already "fatigued"; the severity of this fatigue should be judged by the storyguide. A Tytalus may take the most preposterous stances against a demonstratively false proposition at an eristic moot to prove his skill rather than to determine the truth of the issue.
+> 
+> If a character knows that the side he is taking is false, then his Defense Totals are penalized by his Truthful Personality Trait, if any. No benefit from deceitful Personality Traits is gained in such situations.
 
-### The Power of Truth
+If a debate ends because one opponent's argument loses 5 or more Fatigue Levels, then the winner is clear. Otherwise, the opponent whose argument has the smallest Fatigue penalty is deemed to be the technical victor. To convert winning an argument into winning a vote, the storyguide must first divide the observers of the debate into factions, depending upon whether they were initially inclined towards the defense principle, the prosecution principle, or neither. Where there are more than two opponents in a debate, this factioning becomes more complex, but the overall concept still applies. The number of votes available in each faction should be detailed by the storyguide, for this is not necessarily the same as the number of magi. The neutral faction is the vitally important one; the main purpose of any debate at Tribunal is to win those over to one's side, and these voters abstain unless swayed one way or the other. Once the spectators have been divided into three camps, calculate the **Argument Strength** of the victor:
 
-A character who wishes to debate a patently flawed thesis, or one held in overwhelming contempt by the audience, might begin the debate already "fatigued"; the severity of this fatigue should be judged by the storyguide. A Tytalus may take the most preposterous stances against a demonstratively false proposition at an eristic moot to prove his skill rather than to determine the truth of the issue.
+**Argument Strength: Difference between the number of Fatigue Levels lost**
 
-If a character knows that the side he is taking is false, then his Defense Totals are penalized by his Truthful Personality Trait, if any. No benefit from deceitful Personality Traits is gained in such situations.
+Refer to the table at the bottom of the page for the effects of the Argument Strength on the voting pattern of the audience. Note that if a debater roundly defeats his opponent, then some of his opponent's allies are so swayed by the force of the winner's debate that they abandon their faction and vote for the winner.
 
-factioning becomes more complex, but the overall concept still applies. The number of votes available in each faction should be detailed by the storyguide, for this is not necessarily the same as the number of magi. The neutral faction is the vitally important one; the main purpose of any debate at Tribunal is to win those over to one's side, and these voters abstain unless swayed one way or the other. Once the spectators have been divided into three camps, calculate the **Argument Strength** of the victor:
+> | Argument Strength | Description        | % of Neutral Vote | % of Hostile Vote |
+> |-------------------|--------------------|-------------------|-------------------|
+> | 1                 | Inconclusive       | —                 | —                 |
+> | 2                 | Edge               | 10                | —                 |
+> | 3                 | Upper Hand         | 20                | —                 |
+> | 4                 | Clear Victory      | 30                | —                 |
+> | 5                 | Triumphant Victory | 40                | 10                |
+> | 6                 | Momentous Victory  | 50                | 20                |
+> | 7+                | Landslide Victory  | 60                | 30                |
 
-#### Argument Strength: Difference between the number of Fatigue Levels lost
+> ## Using Certamen Instead of Debate
+> 
+> For personal issues at Tribunal, certamen is often used to resolve differences. If a certamen takes the place of a formal debate, then the result of the certamen is binding no matter how erudite or persuasive the loser. However, certamen may also be used to resolve single issues that are part of a bigger case, in which case the winner of certamen may not automatically win the vote as well. For example, conflicting testimony regarding what was intended by an action might be resolved with certamen, but this does not settle the entire case. In this situation, simply use the actual Fatigue Levels lost rather than debating Fatigue Levels when calculating the Argument Strength of the winner.
 
-Refer to the table at the bottom of the page for the effects of the Argument Strength on the voting pattern of the audience. Note that if a debater roundly defeats
-
-| Argument<br>Strength | Description        | % of Neutral Vote | % of<br>Hostile Vote |
-|----------------------|--------------------|-------------------|----------------------|
-| 1                    | Inconclusive       | —                 | —                    |
-| 2                    | Edge               | 10                | —                    |
-| 3                    | Upper Hand         | 20                | —                    |
-| 4                    | Clear Victory      | 30                | —                    |
-| 5                    | Triumphant Victory | 40                | 10                   |
-| 6                    | Momentous Victory  | 50                | 20                   |
-| 7+                   | Landslide Victory  | 60                | 30                   |
-|                      |                    |                   |                      |
-
-
-### Using Certamen Instead of Debate
-
-For personal issues at Tribunal, certamen is often used to resolve differences. If a certamen takes the place of a formal debate, then the result of the certamen is binding no matter how erudite or persuasive the loser. However, certamen may also be used to resolve single issues that are part of a bigger case, in which case the winner of certamen may not automatically win the vote as well. For example, conflicting testimony regarding what was intended by an action might be resolved with certamen, but this does not settle the entire case. In this situation, simply use the actual Fatigue Levels lost rather than debating Fatigue Levels when calculating the Argument Strength of the winner.
-
-### Example Proposal Cases
-
-**Clarification:** A magus wishes it to be made clear that a particular hedge wizard is an enemy of the Order.
-
-**Addition:** Currently, a magus must provide his name and home Tribunal when asked by another magus. The proposer wishes that apprentices should also be accorded the privilege of receiving this information.
-
-**Alteration:** Some magi within the Loch Leglean Tribunal want to add a provision to their Peripheral Code allowing them to steal from each other's vis supplies, to keep up their time-honored traditions of raiding.
-
-his opponent, then some of his opponent's allies are so swayed by the force of the winner's debate that they abandon their faction and vote for the winner.
+> ## Example Proposal Cases
+> 
+> **Clarification:** A magus wishes it to be made clear that a particular hedge wizard is an enemy of the Order.
+> 
+> **Addition:** Currently, a magus must provide his name and home Tribunal when asked by another magus. The proposer wishes that apprentices should also be accorded the privilege of receiving this information.
+> 
+> **Alteration:** Some magi within the Loch Leglean Tribunal want to add a provision to their Peripheral Code allowing them to steal from each other's vis supplies, to keep up their time-honored traditions of raiding.
 
 Having determined which way the Tribunal votes, the storyguide should tally up the results to determine the final outcome of the debate. Note that those neutral votes that remain unassigned abstain from voting.
 
-*Example: Moratamis the Quaesitor is a popular figure at Tribunal. Of the 55 votes present,*
+*Example: Moratamis the Quaesitor is a popular figure at Tribunal. Of the 55 votes present, the storyguide estimates that 20 are her solid allies, whereas Carolus has the certain support of only ten other magi. Nevertheless, he won the debate with an Argument Strength of 3, which means he wins 20% of the 25 neutral voters, for a total of 5 other votes. This still gives him only 15 votes; not enough to win the case. He would have needed to have had an Argument Strength of at least 5 to have won this issue; that would have given him 40% of the neutral vote (ten extra votes) and 10% of Moratamis's faction (two extra votes). Instead, Carolus mentally rehearses his "contrite" plea for mercy.*
 
-### Other Uses for the Debate Rules
-
-Debates do not only have their purpose in the Tribunal halls of the Order. Mundane courts of law can also be persuaded by a strong argument, regardless of the evidence either way. For most of Mythic Europe, the winner of a debate is judged the winner of the case, unless the arbiter of justice is corrupt. In the Kingdom of England, Common Law prevails, which institutes a jury (of 12, 24, or 48 peers) to judge the case; such trials should be judged according to the voting system described above. However, jurors should be randomly assigned to the friendly, neutral, and hostile factions. If a character with The Gift is on trial, only 10% of the jurors begin the case sympathetic towards that character's position. Furthermore, the social penalty of The Gift is applied to the Defense Total of a magus when debating with mundanes before witnesses.
-
-*the storyguide estimates that 20 are her solid allies, whereas Carolus has the certain support of only ten other magi. Nevertheless, he won the debate with an Argument Strength of 3, which means he wins 20% of the 25 neutral voters, for a total of 5 other votes. This still gives him only 15 votes; not enough to win the case. He would have needed to have had an Argument Strength of at least 5 to have won this issue; that would have given him 40% of the neutral vote (ten extra votes) and 10% of Moratamis's faction (two extra votes). Instead, Carolus mentally rehearses his "contrite" plea for mercy.*
+> ## Other Uses for the Debate Rules
+> 
+> Debates do not only have their purpose in the Tribunal halls of the Order. Mundane courts of law can also be persuaded by a strong argument, regardless of the evidence either way. For most of Mythic Europe, the winner of a debate is judged the winner of the case, unless the arbiter of justice is corrupt. In the Kingdom of England, Common Law prevails, which institutes a jury (of 12, 24, or 48 peers) to judge the case; such trials should be judged according to the voting system described above. However, jurors should be randomly assigned to the friendly, neutral, and hostile factions. If a character with The Gift is on trial, only 10% of the jurors begin the case sympathetic towards that character's position. Furthermore, the social penalty of The Gift is applied to the Defense Total of a magus when debating with mundanes before witnesses.
 
 #### Case Rulings
 
 As detailed in *Houses of Hermes: True Lineages*: House Guernicus, most cases (i.e., those with clear legal merit) do not make it to a public hearing, instead being mediated by a Quaesitor prior to the Tribunal. Those cases that do make it to the Order's debating floor are those in which the interpretation of the Code is not cut and dried, and it is here where political magi such as the Tytali excel.
+
+Once the evidence has been presented by both principles in a case in the form of testimonies, the two sides engage in a debate contest in front of the Tribunal. The praeco typically ends the debate if the battle extends past 10 rounds. Each testimony possessed by an opponent may be used once per debate to support an argument. The prosecution principle may use a testimony to increase her Attack Total, whereas the defense principle may use a testimony to support his Defense Total. Once used in a round, the testimony may not be used again in the debate. The player should describe how he is using the witness to support the debating technique they are using, and then receive the bonus described on the following table: 
 
 
 | Type of Testimony                                              | Bonus        |
 |----------------------------------------------------------------|--------------|
 | Written testimony                                              | +1           |
 | Testimony of a mundane                                         | +1           |
-| Testimony of a social inferior<br>(apprentice, familiar, etc.) | +2           |
-| Testimony of a peer (another                                   | +3           |
-| magus)                                                         |              |
-| Testimony ratified by                                          | +3           |
-| Quaesitorial examination                                       | (cumulative) |
+| Testimony of a social inferior (apprentice, familiar, etc.)    | +2           |
+| Testimony of a peer (another magus)                            | +3           |
+| Testimony ratified by Quaesitorial examination                 | +3 (cumulative)|
 
 #### Proposal Cases
 
 Proposal cases are ones in which a magus seeks a correction, clarification, or addition to the Code of Hermes. In such cases, the debate is held between the proposer and the rest of the Tribunal. Any magus may enter into a debate with the proposer, and once the praeco feels that the case has been fully discussed, he stops the debate and calls for a vote. In game terms, the debate continues for a preset number of rounds, typically 5–10 (although the players do not know in advance how many rounds will eventually take place). Each round, the proposer faces a question or objection from a member of the audience. The storyguide should present each opponent's argument, allow the player magus to respond, and then make a debate roll. The storyguide should assign Attack and Defense Ability scores to each interrogator, but the proposer is fighting against a single opponent — the whole Tribunal — and the blows he lands are counted against that single entity.
 
-
-#### Societates
-
 Once all the points have been debated, the proposer's Argument Strength is used to determine the margin of victory in the usual way. However, the Argument Strength may suffer a penalty determined by the type of modification required to the Code. Magi are wary about making drastic changes to the Code of Hermes, and thus the more alteration required, the more difficult it is to win the case. A **clarification** does not propose to change the Code, it merely asks for a clear statement to be made about the Tribunal's attitude towards a specific position. An **addition** doesn't change the Code of Hermes either, but it expands the meaning of a specific case to cover a more general situation. An **alteration** of the Code actually suggests that a previously made ruling was incorrect, and should be replaced with a superior version, authored, of course, by the proposer. Note that a regional Tribunal can only make modifications to the local Peripheral Code, although they can recommend that a successful proposal case be taken to the next Grand Tribunal, where it may modify the Code as practiced in all Tribunals.
 
-| Type of Case                              | Penalty to<br>Argument<br>Strength |
-|-------------------------------------------|------------------------------------|
-| Clarification                             | 0                                  |
-| Addition                                  | –1                                 |
-| Alteration                                | –3                                 |
-| Case being heard at<br>the Grand Tribunal | –1 (cumulative)                    |
+> | Type of Case                           | Penalty to Argument Strength |
+> |----------------------------------------|------------------------------|
+> | Clarification                          | 0                            |
+> | Addition                               | –1                           |
+> | Alteration                             | –3                           |
+> | Case being heard at the Grand Tribunal | –1 (cumulative)              |
 
-# Characters
+## Characters
 
 *A magus who does not have at least one disgraced magus in his ancestry has displayed a distinct lack of enterprise.*
 
@@ -4130,12 +3846,9 @@ Once all the points have been debated, the proposer's Argument Strength is used 
 
 House Tytalus is a diverse group. Unlike other Houses, they do not demand lineage from the Founder or adherence to a Mystery Cult to be a member, just adherence to the House philosophy. In the early decades of the Order it was a fastgrowing House, attracting fully-fledged wizards from aggressive traditions who were capable of besting a Tytalus in an eristic moot. After the founding of House Ex Miscellanea, this stream of new recruits dried up, and yet there has still been cross-fertilization from other Houses, as one of the few available destinations for a magus who has abandoned his lineage or renounced his cult. As a consequence, magi of House Tytalus often do not bear much resemblance to one another; they have no favored type of magic, and few defining Virtues and Flaws save for the Self Confident Virtue, which is a product of their hard apprenticeship.
 
-
 However, there are two groups within House Tytalus that practice a specific type of magic, both descended from Tytalus. The **Titanoi** are a Mystery Cult who are heirs to the Founder's magical tradition, whereas the **leper magi** are a lineage who draw strength from the terrible disease that has passed to pupil from master right back to Tytalus himself. See below for details of these two groups.
 
-There are some general themes that one should keep in mind when designing a magus of House Tytalus. It is very important to have a clear idea of his inner nature, because the conflicts he faces in life are geared towards its betterment. Most Tytalan magi therefore have a Major Personality Flaw, for they have been taught to be ruled by their passions, not constrain them to suit society. For magi interested in politics, Virtues that assist them in this arena include: Affinity with or Puissant Artes Liberales, Folk Ken, or Intrigue; Clear Thinker; Famous; Inspirational; and Piercing Gaze. For those more interested in the clandestine world of cabals and personae, the Gentle Gift is a major boon, as is Affinity with or
-
-Puissant Stealth, Gossip, Light Touch, or Social Contacts.
+There are some general themes that one should keep in mind when designing a magus of House Tytalus. It is very important to have a clear idea of his inner nature, because the conflicts he faces in life are geared towards its betterment. Most Tytalan magi therefore have a Major Personality Flaw, for they have been taught to be ruled by their passions, not constrain them to suit society. For magi interested in politics, Virtues that assist them in this arena include: Affinity with or Puissant Artes Liberales, Folk Ken, or Intrigue; Clear Thinker; Famous; Inspirational; and Piercing Gaze. For those more interested in the clandestine world of cabals and personae, the Gentle Gift is a major boon, as is Affinity with or Puissant Stealth, Gossip, Light Touch, or Social Contacts.
 
 If Tytali could be said to have Flaws in common, they would be related to internecine struggles. The new Flaw of Beloved Rival (described below) encapsulates the love-hate relationship that Tytali often maintain with their sodales. Enemies and Feud can both be used to represent a rivalry that relates more to persecution than the normal competition. Tormenting Master and Weak Parens can both result from apprenticeship (see above).
 
@@ -4145,30 +3858,27 @@ If Tytali could be said to have Flaws in common, they would be related to intern
 
 *Major, Hermetic (House Tytalus only)*
 
-This Virtue describes the mystic legacy passed on from Tytalus to Hariste's line through the vector of leprosy. This Virtue can only be bought if the character also has the Leprosy Flaw. It allows him to draw upon the strength of his body to increase the power of his magic, granting the Life Boost Minor Virtue. He can also draw even deeper into this power if he desires, mortifying his disease-ridden flesh to produce vis to power his own spells. The vis generated in this way can only be used by the magus himself, in spellcasting or laboratory activities (but not study), and cannot be stored in any way — in fact, it never leaves his body. By accepting a Light Wound, the magus can infuse a single magical working with three pawns of vis, of any Technique or Form. A Medium Wound supplies six pawns, a Heavy Wound nine pawns, an Incapacitating Wound 12 pawns, and a Deadly Wound (killing the magus) 15 pawns. Any vis that is produced beyond the magus's capacity to use in the current magical activity is lost, as is any vis surplus to the requirements of the activity to which this power is applied. Leprotic wounds open on the magus's body as he calls upon this power, but not quickly enough to affect the Casting Total of a non-Ritual spell affected by this power. All Lab Totals suffer the wound penalty as normal, as do the Casting Totals of spells that take more than one round to cast (such as Ritual spells). These wounds
+This Virtue describes the mystic legacy passed on from Tytalus to Hariste's line through the vector of leprosy. This Virtue can only be bought if the character also has the Leprosy Flaw. It allows him to draw upon the strength of his body to increase the power of his magic, granting the Life Boost Minor Virtue. He can also draw even deeper into this power if he desires, mortifying his disease-ridden flesh to produce vis to power his own spells. The vis generated in this way can only be used by the magus himself, in spellcasting or laboratory activities (but not study), and cannot be stored in any way — in fact, it never leaves his body. By accepting a Light Wound, the magus can infuse a single magical working with three pawns of vis, of any Technique or Form. A Medium Wound supplies six pawns, a Heavy Wound nine pawns, an Incapacitating Wound 12 pawns, and a Deadly Wound (killing the magus) 15 pawns. Any vis that is produced beyond the magus's capacity to use in the current magical activity is lost, as is any vis surplus to the requirements of the activity to which this power is applied. Leprotic wounds open on the magus's body as he calls upon this power, but not quickly enough to affect the Casting Total of a non-Ritual spell affected by this power. All Lab Totals suffer the wound penalty as normal, as do the Casting Totals of spells that take more than one round to cast (such as Ritual spells). The character makes no Recovery rolls for this wound until the magical activity that the vis is being used for is complete (i.e., at the end of the casting of the spell, or the end of a season for lab work). While this means that the wound cannot get better, it also means that it does not risk worsening. Since the power is expressed from the pain of this wound, magic used to negate that pain also negates the benefits of this Virtue. A wound taken in this fashion must heal completely before the power may be used again, and any character using this power more than three times a year must make an extra Aging roll in winter.
 
-
-### The Titans
-
-The Titans (according to House Tytalus) were the means by which the world was created. The elder generation of Titans were the rulers of the universe before the gods of Olympus usurped their position. The gods fought with and eventually imprisoned the Titans, leaving them capable of ordering the universe, but only with the permission of their captors. According to legend, the Titans also created man and his base nature, but it was a god who brought justice, conscience, and laws from heaven to man — Hermes.
-
-There were 12 Elder Titans, children of the Earth and the Sky. Their offspring, the Younger Titans, were of more interest to Tytalus than their vastly more powerful parents, and they fathered a host of Daimons, spirits of primal concepts such as love, war, and envy. Included in this group are famous members such as Helios the Sun, Selene the Moon, Hekate the Witch, the four winds, the Muses, the Graces, and the Fates. However, one particular family of Titans was employed to great effect against Guorna, and they are summarized below.
-
-**Pallas** is the Titan of war-craft. He is the son of Krios, the Elder Titan of leadership, and is a goat-like spirit who was eventually defeated by Athene, who formed her aegis (shield) from his skin.
-
-**Styx** is the wife of Pallas, and represents the underworld river that bears her name, and upon which the most solemn oaths are sworn. Her name means "hatred." With Pallas she had two sons (Zelos and Kratos) and three daughters (Peitho, Nike, and Bia).
-
-**Zelos** is the Daimon of eager rivalry, emulation, envy, and jealousy. Tytalus saw this spirit as his personal patron, and by extension, the patron of his House.
-
-**Nike** is the Daimon of victory, in both battle and peaceful competition.
-
-**Bia** is the Daimon of force, power, and compulsion.
-
-**Kratos** is the Daimon of might, bodily strength, and sovereign rule.
-
-**Peitho** is the Daimon of persuasion and charming speech, and with her sister Bia she represents forceful inducement.
-
-do not start to heal until the magical activity that they are being used for is complete (i.e., at the end of the casting of the spell, or the end of a season for lab work), and since the power is expressed from the pain of these wounds, magic used to negate that pain also negates the benefits of this Virtue. A wound taken in this fashion must heal completely before the power may be used again, and any character using this power more than three times a year must make an extra Aging roll in winter.
+> ### The Titans
+> 
+> The Titans (according to House Tytalus) were the means by which the world was created. The elder generation of Titans were the rulers of the universe before the gods of Olympus usurped their position. The gods fought with and eventually imprisoned the Titans, leaving them capable of ordering the universe, but only with the permission of their captors. According to legend, the Titans also created man and his base nature, but it was a god who brought justice, conscience, and laws from heaven to man — Hermes.
+> 
+> There were 12 Elder Titans, children of the Earth and the Sky. Their offspring, the Younger Titans, were of more interest to Tytalus than their vastly more powerful parents, and they fathered a host of Daimons, spirits of primal concepts such as love, war, and envy. Included in this group are famous members such as Helios the Sun, Selene the Moon, Hekate the Witch, the four winds, the Muses, the Graces, and the Fates. However, one particular family of Titans was employed to great effect against Guorna, and they are summarized below.
+> 
+> **Pallas** is the Titan of war-craft. He is the son of Krios, the Elder Titan of leadership, and is a goat-like spirit who was eventually defeated by Athene, who formed her aegis (shield) from his skin.
+> 
+> **Styx** is the wife of Pallas, and represents the underworld river that bears her name, and upon which the most solemn oaths are sworn. Her name means "hatred." With Pallas she had two sons (Zelos and Kratos) and three daughters (Peitho, Nike, and Bia).
+> 
+> **Zelos** is the Daimon of eager rivalry, emulation, envy, and jealousy. Tytalus saw this spirit as his personal patron, and by extension, the patron of his House.
+> 
+> **Nike** is the Daimon of victory, in both battle and peaceful competition.
+> 
+> **Bia** is the Daimon of force, power, and compulsion.
+> 
+> **Kratos** is the Daimon of might, bodily strength, and sovereign rule.
+> 
+> **Peitho** is the Daimon of persuasion and charming speech, and with her sister Bia she represents forceful inducement.
 
 #### Persona
 
@@ -4188,8 +3898,7 @@ A leper has a permanent –2 modifier to her Living Conditions (with an addition
 
 *Minor, Story*
 
-The character has a rival who is both fiercely protective of him and obsessed with opposing him at every turn. For Tytalan magi, this rival is usually an older maga, most likely the magus's former teacher, or possibly an elder apprentice
-
+The character has a rival who is both fiercely protective of him and obsessed with opposing him at every turn. For Tytalan magi, this rival is usually an older maga, most likely the magus's former teacher, or possibly an elder apprentice of the character’s master. Much like the Enemies Flaw (ArM5, page 53), the rival periodically causes trouble for the magus; however, she jealously guards the privilege of making the magus’s life a misery, and often steps in to remove obstacles that are not of her own making. The rival genuinely believes that her opposition benefits her victim, and desires to see him prosper through adversity. 
 
 ### Titanoi
 
@@ -4199,61 +3908,53 @@ The Titanoi of House Tytalus are a Mystery Cult that preserves the knowledge and
 
 The Betrayal (see History, above) nearly saw the end of the Titanoi. Only a handful of its magi survived the purge, and they were mostly young magi who were poorly versed in the Ars Goetia. After the Schism War, the remaining members of the lineage convinced a small sect of Greek theurgists to defect from House Ex Miscellanea and join Tytalus, to revive the Titanoi. These theurgists reformed the Titanoi into a Mystery Cult, but it subsequently lost most of its religious elements due to the strong Sophist leanings of House Tytalus. The cult now serves to offer praise and honor to the governors of the Universe, rather than give them worship. Consequently, not all the members of the cult are pagan, but all have decidedly heterodox views about how the universe was created and is run.
 
-
 The Titanoi excel in the summoning and control of spiritual entities. They concentrate on the Titans and their children (see insert), but no Titanos is adverse to spells relating to other spirits, such as ghosts, elemental spirits, and the like. A magus raised in the cult develops a Major Magical Focus in Spirits during his apprenticeship, which applies to all supernatural entities that have a naturally insubstantial form. This includes ghosts, but does not extend to other aspects of necromancy such as the animation of corpses. He is also taught Magic Lore and Titanoi Cult Lore. Many Titanoi do not seek further Initiation into the Mysteries of the cult due to the social stigma attached to its practices since the Betrayal. Nevertheless, the lure of more powerful magics offered by the cult often attracts a Titanos after he has had the chance to develop a few powerful enemies. The cult can Initiate the following Virtues: Hermetic Theurgy, Invocation Magic, Names of Power, Theurgic Spirit Familiar, and Student of Magic Realm. For details of these Mystery Virtues, see *The. Mysteries.Revised.Edition*.
 
 The taint of Tasgillia's trial still runs deep in this lineage, and a Titanos who is open about his membership of this tradition might suffer from the attentions of a suspicious member of House Guernicus, determined to uncover the diabolic roots of the magus; thus, Titanoi characters frequently have the Enemy Flaw.
 
 ### Leper Magi
 
-**symbol:.**A hedera made of two intertwined ribbons or snakes.
+**Symbol:** A hedera made of two intertwined ribbons or snakes.
 
-Tytalus contracted the dread curse of leprosy from his mater Guorna, but managed to spare all but one of his followers from the contagion. To his great chagrin, it was Hariste, his cherished fi lia, who was the unfortunate victim of this disease. Hariste herself took the knowledge that she had contracted the curse with remarkable sangfroid; secretly she rejoiced, for the disease identifi ed her even more closely with the man whom she loved and respected, and it removed the last barrier between the two of them. When Tytalus disappeared, Hariste was over-wrought
+Tytalus contracted the dread curse of leprosy from his mater Guorna, but managed to spare all but one of his followers from the contagion. To his great chagrin, it was Hariste, his cherished filia, who was the unfortunate victim of this disease. Hariste herself took the knowledge that she had contracted the curse with remarkable sangfroid; secretly she rejoiced, for the disease identified her even more closely with the man whom she loved and respected, and it removed the last barrier between the two of them. When Tytalus disappeared, Hariste was over-wrought with grief, and only the consolation of her devoted pupil Epimetheus saved her from self-destruction. However, in consoling her, he contracted the disease himself and the lineage was born.
 
-### The Curse of Leprosy
-
-*Thou. shalt. not. bow. down. thyself. to. them,. nor. serve.them:.for.I.the.LORD.thy.God.am.a.jealous.God,.visiting.the.sins.of.the.fathers.upon.the. children. unto. the. third. and. fourth. generation. of. them.that.hate.me.*
-
-*—.*Exodus 20:5
-
-Leprosy in Mythic Europe is a Divine Curse (see *City.&.Guild*, Chapter 1: Towns & Cities, Disease), meted out to those betray God. It cannot be cured, and is only contracted by those who are spiritually impure. While this description certainly fi ts Guorna, and probably Tytalus, it is not clear why the curse propagated itself to Hariste and Epimetheus, although some have cited the above passage from Exodus as a possible reason. The fi fth and subsequent generations of leper magi have been found by their masters among lepers rather than contracting the curse from the elder magus; upon being opened to the Arts they acquire the Leper Magus Virtue. The small size of this lineage is testament to the rarity of lepers with The Gift, and magi are lucky if they can fi nd one in their entire lives.
-
-In Mythic Europe, lepers are legally and spiritually dead, separated from society by a rite called the Offi ce of the Seclusion of the Leper. This rite sets out stringent rules governing the conduct of lepers and their contact with the healthy, although civil laws impose other rules, which differ between regions. They cannot enter any place where people assemble (such as a church or market), or where food is prepared. They cannot touch objects that do not belong to them, and can neither own property or inherit it. They are even enjoined to stand downwind of anyone
-
-who wishes to talk to them. They must live apart from the healthy; always wear a gray or russet leper's robe, elbowlength gloves, and either a mask, hood, or veil; and carry a clapper or bell, which they must ring to alert others of their presence. Many lepers are wanderers or live in leper colonies, but they may also elect to remain in their home communities, in a separate dwelling outside the bounds of the village or town. Despite being legally protected from harm (so long as they follow the seclusion laws), lepers were frequently subjected to beatings and even murder, often by being burned alive.
+> ## The Curse of Leprosy
+> 
+> *Thou. shalt. not. bow. down. thyself. to. them,. nor. serve.them:.for.I.the.LORD.thy.God.am.a.jealous.God,.visiting.the.sins.of.the.fathers.upon.the. children. unto. the. third. and. fourth. generation. of. them.that.hate.me.*
+> 
+> *—.*Exodus 20:5
+> 
+> Leprosy in Mythic Europe is a Divine Curse (see *City.&.Guild*, Chapter 1: Towns & Cities, Disease), meted out to those betray God. It cannot be cured, and is only contracted by those who are spiritually impure. While this description certainly fits Guorna, and probably Tytalus, it is not clear why the curse propagated itself to Hariste and Epimetheus, although some have cited the above passage from Exodus as a possible reason. The fifth and subsequent generations of leper magi have been found by their masters among lepers rather than contracting the curse from the elder magus; upon being opened to the Arts they acquire the Leper Magus Virtue. The small size of this lineage is testament to the rarity of lepers with The Gift, and magi are lucky if they can find one in their entire lives.
+> 
+> In Mythic Europe, lepers are legally and spiritually dead, separated from society by a rite called the Office of the Seclusion of the Leper. This rite sets out stringent rules governing the conduct of lepers and their contact with the healthy, although civil laws impose other rules, which differ between regions. They cannot enter any place where people assemble (such as a church or market), or where food is prepared. They cannot touch objects that do not belong to them, and can neither own property or inherit it. They are even enjoined to stand downwind of anyone who wishes to talk to them. They must live apart from the healthy; always wear a gray or russet leper's robe, elbowlength gloves, and either a mask, hood, or veil; and carry a clapper or bell, which they must ring to alert others of their presence. Many lepers are wanderers or live in leper colonies, but they may also elect to remain in their home communities, in a separate dwelling outside the bounds of the village or town. Despite being legally protected from harm (so long as they follow the seclusion laws), lepers were frequently subjected to beatings and even murder, often by being burned alive.
 
 with grief, and only the consolation of her devoted pupil Epimetheus saved her from self-destruction. However, in consoling her, he contracted the disease himself and the lineage was born.
 
-The **magi aegroti**, as they are known, are a distinct minority in the House; there are usually fewer than a dozen at any one time, for it is hard for them to fi nd apprentices. Leper magi are treated with a certain amount of ambivalence in the House and the Order. They are known to be powerful healers and experts in longevity, but the appearance of one in a region is accompanied by dread, due to their affl iction. Despite the stringent rules regarding the conduct of lepers, magi aegroti feel no compulsion to follow them, although many do in deference to the sensibilities of
-
-
-*Infernal Taint* The magical arts practiced by
-
-Guorna and Tytalus included the Ars Goetia (see *Realms of Power: The Infernal*, Chapter 11: Ars Goetia), which deals with the summoning, binding, commanding, and punishment of spiritual entities of all realms except the Divine. While these powers are not inherently evil, their association with spirits and the underworld make them tainted, socially and supernaturally. Modern Titanoi claim to employ only Hermetic practices, and thus avoid any sorcerous taint of the Ars Goetia. They do not admit to also preserving the original magics of their Founder (in the form of Goetic Magic), but it is known for a certainty that Tasgillia did, and it seems unlikely that this knowledge was completely purged from the House by the Quaesitores.
-
-At the option of the storyguide, the Mystagogues of the Titanoi can also Initiate the Goetic Arts of Summoning, Ablating, Binding, and Commanding as Major Mystery Virtues, and teach Goetic Spell Mastery.
-
-their sodales. Even if a leper magus can persuade a covenant to let him join, his sanctum is often placed outside the walls (and possibly the aura) of the covenant in accordance with the seclusion laws; as a consequence many magi aegroti are wanderers. Most leper magi enjoy the mystique that surrounds them, and tend to play up their role somewhat, wearing the tattered leper's outfit and enchanting the bell or clapper they carry with protective charms against disease. Most hold Hippian ethics with respect to the House philosophy, and consider caring for the sick and healing their ills to be one of the universal, unwritten laws. They take their conflict within the human body, struggling against contagion and ill-health. Magi aegroti have the same combative spirit as the rest of their House, and they can be dangerous when roused.
+The **magi aegroti**, as they are known, are a distinct minority in the House; there are usually fewer than a dozen at any one time, for it is hard for them to find apprentices. Leper magi are treated with a certain amount of ambivalence in the House and the Order. They are known to be powerful healers and experts in longevity, but the appearance of one in a region is accompanied by dread, due to their affliction. Despite the stringent rules regarding the conduct of lepers, magi aegroti feel no compulsion to follow them, although many do in deference to the sensibilities of their sodales. Even if a leper magus can persuade a covenant to let him join, his sanctum is often placed outside the walls (and possibly the aura) of the covenant in accordance with the seclusion laws; as a consequence many magi aegroti are wanderers. Most leper magi enjoy the mystique that surrounds them, and tend to play up their role somewhat, wearing the tattered leper's outfit and enchanting the bell or clapper they carry with protective charms against disease. Most hold Hippian ethics with respect to the House philosophy, and consider caring for the sick and healing their ills to be one of the universal, unwritten laws. They take their conflict within the human body, struggling against contagion and ill-health. Magi aegroti have the same combative spirit as the rest of their House, and they can be dangerous when roused.
 
 All magi aegroti must buy the Leper Magus Virtue and the Leprosy Flaw. Should they ever somehow lift the curse of leprosy, they lose the Leper Magus Virtue. All also have a Minor Magical Focus in either disease, wounds, or aging. They are inevitably specialized in Corpus magics, and usually have either Affinity with Corpus or Puissant Corpus. The Painful Magic Flaw is unfortunately common; those who are lucky enough to escape it developing with their leprosy may acquire it through Twilight episodes later in life.
+
+> ## Infernal Taint
+> 
+> The magical arts practiced by Guorna and Tytalus included the Ars Goetia (see *Realms of Power: The Infernal*, Chapter 11: Ars Goetia), which deals with the summoning, binding, commanding, and punishment of spiritual entities of all realms except the Divine. While these powers are not inherently evil, their association with spirits and the underworld make them tainted, socially and supernaturally. Modern Titanoi claim to employ only Hermetic practices, and thus avoid any sorcerous taint of the Ars Goetia. They do not admit to also preserving the original magics of their Founder (in the form of Goetic Magic), but it is known for a certainty that Tasgillia did, and it seems unlikely that this knowledge was completely purged from the House by the Quaesitores.
+> 
+> At the option of the storyguide, the Mystagogues of the Titanoi can also Initiate the Goetic Arts of Summoning, Ablating, Binding, and Commanding as Major Mystery Virtues, and teach Goetic Spell Mastery.
 
 # Magic
 
 *Critias said that more men are good from practice than from nature. A magus who does not practice will never be good, no matter what his nature.*
 
-*—* Analects of Tytalus
+— Analects of Tytalus
 
 Tytalus magi have different interests, and thus may have very different tastes in magic. However, all show a fascination for intrigue, which lends itself well to the practice of Mentem magics. The following sections describe some useful spells for activities in which Tytalan magi usually excel.
 
 #### Magic for the Debating Arena
 
-The use of magic in the debating arena is heavily frowned upon by the Order of Hermes. Several Tribunal meetings take place under an *Aegis of the Hearth* cast by the praeco and the presiding Quaesitor specifically to inhibit magic that might influence the democratic processes of the Order. In other Tribunals, the Quaesitores specifically request that enchantments not be used in the debating arena, and run periodic checks against them. Not all Tribunals take such precautions, however, and a member of House Tytalus can often benefit from some judicial use of debating magic. Magi taking this perilous route should concentrate on magic that enhances their own abilities rather than directly affecting the audience. For example, *Aura of Ennobled Presence* changes the magus's image so that he emits species of sight and hearing that make him appear more convincing, granting a +3 bonus to all debating Defense Totals that
-
-use the Leadership Ability. Tytalan magi have developed similar spells that make them seem more likeable (and thus affect Charm defenses) or more believable (and thus improve Guile defenses); see the spells *Aura of Beguiling Appearance* and *Aura of Childlike Innocence* below. At the option of the storyguide, *Aura of Ennobled Presence* might warp the manifestation of The Gift in the same way as these two spells; while still giving the usual bonus against mundanes, the character expresses his enhanced leadership as a harsh taskmaster or cruel lord.
+The use of magic in the debating arena is heavily frowned upon by the Order of Hermes. Several Tribunal meetings take place under an *Aegis of the Hearth* cast by the praeco and the presiding Quaesitor specifically to inhibit magic that might influence the democratic processes of the Order. In other Tribunals, the Quaesitores specifically request that enchantments not be used in the debating arena, and run periodic checks against them. Not all Tribunals take such precautions, however, and a member of House Tytalus can often benefit from some judicial use of debating magic. Magi taking this perilous route should concentrate on magic that enhances their own abilities rather than directly affecting the audience. For example, *Aura of Ennobled Presence* changes the magus's image so that he emits species of sight and hearing that make him appear more convincing, granting a +3 bonus to all debating Defense Totals that use the Leadership Ability. Tytalan magi have developed similar spells that make them seem more likeable (and thus affect Charm defenses) or more believable (and thus improve Guile defenses); see the spells *Aura of Beguiling Appearance* and *Aura of Childlike Innocence* below. At the option of the storyguide, *Aura of Ennobled Presence* might warp the manifestation of The Gift in the same way as these two spells; while still giving the usual bonus against mundanes, the character expresses his enhanced leadership as a harsh taskmaster or cruel lord.
 
 Other magi are quick to cry foul if they discover that such spells have been used during a Tribunal meeting, but there is no provision in the Code of Hermes to prevent these tactics. Of course, should their use become widespread then either the advantage will be lost to the Tytali, or magical or legal countermeasures will be taken to negate them. Tytalan magi are warned by their parentes to use these spells with care (or with a good *Masking the Odor of Magic* spell!).
 
-#### Aura of Beguiling Appearance
+##### Aura of Beguiling Appearance
 
 MuIm 10
 
@@ -4263,7 +3964,7 @@ This spell is a variant of *Aura of Ennobled Presence*, except that it causes th
 
 (Base 3, +1 Touch, +2 Sun)
 
-#### Aura of Childlike Innocence
+##### Aura of Childlike Innocence
 
 MuIm 10
 
@@ -4273,15 +3974,13 @@ This spell is a variant of *Aura of Ennobled Presence*, except that it causes th
 
 (Base 3, +1 Touch, +2 Sun)
 
-
 #### The Magic of Impersonation
 
 Those magi who have spent time and effort developing personae often learn or invent spells that assist them in maintaining these separate identities. Most Tytalan magi do not rely upon a magical disguise when using a persona because of the need to renew it on a regular basis, and the fact that some individuals are gifted with Second Sight or Magic Sensitivity, and can destroy their cover easily. Nevertheless, a magical enchantment can overcome these limitations with a constant effect in an enchantment, particularly if coupled with *Mask the Odor of Magic*. Despite the problems associated with a magically maintained persona, some magi do employ such tricks. Occasionally it is necessary to create a persona of the opposite sex, with a specific characteristic such as red hair or dwarf stature, or even with all the particular features of a certain real person. In such cases, spells such as *Disguise of the Transformed Image* and *Disguise of the New Visage* can prove very useful. Members of House Tytalus even trade Lab Texts of such spells that cause the caster to become a specific individual; those versions can only be used to adopt the guise of the person determined when the spell was invented, but that disguise is flawless, and does not rely on the caster knowing the individual whom he is copying.
 
 The Tytalan spell *Donning the Mask of Another* allows a magus to acquire a deep cover disguise by stealing one from another. This spell is most commonly used to pass a cover on to another magus once it is no longer useful to the magus who initially developed it, perhaps because he has finished with the schemes that precipitated its creation. In this case the spell is often cast through a *Wizard's Communion*, and the caster extends his Parma round the donor (ArM5, page 87) so that only the Form Resistance of the donor needs to be overcome by the spell's Penetration. Such an arrangement usually places the new owner in the debt of the former owner. However, this spell may also be used to steal a persona from another; with a Perdo requisite added to the spell during its invention, it can even remove all memory of the identity from the donor's mind.
 
-
-**The Succubus's Trick**
+##### The Succubus's Trick
 
 MuCo 5
 
@@ -4291,7 +3990,7 @@ This spell causes a female caster to adopt male physical characteristics. A simi
 
 (Base 3, +2 Sun)
 
-**The Far-Speaking Voice**
+#### The Far-Speaking Voice
 
 CrMe 20
 
@@ -4301,7 +4000,7 @@ The caster can deliver two minutes of conversation directly into the mind of the
 
 (Base 3, +4 Arc, +1 Diam)
 
-**Donning the Mask of Another**
+##### Donning the Mask of Another
 
 MuMe 35
 
@@ -4309,10 +4008,7 @@ R: Touch, D: Year, T: Ind, Ritual
 
 This spell creates a persona from the identity of another (henceforth called the donor). The donor must be present during the Ritual spell, but need not be willing or even conscious for the correct operation of the spell, though it must penetrate any Magic Resistance as usual.
 
-The caster acquires the full memories and personality of the donor as a deep cover disguise with a Reputation score of 3, but which offers no reduction in the social penalty of the caster's Gift. This spell can also be used on characters who have established a deep cover disguise of their own, in which case it confers the Reputation at the same score as the donor's, with the
-
-
-same reduction in The Gift's effects that he enjoyed. If, in the year that the caster maintains this foreign identity, he is able to apply at least 5 experience points to the Reputation, then the Reputation persists once the spell's Duration expires.
+The caster acquires the full memories and personality of the donor as a deep cover disguise with a Reputation score of 3, but which offers no reduction in the social penalty of the caster's Gift. This spell can also be used on characters who have established a deep cover disguise of their own, in which case it confers the Reputation at the same score as the donor's, with the same reduction in The Gift's effects that he enjoyed. If, in the year that the caster maintains this foreign identity, he is able to apply at least 5 experience points to the Reputation, then the Reputation persists once the spell's Duration expires.
 
 The caster must employ further magic to acquire the physical resemblance of the persona. The caster could even fool close friends and family, if his physical disguise is good enough. This spell inflicts one Warping Point on both the caster and donor when it is cast (from the powerful mystical effect), and the caster suffers an additional Warping Point at the end of the spell's duration (from the constant mystical effect).
 
@@ -4324,15 +4020,13 @@ Magi of House Tytalus often employ magics that assist them in their intrigues. S
 
 Tytali rarely control the mundane agents of their schemes directly with magic; these spells tend to inhibit freedom of thought, and Tytalan magi prefer agents who are capable of adapting to a situation over mindless automata. Furthermore, Rego Mentem spells that are powerful enough to be of use usually cause Warping, which is an annoyance for any agent who is to be used more than once. More subtle spells, such as ones to induce feelings of loyalty, or to spread malicious gossip about a rival (see *Burning Issue of the Day*, below), are far more popular.
 
-#### Houses of Hermes
-
 For meeting with co-conspirators, Tytalan magi often preserve their anonymity with face-changing or face-blurring magic (see *The Clandestine Mask*, below), or else meet in total darkness. Some do both, just in case one concealment method is negated by treachery. Spells can be employed to ensure the secure transfer of information between conspirators (see *Enchantment of the Pedestrian Pigeon*, below), or else communications can be written in Tytalan ink (see below).
 
 #### Tytalan Ink
 
 Tytalan ink is a charged item that takes the form of colorless ink. A Dexterity + Artes Liberales roll of 9 or more is required to write legible text with ink that cannot be seen. Upon uttering the command word, the ink becomes black (or any other color determined at the ink's creation) until the Duration expires, at which point it reverts to its colorless state. Each charge produces enough ink to for approximately two pages of writing; alternatively, multiple charges can be placed in the same vial of ink, allowing the message to be read multiple times.
 
-#### Reveal the Hidden Words
+##### Reveal the Hidden Words
 
 MuAq 5
 
@@ -4344,7 +4038,7 @@ Any group of words written in the enchanted, colorless liquid becomes visible up
 
 (Base 2, +1 Diam, +2 Group)
 
-#### The Clandestine Mask
+##### The Clandestine Mask
 
 MuIm 4
 
@@ -4355,7 +4049,7 @@ This spell blurs the face and distorts the voice of the caster, so that she may 
 (Base 2, +2 Sun)
 
 
-**the Jealous Mind**
+##### Betraying Whispers of the Jealous Mind
 
 InMe 30
 
@@ -4365,7 +4059,7 @@ This spell allows the caster to hear the dominant emotion regarding himself from
 
 (Base 5, +1 Conc, +3 Hearing, +1 complexity — only detects emotions concerning the caster)
 
-#### Enchantment of the Pedestrian Pigeon
+##### Enchantment of the Pedestrian Pigeon
 
 MuMe 15
 
@@ -4375,7 +4069,7 @@ After telling a person a piece of information, this spell is cast to occlude the
 
 (Base 2, +1 Eye, +3 Moon, +1 complexity)
 
-#### Burning Issue of the Day
+##### Burning Issue of the Day
 
 ReMe 30
 
@@ -4385,82 +4079,83 @@ After casting this spell, the caster utters a piece of information (true or fals
 
 (Base 5, +1 Eye, +2 Sun, +2 Group)
 
+#### The Magic of the Titanoi
 
-#### tHe.magic oF tHe.titanoi
-
-Spirits abound in Mythic Europe, present wherever an object exists which expresses a particular quality strongly. Thus, spirits of fi re can be found near open fl ames and spirits of love can be found near courting couples. These spirits are akin to animals and plants, have no personal names, and do not involve themselves in the physical world unless forced to through magic. Spells of a specifi c Form can command any spirit tied to that Form, for example, Ignem can command any fi ery spirit. Mentem spells (using the Rego Mentem guidelines, ArM5, page 151) can command any spirit with an Intelligence score, but some spirits have no Intelligence, and those are affected by Rego (Form) spells.
+Spirits abound in Mythic Europe, present wherever an object exists which expresses a particular quality strongly. Thus, spirits of fire can be found near open flames and spirits of love can be found near courting couples. These spirits are akin to animals and plants, have no personal names, and do not involve themselves in the physical world unless forced to through magic. Spells of a specific Form can command any spirit tied to that Form, for example, Ignem can command any fiery spirit. Mentem spells (using the Rego Mentem guidelines, ArM5, page 151) can command any spirit with an Intelligence score, but some spirits have no Intelligence, and those are affected by Rego (Form) spells.
 
 The Titanoi are also interested in the named spirits, the Daimons. Such spirits are not so easy to control, and only those versed in the Mystery of Theurgy are truly skilled in doing so. Unlike simpler spirits, a Daimon can manifest in several places simultaneously, by projecting only one Aspect of itself in each. Instead of summoning such a spirit, the Titanos instead forms a pact with one, causing it to send an Aspect to the magus to perform some task on his behalf in return for the spiritual sustenance provided by casting a ritual spell.
 
 For more information about spirits and Daimons, see *The. Mysteries. Revised. Edition*.
 
-#### coerce tHe.sPirit oF.anger
+##### Coerce the Spirit of Anger
 
 ReMe 20
 
 R: Voice, D: Conc, T: Ind
 
-This spell makes a spirit of anger obey the caster as long as he can coerce it with threats. The more lurid and dramatic the threats, the more cooperative the spirit is. If the spell penetrates the spirit's Magic Resistance, make a stress roll of Communication + Leadership to see how effective the threats are. The storyguide should always give a bonus or penalty depending on the potency of the threat, but note that any roll other than a botch compels at least minimal obedience, while increasing rolls indicate a more cooperative spirit. Note that the caster must be capable of sensing the spirit to use this spell,
+This spell makes a spirit of anger obey the caster as long as he can coerce it with threats. The more lurid and dramatic the threats, the more cooperative the spirit is. If the spell penetrates the spirit's Magic Resistance, make a stress roll of Communication + Leadership to see how effective the threats are. The storyguide should always give a bonus or penalty depending on the potency of the threat, but note that any roll other than a botch compels at least minimal obedience, while increasing rolls indicate a more cooperative spirit. Note that the caster must be capable of sensing the spirit to use this spell, unless it is reinvented at Range Arcane Connection.
 
+(Base 5 \[see *The.Mysteries.Revised.Edition*, page 28\], +2 Voice, +1 Conc)
 
-unless it is reinvented at Range Arcane Connection.
-
-(Base 5 [see *The.Mysteries.Revised.Edition*, page 28], +2 Voice, +1 Conc)
-
-#### summoning tHe.sPirit oF.anger
+##### Summoning the Spirit of Anger
 
 ReMe 40
 
 R: Arc, D: Conc, R: Ind
 
-This spell calls a spirit of wrath to the magus's current location, if he has an Arcane Connection or knows its full name, and overcomes its Magic Resistance. The name can be a non-magical name, and need not be a magical True Name. A wrathful person serves as an Arcane Connection to any spirit of anger; if he has a Major Personality Flaw such as Wrathful, then the spirit has a Magic Might of 30. A Minor Personality Flaw attracts a spirit of Might 20. Otherwise, the spirit has a Might equal to (5 x Angry Personality Trait). Casting this spell infl icts a Warping Point on the source of the anger, unless it is the caster himself.
+This spell calls a spirit of wrath to the magus's current location, if he has an Arcane Connection or knows its full name, and overcomes its Magic Resistance. The name can be a non-magical name, and need not be a magical True Name. A wrathful person serves as an Arcane Connection to any spirit of anger; if he has a Major Personality Flaw such as Wrathful, then the spirit has a Magic Might of 30. A Minor Personality Flaw attracts a spirit of Might 20. Otherwise, the spirit has a Might equal to (5 x Angry Personality Trait). Casting this spell inflicts a Warping Point on the source of the anger, unless it is the caster himself.
 
 Similar spells exist for summoning the spirits of other emotions.
 
-### A Spirit of a Person's Anger
+(Base 15 \[see *The. Mysteries. Revised. Edition*, page 28\], +4 Arc, +1 Conc)
 
-**Magic Might**: 20 (Mentem) **Characteristics**: Cun –1, Per 0, Pre +1, Com +3, Str +3, Sta +1, Dex +2,
+> ## A Spirit of a Person's Anger
+> 
+> **Magic Might**: 20 (Mentem) **Characteristics**: Cun –1, Per 0, Pre +1, Com +3, Str +3, Sta +1, Dex +2,
+> 
+> Qik +1
+> 
+> **Virtues and Flaws**: Wrathful **Personality Traits**: Angry +6 **Powers**:
+> 
+> *Incorporeal*, 0 points, Init Constant, Mentem: The spirit is both invisible and intangible, and cannot be influenced by the physical world. Magic may only directly target the spirit if the caster can sense its existence. The physical characteristics of the spirit are only used when dealing with other incorporeal creatures.
+> 
+> *Fury*, 3 points, Init +2, Mentem: The target of this power must roll 9 or higher on a stress die to avoid flying into a destructive, uncontrollable rage. He gets another roll every round to try to calm down. On a botch, he tries to kill everyone around him. Appropriate Personality Traits add to or subtract from the roll.
+> 
+> **Appearance**: To those with Second Sight (or similar magic), a spirit of anger appears to be a red-faced man. His muscles and tendons are taut with his furious anger, and he is constantly bellowing his rage at the world.
 
-Qik +1
-
-**Virtues and Flaws**: Wrathful **Personality Traits**: Angry +6 **Powers**:
-
-*Incorporeal*, 0 points, Init Constant, Mentem: The spirit is both invisible and intangible, and cannot be infl uenced by the physical world. Magic may only directly target the spirit if the caster can sense its existence. The physical characteristics of the spirit are only used when dealing with other incorporeal creatures.
-
-*Fury*, 3 points, Init +2, Mentem: The target of this power must roll 9 or higher on a stress die to avoid fl ying into a destructive, uncontrollable rage. He gets another roll every round to try to calm down. On a botch, he tries to kill everyone around him. Appropriate Personality Traits add to or subtract from the roll.
-
-**Appearance**: To those with Second Sight (or similar magic), a spirit of anger appears to be a red-faced man. His muscles and tendons are taut with his furious anger, and he is constantly bellowing his rage at the world.
-
-(Base 15 [see *The. Mysteries. Revised. Edition*, page 28], +4 Arc, +1 Conc)
-
-#### reveal tHe.lurking.WatcHers
+##### Reveal the Lurking Watchers
 
 InVi 30
 
 R: Per, D: Conc, T: Vision
 
-This spell allows the caster to see any creatures of the Magic realm within his fi eld of view and identify them as possessing Magic Might. The spell does not distinguish between what is spiritual and what is not, so if a spirit has an animal form, the caster may mistake it for a magical animal. The caster receives no information about the type of creature except that which can be deduced from its appearance. This spell must penetrate the Magic Resistance of
-
-
-**Magic Might**: 20
-
-**Characteristics**: Int +3, Per +4, Pre +2, Com +2, Str 0, Sta +1, Dex +1, Qik +2
-
-**Virtues and Flaws**: Puissant Intrigue **Personality Traits**: Sly +3
-
-**Abilities**: Folk Ken 4 (rivalries), Intrigue 6+2 (competition)
-
-#### Powers:
-
-*Incorporeal*, 0 points, Init Constant, Mentem: The spirit is both invisible and intangible, and cannot be influenced by the physical world. Magic may only directly target the spirit if the caster can sense its existence. The physical characteristics of the spirit are only used when dealing with other incorporeal creatures.
-
-*Grant Incorporeality*, 5 points, Init +1, Corpus: Zelos can share his incorporeal nature with another; this Power lasts until he breaks contact with the target. This Power must penetrate, so
-
-the creature; if it fails to penetrate a spirit's Might, then the spirit cannot be seen by the caster.
+This spell allows the caster to see any creatures of the Magic realm within his field of view and identify them as possessing Magic Might. The spell does not distinguish between what is spiritual and what is not, so if a spirit has an animal form, the caster may mistake it for a magical animal. The caster receives no information about the type of creature except that which can be deduced from its appearance. This spell must penetrate the Magic Resistance of the creature; if it fails to penetrate a spirit's Might, then the spirit cannot be seen by the caster.
 
 (Base 5, +1 Conc, +4 Vision)
 
-#### Invoke the Pact of Zelos
+> ## An Aspect of Zelos
+> 
+> **Magic Might**: 20
+> 
+> **Characteristics**: Int +3, Per +4, Pre +2, Com +2, Str 0, Sta +1, Dex +1, Qik +2
+> 
+> **Virtues and Flaws**: Puissant Intrigue **Personality Traits**: Sly +3
+> 
+> **Abilities**: Folk Ken 4 (rivalries), Intrigue 6+2 (competition)
+> 
+> #### Powers:
+> 
+> *Incorporeal*, 0 points, Init Constant, Mentem: The spirit is both invisible and intangible, and cannot be influenced by the physical world. Magic may only directly target the spirit if the caster can sense its existence. The physical characteristics of the spirit are only used when dealing with other incorporeal creatures.
+> 
+> *Grant Incorporeality*, 5 points, Init +1, Corpus: Zelos can share his incorporeal nature with another; this Power lasts until he breaks contact with the target. This Power must penetrate, so a magus usually has to drop his Parma for it to work.
+> 
+> *Navigate Contention's Ocean*, 2 points, Init +5, Mentem: The spirit can perceive all the plots currently surrounding an individual, and instantly travel to the location of any active rival. He can take any incorporeal being with him when he travels in this way.
+> 
+> **Appearance**: Zelos appears as a Greek youth dressed in a simple tunic, with a huge pair of black-feathered wings. He holds a laurel crown.
+> 
+> Zelos is the Daimon of rivalry, envy, and competition, and as such he never assists a character to resolve a conflict with another, but he has no difficulty with providing assistance to propagate contention. To Zelos, the network of rivalry and jealousy around a person appears as a web of intrigue, and he can follow those threads back to their sources.
+
+##### Invoke the Pact of Zelos
 
 ReVi Gen
 
@@ -4468,29 +4163,21 @@ R: Arc, D: Mom, T: Ind, Ritual
 
 This spell represents the formation of a pact with Zelos, the Daimon of rivalry and contention. It targets a duplicate (called an Aspect) of Zelos, rather than the spirit itself, and if the spell penetrates the Aspect's Might (see insert), that Aspect appears before the caster to perform a specific service. This spell does not exert any control over this spirit.
 
-a magus usually has to drop his Parma for it to work.
-
-*Navigate Contention's Ocean*, 2 points, Init +5, Mentem: The spirit can perceive all the plots currently surrounding an individual, and instantly travel to the location of any active rival. He can take any incorporeal being with him when he travels in this way.
-
-**Appearance**: Zelos appears as a Greek youth dressed in a simple tunic, with a huge pair of black-feathered wings. He holds a laurel crown.
-
-Zelos is the Daimon of rivalry, envy, and competition, and as such he never assists a character to resolve a conflict with another, but he has no difficulty with providing assistance to propagate contention. To Zelos, the network of rivalry and jealousy around a person appears as a web of intrigue, and he can follow those threads back to their sources.
-
 Without the Mystery Virtue of Hermetic Theurgy, this spell must have a level of at least 40 (twice the Might of the Daimon's Aspect), and it usually needs to be cast using *Wizard's Communion*, to achieve sufficient Penetration. As a spell adapted from non-Hermetic theurgic practices, it requires knowledge of a Mystery, or a Hermetic Breakthrough, to invent, although nontheurgist Hermetic magi can learn the spell from a Lab Text or from a teacher. Acquiring an Arcane Connection to a Daimon such as Zelos is no simple task, and may be the focus of a story in its own right.
 
 (General effect, +4 Arc, see *The Mysteries Revised Edition*, Chapter 9: Hermetic Theurgy for more details)
 
-### An Aspect of Zelos New Corpus Guidelines
-
-**Creo Corpus**
-
-Level 25: Improve all wounds by one level of severity.
+> ## ANew Corpus Guidelines
+> 
+> **Creo Corpus**
+> 
+> Level 25: Improve all wounds by one level of severity.
 
 #### The Magic of the Leper Magi
 
 The leper magi employ all of the magical techniques of other Tytali, but they also have a strong focus in spells of health and healing. Nearly every magus aegrotus knows *Chirurgeon's Healing Touch*, as well as other spells that heals more serious wounds. It is the combating of diseases at which they excel, however, as well as the prolongation of life through the creation on Longevity Rituals and the resolution of Aging Crises.
 
-#### Ward the Cruel Touch of Pestilence
+##### Ward the Cruel Touch of Pestilence
 
 CrCo 20
 
@@ -4500,7 +4187,7 @@ The target gains a +9 bonus to Stamina rolls to avoid contracting diseases (see 
 
 (Base 4, +1 Touch, +3 Moon)
 
-#### Gentle Caress of Aesclepius
+##### Gentle Caress of Aesclepius
 
 CrCo 30
 
@@ -4510,60 +4197,49 @@ All of the target's wounds immediately improve by one level of severity; an Inca
 
 (Base 25, +1 Touch)
 
-
-### Chapter Four
-
-# House Ex Miscellanea
+# Chapter Four: House Ex Miscellanea
 
 *We.are.the.Order's.forsaken.army;.they.have.used. us.to.defeat.their.foe,.and.now.they.wish.us.to.depart. back. to. the. hedges. and. the. crags. from. which. we. came..It.shall.not.be.so!.We.might.be.hedge.wizards. and. crag. witches,. but. we. have. proven. our. power. 'gainst.a.foe.the.Order.itself.feared.to.face..If.they. must.be.forced.to.recognize.us.as.equals,.then.we.must. be.the.crooked.staff.which.applied.that.force!.*
 
-*—.*Pralix fi lia Tytalus, 816 AD
+— Pralix filia Tytalus, 816 AD
 
-House Ex Miscellanea is the largest of the Order's 12 Houses, and yet it has the least prestige and recognition among other magi. This is because, unlike other Houses, there is no unifying concept that unites the House, no common descent, single cultic belief, nor shared philosophy. Instead, this House is composed of numerous Lineages, Mystery Cults, and Societates, each one with its own history, culture, and magic. This chapter is divided into two parts: the fi rst part provides the reader with some facts about the House as a whole, and the second part is devoted to the description of nine traditions of House Ex Miscellanea.
+House Ex Miscellanea is the largest of the Order's 12 Houses, and yet it has the least prestige and recognition among other magi. This is because, unlike other Houses, there is no unifying concept that unites the House, no common descent, single cultic belief, nor shared philosophy. Instead, this House is composed of numerous Lineages, Mystery Cults, and Societates, each one with its own history, culture, and magic. This chapter is divided into two parts: the first part provides the reader with some facts about the House as a whole, and the second part is devoted to the description of eight traditions of House Ex Miscellanea.
 
-# History
+## History
 
-The story of the formation of the House was a major event in the history of the Order of Hermes, and is well known (ArM5, page 10). Briefl y, Pralix the pupil of Tytalus was charged with hunting down a non-Hermetic warlock called Damhan-Allaidh (pronounced DAH-van-AHL-ee; often Latinized to Davanallus) who had recruited an army of Anglo-Saxon runewizards and monstrous shapechangers and posed a threat to the Order in the early ninth century. To assist her with this task,
+The story of the formation of the House was a major event in the history of the Order of Hermes, and is well known (ArM5, page 10). Briefly, Pralix the pupil of Tytalus was charged with hunting down a non-Hermetic warlock called Damhan-Allaidh (pronounced DAH-van-AHL-ee; often Latinized to Davanallus) who had recruited an army of Anglo-Saxon runewizards and monstrous shapechangers and posed a threat to the Order in the early ninth century. To assist her with this task, Pralix needed an army of her own, and so she recruited native magicians from all over the British Isles who had also suffered under this warlock. At the head of this army, she faced her foe first at Loch Leglean in Scotland, then all through northern England, until they met finally at Cad Gadu in Wales. There, during the Battle of the False Sun, Damhan-Allaidh and his fearsome allies were finally defeated.
 
-### Key Facts
-
-**PoPulation:.** Estimated at 180, although a census is currently underway which may revise this number.
-
-**Primus:.**Ebroin
-
-**domus. magna:.** Cad Gadu, in North Wales (Stonehenge Tribunal). The covenant lies on an island in a lake, at the top level of magical regio where the aura is of strength 8. The whole island is frequently shrouded in mist, and people have been known to be lost forever in these mists if they stray from the marked path. Cad Gadu was originally the home of a tradition of hedge wizards called the Columbae, but its current name comes from the fi nal battle between Pralix and Damhan-Allaidh, and means "the forsaken army" in honor of all the magi who perished in this war.
-
-**Favored. tribunals:.** Magi Ex Miscellanea are found equally in all Tribunals.
-
-**motto:.** *Totus. multitudinem. componet* ("the whole is composed of many parts")
-
-**symbol:.**A crooked staff
-
-Pralix needed an army of her own, and so she recruited native magicians from all over the British Isles who had also suffered under this warlock. At the head of this army, she faced her foe fi rst at Loch Leglean in Scotland, then all through northern England, until they met fi nally at Cad Gadu in Wales. There, during the Battle of the False Sun, Damhan-Allaidh and his fearsome allies were fi nally defeated.
+> ## Key Facts
+> 
+> **Population:** Estimated at 180, although a census is currently underway which may revise this number.
+> 
+> **Primus:** Ebroin
+> 
+> **Domus Magna:** Cad Gadu, in North Wales (Stonehenge Tribunal). The covenant lies on an island in a lake, at the top level of magical regio where the aura is of strength 8. The whole island is frequently shrouded in mist, and people have been known to be lost forever in these mists if they stray from the marked path. Cad Gadu was originally the home of a tradition of hedge wizards called the Columbae, but its current name comes from the final battle between Pralix and Damhan-Allaidh, and means "the forsaken army" in honor of all the magi who perished in this war.
+> 
+> **Favored tribunals:** Magi Ex Miscellanea are found equally in all Tribunals.
+> 
+> **Motto:** *Totus multitudinem componet* ("the whole is composed of many parts")
+> 
+> **Symbol:** A crooked staff
 
 When Pralix declined to return to home in triumph, Mercere visited her in person at Cad Gadu, but was refused entrance. Pralix had renounced both her House and the Order, and was now the leader of a new Order, the Ordo Miscellanea. It offered protection to all magicians who had been rejected or persecuted by the Order of Hermes because their powers were too paltry, or did not bear the legacy of mighty Rome. The outraged Order of Hermes called for the immediate extirpation of both Pralix and her upstart order, but Hariste (Tytalus's successor) and Trianoma both argued for a settlement. While the Order of Hermes was paralyzed with indecision, the Ordo Miscellanea recruited aggressively throughout northern and western Europe. Eventually, in 817, the cooler heads prevailed, and the Ordo Miscellanea joined the Order of Hermes as a 13th house, House Ex Miscellanea. This move doubled the size of the Order at that time.
 
-Under Pralix, the House was ruled by a Council of Four, representing different facets of the House's interests. It was initially a martial House populated by battle-hardened wizards, and ruthlessly pursued the "join or die" imperative of the Order, making enemies of both Tremere and Flambeau, who felt that their own House identities were being threatened,
+Under Pralix, the House was ruled by a Council of Four, representing different facets of the House's interests. It was initially a martial House populated by battle-hardened wizards, and ruthlessly pursued the "join or die" imperative of the Order, making enemies of both Tremere and Flambeau, who felt that their own House identities were being threatened, by numbers if not power. Pralix disappeared in 863 while returning from a visit to her former domus magna, and many suspected members of Houses Flambeau and/or Tremere of foul play. Without her firm guidance, House Ex Miscellanea gradually lost its former coherence as each tradition of magi pursued their own agenda without any thought towards the House as a whole.
 
+Immediately before the Schism War, a new Primus named Basilicus seized control of the House. By this time, the House had become bloated with many traditions seeking the protection of the Order, and had sacrificed its martial focus for diversity. Basilicus re-instituted the Council of Four, and whipped the House back into a shadow of its former self. He had been warned by his own prophetic abilities of the coming strife, and was determined that House Ex Miscellanea would not suffer because of it. In fact, many of the founding traditions of the House harbored a great deal of resentment for House Diedne due to antipathies which reached back to before the Founding of the Order; in Britain, at least, many Diedne magi died at the hands of the magi Ex Miscellanea. However, once again, upon the passing of Basilicus the House entered a decline again, from which it is yet to raise itself.
 
-### Rumors and Stories
+> ### Rumors and Stories
+> 
+> - Damhan-Allaidh may not have died at the hands of Pralix, but perhaps feigned his death and escaped. Sightings of the warlock abounded in Scotland (and further afield) in the ninth and tenth centuries, but none have been reported since the Schism War. The suspicion remains that Damhan-Allaidh or his descendents still plot the downfall of the Order, starting with House Ex Miscellanea.
+> - Pralix is still technically the leader of Cad Gadu; a seat is left for her at the Council, and her opinion is requested on any motion. Is there any connection between her disappearance and that of Prima Hariste of House Tytalus, which occurred just a few months later?
+> - Is there any truth to the conspiracy rumors that other Houses deliberately limit the resources of House Ex Miscellanea? The House could be a force to be reckoned with, were it not so disparate.
 
-- Damhan-Allaidh may not have died at the hands of Pralix, but perhaps feigned his death and escaped. Sightings of the warlock abounded in Scotland (and further afield) in the ninth and tenth centuries, but none have been reported since the Schism War. The suspicion remains that Damhan-Allaidh or his descendents still plot the downfall of the Order, starting with House Ex Miscellanea. •
-- Pralix is still technically the leader of Cad Gadu; a seat is left for her at the Council, and her opinion is requested on any motion. Is there any connection between her disappearance and that of Prima Hariste of House Tytalus, which occurred just a few months later? •
-- Is there any truth to the conspiracy rumors that other Houses deliberately limit the resources of House Ex Miscellanea? The House could be a force to be reckoned with, were it not so disparate. •
+> ## The Name "Ex Miscellanea"
+> 
+> *Miscellanea*, in ancient Rome, was the name given to the food provided to gladiators to keep them strong: a porridge made of blood, offal, and oats. The name was well chosen by Pralix, because she intended the Ordo Miscellanea to strengthen the Order of Hermes through opposition. However, with her characteristic wry humor, when they joined the Order she named them House Ex Miscellanea, with a meaning more like "from out of the rag-tag mixture," indicating the diverse nature of the House. A member of this House is correctly referred to as a magus Ex Miscellanea, not a magus *of House* Ex Miscellanea, or any variant thereof. Of course, these magi are more likely to refer to themselves by their traditions rather than their House.
 
-by numbers if not power. Pralix disappeared in 863 while returning from a visit to her former domus magna, and many suspected members of Houses Flambeau and/or Tremere of foul play. Without her firm guidance, House Ex Miscellanea gradually lost its former coherence as each tradition of magi pursued their own agenda without any thought towards the House as a whole.
-
-Immediately before the Schism War, a new Primus named Basilicus seized control of the House. By this time, the House had become bloated with many traditions seeking the protection of the Order, and had sacrificed its martial focus for diversity. Basilicus re-instituted the Council of Four, and whipped the House back into a shadow of its former self. He had been warned by his own prophetic abilities of the coming strife, and was determined that House Ex Miscellanea would not suffer because of it. In fact, many of the founding traditions of the House harbored a great deal of resentment for House Diedne due to antipathies which reached back to before
-
-### The Name "Ex Miscellanea"
-
-*Miscellanea*, in ancient Rome, was the name given to the food provided to gladiators to keep them strong: a porridge made of blood, offal, and oats. The name was well chosen by Pralix, because she intended the Ordo Miscellanea to strengthen the Order of Hermes through opposition. However, with her characteristic wry humor, when they joined the Order she named them House Ex Miscellanea, with a meaning more like "from out of the rag-tag mixture," indicating the diverse nature of the House. A member of this House is correctly referred to as a magus Ex Miscellanea, not a magus *of House* Ex Miscellanea, or any variant thereof. Of course, these magi are more likely to refer to themselves by their traditions rather than their House.
-
-
-the Founding of the Order; in Britain, at least, many Diedne magi died at the hands of the magi Ex Miscellanea. However, once again, upon the passing of Basilicus the House entered a decline again, from which it is yet to raise itself.
-
-# Culture
+## Culture
 
 House Ex Miscellanea, despite its predominantly British roots, now encompasses magi from all over Europe. Before its formation, hedge wizards were recruited either into the Mystery Houses (if their ideology was appropriate) or the Societates (often House Flambeau). House Diedne was a common recipient of hedge wizards, and since the demise of that House during the Schism War, House Ex Miscellanea has inherited its stereotype of having naturalistic, primitive wizards with little classical education and poorly developed Hermetic magic. This stereotype is not wholly justified, for many of the traditions of House Ex Miscellanea have roots that are every bit as noble and sophisticated as those of the Founders themselves. However, the stereotype is not wholly wrong either, for there are a large number of magi Ex Miscellanea who are uninterested in the Order as a political body — their membership is purely to prevent harassment from the other Houses, so that they may pursue their own goals in peace.
 
@@ -4573,8 +4249,7 @@ There is hardly any "House culture" at all. Magi of this House congregate only s
 
 In 1220, for nearly the first time, the House seems to have a chance at rejuvenation. For the last eight decades, the Prima of House Ex Miscellanea was Immanola, from a tradition of seers. In her youth she was a firebrand who excited the Stonehenge Tribunal with her dire prophecies, none of which appeared to come true. As age caught up with her and senility set in, she was respected less and less. She has now sat unmoving for twelve years, gazing into a pool at Cad Gadu. Four years ago she was declared to have entered Final Twilight, and the House elected Ebroin to be Primus. Ebroin is a young and vibrant magus who has attempted a number of reforms. He has re-instated the Council of Four, placing nominal control of three Tribunals under each of the Council members, leaving himself in charge of the magi Ex Miscellanea of the Stonehenge Tribunal. He has called for a census of the House, and seems to have plans for the revitalization of the House. Only time will tell whether his plans will bear any fruit, or whether he will fail like others before him.
 
-
-# Magic
+## Magic
 
 Most of the traditions of House Ex Miscellanea have preserved some aspect of their pre-Hermetic powers that they consider superior to those of the Order. While the magic practiced by the Order of Hermes is superior to all other magical traditions (past and present), even its most ardent supporters admit that in some cases, potency has been sacrificed for flexibility. In addition to the Limits of Magic, there are some areas of magic that some wizards found exceptionally easy, but are quite difficult under Hermetic theory.
 
@@ -4584,25 +4259,23 @@ The Major Virtue represents the legacy of the magus's tradition before joining t
 
 The Minor Virtue represents a successful re-focusing of non-Hermetic powers into Hermetic channels when the tradition first joined the Order. This Virtue should affect how the magus's magic operates, such as Affinity with Art, Cyclical Magic, Enduring Magic, Life Boost, Minor Magical Focus, Puissant Art, Side Effect, and Special Circumstances.
 
-Note that Hermetic Virtues and Flaws, including the ones gained by being a member of House Ex Miscellanea, affect only
+Note that Hermetic Virtues and Flaws, including the ones gained by being a member of House Ex Miscellanea, affect only the exercise of Hermetic magic, not non-Hermetic powers.
 
-### The Primus Ex Miscellanea
+> ## The Primus Ex Miscellanea
+> 
+> When a Primus Ex Miscellanea dies or enters Final Twilight, all the members of Cad Gadu become eligible candidates to the position. The magi Ex Miscellanea of each Tribunal must then reach a consensus of which of the candidates they support. The candidate with the most votes from the thirteen Tribunals is appointed as the new Primus, and given the Robes of Dusty Dawn (see below) as a symbol of his position. The first act of the new Primus is to dismiss the members of the Covenant of Cad Gadu, and redistribute their positions to any magi of the House whom he feels are worthy. He is also responsible for choosing replacements for magi of the covenant when they pass on.
+> 
+> This system is clearly open to corruption. Under an aging Primus, the membership of Cad Gadu (and thus the candidature for their successor) is easy to fix. Furthermore, it is not unknown for the votes of the Tribunals to be incorrectly performed or reported to Cad Gadu. However, few magi Ex Miscellanea care enough about the governance of their House to make an issue of procedural irregularities.
+> 
+> The **Robes of Dusty Dawn** were given to Pralix by the Columbae (see later) when she assumed leadership of the British wizards against Damhan-Allaidh. The robes are much too big to fit Primus Ebroin comfortably, and he finds them stifling. Therefore, despite the substantial magical protection they offer, they are most commonly found slung over a chair or in a crumbled heap upon the floor, discarded by the Primus.
 
-When a Primus Ex Miscellanea dies or enters Final Twilight, all the members of Cad Gadu become eligible candidates to the position. The magi Ex Miscellanea of each Tribunal must then reach a consensus of which of the candidates they support. The candidate with the most votes from the thirteen Tribunals is appointed as the new Primus, and given the Robes of Dusty Dawn (see below) as a symbol of his position. The first act of the new Primus is to dismiss the members of the Covenant of Cad Gadu, and redistribute their positions to any magi of the House whom he feels are worthy. He is also responsible for choosing replacements for magi of the covenant when they pass on.
-
-This system is clearly open to corruption. Under an aging Primus, the membership of Cad Gadu (and thus the candidature for their successor) is easy to fix. Furthermore, it is not unknown for the votes of the Tribunals to be incorrectly performed or reported to Cad Gadu. However, few magi Ex Miscellanea care enough about the governance of their House to make an issue of procedural irregularities.
-
-The **Robes of Dusty Dawn** were given to Pralix by the Columbae (see later) when she assumed leadership of the British wizards against Damhan-Allaidh. The robes are much too big to fit Primus Ebroin comfortably, and he finds them stifling. Therefore, despite the substantial magical protection they offer, they are most commonly found slung over a chair or in a crumbled heap upon the floor, discarded by the Primus.
-
-### Saga Seed: The Boy King
-
-Primus Ebroin has big plans for his House, but there are a number of stumbling blocks in his way. Firstly, the Council of Four that he has instituted has not been wisely chosen. None of the four magi have any respect for each other, or for the Primus, although they pretend otherwise. Each has his own agenda, and all of them are mutually incompatible. The Primus is both young and inexperienced, and clearly a poor judge of character. Those who meet him frequently decide he is a bumbling fool, but they would be wrong. Ebroin is an *orbus* (see below), although he prefers it that this is not widely known.
-
-Furthermore, the circumstances of his expulsion from his House are not altogether clear, and there is a hint of a suggestion that he may still be loyal to his former Primus. In addition to Gwhyr of the Columbae (see Columbae, The Fate of Cad Gadu, below), the Council of Four also includes a Donator and a member of the Damhadh-Duidsan.
-
-The machinations of the leadership of House Ex Miscellanea would make an interesting backdrop for a saga. It would work best in either the Stonehenge Tribunal or one of its neighbors. It is left to the storyguide to decide upon Ebroin's former House and his future plans.
-
-the exercise of Hermetic magic, not non-Hermetic powers.
+> ## Saga Seed: The Boy King
+> 
+> Primus Ebroin has big plans for his House, but there are a number of stumbling blocks in his way. Firstly, the Council of Four that he has instituted has not been wisely chosen. None of the four magi have any respect for each other, or for the Primus, although they pretend otherwise. Each has his own agenda, and all of them are mutually incompatible. The Primus is both young and inexperienced, and clearly a poor judge of character. Those who meet him frequently decide he is a bumbling fool, but they would be wrong. Ebroin is an *orbus* (see below), although he prefers it that this is not widely known.
+> 
+> Furthermore, the circumstances of his expulsion from his House are not altogether clear, and there is a hint of a suggestion that he may still be loyal to his former Primus. In addition to Gwhyr of the Columbae (see Columbae, The Fate of Cad Gadu, below), the Council of Four also includes a Donator and a member of the Damhadh-Duidsan.
+> 
+> The machinations of the leadership of House Ex Miscellanea would make an interesting backdrop for a saga. It would work best in either the Stonehenge Tribunal or one of its neighbors. It is left to the storyguide to decide upon Ebroin's former House and his future plans.
 
 ### Supernatural Abilities
 
@@ -4612,18 +4285,15 @@ Ex Miscellanea. These rules may also be used by the storyguide to create Major S
 
 #### The Basics
 
-All Supernatural Virtues created with this system are associated with a Supernatural Ability, which represents how
-
-
-### Accelerated Abilities
-
-This chapter describes some Supernatural Abilities that use the Art experience scale rather than the Ability experience scale. These are a new type of Ability, called Accelerated Abilities to distinguish them from standard Abilities. These Abilities use the Art experience scale because they are designed to be compared against an Ease Factor outside the usual range (where 21 is extremely difficult, even for a specialist). Instead, typical Ease Factors for Accelerated Abilities are the Mights of supernatural beings, or spell levels. The only other difference between a Supernatural Accelerated Ability and a Supernatural Ability is that the equivalent spell level for an Accelerated Ability is equal to the Casting Total, not (Ability x 5).
-
-Accelerated Abilities are not, however, Arts. The important difference between an Art and an Ability is that an Art is useless on its own — it needs to be paired with at least one other Art to have an effect (even if the score in that Art is zero). An Ability, on the other hand, appears alone in any total. In all respects other than advancement and equivalent spell level, a Supernatural Accelerated Ability should be treated the same as a standard Supernatural Ability; for example, an Accelerated Ability cannot be studied from vis, only receives a +1 bonus per pawn of vis expended, receives a +2 rather than +3 bonus from the Puissant (Ability) Virtue.
-
-much command the character has over his magic. It is assumed that for magi Ex Miscellanea, this Ability is affiliated with the Magic realm, although in fact it can be associated with any of the four supernatural realms, creating a character with multiple affiliations (since The Gift itself is always aligned to the Magic realm).
+All Supernatural Virtues created with this system are associated with a Supernatural Ability, which represents how much command the character has over his magic. It is assumed that for magi Ex Miscellanea, this Ability is affiliated with the Magic realm, although in fact it can be associated with any of the four supernatural realms, creating a character with multiple affiliations (since The Gift itself is always aligned to the Magic realm).
 
 To use the Ability in a specific instance, the player must first determine what his character is trying to achieve with his magic. The storyguide then assigns an Ease Factor to that task, and the player makes a die roll and adds a Characteristic and his score in the Supernatural Ability. The Characteristic used varies according to the Ability used. This is the equivalent to the Casting Total of a Hermetic spell. If the Ease Factor is achieved, then the magical effect is successful. There is no fatigue loss in using a Supernatural Ability, unless the specific Ability requires it. The calculation of the Penetration Total, if required, is equal to the Casting Total minus the Ease Factor, plus the Penetration Bonus, calculated as for Hermetic magic (ArM5, page 84); hedge magic still benefits from the Penetration Ability. If the level of the magical effect is required, for example, if it is struck by *Wind of Mundane Silence*, then substitute the character's Supernatural Ability multiplied by five.
+
+> ## Accelerated Abilities
+> 
+> This chapter describes some Supernatural Abilities that use the Art experience scale rather than the Ability experience scale. These are a new type of Ability, called Accelerated Abilities to distinguish them from standard Abilities. These Abilities use the Art experience scale because they are designed to be compared against an Ease Factor outside the usual range (where 21 is extremely difficult, even for a specialist). Instead, typical Ease Factors for Accelerated Abilities are the Mights of supernatural beings, or spell levels. The only other difference between a Supernatural Accelerated Ability and a Supernatural Ability is that the equivalent spell level for an Accelerated Ability is equal to the Casting Total, not (Ability x 5).
+> 
+> Accelerated Abilities are not, however, Arts. The important difference between an Art and an Ability is that an Art is useless on its own — it needs to be paired with at least one other Art to have an effect (even if the score in that Art is zero). An Ability, on the other hand, appears alone in any total. In all respects other than advancement and equivalent spell level, a Supernatural Accelerated Ability should be treated the same as a standard Supernatural Ability; for example, an Accelerated Ability cannot be studied from vis, only receives a +1 bonus per pawn of vis expended, receives a +2 rather than +3 bonus from the Puissant (Ability) Virtue.
 
 If concentration rolls are required, use the rules for Hermetic magic (ArM5, page 82). Raw vis can be used to boost the Casting Total: the Art of the vis must be appropriate to the Supernatural Ability, and the character cannot use more pawns than his score in the Supernatural Ability. Each pawn used adds one to the casting total, and an extra botch die.
 
@@ -4657,10 +4327,7 @@ All Supernatural Abilities fix three of these parameters as unchangeable, and al
 
 When assigning the parameters of an effect to an Ability score or Ease Factor, care should be taken to ensure that the Ability does not become too powerful. If the breadth of the Ability is important, but it has little impact on other beings, then assign the variable parameter to the Ability score. If the Ability affects other beings, then its ability to do so should be assigned to the Ease Factor. Thus, an Ability that works like Shapeshifter, but instead is used against another being, should not be designed like Shapeshifter at all, but instead have an effect based on casting total: the higher the total, the more change is achieved.
 
-When invoking her non-Hermetic magic, a maga Ex Miscellanea usually does so in a manner alien to Hermetic magi.
-
-
-She might use a dead language other than Latin, or scratch runes on the ground, or employ powders and potions. The details of this procedure should be given in the description of the Ability, and should be no more restrictive than the requirement for words and gestures from a Hermetic magus. However, all uses of the Ability absolutely require the exercise of these practices; they cannot be avoided in the same way that a Hermetic magus can use restricted words and gestures. The invocation of Hermetic magic by magi Ex Miscellanea is (usually) identical to other magi.
+When invoking her non-Hermetic magic, a maga Ex Miscellanea usually does so in a manner alien to Hermetic magi. She might use a dead language other than Latin, or scratch runes on the ground, or employ powders and potions. The details of this procedure should be given in the description of the Ability, and should be no more restrictive than the requirement for words and gestures from a Hermetic magus. However, all uses of the Ability absolutely require the exercise of these practices; they cannot be avoided in the same way that a Hermetic magus can use restricted words and gestures. The invocation of Hermetic magic by magi Ex Miscellanea is (usually) identical to other magi.
 
 ### Example Supernatural Abilities
 
@@ -4670,59 +4337,47 @@ Described below are a few examples of this system in action. All of these are su
 
 This Ability allows the character to summon mundane animals over long distances. To use this Ability, the character must be capable of making an audible call to the creatures he wishes to summon , although the targets need not be able to hear it, and must be within one day's journey of a habitat where the required species are found. The number of animals that respond to his summons is determined by the score in the character's Ability; see the table below. He must then make a Communication + Summon Animals roll against an Ease Factor of 9. If successful, the animals arrives within one hour of the character making the call, although exceeding the Ease Factor by 3 makes them come in two minutes, and exceeding it by 6 summons them in a single round.
 
-The character cannot directly communicate with the animals unless he has another Ability that allows him to do so (such as Animal Ken), and they depart naturally as determined by the storyguide. Even if the character lacks the ability to communicate with the animals, they
+The character cannot directly communicate with the animals unless he has another Ability that allows him to do so (such as Animal Ken), and they depart naturally as determined by the storyguide. Even if the character lacks the ability to communicate with the animals, they are friendly towards him, and if naturally aggressive, may fight to defend him.
 
-#### Societates
-
-are friendly towards him, and if naturally aggressive, may fight to defend him.
-
-| Ability<br>Score | Number of Animals<br>Arriving                                                                                      |
-|------------------|--------------------------------------------------------------------------------------------------------------------|
-| 1                | 1 animal of Size –2, or<br>equivalent mass (3 of Size<br>–3, 5 of Size –4, 10 of Size<br>–5, 30 of Size –6, etc.)  |
-| 2                | 3 animals of Size –2, or<br>equivalent mass (1 of Size<br>–1, 5 of Size –3, 10 of Size<br>–4, 30 of Size –5, etc.) |
-| 3                | 5 animals of Size –2, or<br>equivalent mass (1 of Size 0,<br>3 of Size –1, 10 of Size –3,<br>30 of Size –4, etc.)  |
-| 4                | 10 animals of Size –2, or<br>equivalent mass (1 of Size<br>+1, 3 of Size 0, 5 of Size –1,<br>30 of Size –3, etc.)  |
-| 5                | 30 animals of Size –2, or<br>equivalent mass (1 of Size<br>+2, 3 of Size +1, 5 of Size<br>0, 10 of Size –1, etc.)  |
+| Ability Score | Number of Animals Arriving |
+|:-------------:|----------------------------|
+| 1 | 1 animal of Size –2, or equivalent mass (3 of Size –3, 5 of Size –4, 10 of Size –5, 30 of Size –6, etc.) |
+| 2 | 3 animals of Size –2, or equivalent mass (1 of Size –1, 5 of Size –3, 10 of Size –4, 30 of Size –5, etc.) |
+| 3 | 5 animals of Size –2, or equivalent mass (1 of Size 0, 3 of Size –1, 10 of Size –3, 30 of Size –4, etc.) |
+| 4 | 10 animals of Size –2, or equivalent mass (1 of Size +1, 3 of Size 0, 5 of Size –1, 30 of Size –3, etc.) |
+| 5 | 30 animals of Size –2, or equivalent mass (1 of Size +2, 3 of Size +1, 5 of Size 0, 10 of Size –1, etc.) |
 
 **Specialties**: a particular type of animal (Supernatural)
 
+> ### Story Seed: Animal Experimentation
+> 
+> The Summon Animals Ability can call animals more quickly than they could possibly travel under their own speed, and therefore breaks the Limit of Arcane Connection. A magus interested in pursuing Breakthroughs in Magic Theory might seek out a character with this Ability.
+
 #### Whistle Up the Wind
 
-A character with this Ability is able to create a wind, duplicating the effects of any wind-based Creo Auram spell at Range Voice and Target Individual; similar Supernatural Abilities exist for other weather phenomena. To invoke the wind, the character literally has to whistle, and makes a Stamina + Whistle Up the Wind roll, against the Ease Factor listed in the table below. If successful, the wind immediately starts to blow as commanded by the character. It continues to blow in the same manner even if the character stops whistling. A character who summons a wind at a particular strength can change that wind to another type with a similar strength (such as from *Circular Winds of Protection* to *Broom of the Winds*), diminish it to a weaker effect (such as *Chamber of Spring Breezes*), or end it entirely. Each of these changes requires a Communication + Music roll, using the Ease Factors for maintaining
+A character with this Ability is able to create a wind, duplicating the effects of any wind-based Creo Auram spell at Range Voice and Target Individual; similar Supernatural Abilities exist for other weather phenomena. To invoke the wind, the character literally has to whistle, and makes a Stamina + Whistle Up the Wind roll, against the Ease Factor listed in the table below. If successful, the wind immediately starts to blow as commanded by the character. It continues to blow in the same manner even if the character stops whistling. A character who summons a wind at a particular strength can change that wind to another type with a similar strength (such as from *Circular Winds of Protection* to *Broom of the Winds*), diminish it to a weaker effect (such as *Chamber of Spring Breezes*), or end it entirely. Each of these changes requires a Communication + Music roll, using the Ease Factors for maintaining concentration on a spell (ArM5, page 82). Whistling a new tune in this manner cannot increase the strength of a wind, nor return a diminished wind to its former intensity; instead the character must make a new Whistle Up the Wind roll. All effects of this Ability diminish to the next lowest level of strength each day when the sun sets, until they dwindle to nothing.
 
-### Story Seed: Animal Experimentation
-
-The Summon Animals Ability can call animals more quickly than they could possibly travel under their own speed, and therefore breaks the Limit of Arcane Connection. A magus interested in pursuing Breakthroughs in Magic Theory might seek out a character with this Ability.
-
-concentration on a spell (ArM5, page 82). Whistling a new tune in this manner cannot increase the strength of a wind, nor return a diminished wind to its former intensity; instead the character must make a new Whistle Up the Wind roll. All effects of this Ability diminish to the next lowest level of strength each day when the sun sets, until they dwindle to nothing.
-
-| Ease Factor | Strength<br>Wind<br>of                                              |
-|-------------|---------------------------------------------------------------------|
-| 6           | Light breeze, strong<br>enough to clear a<br>stench from a room     |
-| 9           | Moderate wind, strong<br>enough to affect the<br>accuracy of arrows |
-| 12          | Strong wind, powerful<br>enough to propel a sail<br>ing ship        |
-| 15          | Gale force wind, strong<br>enough to knock some<br>one over         |
-| 18          | Hurricane force wind,<br>strong enough to<br>uproot trees           |
+| Ease Factor | Strength of Wind |
+|-------------|------------------|
+| 6           | Light breeze, strong enough to clear a stench from a room |
+| 9           | Moderate wind, strong enough to affect the accuracy of arrows |
+| 12          | Strong wind, powerful enough to propel a sailing ship |
+| 15          | Gale force wind, strong enough to knock someone over |
+| 18          | Hurricane force wind, strong enough to uproot trees |
 
 **Specialties**: at sea, in mountains, during the winter (Supernatural)
 
 #### Control Fertility
 
-Characters with this Ability may enhance or withdraw the vegetative spirits present in all living things. In plants, this makes them more fertile, or more prone to disease. Cows can be made to produce more milk, or to dry up entirely. A blessing on a woman might guarantee the conception of a child, or render her
+Characters with this Ability may enhance or withdraw the vegetative spirits present in all living things. In plants, this makes them more fertile, or more prone to disease. Cows can be made to produce more milk, or to dry up entirely. A blessing on a woman might guarantee the conception of a child, or render her barren. The Target affected by this Ability is one human, one animal of Size +2 (or an equivalent mass: 1 cow, 5 pigs, 10 sheep, 100 chickens), or one tree (or an equivalent mass: 10 fruit bushes, a small crop of field vegetables or grain). The character's score in Fertility determines the scope of effects that she can produce. The character must physically mark the target in some way to use this power; this might involve a smudge of soot on the face, a ribbon tied around the neck, a charm buried in a field, and so forth (effectively requiring Range Touch). She must then make a Presence + Fertility roll against an Ease Factor of 9 to affect the target with the chosen power for a month; for every full 3 points over this Ease Factor, the target is affected for one additional month. To make a substantial impact on a target's livelihood, these effects must last for at least a growing season (three months). Once affected, the same target cannot be affected again by this Ability until the following spring.
 
-
-barren. The Target affected by this Ability is one human, one animal of Size +2 (or an equivalent mass: 1 cow, 5 pigs, 10 sheep, 100 chickens), or one tree (or an equivalent mass: 10 fruit bushes, a small crop of field vegetables or grain). The character's score in Fertility determines the scope of effects that she can produce. The character must physically mark the target in some way to use this power; this might involve a smudge of soot on the face, a ribbon tied around the neck, a charm buried in a field, and so forth (effectively requiring Range Touch). She must then make a Presence + Fertility roll against an Ease Factor of 9 to affect the target with the chosen power for a month; for every full 3 points over this Ease Factor, the target is affected for one additional month. To make a substantial impact on a target's livelihood, these effects must last for at least a growing season (three months). Once affected, the same target cannot be affected again by this Ability
-
-until the following spring.
-
-| Ability<br>Score | Possible Eff<br>ects                                                                                                                                                        |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1                | Keep minor diseases away<br>from plants                                                                                                                                     |
-| 2                | Double the daily produc<br>tion of an animal (eggs,<br>milk, weight gain), or pre<br>vent daily production                                                                  |
-| 3                | Grant a +3 or –3 modifier<br>to Stamina rolls to avoid<br>contracting a disease,<br>increase or decrease crop<br>yield by one-half                                          |
-| 4                | Ensure the conception of<br>a baby, strike a creature<br>barren, ensure an easy<br>childbirth, grant a +1 or –1<br>Living Condition Modifier<br>to Aging (must last a year) |
-| 5                | Grant a +6 or –6 modifier<br>to Stamina rolls to avoid<br>contracting a disease                                                                                             |
-|                  |                                                                                                                                                                             |
+| Ability Score | Possible Effects |
+|---------------|------------------|
+| 1 | Keep minor diseases away from plants |
+| 2 | Double the daily production of an animal (eggs, milk, weight gain), or prevent daily production |
+| 3 | Grant a +3 or –3 modifier to Stamina rolls to avoid contracting a disease, increase or decrease crop yield by one-half |
+| 4 | Ensure the conception of a baby, strike a creature barren, ensure an easy childbirth, grant a +1 or –1 Living Condition Modifier to Aging (must last a year) |
+| 5 | Grant a +6 or –6 modifier to Stamina rolls to avoid contracting a disease| 
 
 **Specialties**: vegetables, cows, women (Supernatural)
 
@@ -4730,7 +4385,7 @@ until the following spring.
 
 All magi Ex Miscellanea must take a Major non-Hermetic Virtue, but not all members of this House have a Supernatural Ability as their compulsory Virtue. The only requirement is that this Major Virtue represents some aspect of the magus's non-Hermetic tradition. (Thus, Wealthy is not an option, although Magister in Artibus may well be.) It may describe another capability he possesses, such as Greater Immunity, Greater Purifying Touch, or Ways of the (Land). It may be suggestive of his background, such as Strong Faerie Blood or Giant Blood. New Supernatural Virtues that are not controlled by an Ability score should be designed following the rules for effects instilled into items, complete with uses per day, and should not exceed seventh magnitude. It should have no more flexibility in its effects than a Minor Magical Focus.
 
-# Characters
+## Characters
 
 There are a number of different types of characters within House Ex Miscellanea, who can be broadly split into three groups (although there is shading between all three).
 
@@ -4738,21 +4393,17 @@ There are a number of different types of characters within House Ex Miscellanea,
 
 These magi make up the majority of the House, and are created according to the usual mechanics presented here and in **Ars Magica Fifth Edition**. If a Supernatural Ability is acquired as part of the apprenticeship of a magus Ex Miscellanea (that is, as his House Virtue), then this Ability should be considered to be his Favored Ability, and the character does not suffer any penalty to the Source Quality (ArM5, page 166) from his Art scores if learning his Favored Ability after his Hermetic training.
 
-### Favored Abilities
+> ## Favored Abilities
+> 
+> As a Gifted character learns Supernatural Abilities, it normally becomes more difficult to learn new ones (ArM5, page 166). However, many traditions have a group of **Favored Abilities**. Scores in these Abilities do not penalize the Source Quality for learning other Favored Abilities. The Source Qualities to learn Favored Abilities are still penalized by scores in other Supernatural Abilities, and scores in Favored Abilities penalize the Source Quality to learn other Supernatural Abilities. For most magi, the Hermetic Arts are the Favored Abilities, although as they are all opened in one season this is largely an academic distinction. Magi Ex Miscellanea treat the Hermetic Arts and the Supernatural Ability of their tradition as Favored Abilities.
 
-As a Gifted character learns Supernatural Abilities, it normally becomes more difficult to learn new ones (ArM5, page 166). However, many traditions have a group of **Favored Abilities**. Scores in these Abilities do not penalize the Source Quality for learning other Favored Abilities. The Source Qualities to learn Favored Abilities are still penalized by scores in other Supernatural Abilities, and scores in Favored Abilities penalize the Source Quality to learn other Supernatural Abilities. For most magi, the Hermetic Arts are the Favored Abilities, although as they are all opened in one season this is largely an academic distinction. Magi Ex Miscellanea treat the Hermetic Arts and the Supernatural Ability of their tradition as Favored Abilities.
-
-### Mythic Companions
-
-Mythic Companions (a new type of character first introduced in *Houses of Hermes: True Lineages*, page 104), may also fill the role of non-Hermetic magicians within the Order, but these characters do not have The Gift. Instead, a Mythic Companion has a Special Virtue akin to The Gift, which grants a Minor Virtue at no cost, and then two Virtue points for every point of Flaw he takes. A Mythic Companion character usually has access to strong non-Hermetic magic or Powers, described in other source books for **Ars Magica Fifth Edition**.
+> ## Mythic Companions
+> 
+> Mythic Companions (a new type of character first introduced in *Houses of Hermes: True Lineages*, page 104), may also fill the role of non-Hermetic magicians within the Order, but these characters do not have The Gift. Instead, a Mythic Companion has a Special Virtue akin to The Gift, which grants a Minor Virtue at no cost, and then two Virtue points for every point of Flaw he takes. A Mythic Companion character usually has access to strong non-Hermetic magic or Powers, described in other source books for **Ars Magica Fifth Edition**.
 
 #### Magi Orbi
 
-These magi (or their ancestors) began their careers in a different House, but were then exiled (or chose to leave), and could only find solace in House Ex Miscellanea. "Orbus" means "orphaned" in Latin (the feminine form is "orba"), and describes the maga's severance from her parent tradition. A maga orba is created using the rules for her former House, except that she is denied access to any privileges and secrets of that
-
-
-
-House. This includes its Mystery Cults, which cannot be pursued further, nor can an orba Initiate any of her apprentices into the Outer Mystery of their former House.
+These magi (or their ancestors) began their careers in a different House, but were then exiled (or chose to leave), and could only find solace in House Ex Miscellanea. "Orbus" means "orphaned" in Latin (the feminine form is "orba"), and describes the maga's severance from her parent tradition. A maga orba is created using the rules for her former House, except that she is denied access to any privileges and secrets of that House. This includes its Mystery Cults, which cannot be pursued further, nor can an orba Initiate any of her apprentices into the Outer Mystery of their former House.
 
 A magus orbus has a Hermetic Reputation as an Orbus at a score of 2, and probably avoids his former colleagues. Occasionally, magi orbi have their apprentices trained in one of their adopted House's traditions, in which case these apprentices adopt the characteristics of a normal magus Ex Miscellanea, and do not inherit the status of orbus.
 
@@ -4768,13 +4419,9 @@ On occasion, however, House Ex Miscellanea assimilates a whole tradition (or a s
 
 Both of these situations are very rare. However, a player who wishes to take this option can create her character in the following manner:
 
-Take The Gift and Hermetic Magus Social Status Virtues. Taking The Gift •
-
-#### Societates
-
-- also grants one Supernatural Ability without the need for any other Virtue (ArM5, page 36).
-- Complete character creation as a Companion, but the player can choose Arcane Abilities. Supernatural Abilities are encouraged. Include Parma Magica 1 when allotting experience. •
-- Gain the Reputation Hedge Wizard 2 (Hermetic) •
+- Take The Gift and Hermetic Magus Social Status Virtues. Taking The Gift also grants one Supernatural Ability without the need for any other Virtue (ArM5, page 36).
+- Complete character creation as a Companion, but the player can choose Arcane Abilities. Supernatural Abilities are encouraged. Include Parma Magica 1 when allotting experience.
+- Gain the Reputation Hedge Wizard 2 (Hermetic)
 
 Since the character has The Gift, she can learn any Supernatural Ability after character creation (ArM5, page 166), but it is assumed that opening the Arts for Hermetic magic has either failed or is not desired. The Supernatural Ability granted by The Gift, and any others paid for with Virtue points, constitute the character's Favored Abilities (see above). Given the central importance of the Order of Hermes in an *Ars Magica* saga, troupes should consider whether a Gifted Companion should take the place of a player's magus character, even though he may not be as powerful.
 
@@ -4805,7 +4452,6 @@ The character must have at least one Major Supernatural Virtue to take this Flaw
 *Minor, Hermetic*
 
 The magus's magic is susceptible to various folk-remedies for averting hostile spells. Any target who is aware that the magus has just used his magic may attempt a folk ritual such as making a sign against evil, or spitting, and so forth. This grants the target or targets a Magic Resistance equal to (5 x the target's Magic Lore), or 0 if the target does not have this Ability, against the magus's magic only. Furthermore, someone with Magic Lore may be able to devise a manner to break a lasting enchantment, such as sprinkling with salt or lying on an iron bed; this typically requires an Intelligence + Magic Lore roll against an Ease Factor of (9 + the spell's magnitude) or greater.
-
 
 ### Traditions of House Ex Miscellanea
 
@@ -4847,7 +4493,6 @@ The Hermetic Haruspexes are an ancient Roman tradition who hold the secret of "T
 
 **Major Hermetic Flaw:** Twilight Prone
 
-
 #### Karaites
 
 Karaism is a sect comprised of Jews who reject the Oral Law of the rabbis, and interpret their holy commandments through a literal reading of the Tanakh only. According to Karaite philosophy, everything that happens in the world is God's will, and this can be understood by carefully studying the scriptures. Only through human actions can evil come to pass, and thus bad things happen as divine punishment for human transgressions. For example, human and worldly medicine should be avoided, for sickness is evidence of human failing, and God alone should be consulted as physician. Because of their unorthodox interpretations of scripture, pious Karaites (unlike other pious Jews) with The Gift may join the Order of Hermes, so long as they practice holy magic. They believe the laws against enchantment and divination in the Torah do not apply if the effect comes directly from God, though they do not allow other magi to cast spells upon them as this is obviously unclean.
@@ -4862,11 +4507,7 @@ Karaism is a sect comprised of Jews who reject the Oral Law of the rabbis, and i
 
 #### Malocchi
 
-The Malocchi are a tradition of Italian magi who practice the magic of Entrancement. Being so deeply imbedded in a region's culture can make it difficult to be a member of this tradition. A maloccho (singular masculine, the feminine form is "maloccha") is considered to bring terrible luck, and all avoid meeting his gaze, which is believed to not only ensorcel, but also to cause all sorts of other ill-effects. As well as his free Virtues and Flaws, a
-
-
-
-maloccho must also take Piercing Gaze as a compulsory Virtue. The Hex Virtue (from *Realms of Power: The Infernal*) is also highly appropriate.
+The Malocchi are a tradition of Italian magi who practice the magic of Entrancement. Being so deeply imbedded in a region's culture can make it difficult to be a member of this tradition. A maloccho (singular masculine, the feminine form is "maloccha") is considered to bring terrible luck, and all avoid meeting his gaze, which is believed to not only ensorcel, but also to cause all sorts of other ill-effects. As well as his free Virtues and Flaws, a maloccho must also take Piercing Gaze as a compulsory Virtue. The Hex Virtue (from *Realms of Power: The Infernal*) is also highly appropriate.
 
 **Major Non-Hermetic Virtue:** Entrancement
 
@@ -4886,23 +4527,7 @@ The herb-wives and faerie doctors of Mythic Europe have a few representatives in
 
 #### Tempestaria (Weather Witch)
 
-This tradition figures prominently in lands occupied by the Saxons, including their homeland in northern Germany as well as in England and Denmark. Weather magic is well integrated into Hermetic magic, and the art of Auram is populated with highly useful spells. The hedge witches known as Tempestariae are experts in these very magics. However, the weatherwitch is capable of summoning weather
-
-### Ringing the Changes
-
-Several of the traditions of House Ex Miscellanea are specific to a culture or a geographic area. While it is perfectly possible that a wandering magus might bring his magic into a different culture or region, it is a comparably simple task to make a few changes to a tradition and relocate them to a different area:
-
-- The Koldun are shamanic wizards from the Novgorod Tribunal who have abandoned their roles as pagan priests in favor of the practice of sorcery. (Witches of Thessaly) •
-- There are said to be wizards called the Trollsynir who still live in the northern lands of Scandinavia and Iceland, who claim descent from the giants, and who bear the power to curse their enemies. (Damhadh-Duidsan) •
-- An Irish tradition of wizards called the Corrguineach display control over elemental spirits; they were •
-
-powerful enemies of House Diedne and joined forces with House Flambeau to exterminate them. (Hermetic Sahir)
-
-- Breton bards who bear the blood of a water faerie called the Melusine left House Diedne for House Ex Miscellanea a mere score years before the Schism War. They have the power to enchant with the music played on their harps. (Seirenes) •
-- A group of Roman necromancers use their power over spirits to terrorize the locals and win power for themselves. (Donatores) •
-- The Taltos from among the Magyar people of the Hungarian plains use their knowledge of herbcraft to increase their physical characteristics and martial skills, as well as for healing. Many Taltos have the Skinchanger Virtue, allowing them to assume the form of a white horse. (Pharmocopoeians) •
-
-that exceeds the capacity of his Hermetic powers. There are weather-witches who can summon rain that can last for days, or who can cause no rain to fall at all for an entire season. The fogs summoned by a tempestaria from the sea have bound ships into the harbors all along an entire coastline. The most common type of tempestaria, however, is one who can bind the wind to her service. They require simple improvised tools that have sympathetic relationships to their spells — feathers for snow magic, drums for thunder magic, scattered sand for rain magic, and so forth.
+This tradition figures prominently in lands occupied by the Saxons, including their homeland in northern Germany as well as in England and Denmark. Weather magic is well integrated into Hermetic magic, and the art of Auram is populated with highly useful spells. The hedge witches known as Tempestariae are experts in these very magics. However, the weatherwitch is capable of summoning weather that exceeds the capacity of his Hermetic powers. There are weather-witches who can summon rain that can last for days, or who can cause no rain to fall at all for an entire season. The fogs summoned by a tempestaria from the sea have bound ships into the harbors all along an entire coastline. The most common type of tempestaria, however, is one who can bind the wind to her service. They require simple improvised tools that have sympathetic relationships to their spells — feathers for snow magic, drums for thunder magic, scattered sand for rain magic, and so forth.
 
 **Major Non-Hermetic Virtue:** Whistle Up the Wind (or similar Ability)
 
@@ -4920,8 +4545,18 @@ The original Thessalians were reclusive worshipers of sinister gods of the under
 
 **Major Hermetic Flaw:** Painful Magic
 
-
 (More details on the Witches of Thessaly and description of Summoning can be found in *Realms of Power: The Infernal.*)
+
+> ## Ringing the Changes
+> 
+> Several of the traditions of House Ex Miscellanea are specific to a culture or a geographic area. While it is perfectly possible that a wandering magus might bring his magic into a different culture or region, it is a comparably simple task to make a few changes to a tradition and relocate them to a different area:
+> 
+> - The Koldun are shamanic wizards from the Novgorod Tribunal who have abandoned their roles as pagan priests in favor of the practice of sorcery. (Witches of Thessaly)
+> - There are said to be wizards called the Trollsynir who still live in the northern lands of Scandinavia and Iceland, who claim descent from the giants, and who bear the power to curse their enemies. (Damhadh-Duidsan)
+> - An Irish tradition of wizards called the Corrguineach display control over elemental spirits; they were powerful enemies of House Diedne and joined forces with House Flambeau to exterminate them. (Hermetic Sahir)
+> - Breton bards who bear the blood of a water faerie called the Melusine left House Diedne for House Ex Miscellanea a mere score years before the Schism War. They have the power to enchant with the music played on their harps. (Seirenes)
+> - A group of Roman necromancers use their power over spirits to terrorize the locals and win power for themselves. (Donatores)
+> - The Taltos from among the Magyar people of the Hungarian plains use their knowledge of herbcraft to increase their physical characteristics and martial skills, as well as for healing. Many Taltos have the Skinchanger Virtue, allowing them to assume the form of a white horse. (Pharmocopoeians)
 
 # Columbae
 
@@ -4929,7 +4564,11 @@ The *swynwyr* (pronounced "SWINweer;" singular *swynwr*, "SWIN-oor"; feminine si
 
 ### Key Facts
 
-**Favored Tribunals:** Stonehenge **Major Non-Hermetic Virtue:** Warding **Minor Hermetic Virtue:** Ring/Circle Magic
+**Favored Tribunals:** Stonehenge
+
+**Major Non-Hermetic Virtue:** Warding
+
+**Minor Hermetic Virtue:** Ring/Circle Magic
 
 **Major Hermetic Flaw:** Necessary Condition (must mark their target)
 
@@ -4943,42 +4582,26 @@ The leader of the tradition when it officially joined the Order was named Colome
 
 ### Culture
 
-The Columbae have very few traditions unique to their line, instead having adopted the few trappings associated with the House as a whole, many of which originally came from them. They often wear white or very pale-colored clothing, and usually carry chalk or some other soft, light-colored stone with which to draw their circles — charred wood will also do,
-
+The Columbae have very few traditions unique to their line, instead having adopted the few trappings associated with the House as a whole, many of which originally came from them. They often wear white or very pale-colored clothing, and usually carry chalk or some other soft, light-colored stone with which to draw their circles — charred wood will also do, as will their own blood when they are desperate. Many of them carry a gnarled staff, the symbol of the House, and also a useful means of drawing a ring in soft ground. Among their own kind they speak Welsh and still refer to each other as swynwyr. Among others, they tend to speak Latin poorly and try to maintain their image of affable, friendly foreigners.
 
 Being Welsh, traditions of family and their shared cultural heritage are very important to the Columbae. According to Welsh inheritance customs, property is divided more or less equally among a man's sons, or other male relatives if there are no sons, and men can only inherit from other men in their *cenedl* ("ken-ED-el"), the group of men male-line descended from a single ancestor. A group of Welshmen who are male-line descended from a common greatgrandfather are called kindred, and they are responsible for keeping order among their members. They are also responsible for looking after orphans and widows, resolving minor disputes between family members, and arbitrating the sale of land; no land may change owners without their consent. Thus, kindred keep careful track of their relatives and their property, and male Columbae often have many societal obligations.
 
 For these reasons, unGifted Columbae are almost always women, and have been throughout history, as they have fewer responsibilities in Welsh society and are more encouraged to pursue magical interests. Unmarried women are essentially inconsequential in Wales, at least as far as inheritance and politics are concerned, and so as long as they can care for themselves, they are left alone for the most part. Because of this, and because most Columbae were women when they first joined the Order, magi commonly use the feminine gender when describing their magic or their followers.
 
-The Gift is unpredictable and does not favor one sex or the other, but because most unGifted Columbae are women, the Columbine magi still adhere to the culture of their mundane counterparts, and often behave as if they were superior to their female counterparts. Since they joined the Order, the structure of the tradition has come to more closely resemble a patriarchy, where magi outrank magae,
+The Gift is unpredictable and does not favor one sex or the other, but because most unGifted Columbae are women, the Columbine magi still adhere to the culture of their mundane counterparts, and often behave as if they were superior to their female counterparts. Since they joined the Order, the structure of the tradition has come to more closely resemble a patriarchy, where magi outrank magae, and Gifted boys are much more desirable apprentices than girls. For this reason, Columbine magae tend to associate with unGifted members of their tradition more often than Gifted, and do not involve themselves in their political affairs. To outsiders it might even appear that there are no female Columbae in 1220.
 
-
-*110*
-
-### The Robes of Dusty Dawn
-
-The event that made the *swynwyr* decide to join with Pralix against Damhan-Allaidh was the sudden death of their eldest *swynwraig*, named Gwawrieir ("gwah-REE-eyr"), who was effectively the leader of their magical tradition, and who
-
-staunchly opposed getting involved in the battle with the wizards of the mainland. Her lifeless body was found lying within one of her own protective circles, and she had eight long, black marks upon her throat, as if she had been strangled from behind by four pairs of hands. Her family was forced to conclude that she had been killed by the evil magic of their northern enemy, and this assumption was supported by the fact that she still wore her enchanted robes, a fabulous treasure said to protect her against all natural threats and every kind of supernatural creature.
-
-The remaining *swynwyr* were frightened and wavering, unsure what to do against powers that could penetrate such powerful magical protection. Though they had rudely refused her last visit, they sent a messenger to Pralix requesting another audience with her, and invited her to make her case again. Her eloquence, coupled with the terror and confu-
-
-sion left in the wake of Gwawrier's passing, quickly convinced them to join her cause. While they made preparations for war, she proceeded to seek out the other nonaligned wizards of Britain and convert them, and three months later, on the eve of their departure for battle, the *swynwyr* gave her the magical garment once worn by her predecessor as a sign that she had become one of them. She accepted their gift, and named them the Robes of Dusty Dawn.
-
-It remains a great mystery why half a century later Pralix departed from Cad Gadu without wearing the robes, for she had never before gone anywhere without
-
-them. Perhaps it was because her trip was personal, rather than official, or it might be that she had decided they were too much trouble while traveling. Many think that she knew she was going away forever, and left them for her successor, continuing the tradition that brought the robes to her; for this reason, the robes are now treated as a symbol of the office of Primus, and pass with the position to each newly-elected magus. Others in the House suspect betrayal, arguing that Pralix must have been abducted or murdered by one of her own, someone close to her who knew she would be
-
-traveling unprotected. To quell such accusations, the first Prima of the House instituted the tradition of holding a council seat for Pralix and maintaining the illusion that she is still the leader of the covenant.
-
-The robes still appear exactly the same in 1220 as they did when Pralix first received them. They are woven of fine wool, dyed a pale lavender-rose color. The bottom half appears to be faded, and upon closer examination one can see that the cloth is covered with many lines of chalk markings, more than two dozen distinct bands of arcane symbols and shapes written directly upon the threads. It looks dusty; if one could swat the garment with a hand or stick, a great cloud of chalk dust would surely form, but its powerful magic prevents this. It may be pulled over the head when worn, and removed the same way, but no natural substance or phenomenon may otherwise pass within the perimeter formed by the hem, and thus it must
-
-be removed to eat or drink.
-
-The robes are rumored to possess other great powers as well, and a popular Hermetic legend tells that they were enchanted by Verditius the Founder as a gift to Pralix — though since Verditius died at about the same time as the war against Damhan-Allaidh, this is probably only a myth.
-
-
-and Gifted boys are much more desirable apprentices than girls. For this reason, Columbine magae tend to associate with unGifted members of their tradition more often than Gifted, and do not involve themselves in their political affairs. To outsiders it might even appear that there are no female Columbae in 1220.
+> ## The Robes of Dusty Dawn
+> 
+> The event that made the *swynwyr* decide to join with Pralix against Damhan-Allaidh was the sudden death of their eldest *swynwraig*, named Gwawrieir ("gwah-REE-eyr"), who was effectively the leader of their magical tradition, and who staunchly opposed getting involved in the battle with the wizards of the mainland. Her lifeless body was found lying within one of her own protective circles, and she had eight long, black marks upon her throat, as if she had been strangled from behind by four pairs of hands. Her family was forced to conclude that she had been killed by the evil magic of their northern enemy, and this assumption was supported by the fact that she still wore her enchanted robes, a fabulous treasure said to protect her against all natural threats and every kind of supernatural creature.
+> 
+> The remaining *swynwyr* were frightened and wavering, unsure what to do against powers that could penetrate such powerful magical protection. Though they had rudely refused her last visit, they sent a messenger to Pralix requesting another audience with her, and invited her to make her case again. Her eloquence, coupled with the terror and confusion left in the wake of Gwawrier's passing, quickly convinced them to join her cause. While they made preparations for war, she proceeded to seek out the other nonaligned wizards of Britain and convert them, and three months later, on the eve of their departure for battle, the *swynwyr* gave her the magical garment once worn by her predecessor as a sign that she had become one of them. She accepted their gift, and named them the Robes of Dusty Dawn.
+> 
+> It remains a great mystery why half a century later Pralix departed from Cad Gadu without wearing the robes, for she had never before gone anywhere without them. Perhaps it was because her trip was personal, rather than official, or it might be that she had decided they were too much trouble while traveling. Many think that she knew she was going away forever, and left them for her successor, continuing the tradition that brought the robes to her; for this reason, the robes are now treated as a symbol of the office of Primus, and pass with the position to each newly-elected magus. Others in the House suspect betrayal, arguing that Pralix must have been abducted or murdered by one of her own, someone close to her who knew she would be traveling unprotected. To quell such accusations, the first Prima of the House instituted the tradition of holding a council seat for Pralix and maintaining the illusion that she is still the leader of the covenant.
+> 
+> The robes still appear exactly the same in 1220 as they did when Pralix first received them. They are woven of fine wool, dyed a pale lavender-rose color. The bottom half appears to be faded, and upon closer examination one can see that the cloth is covered with many lines of chalk markings, more than two dozen distinct bands of arcane symbols and shapes written directly upon the threads. It looks dusty; if one could swat the garment with a hand or stick, a great cloud of chalk dust would surely form, but its powerful magic prevents this. It may be pulled over the head when worn, and removed the same way, but no natural substance or phenomenon may otherwise pass within the perimeter formed by the hem, and thus it must be removed to eat or drink.
+> 
+> The robes are rumored to possess other great powers as well, and a popular Hermetic legend tells that they were enchanted by Verditius the Founder as a gift to Pralix — though since Verditius died at about the same time as the war against Damhan-Allaidh, this is probably only a myth.
+> 
 
 ### Characters
 
@@ -4994,136 +4617,125 @@ When the character wishes to use her power, she must draw a circle in the same m
 
 As soon as the circle is finished, the Columba enchants the perimeter with her magical power, and this effort always costs her a Fatigue level. Roll a stress die, applying her Stamina score, her Warding score, and the bonus or penalty for the aura to the total, in addition to any other appropriate modifiers.
 
-#### Warding Total: stress die + Stamina + Warding + aura
+**Warding Total: stress die + Stamina + Warding + aura**
 
 If the ward is designed to affect a natural object or type of material, treat this result as the character's Casting Total for a Hermetic spell of the appropriate Form and level to determine if a particular target will be warded away. (To make this easier to calculate, these spell guidelines are collected below.) For example, a ring designed to ward away mundane animals would succeed if the Warding Total were 5 or greater, and a ward against objects made of wood requires a Warding Total of at least 30.
 
-Warding is best at warding away supernatural creatures with a Might score; when it is used to affect beings with Might, calculate the character's Penetration Total as if the spell level were 0, and treat the full
+Warding is best at warding away supernatural creatures with a Might score; when it is used to affect beings with Might, calculate the character's Penetration Total as if the spell level were 0, and treat the full Penetration Total as the final level of the effect. For example, to ward against a target with Might 15, a Columba would only need a (Warding Total + Penetration Total) of 15. As mentioned above, a Columba can incorporate an Arcane Connection to a particular target into her ward, so that the power only affects that target, and her Penetration Total is boosted even further against it.
 
-### The Fate of Cad Gadu
+Unfortunately, Warding cannot affect creatures with Magic Resistance instead of Might, and so the Penetration Total of the effect is 0 when the warded thing is not a supernatural being. Because Warding only affects either natural or supernatural things, Columbine wards are extremely vulnerable to beings that do not fit perfectly into one of these categories; anyone who has Magic Resistance but no Might score is essentially immune to the effects.
 
-Cad Gadu ("KAHD GAH-dee") is primarily encompassed by a magical regio, but the parts of it that extend into the mundane world are built on an island that is technically owned by a Columbine magus, Gwrhyr ("GOOrear") Ex Miscellanea, who has no children but many male relatives. He is a blustering incompetent, extremely old and seemingly very dim, who constantly demands the "proper respect" for his abilities, and by virtue of his age and status in the covenant he has gained a seat on the Council of Four. He does have a filius, Culhwch ("KEEL-hookh") Ex Miscellanea, but they are not related by blood. Both of them are extremely disliked by Gwrhyr's kindred, who have refused to allow him to give the property to his adopted son. When Gwrhyr finally dies, an event that his relatives believe must happen soon, they will claim ownership of the covenant lands and evict the magi, all with the law entirely on their side.
+> ## The Fate of Cad Gadu
+> 
+> Cad Gadu ("KAHD GAH-dee") is primarily encompassed by a magical regio, but the parts of it that extend into the mundane world are built on an island that is technically owned by a Columbine magus, Gwrhyr ("GOOrear") Ex Miscellanea, who has no children but many male relatives. He is a blustering incompetent, extremely old and seemingly very dim, who constantly demands the "proper respect" for his abilities, and by virtue of his age and status in the covenant he has gained a seat on the Council of Four. He does have a filius, Culhwch ("KEEL-hookh") Ex Miscellanea, but they are not related by blood. Both of them are extremely disliked by Gwrhyr's kindred, who have refused to allow him to give the property to his adopted son. When Gwrhyr finally dies, an event that his relatives believe must happen soon, they will claim ownership of the covenant lands and evict the magi, all with the law entirely on their side.
+> 
+> The former Prima Immanola woefully neglected this situation, and with the recent confusion associated with the elevation of a new Primus, and with Gwrhyr himself sitting on the Council, no one has yet brought the matter to Ebroin's attention. When the issue is finally addressed, those dispatched to deal with the problem may find that the members of Gwrhyr's family are already suspicious of both his great age and his reputation as a sorcerer, and have managed to bring the matter to the attention of the Prince of Gwynedd, who has expressed an interest in meeting this seemingly immortal Welshman. A court date has been set, and if Gwrhyr does not appear and stand for examination, the land will automatically default to his heirs.
 
-The former Prima Immanola woefully neglected this situation, and with the recent confusion associated with the elevation of a new Primus, and with Gwrhyr himself sitting on the Council, no one has yet brought the matter to Ebroin's attention. When the issue is finally addressed, those dispatched to deal with the problem may find that the members of Gwrhyr's family are already suspicious of both his great age and his reputation as a sorcerer, and have managed to bring the matter to the attention of the Prince of Gwynedd, who has expressed an interest in meeting this seemingly immortal Welshman. A court date has been set, and if Gwrhyr does not appear and stand for examination, the land will automatically default to his heirs.
+> ### Wards and Penetration
+> 
+> Hermetic warding spells were all originally adapted from the Columbine tradition, and like any Hermetic spell, these wards must penetrate Magic Resistance to have their effect. A spell like *Circular Ward Against Demons* is much harder to cast at high levels, since both the spell level and the Penetration Total must exceed any affected demon's Might Score. For this reason, magi rarely learn or cast versions of these spells more powerful than about Level 30, instead favoring Rego spells of lower levels that hinder the target's movements more directly.
+> 
+> Since in most cases Hermetic wards do not actually target the creatures affected by them, most magi cannot boost their Penetration Total with an Arcane Connection to a supernatural being, unless that being is inside the circle when the ward is cast. This could be due to a flaw in Hermetic theory, or it could be that the Columbine wards were never perfectly adapted to Hermetic magic. Columbae can do this with their Warding power because they incorporate a set of magical symbols into the circle that describe the warded being.
+> 
+> Neither the Columbine wards nor the Hermetic wards based on them are as useful against beings with Magic Resistance not based on Might, such as men and women with True Faith or magi with the Parma Magica — Hermetic wards must penetrate the person's Magic Resistance, but Warding cannot affect them at all. For this reason, most magi prefer to protect their sancta and their persons with effects like *Watching Ward* or *Waiting Spell* that do not come from the Columbine tradition, instead triggering other effects designed to drive away threats or punish intruders.
 
-Penetration Total as the final level of the effect. For example, to ward against a target with Might 15, a Columba would only need a (Warding Total + Penetration Total) of 15. As mentioned above, a Columba
-
-### Wards and Penetration
-
-Hermetic warding spells were all originally adapted from the Columbine tradition, and like any Hermetic spell, these wards must penetrate Magic Resistance to have their effect. A spell like *Circular Ward Against Demons* is much harder to cast at high levels, since both the spell level and the Penetration Total must exceed any affected demon's Might Score. For this reason, magi rarely learn or cast versions of these spells more powerful than about Level 30, instead favoring Rego spells of lower levels that hinder the target's movements more directly.
-
-Since in most cases Hermetic wards do not actually target the creatures affected by them, most magi cannot boost their Penetration Total with an Arcane Connection to a supernatural being, unless that being is inside the circle when the ward is cast. This could be due to a flaw in Hermetic theory, or it could be that the Columbine wards were never perfectly adapted to Hermetic magic. Columbae can do this with their Warding power because they incorporate a set of magical symbols into the circle that describe the warded being.
-
-Neither the Columbine wards nor the Hermetic wards based on them are as useful against beings with Magic Resistance not based on Might, such as men and women with True Faith or magi with the Parma Magica — Hermetic wards must penetrate the person's Magic Resistance, but Warding cannot affect them at all. For this reason, most magi prefer to protect their sancta and their persons with effects like *Watching Ward* or *Waiting Spell* that do not come from the Columbine tradition, instead triggering other effects designed to drive away threats or punish intruders.w
-
-can incorporate an Arcane Connection to a particular target into her ward, so that the power only affects that target, and her Penetration Total is boosted even further against it.
-
-Unfortunately, Warding cannot affect creatures with Magic Resistance instead of
-
-### Warding vs. Wards
-
-Since Warding is a kind of hedge magic that has been almost completely integrated into Hermetic magic, wards designed using that power are generally inferior to the wards that magi can make. A magus who devotes his study to Rego can find more and better study sources than a Columba who focuses on Warding, and is able to do much more than just ward circles, including the creation of wards bound to Targets other than Circle. Magi can also increase two Arts to influence their casting total, not just one, and can invent formulaic spells that ensure they do not become fatigued, and which they can Master for other advantages. There are also many Hermetic Virtues that the magus may have to increase his Casting Total in certain circumstances.
-
-For a direct comparison of wards, consider an experienced magus with Rego 20, and an experienced Columba with Warding 20. The magus can probably cast a formulaic spell to ward away any natural thing from the circle, while the Columba can most likely manage the same with her Ability (though it is useless against natural things with Magic Resistance). Assuming no Penetration, the magus can develop a formulaic spell that will almost certainly affect a supernatural creature with Might 10, and may even be able to manage Might 15. The Columba, however, also leaving aside Penetration, can produce a ward that affects beings with twice that score, certainly warding away beings with Might 20, and sometimes keeping at bay beings with Might 30 or more.
-
-Hermetic magic can thus be seen to be superior to Warding in nearly every application involving wards, but the Columbae still have a slight advantage when Warding against supernatural beings, and so retain their distinct identity within the House and the Order. For protecting a covenant, the *Aegis of the Hearth* is always a better choice, but when away from their home and faced with beings that possess a Might Score of 50 or more, Columbae who have specialized in Warding are probably the only characters who can set up a reliable magical defense against them.
-
-Might, and so the Penetration Total of the effect is 0 when the warded thing is not a supernatural being. Because Warding only affects either natural or supernatural things, Columbine wards are extremely vulnerable to beings that do not fit perfectly into one of these categories; anyone who has Magic Resistance but no Might score is essentially immune to the effects.
+> ## Warding vs. Wards
+> 
+> Since Warding is a kind of hedge magic that has been almost completely integrated into Hermetic magic, wards designed using that power are generally inferior to the wards that magi can make. A magus who devotes his study to Rego can find more and better study sources than a Columba who focuses on Warding, and is able to do much more than just ward circles, including the creation of wards bound to Targets other than Circle. Magi can also increase two Arts to influence their casting total, not just one, and can invent formulaic spells that ensure they do not become fatigued, and which they can Master for other advantages. There are also many Hermetic Virtues that the magus may have to increase his Casting Total in certain circumstances.
+> 
+> For a direct comparison of wards, consider an experienced magus with Rego 20, and an experienced Columba with Warding 20. The magus can probably cast a formulaic spell to ward away any natural thing from the circle, while the Columba can most likely manage the same with her Ability (though it is useless against natural things with Magic Resistance). Assuming no Penetration, the magus can develop a formulaic spell that will almost certainly affect a supernatural creature with Might 10, and may even be able to manage Might 15. The Columba, however, also leaving aside Penetration, can produce a ward that affects beings with twice that score, certainly warding away beings with Might 20, and sometimes keeping at bay beings with Might 30 or more.
+> 
+> Hermetic magic can thus be seen to be superior to Warding in nearly every application involving wards, but the Columbae still have a slight advantage when Warding against supernatural beings, and so retain their distinct identity within the House and the Order. For protecting a covenant, the *Aegis of the Hearth* is always a better choice, but when away from their home and faced with beings that possess a Might Score of 50 or more, Columbae who have specialized in Warding are probably the only characters who can set up a reliable magical defense against them.
 
 ### Minor Hermetic Virtue: Ring/Circle Magic
 
-Because the Columbae introduced the Ring Duration and Circle Target to Hermetic magic, their followers are not as constrained as other magi regarding how they use them with their spells. For one thing, they can draw a typical circle much more quickly, moving at twice the normal speed, and they only need to roll their Concentration if the circle is broken while casting, not to maintain the spell
-
-while they are drawing the ring. Also, their Ease Factor for maintaining Concentration while casting a spell on a ring or a circle is reduced by 3.
+Because the Columbae introduced the Ring Duration and Circle Target to Hermetic magic, their followers are not as constrained as other magi regarding how they use them with their spells. For one thing, they can draw a typical circle much more quickly, moving at twice the normal speed, and they only need to roll their Concentration if the circle is broken while casting, not to maintain the spell while they are drawing the ring. Also, their Ease Factor for maintaining Concentration while casting a spell on a ring or a circle is reduced by 3.
 
 In addition, a Columba can treat any well-defined boundary as a Circle by marking it plainly, using the same symbols she uses to make her Warding circles. She may cast a spell upon a room or building by inscribing her marks on the door, for example. If her target is an enclosed space, she has only to mark the outside of each entrance. If it is a natural boundary, such as the edge of a forest or a city wall, she must traverse the border at the same speed as if she were drawing a ring (which is still twice as fast as other magi), and mark it so that one of her symbols is visible from every direction. If any of these marks are erased or damaged, it is the same as if the circle had been broken, and the effect immediately ends.
 
-When drawing a circle, a Columba can forgo her faster casting time and her
-
-
-# Ward Guidelines
-
-Here are the various guidelines for warding the different Forms in **Ars Magica Fifth Edition**. All of them are presented at Range Touch, Duration Ring, and Target: Circle, since Warding always uses those same parameters.
-
-Since Hermetic wards must penetrate a being's Magic Resistance to be effective, it is a good idea to note the caster's Penetration Total in addition to the level of the spell. Even with spells that are designed to affect mundane things, it is possible that the character could encounter a special type of target that can resist the effect. For example, a spell designed to ward away animals will not affect a Bjornaer magus in animal form unless it penetrates his Parma Magica.
-
-#### Animal
-
-**General:** Ward against beings associated with Animal from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 5:** Ward against animals or objects made from animal products. (Touch, Ring, Circle)
-
-#### Aquam
-
-**General:** Ward against beings associated with Aquam from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 20:** Ward against liquids. (Touch, Ring, Circle)
-
-#### Auram
-
-**General:** Ward against beings associated with Auram from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 10:** Ward against a type of minor weather phenomenon, such as mist. (Touch, Ring, Circle)
-
-**Level 15:** Ward against a type of normal weather phenomenon, such as rain. (Touch, Ring, Circle)
-
-**Level 20:** Ward against a type of severe weather phenomenon, such as gale force wind. (Touch, Ring, Circle)
-
-**Level 25:** Ward against a type of very severe weather phenomenon, such as a bolt of lightning. (Touch, Ring, Circle)
-
-#### Corpus
-
-**General:** Ward against beings associated with Corpus from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 30:** Ward against human beings. (Touch, Ring, Circle)
-
-#### Herbam
-
-**General:** Ward against beings associated with Herbam from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 30:** Ward against plant products. (Touch, Ring, Circle)
-
-#### Ignem
-
-**General:** Ward against beings associated with Ignem from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 15:** Ward against fire doing up to +5 damage. (Touch, Ring, Circle)
-
-**Level 20:** Ward against fire doing up to +10 damage. (Touch, Ring, Circle)
-
-**Level 25:** Ward against fire doing up to +15 damage. (Touch, Ring, Circle)
-
-**Level 30:** Ward against fire doing up to +20 damage. (Touch, Ring, Circle)
-
-**Level 35:** Ward against fire doing up to +25 damage. (Touch, Ring, Circle)
-
-**Level 40:** Ward against fire doing up to +30 damage. (Touch, Ring, Circle)
-
-#### Imaginem
-
-**General:** Ward against beings associated with Imaginem from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-#### Mentem
-
-**General:** Ward against beings associated with Mentem from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-#### Terram
-
-**General:** Ward against beings associated with Terram from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-**Level 20:** Ward against dirt, sand, mud, or clay. (Touch, Ring, Circle)
-
-**Level 25:** Ward against stone or glass. (Touch, Ring, Circle)
-
-**Level 30:** Ward against metal or gemstone. (Touch, Ring, Circle)
-
-#### Vim
-
-**General:** Ward against all supernatural beings from one realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
-
-ability to simply mark the perimeter of the circle, and instead add the magical symbols associated with Warding, allowing her to target or exclude from the effect things of a specific shape or material, just as when using her Warding power. This also allows her to incorporate an Arcane Connection into the spell to boost her Penetration against a particular being. For example, an Intellego Vim spell intended to alert the caster whenever faeries enter the ring might be cast with an Arcane Connection to a particularly powerful faerie instead, limiting her effect to that faerie but ensuring that the spell will penetrate its Faerie Might.
+When drawing a circle, a Columba can forgo her faster casting time and her ability to simply mark the perimeter of the circle, and instead add the magical symbols associated with Warding, allowing her to target or exclude from the effect things of a specific shape or material, just as when using her Warding power. This also allows her to incorporate an Arcane Connection into the spell to boost her Penetration against a particular being. For example, an Intellego Vim spell intended to alert the caster whenever faeries enter the ring might be cast with an Arcane Connection to a particularly powerful faerie instead, limiting her effect to that faerie but ensuring that the spell will penetrate its Faerie Might.
 
 Columbae can only take advantage of these benefits when casting Hermetic spells of Range Touch, Duration Ring, and Target Circle (ArM5, page 114) — any deviation from these parameters and this Virtue no longer applies. They cannot apply them to their Warding power, as they represent ways that their tradition's deep understanding of magical wards has improved their Hermetic magic.
+
+> ## Ward Guidelines
+> 
+> Here are the various guidelines for warding the different Forms in **Ars Magica Fifth Edition**. All of them are presented at Range Touch, Duration Ring, and Target: Circle, since Warding always uses those same parameters.
+> 
+> Since Hermetic wards must penetrate a being's Magic Resistance to be effective, it is a good idea to note the caster's Penetration Total in addition to the level of the spell. Even with spells that are designed to affect mundane things, it is possible that the character could encounter a special type of target that can resist the effect. For example, a spell designed to ward away animals will not affect a Bjornaer magus in animal form unless it penetrates his Parma Magica.
+> 
+> #### Animal
+> 
+> **General:** Ward against beings associated with Animal from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 5:** Ward against animals or objects made from animal products. (Touch, Ring, Circle)
+> 
+> #### Aquam
+> 
+> **General:** Ward against beings associated with Aquam from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 20:** Ward against liquids. (Touch, Ring, Circle)
+> 
+> #### Auram
+> 
+> **General:** Ward against beings associated with Auram from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 10:** Ward against a type of minor weather phenomenon, such as mist. (Touch, Ring, Circle)
+> 
+> **Level 15:** Ward against a type of normal weather phenomenon, such as rain. (Touch, Ring, Circle)
+> 
+> **Level 20:** Ward against a type of severe weather phenomenon, such as gale force wind. (Touch, Ring, Circle)
+> 
+> **Level 25:** Ward against a type of very severe weather phenomenon, such as a bolt of lightning. (Touch, Ring, Circle)
+> 
+> #### Corpus
+> 
+> **General:** Ward against beings associated with Corpus from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 30:** Ward against human beings. (Touch, Ring, Circle)
+> 
+> #### Herbam
+> 
+> **General:** Ward against beings associated with Herbam from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 30:** Ward against plant products. (Touch, Ring, Circle)
+> 
+> #### Ignem
+> 
+> **General:** Ward against beings associated with Ignem from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 15:** Ward against fire doing up to +5 damage. (Touch, Ring, Circle)
+> 
+> **Level 20:** Ward against fire doing up to +10 damage. (Touch, Ring, Circle)
+> 
+> **Level 25:** Ward against fire doing up to +15 damage. (Touch, Ring, Circle)
+> 
+> **Level 30:** Ward against fire doing up to +20 damage. (Touch, Ring, Circle)
+> 
+> **Level 35:** Ward against fire doing up to +25 damage. (Touch, Ring, Circle)
+> 
+> **Level 40:** Ward against fire doing up to +30 damage. (Touch, Ring, Circle)
+> 
+> #### Imaginem
+> 
+> **General:** Ward against beings associated with Imaginem from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> #### Mentem
+> 
+> **General:** Ward against beings associated with Mentem from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> #### Terram
+> 
+> **General:** Ward against beings associated with Terram from one supernatural realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
+> 
+> **Level 20:** Ward against dirt, sand, mud, or clay. (Touch, Ring, Circle)
+> 
+> **Level 25:** Ward against stone or glass. (Touch, Ring, Circle)
+> 
+> **Level 30:** Ward against metal or gemstone. (Touch, Ring, Circle)
+> 
+> #### Vim
+> 
+> **General:** Ward against all supernatural beings from one realm (Divine, Faerie, Infernal, or Magic) with Might less than or equal to the level of the spell. (Touch, Ring, Circle)
 
 ## Major Hermetic Flaw: Necessary Condition
 
@@ -5131,13 +4743,19 @@ All Columbae must mark their targets as part of their magic. That is, they must 
 
 Columbae can sometimes make a model or a representation of their target, like a picture or a figurine that clearly resembles their target, and write their marks on that. They can also draw on an Arcane Connection to their target. These methods are usually sufficient for when they need to affect something at greater than Touch Range.
 
-# The Donatores Requietis Aeternae
+## The Donatores Requietis Aeternae
 
 The Donatores Requietis Aeternae ("Givers of Eternal Rest") is a young tradition of magi with religious backgrounds that exists to ensure that the spirits of the dead reach their final resting place.
 
 ### Key Facts
 
-**Favored Tribunals:** Their strongest concentration is in Normandy and Stonehenge, but the Donatores are also present in the adjacent Tribunals. **Major Non-Hermetic Virtue:** Banishing **Minor Hermetic Virtue:** Minor Magical Focus (in Mentem for spirits/ghosts, or Corpus for animated dead) **Major Hermetic Flaw:** Restriction (cannot cast spells on consecrated ground)
+**Favored Tribunals:** Their strongest concentration is in Normandy and Stonehenge, but the Donatores are also present in the adjacent Tribunals.
+
+**Major Non-Hermetic Virtue:** Banishing
+
+**Minor Hermetic Virtue:** Minor Magical Focus (in Mentem for spirits/ghosts, or Corpus for animated dead)
+
+**Major Hermetic Flaw:** Restriction (cannot cast spells on consecrated ground)
 
 ### History
 
@@ -5170,32 +4788,25 @@ While the Donatores were fighting the rising tide of restless dead, members of t
 
 Muirgheal, a Quaesitor leading the group, invited the Gifted Donatores to join the Order en masse. Most Donatores were willing to swear the Hermetic Oath and join, but several others initially resisted because of their desire to remain a part of the Church. Other Donatores refused because they were familiar with the Order and believed that its magi were members of the cult of the dead and the source of all of the troubles. Muirgheal brought several of the recalcitrant Donatores to her covenant and convinced them that the Order was not involved in the problem. Murigheal explained the Order's prohibition against dealing with the Infernal and recounted the punishment that House Tytalus had endured for its corruption.
 
-After swearing the Oath, the Donatores accompanied Murigheal to the next Tribunal for their introduction to the rest of the Order. Their presence lead to an acrimonious debate where some magi suggested the Order should instantly March the Donatores to prevent the Church from discovering the
+After swearing the Oath, the Donatores accompanied Murigheal to the next Tribunal for their introduction to the rest of the Order. Their presence lead to an acrimonious debate where some magi suggested the Order should instantly March the Donatores to prevent the Church from discovering the inner secrets of the Order. Others argued that this hysterical fear of the Donatores was completely unwarranted. The debate served as a proxy for the magi to discuss the feelings many had concerning the March on House Diedne without forcing the magi to comment publicly on the prudence of the Schism War. Ultimately, the Donatores Requietis Aeternae were allowed to remain in the Order under the condition that House Guernicus monitor their relations with the Church closely.
 
-### Baptism
-
-Most people are properly laid to rest according to the religious customs of the locale. In Christian areas, there were, however, some people whom the Church refused to lay to rest. Only baptized persons have a claim to a Christian burial. This rule often prevents stillborn children or those who die before their baptism from being laid to rest. They might be buried near the church or in a special, unconsecrated corner of the graveyard that is removed from the rest of the graves, if the Church buries them at all.
-
-The age at which someone entering the Church was baptized varied by location. Some areas only allowed children to be baptized by a cardinal or bishop during one of his visits to the local church. Other areas held group baptisms of children during the Easter or Whitsun Mass. However, in the 13th century most areas began adopting rules that required a child's baptism to occur within one week of its birth. Many believed that if a child died unbaptized it had not been absolved of its original sin and it would never be able to go to Heaven. In some areas, they believed that unbaptized babies would go to the Faerie realm to live out their lives or return as ghosts.
-
-inner secrets of the Order. Others argued that this hysterical fear of the Donatores was completely unwarranted. The debate served as a proxy for the magi to discuss the feelings many had concerning the March on House Diedne without forcing the magi to comment publicly on the prudence of the Schism War. Ultimately, the Donatores Requietis Aeternae were allowed to remain in the Order under the condition that House Guernicus monitor their relations with the Church closely.
+> ## Baptism
+> 
+> Most people are properly laid to rest according to the religious customs of the locale. In Christian areas, there were, however, some people whom the Church refused to lay to rest. Only baptized persons have a claim to a Christian burial. This rule often prevents stillborn children or those who die before their baptism from being laid to rest. They might be buried near the church or in a special, unconsecrated corner of the graveyard that is removed from the rest of the graves, if the Church buries them at all.
+> 
+> The age at which someone entering the Church was baptized varied by location. Some areas only allowed children to be baptized by a cardinal or bishop during one of his visits to the local church. Other areas held group baptisms of children during the Easter or Whitsun Mass. However, in the 13th century most areas began adopting rules that required a child's baptism to occur within one week of its birth. Many believed that if a child died unbaptized it had not been absolved of its original sin and it would never be able to go to Heaven. In some areas, they believed that unbaptized babies would go to the Faerie realm to live out their lives or return as ghosts.
+> 
+> A dead person cannot receive a baptism, but one that shows signs of life can. The rule caused many parents and clergymen to perform elaborate practices to simulate signs of life in a dead child. The child might be left in the cold and then warmed before the priest, who would see changes in coloration or involuntary muscle spasms as "signs of life" and then be able to baptize the child. The Church created rules against this sort of chicanery, but they were often ignored. Obviously, most Hermetic magi would have little problem simulating signs of life in a stillborn child. The effects of a baptism on a corpse should be left to the storyguide, but the most relevant consequence is that the body is eligible for Christian burial.
+> 
+> Because the funerary rites are considered a form of respect for the dead, the Church also refuses to administer them to victims of suicide, to notorious or unrepentant criminals, and to excommunicated individuals. Even the very poor, if their families had not tithed and could not afford the honoraria for the funeral services, might be refused a Christian burial. Excommunicated and unrepentant sinners were often buried at a crossroads or intersection and would likely haunt them.
 
 ### Culture
 
-The primary goal of the Donatores Requietis Aeternae is to assist the dead in passing out of the world of the living. In dealing with the dead, the Donatores may come into contact with several types
-
-A dead person cannot receive a baptism, but one that shows signs of life can. The rule caused many parents and clergymen to perform elaborate practices to simulate signs of life in a dead child. The child might be left in the cold and then warmed before the priest, who would see changes in coloration or involuntary muscle spasms as "signs of life" and then be able to baptize the child. The Church created rules against this sort of chicanery, but they were often ignored. Obviously, most Hermetic magi would have little problem simulating signs of life in a stillborn child. The effects of a baptism on a corpse should be left to the storyguide, but the most relevant consequence is that the body is eligible for Christian burial.
-
-Because the funerary rites are considered a form of respect for the dead, the Church also refuses to administer them to victims of suicide, to notorious or unrepentant criminals, and to excommunicated individuals. Even the very poor, if their families had not tithed and could not afford the honoraria for the funeral services, might be refused a Christian burial. Excommunicated and unrepentant sinners were often buried at a crossroads or intersection and would likely haunt them.
-
-of creatures: the evil dead, ghosts who are in purgatory, spirits who were not buried under the protection of the Divine, and those who died under unfortunate circumstances.
+The primary goal of the Donatores Requietis Aeternae is to assist the dead in passing out of the world of the living. In dealing with the dead, the Donatores may come into contact with several types of creatures: the evil dead, ghosts who are in purgatory, spirits who were not buried under the protection of the Divine, and those who died under unfortunate circumstances.
 
 #### Quieting the Restless Dead
 
-When a person dies with an important task unfinished, while in a highly emotional state, or as the victim of violence, he is likely to return as a spirit. In addition, the dead may return from the grave if they died under other unfortunate circumstances. A suicide, a mother who dies in childbirth, or a stillborn baby could return. These restless dead often seek something from the world of the living. They might want to exact revenge, to right a wrong, or to participate in the family life that they were denied by death. Donatores use their powers to
-
-
-investigate the causes of these types of hauntings, and are loath to simply destroy such spirits. The Donatores consider using Perdo magic on these spirits the equivalent of murder. (See *The Mysteries Revised Edition* and *Realms of Power: Magic* for a more complete discussion of ghosts.)
+When a person dies with an important task unfinished, while in a highly emotional state, or as the victim of violence, he is likely to return as a spirit. In addition, the dead may return from the grave if they died under other unfortunate circumstances. A suicide, a mother who dies in childbirth, or a stillborn baby could return. These restless dead often seek something from the world of the living. They might want to exact revenge, to right a wrong, or to participate in the family life that they were denied by death. Donatores use their powers to investigate the causes of these types of hauntings, and are loath to simply destroy such spirits. The Donatores consider using Perdo magic on these spirits the equivalent of murder. (See *The Mysteries Revised Edition* and *Realms of Power: Magic* for a more complete discussion of ghosts.)
 
 Where ghosts or the restless dead are engaged in wanton destruction and killing, they are likely to be Infernal creatures, and the Donatores are less concerned about the use of destructive magic. This is not always the case, however, especially where a spirit is killing to right a wrong that could not be corrected in life. These ghosts are just as likely to be of the Magic or Faerie realms. Regardless of the source of their power, the Donatores are concerned with combating the destructive restless dead. They are always very careful to confirm the origin of any restless dead before interacting with it. Not all Infernal spirits engage in this reckless destruction. Many pose as benign spirits of recently deceased family members to corrupt the living and lead them into committing sin. (See *Realms of Power: The Infernal* for a discussion of diabolic spirits.)
 
@@ -5225,7 +4836,6 @@ When a member of the Donatores Requietis Aeternae encounters a spirit he uses hi
 
 The Donatores Requietis Aeternae usually emphasize the study of Mentem for dealing with incorporeal spirits; however, in areas where the walking dead are more prevalent, especially in the Transylvanian and Loch Leglean Tribunals, and in Ultima Thule, many Donatores concentrate on Corpus. Although there are few Abilities beyond Banishing that Donatores favor, many have trained in Dominion, Faerie, Infernal, and Magic Lore to assist them in distinguishing the origin of the restless dead they encounter.
 
-
 #### New Virtue: Banishing
 
 *Major, Supernatural*
@@ -5236,27 +4846,21 @@ To banish a creature, the character loudly calls upon the source of the Accelera
 
 The player must make a stress roll of the character's Presence and Banishing score against the Ease Factor as described below. Multiple creatures may be banished from the designated location; the target Ease Factor does not increase. The amount by which the total exceeds the Ease Factor is the Penetration of the Accelerated Ability.
 
-#### Banishing Total: stress die + Presence + Banishing + aura
+**Banishing Total: stress die + Presence + Banishing + aura**
 
 If Banishing penetrates, the character banishes any creatures of the realm selected from the designated location for Sun Duration. The character must be within the designated area when the Accelerated Ability is used. If the character does not state a specific location, the default Ease Factor is Near Range, which is defined as the area within 10 paces of the character.
 
 | Ease Factor | Area      |
-|-------------|-----------|
+|:-----------:|-----------|
 | 3           | Near      |
 | 6           | Structure |
 | 9           | Boundary  |
 
-A successful Banishing attempt expels all creatures of the appropriate realm from the designated area, whether the character is aware of them or not. The only way
-
-
-to avoid Banishing friendly creatures of the same realm as the one targeted is to include the True Name of the target of the banishment. (See *Realms of Power: The Infernal*, page 34.)
+A successful Banishing attempt expels all creatures of the appropriate realm from the designated area, whether the character is aware of them or not. The only way to avoid Banishing friendly creatures of the same realm as the one targeted is to include the True Name of the target of the banishment. (See *Realms of Power: The Infernal*, page 34.)
 
 A banished creature must depart the designated location by the quickest means available to it. The creature may attempt to return to the designated location by succeeding in a Stamina + (Realm) Lore roll against an Ease Factor of 12, where the applicable (Realm) Lore is the origin of the character's Banishing Ability. If the designated location is within an aura that is aligned with the character's Banishing Ability, the creature's roll is modified by the Realm Interaction Table on ArM5, page 183. If the creature succeeds, it may enter the designated location, but its Might score is reduced by one-half the character's Banishing score. If the creature's Might score would be reduced to zero or lower, the creature may not enter. If the creature leaves the designated location, its Might score returns to normal.
 
-While an affected creature is in the designated location, its Might score is reduced and it suffers overwhelming pain and discomfort (and negative modifiers) as described in *Weight of a Thousand Hells* (ArM5, page 148). This extreme discomfort causes most creatures to develop deep enmity for the character who banished them. Infernal and other creatures of
-
-
-appropriate temperament may develop an obsession with exacting revenge on the character. If a creature is unable to avenge a banishment, it often seeks allies or assistance in punishing the character. Friendly creatures may not go to these lengths for revenge, but few are pleased to suffer the torment of banishment.
+While an affected creature is in the designated location, its Might score is reduced and it suffers overwhelming pain and discomfort (and negative modifiers) as described in *Weight of a Thousand Hells* (ArM5, page 148). This extreme discomfort causes most creatures to develop deep enmity for the character who banished them. Infernal and other creatures of appropriate temperament may develop an obsession with exacting revenge on the character. If a creature is unable to avenge a banishment, it often seeks allies or assistance in punishing the character. Friendly creatures may not go to these lengths for revenge, but few are pleased to suffer the torment of banishment.
 
 Although all of the Donatores's Banishing capabilities are aligned with the Divine, Banishing may be aligned with any realm. A character may use Banishing against creatures aligned with the same realm as the character's Banishing Ability, but it is difficult to keep an aligned creature out of the designated area. Of course, Divine creatures are immune to the effects of Banishing if they are fulfilling God's Divine plans.
 
@@ -5266,38 +4870,31 @@ Although all of the Donatores's Banishing capabilities are aligned with the Divi
 
 #### Favored Virtues and Flaws
 
-Banishing is a required Virtue for the tradition and is the focus of most junior magi. It allows magi fresh from their Gauntlets to combat spirits and ghosts with greater ability than they would oth-
-
-### Saintly Visitations
-
-The people who formed the Donatores Requietis Aeternae were a hodgepodge of village hedge wizards, high-born necromancers, and clergy, including priests, nuns, and monks. Some possessed The Gift, but others had no ability with magic at all before receiving their vision. It is possible that other, non-Christian followers of the Divine have also received the Banishing Virtue, but currently all Donatores are Christian. Although the founders of the Donatores experienced visions from several saints, the three most frequent are described here.
-
-**Saint Gertrude of Nivelles** is the patroness of the recently dead. Popular belief states that the dead travel for three days before reaching the next world. On their first night, they stay under the care of Gertrude and on the second under the Archangel Michael. Gertrude appeared before many Donatores, several of whom were unGifted. Those who experienced her vision often have Premonitions or Visions involving mice and cats. The mice represent lost souls and the cats the Donatores whose task it is to deal with those souls. Magi who received her vision often posses the Virtue Inoffensive to Animals.
-
-erwise be able to do with Hermetic magic alone. As the magus matures and his Arts improve, the importance of Banishing lessens. However, even senior magi utilize Banishing as a way to soften a potential target before sending it to its ultimate rest.
+Banishing is a required Virtue for the tradition and is the focus of most junior magi. It allows magi fresh from their Gauntlets to combat spirits and ghosts with greater ability than they would otherwise be able to do with Hermetic magic alone. As the magus matures and his Arts improve, the importance of Banishing lessens. However, even senior magi utilize Banishing as a way to soften a potential target before sending it to its ultimate rest.
 
 The Donatores Requietis Aeternae suffer from the Hermetic Flaw Restriction. They cannot cast spells on consecrated ground. This Flaw may come from the inability of Hermetic magic to summon or communicate with a spirit that has received a Christian burial or from the unwillingness of the Donatores to violate the sanctity of holy ground. This causes Donatores several problems. Because the remains of a spirit are an Arcane Connection to it, Donatores are often forced to identify and collect those remains without the assistance of Hermetic magic.
 
-Other than the standard Flaws and Virtues for the tradition, the Donatores
+Other than the standard Flaws and Virtues for the tradition, the Donatores Requietis Aeternae do not share many magical similarities. There are, however, several Virtues that are more common among the Donatores than other members of the Order. Donatores who provide a great service to a spirit might possess the Ghostly Warder Virtue. Their frequent trips into consecrated graveyards have given many magi the Sense Holiness and Unholiness Virtue. Likewise, because many members of the Donatores Requietis Aeternae either belonged to the priesthood or have frequent contact with it, they may possess True Faith, and some also hold a Relic. Although not common, a few members of the Donatores tradition practice Holy Magic, as described in *Realms of Power: The Divine*.
 
-**Saint Odilo**, the creator of the Feast of All Soul's Day while the Abbot at Cluny, is the patron saint of souls in Purgatory. He promoted the "Truce of God," by which military hostilities in France would cease for religious holidays. Odilo appeared before many Donatores who were in holy orders. Those who received his vision often possess the Virtues Apt Student, Educated, or Good Teacher. They also tend to have the Flaw Soft-Hearted or Noncombatant.
+The frequent meddling of the Donatores in the world of the dead causes many to suffer from the Plagued by Supernatural Entity Flaw. The supernatural entity is often a spirit that was too powerful for the Donator to defeat. Dealing with a never-ending parade of restless dead also leads many Donatores to develop Second Sight. Many also have a Higher Purpose or Compulsion regarding combating or defending themselves from the restless dead. The frequency of nighttime investigation and activity has led many to have the Nocturnal Flaw. Some Donatores also suffer from Visions, which are usually concerned with the wanderings of the restless dead.
 
-**Saint Demetrius of Sermium**, martyred in the third century for his preaching to Roman soldiers in Thessalonika, modern Croatia, is a patron saint of Crusaders and is often called upon to repel evil spirits. Demetrius appeared before several of the martially inclined Donatores, especially those who had taken the cross. Many of them have the Tough, Reserves of Strength, or Warrior Virtue.
+> ## Saintly Visitations
+> 
+> The people who formed the Donatores Requietis Aeternae were a hodgepodge of village hedge wizards, high-born necromancers, and clergy, including priests, nuns, and monks. Some possessed The Gift, but others had no ability with magic at all before receiving their vision. It is possible that other, non-Christian followers of the Divine have also received the Banishing Virtue, but currently all Donatores are Christian. Although the founders of the Donatores experienced visions from several saints, the three most frequent are described here.
+> 
+> **Saint Gertrude of Nivelles** is the patroness of the recently dead. Popular belief states that the dead travel for three days before reaching the next world. On their first night, they stay under the care of Gertrude and on the second under the Archangel Michael. Gertrude appeared before many Donatores, several of whom were unGifted. Those who experienced her vision often have Premonitions or Visions involving mice and cats. The mice represent lost souls and the cats the Donatores whose task it is to deal with those souls. Magi who received her vision often posses the Virtue Inoffensive to Animals.
+> 
+> **Saint Odilo**, the creator of the Feast of All Soul's Day while the Abbot at Cluny, is the patron saint of souls in Purgatory. He promoted the "Truce of God," by which military hostilities in France would cease for religious holidays. Odilo appeared before many Donatores who were in holy orders. Those who received his vision often possess the Virtues Apt Student, Educated, or Good Teacher. They also tend to have the Flaw Soft-Hearted or Noncombatant.
+> 
+> **Saint Demetrius of Sermium**, martyred in the third century for his preaching to Roman soldiers in Thessalonika, modern Croatia, is a patron saint of Crusaders and is often called upon to repel evil spirits. Demetrius appeared before several of the martially inclined Donatores, especially those who had taken the cross. Many of them have the Tough, Reserves of Strength, or Warrior Virtue.
+> 
+> Although current apprentices are taught Banishing by their parentes, many receive a vision from a saint during their apprenticeship. The apprentice often then develops a Virtue or Flaw that mirrors some aspect of the saint's powers or life.
 
-Although current apprentices are taught Banishing by their parentes, many receive a vision from a saint during their apprenticeship. The apprentice often then develops a Virtue or Flaw that mirrors some aspect of the saint's powers or life.
-
-Requietis Aeternae do not share many magical similarities. There are, however, several Virtues that are more common among the Donatores than other members of the Order. Donatores who provide a great service to a spirit might possess the Ghostly Warder Virtue. Their frequent trips into consecrated graveyards have given many magi the Sense Holiness and Unholiness Virtue. Likewise, because many members of the Donatores Requietis Aeternae either belonged to the priesthood or have frequent contact with it, they may possess True Faith, and some also hold a Relic. Although not common, a few members of the Donatores tradition practice Holy Magic, as described in *Realms of Power: The Divine*.
-
-The frequent meddling of the Donatores in the world of the dead causes many to suffer from the Plagued by Supernatural Entity Flaw. The supernatural entity is often a spirit
-
-
-### Doing it the Hard Way
-
-Magic is not the only way to combat the restless dead. Some ghosts are simply unaware that they are dead and are attempting to complete an important task they failed to finish in life. If a character assists the ghost, it is likely to lay the spirit to rest. Some ghosts wander the earth because they never had a proper burial. Finding their remains and performing the appropriate burial service quiets these spirits. Other ghosts feel an overwhelming guilt for leaving someone behind, or may have a sense of duty to some person. They may remain to protect the person and can only be put to rest if the ward reaches adulthood or demonstrates independence.
-
-For the restless, corporeal dead who seek vengeance on the world — sometimes called revenants — the mundane process of quieting them is quite grisly. If the target against whom the revenant seeks vengeance is killed, the creature usually ceases to wander. Some restless dead, however, might seek vengeance against an entire family, town, or other large group of enemies. In these cases, the character must locate the revenant's tomb, to which the creature must return before dawn. During the day, the character must exhume the revenant, decapitate it, remove its heart, and have its grave blessed with holy water. If these steps are not completed before dusk, the revenant rises and hunts any who disturbed its grave. Other legends require that the corpse be disinterred and incinerated. After its ashes are spread, the revenant does not return.
-
-that was too powerful for the Donator to defeat. Dealing with a never-ending parade of restless dead also leads many Donatores to develop Second Sight. Many also have a Higher Purpose or Compulsion regarding combating or defending themselves from the restless dead. The frequency of nighttime investigation and activity has led many to have the Nocturnal Flaw. Some Donatores also suffer from Visions, which are usually concerned with the wanderings of the restless dead.
+> ### Doing it the Hard Way
+> 
+> Magic is not the only way to combat the restless dead. Some ghosts are simply unaware that they are dead and are attempting to complete an important task they failed to finish in life. If a character assists the ghost, it is likely to lay the spirit to rest. Some ghosts wander the earth because they never had a proper burial. Finding their remains and performing the appropriate burial service quiets these spirits. Other ghosts feel an overwhelming guilt for leaving someone behind, or may have a sense of duty to some person. They may remain to protect the person and can only be put to rest if the ward reaches adulthood or demonstrates independence.
+> 
+> For the restless, corporeal dead who seek vengeance on the world — sometimes called revenants — the mundane process of quieting them is quite grisly. If the target against whom the revenant seeks vengeance is killed, the creature usually ceases to wander. Some restless dead, however, might seek vengeance against an entire family, town, or other large group of enemies. In these cases, the character must locate the revenant's tomb, to which the creature must return before dawn. During the day, the character must exhume the revenant, decapitate it, remove its heart, and have its grave blessed with holy water. If these steps are not completed before dusk, the revenant rises and hunts any who disturbed its grave. Other legends require that the corpse be disinterred and incinerated. After its ashes are spread, the revenant does not return.
 
 #### Preferred Spells
 
@@ -5305,12 +4902,19 @@ For restless dead with Might scores too powerful to defeat unassisted, a Donator
 
 All Donatores learn Penetration and many emphasize the use of low-level spells to maximize their Penetration scores against creatures with Might. Most Donatores also master these spells to allow them to cast multiple copies. Obviously, *Demon's Eternal Oblivion* and *Lay to Rest the Haunting Spirit* are two of the more popular spells. Both are very effective against a creature previously weakened by Banishing.
 
-# The Cult of Orpheus
+## The Cult of Orpheus
 
 In ancient Thrace there lived a poet and musician beloved of gods and men. He is the root of dozens of myths and hundreds of stories. He was an artist, augur, and Argonaut. Orpheus was a master musician and magician, said by some to have been taught these twin arts by Hermes himself. His followers suggest that this makes him the first user of "Hermetic" magic in history.
 
+### Key Facts
 
-**Favored Tribunals:** Tribunal of Thebes, Transylvanian Tribunal, Roman Tribunal **Major Virtue:** Sanguine Humor's Blessing **Minor Hermetic Virtue:** Orphic Magic **Major Hermetic Flaw:** Necessary Condition (True Feeling)
+**Favored Tribunals:** Tribunal of Thebes, Transylvanian Tribunal, Roman Tribunal
+
+**Major Virtue:** Sanguine Humor's Blessing
+
+**Minor Hermetic Virtue:** Orphic Magic
+
+**Major Hermetic Flaw:** Restriction (True Feeling)
 
 ### History
 
@@ -5322,10 +4926,7 @@ Among themselves, Orphic magi still use the Greek title of *magos* (plural *mago
 
 ### Culture
 
-The Cult of Orpheus is similar to a Mystery Cult, and characters must be Initiated into it. In general, however, the Cult of Orpheus seeks out potential *magoi* who already possess the Virtue and/or the
-
-
-Flaw that define their capabilities . Some members believe the Cult's teaching methods are flawed, and that one could learn this magic without taking on the Virtues and Flaws of the Orphics. However, such a method runs counter to the Cult's philosophies, and there is no record of such an attempt.
+The Cult of Orpheus is similar to a Mystery Cult, and characters must be Initiated into it. In general, however, the Cult of Orpheus seeks out potential *magoi* who already possess the Virtue and/or the Flaw that define their capabilities . Some members believe the Cult's teaching methods are flawed, and that one could learn this magic without taking on the Virtues and Flaws of the Orphics. However, such a method runs counter to the Cult's philosophies, and there is no record of such an attempt.
 
 An Initiate makes oaths and performs rituals that cement his place in the Cult forever. Cult members are asked to do varied things, based on visions received during initiation. Common requirements include eschewing the opposite sex, scourging the flesh, and eating no meat. No two Orphic magoi are required to follow the same taboos, and no follower of Orpheus is ever asked to do something that would compromise the connections that power his magic. Common to each Initiation, however, is the insistence that information be hidden from outsiders.
 
@@ -5337,88 +4938,72 @@ Orphics also hide the Cult's belief in the legend of Orpheus, and that he attemp
 
 Orphic cultists use Hermetic magic, but they incorporate some of their pre-Hermetic knowledge to expand their abilities. Orphic magoi begin with the Major General Virtue Sanguine Humour's Blessing, the Minor Hermetic Virtue Orphic Magic, and the Flaw Restriction (True Feeling). An Orphic magos is so connected to certain others that it colors everything he does.
 
-The Major Hermetic Virtue Mercurian Magic is appropriate to Orphic magoi. Many also have the Minor Supernatural
+The Major Hermetic Virtue Mercurian Magic is appropriate to Orphic magoi. Many also have the Minor Supernatural Virtue Enchanting Music, and some learn the Ability itself after their apprenticeship; the difficulty is great, but these magoi feel that to approach Orpheus is worth the effort.
 
-### The Orpheus Legend
+> ## The Orpheus Legend
+> 
+> Orpheus was the finest composer the world has ever known, with music capable of charming the very rocks and trees themselves, and while he was playing the beasts would harm neither him nor one another, merely lying in adoration of his beautiful melodies. His charms won him the affection of a woman, Eurydice, whom he adored with a fierce love, great and unbounded. Tragically, she was lost to him soon after their wedding; she was seen by the god Aristaeus, who desired her beauty. He advanced on her, and she fled, but stepped upon a viper in the grass. She died soon after, but Orpheus could not bear her loss.
+> 
+> Orpheus traveled the breadth of the world in his grief, playing bittersweet tunes on his divine lyre that drew tears from all who heard them. Following advice thus coaxed from sympathetic spirits and gods he traveled down a cave and found himself in the Greek Underworld. There he met Hades and Persephone, its king and queen, and played for them a song so sad, desperate, and haunting that they agreed to allow his love to leave following him, provided he trusted enough to go without turning back to see if she was there. Perhaps Orpheus's resolve failed him, or perhaps the gods are merely fickle, but regardless of the reason, it was near the surface that he glanced back to be greeted with the sight of his beloved being borne away, back into the depths of the Underworld.
+> 
+> Orpheus lost his sanity after this, and wandered the world a second time, and though now in a fit of madness his music was as beautiful as ever. His charms, though, could not protect him from the Maenads, women devoted to Dionysus, who tore him limb from limb in one of their wild rampages through the woods. His head is said to have continued to sing beautifully as it floated down the river and into the sea; his lyre was set among the stars by Zeus himself.
 
-Orpheus was the finest composer the world has ever known, with music capable of charming the very rocks and trees themselves, and while he was playing the beasts would harm neither him nor one another, merely lying in adoration of his beautiful melodies. His charms won him the affection of a woman, Eurydice, whom he adored with a fierce love, great and unbounded. Tragically, she was lost to him soon after their wedding; she was seen by the god Aristaeus, who desired her beauty. He advanced on her, and she fled, but stepped upon a viper in the grass. She died soon after, but Orpheus could not bear her loss.
-
-Orpheus traveled the breadth of the world in his grief, playing bittersweet tunes on his divine lyre that drew tears from all who heard them. Following advice thus coaxed from sympathetic spirits and gods he traveled down a cave and found himself in the Greek Underworld. There he met Hades and
-
-Persephone, its king and queen, and played for them a song so sad, desperate, and haunting that they agreed to allow his love to leave following him, provided he trusted enough to go without turning back to see if she was there. Perhaps Orpheus's resolve failed him, or perhaps the gods are merely fickle, but regardless of the reason, it was near the surface that he glanced back to be greeted with the sight of his beloved being borne away, back into the depths of the Underworld.
-
-Orpheus lost his sanity after this, and wandered the world a second time, and though now in a fit of madness his music was as beautiful as ever. His charms, though, could not protect him from the Maenads, women devoted to Dionysus, who tore him limb from limb in one of their wild rampages through the woods. His head is said to have continued to sing beautifully as it floated down the river and into the sea; his lyre was set among the stars by Zeus himself.
-
-### The Path of Orpheus
-
-It is rumored within the cult, and without, that their leaders have access to a ritual that follows Orpheus's path into the Underworld. Orpheus's original trek may have left traces that later *magoi* could follow, allowing them to restore their own beloved (or despised) to the living world.
-
-If this ritual existed, it would function like the rituals of Fenicil (see *Houses of Hermes: True Lineages*, page 76), with an Ease Factor of 78, Range *Adelphixis*, Duration Momentary, and Target Individual; neither the Cult of Orpheus nor House Guernicus knows that the other group holds such knowledge. For those without *True Lineages*, this is a great ritual which requires the expenditure of dozens of pawns of raw vis and the coordination of
-
-Virtue Enchanting Music, and some learn the Ability itself after their apprenticeship; the difficulty is great, but these magoi feel that to approach Orpheus is worth the effort.
-
-several magi at once, all of whom must know the spell *Wizard's Communion*. During the casting, the ritual leader is drawn into a realm that appears to be the Greek Underworld, where he is sorely tested by Hades himself to demonstrate worthiness before the king will release the soul.
-
-Even if the spell is successfully cast, and Hades's tests are passed, there is no guarantee that the ritual is capable of what is purported. Under the best of circumstances, the ritual will not work on anyone buried on holy ground, and certainly not on anyone directly ascended to Heaven. Even so, the individual who returns may well be simply a demon preying on the desires of the *magos*, and Hermetic magic would be unable to discern this.
+> ### The Path of Orpheus
+> 
+> It is rumored within the cult, and without, that their leaders have access to a ritual that follows Orpheus's path into the Underworld. Orpheus's original trek may have left traces that later *magoi* could follow, allowing them to restore their own beloved (or despised) to the living world.
+> 
+> If this ritual existed, it would function like the rituals of Fenicil (see *Houses of Hermes: True Lineages*, page 76), with an Ease Factor of 78, Range *Adelphixis*, Duration Momentary, and Target Individual; neither the Cult of Orpheus nor House Guernicus knows that the other group holds such knowledge. For those without *True Lineages*, this is a great ritual which requires the expenditure of dozens of pawns of raw vis and the coordination of
+> 
+> several magi at once, all of whom must know the spell *Wizard's Communion*. During the casting, the ritual leader is drawn into a realm that appears to be the Greek Underworld, where he is sorely tested by Hades himself to demonstrate worthiness before the king will release the soul.
+> 
+> Even if the spell is successfully cast, and Hades's tests are passed, there is no guarantee that the ritual is capable of what is purported. Under the best of circumstances, the ritual will not work on anyone buried on holy ground, and certainly not on anyone directly ascended to Heaven. Even so, the individual who returns may well be simply a demon preying on the desires of the *magos*, and Hermetic magic would be unable to discern this.
 
 ## Major General Virtue, Sanguine Humor's Blessing
 
-Of the four humors of Hippocrates, blood is said to govern passion and heat. A
-
-
-
-#### character with this Virtue has strong connections to others who support him, and he can draw on these bonds to give insight to specific tasks.
+Of the four humors of Hippocrates, blood is said to govern passion and heat. A character with this Virtue has strong connections to others who support him, and he can draw on these bonds to give insight to specific tasks.
 
 A character with this Virtue receives a bonus to certain rolls. This is based on his Story Flaw, if appropriate; however, the roll in question does not need to involve the Flaw directly. The Flaw must indicate a True Feeling, and this determination is left up to the storyguide or troupe, but some examples are given below. The bonus is +1 to Ability rolls for Minor Story Flaws and +3 for Major Story Flaws; Hermetic magi with this Virtue, including Orphic *magoi*, gain a +3 bonus to appropriate spellcasting rolls for Minor Flaws and a +5 bonus for Major ones. Note that this is a General Virtue, and thus available to those outside of the Cult of Orpheus.
 
-If the character ever loses the Story Flaw in question, through in-game resolution, this Virtue ceases to provide any benefit until the character gains another such Flaw. If a character has two appropriate Flaws for any reason, only the first one gained affects this Virtue; note, however,
-
-### The Cult of Orpheus in Your Saga
-
-While there may be one or more Orphic *magoi* in your troupe, the Cult can be easily involved in your stories even if no PC is a member. Orphics can be either antagonists or allies of the PCs, depending on your needs.
-
-The Path of Orpheus can serve as the centerpiece to a storyline about dead who return from the grave. The Orphics might either serve to help a PC restore a beloved NPC to life, or as a conduit — witting or unwitting — for demonic influence to enter Mythic Europe.
-
-The Cult of Orpheus is also aware of the Seirenes (see Seirenes in Your Saga, below), and this tradition is the source of speculation among Cult members. The groups distrust one another, but they haven't come into open conflict. Orphic *magoi* might attempt to learn the Seirenes' magic, or, as their founder did, learn to
-
-that under normal circumstances a character may only begin play with one Story Flaw.
+If the character ever loses the Story Flaw in question, through in-game resolution, this Virtue ceases to provide any benefit until the character gains another such Flaw. If a character has two appropriate Flaws for any reason, only the first one gained affects this Virtue; note, however, that under normal circumstances a character may only begin play with one Story Flaw.
 
 Some appropriate Flaws and their corresponding bonuses appear below. Other Flaws may be appropriate, as determined by your troupe or storyguide.
 
-| Flaw                                  | Bonus                                                      |
-|---------------------------------------|------------------------------------------------------------|
-| Dependent                             | Rolls to support or<br>protect                             |
-| Enemies                               | Rolls to attack or<br>defend                               |
-| True Love (NPC)                       | Rolls to impress or<br>persuade                            |
-| Animal/Magical<br>Animal<br>Companion | Rolls involving the<br>natural world                       |
-| Close Family Ties                     | Rolls to empathize<br>with or understand<br>another person |
-| Mentor                                | Rolls to recall<br>or comprehend<br>information            |
+| Flaw                     | Bonus                                   |
+|--------------------------|-----------------------------------------|
+| Dependent                | Rolls to support or protect             |
+| Enemies                  | Rolls to attack or defend               |
+| True Love (NPC)          | Rolls to impress or persuade            |
+| Animal/Magical Animal Companion | Rolls involving the natural world |
+| Close Family Ties        | Rolls to empathize with or understand another person |
+| Mentor                   | Rolls to recall or comprehend information |
 
-For example, a character with the Story Flaw Enemies receives a +3 bonus to any mundane roll that involves attack or defense, or a +5 bonus to such Hermetic counter it with music of their own. Even if this does not happen, it would not take much to convince one group to move against the other, given their mutual legendry.
+For example, a character with the Story Flaw Enemies receives a +3 bonus to any mundane roll that involves attack or defense, or a +5 bonus to such Hermetic spells, regardless of whether the target of the roll is an Enemy as defined by the Flaw. A character with Close Family Ties receives a bonus to rolls to comprehend other people, regardless of whether they are family.
 
-Some Orphic *magoi* also consider the loss of their founder's own magical music unfortunate. An Orphic *magos* might well decide to make it his life's work to rebuild such abilities.
-
-The Cult of Orpheus is aware of the claim of House Tremere to have built their domus magna over Orpheus's portal into Hades, but most consider it a laughable pretense. Orphic teachings indicate that Orpheus did not use any physical gateway, but rather that his grief, his music, and his magic carried him directly there, and that Orpheus's own mind interpreted what was happening as a physical trek.
-
-spells, regardless of whether the target of the roll is an Enemy as defined by the Flaw. A character with Close Family Ties receives a bonus to rolls to comprehend other people, regardless of whether they are family.
+> ## The Cult of Orpheus in Your Saga
+> 
+> While there may be one or more Orphic *magoi* in your troupe, the Cult can be easily involved in your stories even if no PC is a member. Orphics can be either antagonists or allies of the PCs, depending on your needs.
+> 
+> The Path of Orpheus can serve as the centerpiece to a storyline about dead who return from the grave. The Orphics might either serve to help a PC restore a beloved NPC to life, or as a conduit — witting or unwitting — for demonic influence to enter Mythic Europe.
+> 
+> The Cult of Orpheus is also aware of the Seirenes (see Seirenes in Your Saga, below), and this tradition is the source of speculation among Cult members. The groups distrust one another, but they haven't come into open conflict. Orphic *magoi* might attempt to learn the Seirenes' magic, or, as their founder did, learn to counter it with music of their own. Even if this does not happen, it would not take much to convince one group to move against the other, given their mutual legendry.
+> 
+> Some Orphic *magoi* also consider the loss of their founder's own magical music unfortunate. An Orphic *magos* might well decide to make it his life's work to rebuild such abilities.
+> 
+> The Cult of Orpheus is aware of the claim of House Tremere to have built their domus magna over Orpheus's portal into Hades, but most consider it a laughable pretense. Orphic teachings indicate that Orpheus did not use any physical gateway, but rather that his grief, his music, and his magic carried him directly there, and that Orpheus's own mind interpreted what was happening as a physical trek.
 
 ### Minor Hermetic Virtue: Orphic Magic
 
 Orphic *magoi* gain access to the additional Range *Adelphixis*. Spells with this Range may target anyone connected to the *magos* via a Story Flaw that indicates emotion, such as True Love (NPC) or Close Family Ties. At the storyguide's discretion, some Virtues may allow the use of *Adelphixis* as well — for example, True Love (PC). This range is equivalent to Arcane Connection for determining spell level. In essence, the *magos* is using himself as the Arcane Connection required for the spell.
 
-## Major Hermetic Flaw: Restriction (True Feeling)
+### Major Hermetic Flaw: Restriction (True Feeling)
 
-The magic of the Cult of Orpheus ties into feelings for others such that, should those dissolve, the *magos* is unable to use
-
-
-
-magic. Note that the death of other party does not necessarily invalidate the feeling; in the case of Orpheus, he retained his True Love long after Eurydice had died. However, if the character at any time has no Virtue or Flaw representing a strong, emotional connection to another, he loses access to his magic until another such feeling is stirred. In general, Orphic *magoi* have a Flaw appropriate to Sanguine Humor's Blessing, which fulfills this condition as well. However, this Flaw is broader than Sanguine Humor's Blessing, and many Virtues are appropriate, e.g., True Love (NPC) or True Faith.
+The magic of the Cult of Orpheus ties into feelings for others such that, should those dissolve, the *magos* is unable to use magic. Note that the death of other party does not necessarily invalidate the feeling; in the case of Orpheus, he retained his True Love long after Eurydice had died. However, if the character at any time has no Virtue or Flaw representing a strong, emotional connection to another, he loses access to his magic until another such feeling is stirred. In general, Orphic *magoi* have a Flaw appropriate to Sanguine Humor's Blessing, which fulfills this condition as well. However, this Flaw is broader than Sanguine Humor's Blessing, and many Virtues are appropriate, e.g., True Love (NPC) or True Faith.
 
 #### Orphic Spells
 
 Below is a short list of spells using the *Adelphixis* Range. Such spells are rarely passed from parens to apprentice in the normal Hermetic manner, as each Orphic *magos* has his own reasons for joining the Cult. Few interested in *A Father's Concern* would ever consider casting *The End of Hatred*, for example.
 
-#### A Father's Concern
+##### A Father's Concern
 
 InCo 40
 
@@ -5430,7 +5015,7 @@ This spell gives a brief insight into the targets' physical condition. It applie
 
 (Base 10, +4 *Adelphixis*, +2 Group)
 
-#### The End of Hatred
+##### The End of Hatred
 
 PeCo 50
 
@@ -5442,7 +5027,7 @@ When the inventor used it to slay his mundane rival, he was discovered by the Cu
 
 (Base 30, +4 *Adelphixis*)
 
-#### The Private Speech of Eros and Psyche
+##### The Private Speech of Eros and Psyche
 
 In(Cr)Me 60
 
@@ -5454,7 +5039,7 @@ This spell was developed by a *magos* who wanted to hear his True Love's voice a
 
 (Base 15, +4 *Adelphixis*, +4 Year, +1 Creo to send words)
 
-# The Pharmacopoeians
+## The Pharmacopoeians
 
 The Pharmacopoeians comprise a tradition of magi who can trace their ancient lineage back to Crateuas: author of the first pharmacopoeia, illustrator of the first herbal, and the original Root-Cutter. Their magic relies heavily on the curative magic in herbs and plants, which makes them some of the Order's best healers.
 
@@ -5464,7 +5049,9 @@ The Pharmacopoeians comprise a tradition of magi who can trace their ancient lin
 
 **Major Non-Hermetic Virtue:** Mythic Herbalism
 
-**Minor Hermetic Virtue:** Root-Cutter **Major Hermetic Flaw:** Deficient Technique (Perdo)
+**Minor Hermetic Virtue:** Root-Cutter
+
+**Major Hermetic Flaw:** Deficient Technique (Perdo)
 
 **Miscellaneous:** All Root-Cutters have the Virtue Minor Magical Focus (Healing) and one of the following Flaws: Soft-Hearted, Noncombatant, or Vow (Pacifism).
 
@@ -5476,17 +5063,15 @@ As a successful and long-time enemy of Rome, Mithridates VI, king of Pontus, was
 
 Crateuas's potions worked better than Mithridates could have imagined. When Mithridates's armies were finally defeated and the forces of Rome surrounded him, he attempted to take his own life to avoid capture. The king drank poison, but was only weakened. He fell upon his own sword, but did not die. Mithridates could not evade capture and died eventually, but Crateuas's potions allowed him to withstand weeks of agonizing torture by the Romans. After the king's death, Crateuas realized that his powers had been wasted. His prodigious efforts to protect Mithridates could have provided comfort to hundreds of common citizens.
 
+> ## The Herbal of Crateuas
+> 
+> Although most believe that Crateuas's catalog of herbs and their powers has been lost forever, there are occasional rumors of copies surfacing. Crateuas's herbal is written in ancient Greek and is a summa for Profession Apothecary and Medicine (quality 14, level 5), and Mythic Herbalism (quality 9, level 10). Some believe that Crateuas hid a copy of his herbal in a temple dedicated to Aesculapius, the Greek god of healing.
+> 
+> The Greeks founded temples dedicated to Aesculapius across the Grecian peninsula and Asia Minor. The temples were usually located near a mineral spring and were often filled with art and treasure from grateful patients. They also tended to have nurseries for breeding the snakes that symbolized Aesculapius's powers and were used extensively in healing ceremonies.
+> 
+> Pharmacopoeians are keenly interested in recovering Crateuas's herbal and preventing it from falling into the hands of others. They believe that a dedicated researcher could uncover the secrets of the Root-Cutter Virtue with access to the text. It is left to the storyguide's discretion whether these fears are well founded, but if they are true, each volume of the herbal provides a source of Insight to anyone attempting to make a Breakthrough to replicate the Root-Cutter Virtue. (See *Ancient Magic*, page 7 for the applicable rules).
 
-
-### The Herbal of Crateuas
-
-Although most believe that Crateuas's catalog of herbs and their powers has been lost forever, there are occasional rumors of copies surfacing. Crateuas's herbal is written in ancient Greek and is a summa for Profession Apothecary and Medicine (quality 14, level 5), and Mythic Herbalism (quality 9, level 10). Some believe that Crateuas hid a copy of his herbal in a temple dedicated to Aesculapius, the Greek god of healing.
-
-The Greeks founded temples dedicated to Aesculapius across the Grecian peninsula and Asia Minor. The temples were usually located near a mineral spring and were often filled with art and treasure from grateful patients. They also tended to have nurseries for breeding the snakes that symbolized Aesculapius's powers and were used extensively in healing ceremonies.
-
-Pharmacopoeians are keenly interested in recovering Crateuas's herbal and preventing it from falling into the hands of others. They believe that a dedicated researcher could uncover the secrets of the Root-Cutter Virtue with access to the text. It is left to the storyguide's discretion whether these fears are well founded, but if they are true, each volume of the herbal provides a source of Insight to anyone attempting to make a Breakthrough to replicate the Root-Cutter Virtue. (See *Ancient Magic*, page 7 for the applicable rules).
-
-*Culture*
+### Culture
 
 Crateuas's lesson was passed on to his pupils. The Pharmacopoeians, commonly referred to as "Root-Cutters," have a strong sense of responsibility for healing the masses. As a corollary of this responsibility, Pharmacopoeians also feel a duty to train healers. They readily teach Profession Apothecary, Chirurgy, and Medicine to anyone seeking the knowledge. Members of the tradition are more selective in teaching Mythic Herbalism. In general, the knowledge is only passed to an apprentice, but any healer who shows dedication to helping others may be trained. Of course, those trained by the Pharmacopoeians are not as selective, and Mythic Herbalism is practiced by innumerable individuals who have no knowledge of the Root-Cutters' traditions or even their existence.
 
@@ -5496,31 +5081,38 @@ When the Pharmacopoeians were presented with the ultimatum to join the Order or 
 
 ### Characters
 
-The Pharmacopoeians practice a naturalistic form of magic. It is aided by their in-depth knowledge of the natural magic
-
-
-
-in plants, animals, and minerals. The Root-Cutter and Mythic Herbalism Virtues reflect this knowledge. The intense training that Pharmacopoeians undergo provides them with a Minor Magical Focus (Healing). Because of their dependence on the natural cycles of life and their dedication to preserving it, all Pharmacopoeians have the Flaw Deficient Technique (Perdo) and one of the following Flaws: Soft-Hearted, Noncombatant, or Vow (Pacifism).
+The Pharmacopoeians practice a naturalistic form of magic. It is aided by their in-depth knowledge of the natural magic in plants, animals, and minerals. The Root-Cutter and Mythic Herbalism Virtues reflect this knowledge. The intense training that Pharmacopoeians undergo provides them with a Minor Magical Focus (Healing). Because of their dependence on the natural cycles of life and their dedication to preserving it, all Pharmacopoeians have the Flaw Deficient Technique (Perdo) and one of the following Flaws: Soft-Hearted, Noncombatant, or Vow (Pacifism).
 
 For obvious reasons, Pharmacopoeians tend to be specialists in the Arts of Creo and Corpus. Many possess Puissant Creo, Corpus, or Mythic Herbalism, or Affinity with Creo, Corpus, or Mythic Herbalism. Cyclic Magic (positive) tied to the seasons and Purifying Touch are also common Virtues among the Root-Cutters.
 
 All members of the tradition possess some skill in Medicine, Chirurgy, or Profession Apothecary. Many Pharmacopoeians also have some ability in Craft Drawing and Area Lore for various woodlands where herbs grow, which they use to continue the tradition of cataloging and illustrating plants and their medicinal properties. Unlike many apprentices, a Pharmacopoeian often spends more time maintaining his master's herb garden or collecting and recording herbs than he spends in his master's laboratory.
 
+> ## Mythic Herbalism Ease Factor Table
+> 
+> | Ease Factor | Healing Effects | Poisons | Physical Bonuses |
+> |-------------|------------------|---------|------------------|
+> | 3  | Add Mythic Herbalism score to patient’s Stamina roll to resist any disease | Ease Factor 6, Sleep | Add +2 to all Fatigue rolls |
+> | 6  | Prevent all of a patient’s wounds from getting worse for one day | Ease Factor 6, Light Wound | Ignore Wound Penalties up to Medium Wounds |
+> | 9  | Add Mythic Herbalism Score x 2 to Recovery roll | Ease Factor 9, Medium Wound | Add +3 to Soak |
+> | 12 | Add Mythic Herbalism Score x 3 to Recovery roll | Ease Factor 9, Heavy Wound | Ignore one level of Fatigue |
+> | 15 | Add Mythic Herbalism Score x 4 to Recovery roll | Ease Factor 9, Incapacitating Wound | Add +5 to Soak |
+> | 18 | Heal the debilitating after-effects of a disease, poison, or injury | Ease Factor 9, Death | Increase one negative physical characteristic to 0 |
+> | 21 | Resolve a major aging crisis | Heal a Medium Wound caused by poison | Increase one physical characteristic to +1 |
+> | 24 | Resolve a terminal aging crisis | Heal an Incapacitating Wound caused by poison | Increase one physical characteristic to +2 |
+
 #### Profession Apothecary
 
-This Ability allows the character to identify, cultivate, and prepare common herbs, plants, and other ingredients for use in medicinal remedies. Any character without access to proper medicinal supplies makes all Medicine rolls at a penalty of –3 and the Recovery Bonus for his patients is also reduced by 3. (It should be assumed that under normal circumstances all characters have access to medicinal remedies, unless the storyguide decides otherwise.) A skilled apothecary reduces or eliminates this penalty. A medicus with access to remedies prepared by an apothecary with a
-
-### Story Seed: Interfering with the Mundanes
-
-A disgruntled magus grows tired of the Pharmacopoeians voting against him and his House. He threatens to bring a charge against all of them in the Tribunal for interfering with the mundanes because of the attention their healing brings to the Order. Most Pharmacopoeians are willing to abstain from voting against the magus or to vote with him at Tribunal to avoid any possibility of an adverse decision. However, if the charging magus seeks support for a proposal that would harm innocent people, the Pharmacopoeians might submit to trial instead.
-
-If a Pharmacopoeian's healing draws the attention of a powerful noble, especially one with a dread disease or grievously ill family member, she may be forced to violate the Code. Rejecting the noble is likely to bring his wrath on the Pharmacopoeian's covenant and possibly the Order. Accepting the offer could lead other nobles to demand the same services, which is one of the original reasons the Code prohibits magi from becoming court wizards.
-
-score of 1 suffers only –2 to his Medicine rolls, and an apothecary with a score of 2 reduces the penalty to –1. An apothecary with a score higher than 3 does not improve a medicus's Ability in Medicine.
+This Ability allows the character to identify, cultivate, and prepare common herbs, plants, and other ingredients for use in medicinal remedies. Any character without access to proper medicinal supplies makes all Medicine rolls at a penalty of –3 and the Recovery Bonus for his patients is also reduced by 3. (It should be assumed that under normal circumstances all characters have access to medicinal remedies, unless the storyguide decides otherwise.) A skilled apothecary reduces or eliminates this penalty. A medicus with access to remedies prepared by an apothecary with a score of 1 suffers only –2 to his Medicine rolls, and an apothecary with a score of 2 reduces the penalty to –1. An apothecary with a score higher than 3 does not improve a medicus's Ability in Medicine.
 
 Rules for acquiring ingredients and creating medicinal remedies or poisons are beyond the scope of this book and will be detailed in *Art and Academe*.
 
 **Specialties**: finding ingredients, treating diseases, preparing poisons. (General)
+
+> ## Story Seed: Interfering with the Mundanes
+> 
+> A disgruntled magus grows tired of the Pharmacopoeians voting against him and his House. He threatens to bring a charge against all of them in the Tribunal for interfering with the mundanes because of the attention their healing brings to the Order. Most Pharmacopoeians are willing to abstain from voting against the magus or to vote with him at Tribunal to avoid any possibility of an adverse decision. However, if the charging magus seeks support for a proposal that would harm innocent people, the Pharmacopoeians might submit to trial instead.
+> 
+> If a Pharmacopoeian's healing draws the attention of a powerful noble, especially one with a dread disease or grievously ill family member, she may be forced to violate the Code. Rejecting the noble is likely to bring his wrath on the Pharmacopoeian's covenant and possibly the Order. Accepting the offer could lead other nobles to demand the same services, which is one of the original reasons the Code prohibits magi from becoming court wizards.
 
 #### Major Supernatural Virtue: Mythic Herbalism
 
@@ -5557,8 +5149,7 @@ This tradition within House Ex Miscellanea has little in common with the other t
 
 **Favored Tribunals:** Tribunals at the fringes of the Order, to maximize the chances of encountering hedge wizards
 
-**Major Non-Hermetic Virtue:** Comprehend Magic (described below) **Minor Hermetic Virtue:** Minor Magical Focus with Exotic Magic. This
-
+**Major Non-Hermetic Virtue:** Comprehend Magic (described below) **Minor Hermetic Virtue:** Minor Magical Focus with Exotic Magic. This focus applies whenever the magus uses Hermetic magic to investigate, change, control or destroy non-Hermetic magic. It only applies to magic, not to the innate supernatural powers of creatures with Might, and only applies to powers derived from the Magic realm.
 
 **Major Hermetic Flaw:** Weak Magic Resistance, against any spellcaster whom the maga has not analyzed using her Comprehend Magic Ability
 
@@ -5570,19 +5161,7 @@ Pralix never officially joined the House that she created, and since she had for
 
 ### Culture
 
-Pralician magi (who also call themselves Filii Pralicis, the Children of Pralix) are fascinated by exotic magic. Some study
-
-
-
-- Excited by rumors of plentiful vis and exotic magic, a Pralician volunteers to take part in an expedition to claim new territory for the Order, either north into Scandinavia, east into Novgorod and beyond the Caucasus, or south into the desert sands of Africa. •
-- The Order has been contacted by a group of exotic wizards who wish to make a treaty with the Order of Hermes. A Pralician is the obvious choice to accompany a diplomatic mission. •
-- A Pralician may be employed by a team of hoplites who are hunting •
-
-- down a specific hedge wizard. His knowledge of exotic magic could prove invaluable.
-- The discovery of pre-Hermetic magic causes excitement in the Order, and a Pralician is well placed to comprehend its secrets. Perhaps the limits of Hermetic magic can be pushed or even broken. •
-- A new recruit to the Order under the tutelage of a Pralician vanishes one day. While he does not know the Parma Magica, he knows more about the Order than is considered safe. What is worrying is what he will tell his native tradition of the Order. •
-
-it in the hope that its insights can prove useful to the advancement of Hermetic theory, and of all magi outside of House Bonisagus, as a group they are most likely to pursue Original Research (see *Houses of Hermes: True Lineages*, page 26). As well as living traditions, Pralicians are interested in magic that has no extant practitioners, and they often pursue rumors and legends of long-dead magicians.
+Pralician magi (who also call themselves Filii Pralicis, the Children of Pralix) are fascinated by exotic magic. Some study it in the hope that its insights can prove useful to the advancement of Hermetic theory, and of all magi outside of House Bonisagus, as a group they are most likely to pursue Original Research (see *Houses of Hermes: True Lineages*, page 26). As well as living traditions, Pralicians are interested in magic that has no extant practitioners, and they often pursue rumors and legends of long-dead magicians.
 
 As well as this theoretical interest in exotic magic, the Lineage of Pralix are also interested in seeking out new magical traditions and assisting their passage into the Order through House Ex Miscellanea. Such magi hate the idea of a tradition of magic being lost forever, and they are unusually adept at translating exotic magic into its Hermetic equivalents. When a new tradition enters House Ex Miscellanea, the members of this lineage are often instrumental in helping the hedge wizards to train the second generation of pupils, and encouraging the acceptance of Hermetic magic while preserving the original magic.
 
@@ -5592,15 +5171,22 @@ Ironically, the Filii Pralicis are also accused of having precisely the opposite
 
 This fascination with non-Hermetic magic often requires that Pralicians travel extensively, for there are few non-Hermetic wizards left in the heartlands of the Order. In game terms, the study of hedge magic is covered by the Abilities Organization Lore (for traditions of magic) and Magic Lore (for the actual magic they use).
 
+> ## Stories Involving the Lineage of Pralix
+> 
+> - Excited by rumors of plentiful vis and exotic magic, a Pralician volunteers to take part in an expedition to claim new territory for the Order, either north into Scandinavia, east into Novgorod and beyond the Caucasus, or south into the desert sands of Africa.
+> - The Order has been contacted by a group of exotic wizards who wish to make a treaty with the Order of Hermes. A Pralician is the obvious choice to accompany a diplomatic mission.
+> - A Pralician may be employed by a team of hoplites who are hunting
+> - down a specific hedge wizard. His knowledge of exotic magic could prove invaluable.
+> - The discovery of pre-Hermetic magic causes excitement in the Order, and a Pralician is well placed to comprehend its secrets. Perhaps the limits of Hermetic magic can be pushed or even broken.
+> - A new recruit to the Order under the tutelage of a Pralician vanishes one day. While he does not know the Parma Magica, he knows more about the Order than is considered safe. What is worrying is what he will tell his native tradition of the Order.
+
 #### Induction of Hedge Wizards into the Order
 
 When a wizard seeks to join the Order of Hermes, he is usually directed towards a member of the Lineage of Pralix. Only those who possess The Gift are normally considered for membership. Those magi from other Houses who actively seek out hedge wizards (notably House Flambeau) are aware of the tradition, and recognize the service that they perform for the Order. It is not unknown for a Tribunal to reimburse a Pralician maga for the time she spends bringing a hedge wizard under the wing of the Order. During the initial training period, the wizard is accorded all the legal protection of the Code of Hermes afforded apprentices, regardless of his age and ability, and the Pralician maga is considered to be his parens. This apprenticeship is much shorter than a standard Hermetic apprenticeship, typically lasting less than five years. During this apprenticeship, the wizard is taught Magic Theory, the history and customs of the Order, and, if necessary, Latin and Artes Liberales. Unlike a standard Hermetic apprenticeship, these things are taught before the opening of the Arts. The hedge wizard is encouraged to learn Hermetic magic, but it is not a condition of joining the Order. It is important to the Order that the Pralician maga is able to gauge the abilities of the wizard, as well as any potential threat posed by his former tradition. This information is passed back to the Order, usually through House Guernicus or Flambeau.
 
 Many hedge wizards who seek out the Order do so to learn Hermetic magic, but it is made clear to the wizard that the process of opening his Arts may well destroy his non-Hermetic powers. Some are not prepared to take the risk, preferring to just accept the protection of the Oath of Hermes and the Parma Magica instead. However, if the wizard still wishes to go ahead with training in Hermetic magic, the Pralician maga attempts to open him to the Arts. The Pralician maga need not have all Arts above 5 for this process; no penalty is applied by the Code of Hermes should a mature wizard acquire Deficiencies in his Hermetic magic due to the difficulties of inducting a mature wizard in the first place. A trained wizard whose Arts are successfully opened almost always suffers at least one Major Hermetic Flaw due to the mismatch between his native tradition and Hermetic magic.
 
-If the opening the Arts was successful, then the maga usually offers to spend some time teaching the wizard some basics of the Hermetic Arts, often for a small fee. If the attempt to open the Arts fails, or the wizard does not want to take the risk, then the wizard may still join the Order (in game terms, he does so as a Gifted Companion, see above for more details). Regardless of success or failure, the Pralician always spends at least one season teaching the hedge wizard the Parma Magica, and then presents him to a Quaesitor for the swear-
-
-
+If the opening the Arts was successful, then the maga usually offers to spend some time teaching the wizard some basics of the Hermetic Arts, often for a small fee. If the attempt to open the Arts fails, or the wizard does not want to take the risk, then the wizard may still join the Order (in game terms, he does so as a Gifted Companion, see above for more details). Regardless of success or failure, the Pralician always spends at least one season teaching the hedge wizard the Parma Magica, and then presents him to a Quaesitor for the swearing of the Hermetic Oath (whereupon he acquires the Social Status Virtue Hermetic Magus). 
 
 This new member of the Order often does not fit the classic profile of a member of House Ex Miscellanea, usually possessing more than one non-Hermetic Supernatural Ability. However, the apprentices who he trains invariably follow the usual profile, because the master is forced to compromise between Hermetic and non-Hermetic magic as well as propagating his own Hermetic Flaws.
 
@@ -5612,57 +5198,48 @@ Those wizards who do not (or cannot) adopt Hermetic magic upon joining the Order
 
 The Filii Pralicis do not have direct blood descent from Pralix, and yet they refer to themselves as her children, and as bearing her blood. The Lineage of Pralix preserves a non-Hermetic magical Ability that proves exceptionally useful in their chosen role in the Order, the power to acquire insights into hedge traditions through the Ability Comprehend Magic.
 
-### Opening the Arts of a Hedge Wizard
-
-This insert summarizes information from pages 106–107 of **Ars Magica Fifth Edition**.
-
-The maga compares her Intellego Vim Lab Total to the level calculated below. A member of the Lineage of Pralix can apply her Magical Focus to this Lab Total. Supernatural Virtues always have a minimum sum of 10 if provided by a Minor Virtue, or 30 if granted by a Major Virtue. That is, Abilities derived from a Minor Virtue are treated as having a score of at least 2, and those derived from a Major Virtue as having a score of at least 6.
-
-**Level Required for Opening the Arts: 5 x (the sum of all Supernatural Ability scores)**
-
-**Minimum Level per Ability: 10 if the Ability derives from a Minor Virtue, or 30 if it derives from a Major Virtue**
-
-**Intellego Vim Lab Total: Effect of Season**
-
-- **Less than level:** Unable to open the Arts **•**
-- **Greater than or equal to level:** Arts opened, all Supernatural Abilities lost **•**
-- **Greater than or equal to twice level:** Arts opened, some or all Supernatural Abilities converted into Hermetic Virtues **•**
-
-If she is able to convert Virtues, the maga may decide which Virtues of her apprentice are converted into Hermetic Virtues, and those not converted are retained. A Major Supernatural Virtue is converted into a Major Hermetic Virtue; a Minor Supernatural Virtue can be converted into a Minor Hermetic Virtue.
+> ## Opening the Arts of a Hedge Wizard
+> 
+> This insert summarizes information from pages 106–107 of **Ars Magica Fifth Edition**.
+> 
+> The maga compares her Intellego Vim Lab Total to the level calculated below. A member of the Lineage of Pralix can apply her Magical Focus to this Lab Total. Supernatural Virtues always have a minimum sum of 10 if provided by a Minor Virtue, or 30 if granted by a Major Virtue. That is, Abilities derived from a Minor Virtue are treated as having a score of at least 2, and those derived from a Major Virtue as having a score of at least 6.
+> 
+> **Level Required for Opening the Arts: 5 x (the sum of all Supernatural Ability scores)**
+> 
+> **Minimum Level per Ability: 10 if the Ability derives from a Minor Virtue, or 30 if it derives from a Major Virtue**
+> 
+> **Intellego Vim Lab Total: Effect of Season**
+> 
+> - **Less than level:** Unable to open the Arts
+> - **Greater than or equal to level:** Arts opened, all Supernatural Abilities lost
+> - **Greater than or equal to twice level:** Arts opened, some or all Supernatural Abilities converted into Hermetic Virtues
+> 
+> If she is able to convert Virtues, the maga may decide which Virtues of her apprentice are converted into Hermetic Virtues, and those not converted are retained. A Major Supernatural Virtue is converted into a Major Hermetic Virtue; a Minor Supernatural Virtue can be converted into a Minor Hermetic Virtue.
 
 #### New Major Supernatural Virtue: Comprehend Magic
 
 The character is capable of seeing and understanding the nature of active magics. This is a more comprehensive version of Magic Sensitivity, and can do everything that Virtue can, and more. Further, this Virtue does not penalize Magic Resistance like its lesser cousin. Choosing this Virtue confers the Ability Comprehend Magic 1.
 
-### New Supernatural Ability: Comprehend Magic\
+### New Supernatural Ability: Comprehend Magic\*
 
 Through scrutiny of an object or a person, the character can analyze the type of magic it possesses, and its relative strength. Generate a Comprehension Total as follows:
 
-#### Comprehension Total: Perception + Comprehend Magic + stress die
+**Comprehension Total: Perception + Comprehend Magic + stress die**
 
 The value of the Comprehension Total should be compared to the appropriate Ease Factor:
 
-#### Source of Magic Ease Factor
+| Source of Magic                   | Ease Factor                         |
+|-----------------------------------|-------------------------------------|
+| Magus                             | 12 – magnitude of highest Art       |
+| Character with Supernatural Virtue| 15 – Ability score, –3 if he also has The Gift |
+| Creature with Might               | 15 – magnitude of Might score       |
+| Spell or Spell-like Power         | 18 – magnitude of level             |
+| Supernatural Power                | 18 – number of Might Points spent   |
+| Enchanted Item                    | 18 – magnitude of strongest power   |
+| Magic Aura                        | 12 – aura level                     |
+| Vis                               | 9 – number of pawns                 |
 
-| Magus                                    | 12 – magnitude of<br>highest Art                     |
-|------------------------------------------|------------------------------------------------------|
-| Character with<br>Supernatural<br>Virtue | 15 – Ability score,<br>–3 if he also has<br>The Gift |
-| Creature with<br>Might                   | 15 – magnitude of<br>Might score                     |
-| Spell or Spell-like<br>Power             | 18 – magnitude of<br>level                           |
-| Supernatural<br>Power                    | 18 – number of<br>Might Points spent                 |
-| Enchanted Item                           | 18 – magnitude of<br>strongest power                 |
-| Magic Aura                               | 12 – aura level                                      |
-| Vis                                      | 9 – number of<br>pawns                               |
-
-Supernatural Virtues that do not grant a corresponding Ability are assumed to have an Ability score of 3 if a Minor Virtue, or 5 if a Major Virtue. A successful roll identifies the presence or absence of magic. If the character continues to concentrate for a round, he may also determine the type of magic that is being scrutinized: Hermetic magic, curse magic, and so forth. A second round of
-
-
-#### Societates
-
-
-Using Comprehend Magic against another magus is scrying, and forbidden by the Code of Hermes. However, many Tribunals will not convict a maga of scrying if the only information she obtains is whether a given person is a magus or not, no matter what method of detection she uses. That said, the Comprehend Magic Ability can give a Pralician much more information than that, potentially revealing a magus's strongest Art, and its approximate power. If a prosecuting magus at Tribunal proves that a Pralician maga obtained more information about him than the bare minimum, then she will be charged with (and likely convicted of) a High Crime.
-
-study reveals the approximate function of an ongoing spell, power, or enchanted item (in terms of its corresponding Hermetic Arts), or for a being, the Hermetic Form that corresponds most strongly with its magical ability. If the character is familiar with types of magic other than Hermetic magic, then he can determine the type of magic under that frame of reference instead. A third round of study reveals the approximate magnitude of the magic being observed.
+Supernatural Virtues that do not grant a corresponding Ability are assumed to have an Ability score of 3 if a Minor Virtue, or 5 if a Major Virtue. A successful roll identifies the presence or absence of magic. If the character continues to concentrate for a round, he may also determine the type of magic that is being scrutinized: Hermetic magic, curse magic, and so forth. A second round of study reveals the approximate function of an ongoing spell, power, or enchanted item (in terms of its corresponding Hermetic Arts), or for a being, the Hermetic Form that corresponds most strongly with its magical ability. If the character is familiar with types of magic other than Hermetic magic, then he can determine the type of magic under that frame of reference instead. A third round of study reveals the approximate magnitude of the magic being observed.
 
 Although determining the presence of magic requires but a moment of observation, the character must maintain concentration (ArM5, page 82) to acquire any of the subsequent information. If observing a being with Magic Resistance, this power must penetrate, as usual; but even if the Penetration Total proves to be insufficient, the character is aware of the presence of magic if the Ease Factor was met.
 
@@ -5672,6 +5249,11 @@ Additionally, when investigating enchantments (ArM5, page 100) in the laboratory
 
 **Specialities**: magical beings, specific type of magic (Supernatural)
 
+> ## Pralicians and Scrying
+> 
+> Using Comprehend Magic against another magus is scrying, and forbidden by the Code of Hermes. However, many Tribunals will not convict a maga of scrying if the only information she obtains is whether a given person is a magus or not, no matter what method of detection she uses. That said, the Comprehend Magic Ability can give a Pralician much more information than that, potentially revealing a magus's strongest Art, and its approximate power. If a prosecuting magus at Tribunal proves that a Pralician maga obtained more information about him than the bare minimum, then she will be charged with (and likely convicted of) a High Crime
+.
+
 ### Other Magical Interests
 
 The Lineage of Pralix has a number of spells that are targeted directly at exotic magic. They have developed spells directed at suppressing, altering, and dispelling shapeshifting magic, curse magic, spirit magic, and so forth, which are more effective than general purpose spells such as *Wind of Mundane Silence*. Their initial encounters with hedge wizards tend to be hostile, and they like to be well prepared against any aggressive actions.
@@ -5680,7 +5262,7 @@ Apart from their obvious fascination with exotic magic, the Lineage of Pralix ha
 
 #### New Spells
 
-**The Heathen Witch Reborn**
+##### The Heathen Witch Reborn
 
 PeVi Gen
 
@@ -5690,21 +5272,21 @@ This spell cancels the effect of any shapechanging spell or Supernatural Ability
 
 (Base effect, +2 Voice)
 
-**Quiet the Cursing Tongue**
+##### Quiet the Cursing Tongue
 
 ReVi Gen
 
 R: Voice, D: Sun, T: Ind
 
-### New Spell Guideline
-
-**Rego Vim**
-
-**General:** Sustain or suppress a spell of a specific type cast by another with level less than the level + 2 magnitudes of the Vim spell. Examples of specifics types include Hermetic Terram magic and Shamanic spirit control magic.
-
 The target of this spell cannot use any curse magic with a level less than or equal to (spell level – 10). If the curse magic is controlled by a Supernatural Ability, then its level is equivalent to (Score x 5). This spell can be used as a template for spells that affect other types of exotic magic.
 
 (Base effect, +2 Voice, +2 Sun)
+
+> ## New Spell Guideline
+> 
+> **Rego Vim**
+> 
+> **General:** Sustain or suppress a spell or spells of a specific type cast by another with level less than or equal to the level + 2 magnitudes of the Vim spell. Examples of specifics types include Hermetic Terram magic and Shamanic spirit control magic. This guideline may be used to target the spell itself or the caster of the spells.
 
 #### New Mastery Special Ability: Unraveling
 
@@ -5714,19 +5296,19 @@ This Mastery special ability may be applied to any Perdo Vim spell designed to w
 
 This Mastery special ability may be applied to any Muto or Rego Vim spell designed to affect a spell or power used by another being (thus *Wizard's Boost* or *Maintain the Demanding Spell* are not eligible, but *Mirrorof Opposition [Form]* is). The magus may add three times his Mastery score to the effective level of the Vim spell when determining whether or not it can change or control the foreign magic. Thus, a 25th level *Quiet the Cursing Tongue* accompanied with a Mastery score of 2 prevents the casting of curse magics with an equivalent level of 21, rather than 15.
 
-
-
-# Rustic Magi
+## Rustic Magi
 
 Perhaps the most obscure tradition of magi Ex Miscellanea is that of the Mechanicals, also known as the Rusticani or "rustic magi." These are folk magicians who generally eschew interaction with the Order of Hermes and its covenants, and instead live among the common people in villages and other rural communities, whom they consider to be their covenfolk. They have developed a form of magical craft that allows them to build spells and enchanted devices from mundane objects, the effects of which they share freely with their people — but they are disparaged by most other magi for their reclusive and peasant-like ways, and besides respecting the Oath, few of them ever acknowledge that they belong to the Order at all.
 
-### Key Facts
+## Key Facts
 
-**Favored Tribunals:** Rhine, Provencal **Major Non-Hermetic Virtue:** Craft Magic
+**Favored Tribunals:** Rhine, Provencal
 
-#### Houses of Hermes
+**Major Non-Hermetic Virtue:** Craft Magic
 
-**Minor Hermetic Virtue:** Spell Foci **Major Hermetic Flaw:** Weak Spontaneous Magic
+**Minor Hermetic Virtue:** Spell Foci
+
+**Major Hermetic Flaw:** Weak Spontaneous Magic
 
 ### History
 
@@ -5734,8 +5316,7 @@ The mechanical magic that the Rusticani practice appears to descend from a form 
 
 The founder of the tradition, such as it is, is probably the man known as Reismann Ex Miscellanea, a hedge wizard who joined the Order to protect himself and his vis sources against the magi of the Rudiaria covenant in central Germany, and who formally swore the Oath at the Rhine Tribunal of 963. He is believed to have lived as a peregrinator (a magus without a covenant) on the outskirts of the city of Frankfurt, and he wrote a well-known summa on Craft Masonry that also describes a great deal of the symbolism and legendary history associated with his tradition, now located in the great library of Durenmar. Though he was never awarded the rank of master in the Tribunal, he taught two apprentices, and is thought to have perished during the Schism War.
 
-Another hedge wizard presumed to belong to this tradition (but who never joined the Order) was an outlaw named Robert Wood who lived in Yorkshire in the late 1100s. According to private records kept by House Mercere and sworn to by Julia of House Jerbiton, the members of Voluntas covenant registered him and his men as a source of Animal and Herbam vis, the result of a bargain made between them on September 8, 1192. When 12 pawns
-
+Another hedge wizard presumed to belong to this tradition (but who never joined the Order) was an outlaw named Robert Wood who lived in Yorkshire in the late 1100s. According to private records kept by House Mercere and sworn to by Julia of House Jerbiton, the members of Voluntas covenant registered him and his men as a source of Animal and Herbam vis, the result of a bargain made between them on September 8, 1192. When 12 pawns of vis held by Blackthorn covenant were contested by Voluntas at the Stonehenge Tribunal of 1201, the details of this agreement were brought forward to prove their case. All that Julia would say about this Robert was that he was not a magus; that he was an exceptional archer, bowyer, and fletcher with magic in his craft; and that he had a special way with the woods that made finding vis very easy for him. 
 
 In 1214, a rustic magus named Tres Ex Miscellanea was brought to trial in the Provencal Tribunal for his interference with mundanes. He had declared Wizard's War against the magi of another covenant in the region, and with more than a hundred armed men he had marched against their tower, completely destroying it and killing most of the inhabitants. The prosecutors argued that Tres had broken the Code when he hired his army, since he had essentially bought their service with enchanted devices, and that he had thereby become significantly and criminally invested in mundane politics of the region. Tres argued that all of the men in his army belonged to his covenant, which had been duly registered at the previous Tribunal, and that he had the right to support his covenfolk with his magic however he wished. The Tribunal eventually decided in his favor, though the presiding Quaesitor also noted disapprovingly that all of these covenfolk had since left his service.
 
@@ -5743,11 +5324,7 @@ In 1214, a rustic magus named Tres Ex Miscellanea was brought to trial in the Pr
 
 There are so few Rusticani in the Order that they have few if any established traditions or hierarchy, and really have only their magic in common — which most of them arrived at independently of one another's efforts. Their simple lifestyle often brings about a marked interest in common people, and so rustic magi tend to drift away from Hermetic society, usually adopting the roles of cunning men or wise women on the fringes of mundane communities. They usually dress in rough, practical clothing, much like other people of their craft might wear.
 
-Since their powers tend to develop among humble folk with little formal education and no knowledge of Hermetic magic,
-
-
-
-most of them come to the Order much later in life, joining House Ex Miscellanea and learning the Arts, Magic Theory, and the Parma Magica after living for many years as hedge wizards. Their ties to their families, communities, and craft guilds are usually much stronger than their loyalty to other magi. They join the Order for protection from other magi, but primarily consider themselves folk wizards and tend to live as such. While they might belong to a covenant, they seem to prefer to live apart when possible, and are particularly prone to friction when interacting with each other. It is nearly impossible for two Rusticani to work together without a clear master-apprentice relationship. For this reason, new magi typically leave their parentes immediately after passing their Gauntlets, and journeymen taught in the tradition often travel a great distance away from their former masters before settling down in a place of their own.
+Since their powers tend to develop among humble folk with little formal education and no knowledge of Hermetic magic, most of them come to the Order much later in life, joining House Ex Miscellanea and learning the Arts, Magic Theory, and the Parma Magica after living for many years as hedge wizards. Their ties to their families, communities, and craft guilds are usually much stronger than their loyalty to other magi. They join the Order for protection from other magi, but primarily consider themselves folk wizards and tend to live as such. While they might belong to a covenant, they seem to prefer to live apart when possible, and are particularly prone to friction when interacting with each other. It is nearly impossible for two Rusticani to work together without a clear master-apprentice relationship. For this reason, new magi typically leave their parentes immediately after passing their Gauntlets, and journeymen taught in the tradition often travel a great distance away from their former masters before settling down in a place of their own.
 
 The fruits of their magic are ideally suited for sharing with those who have none, and their simple ways usually make their sodales in other Houses treat them as inferiors and hedge wizards. They do have some qualities in common with Houses Jerbiton, Mercere, and Verditius. However, unlike Jerbiton, they have little interest in beauty, instead admiring the practical nature of their magic; unlike Mercere, they have no interest in maintaining the tradition or structure of the Order of Hermes; and unlike Verditius, the devices they make are merely tools, not masterpieces.
 
@@ -5771,26 +5348,24 @@ Third, the character may make charged items in the same way as Hermetic magi (se
 
 *Example: An armor-smith Mechanical has Craft Magic and Puissant Single Weapon. He wants tocraft a puissant heater shield,one that when uncovered gives the wielder the benefit of his Puissant Single Weapon Virtue for the rest of the day. This is a level 20 effect (Base 5, +1 Touch, +2 Sun). His Dexterity is +4, and his Craft Armor score is 8. He may add 5 for the shield's "+5 Protection" bonus, and he spends a Confidence Point to give him the final +3 increase. His total is 20, just enough for him to make one shield. This takes him about nine days to finish; if he reduced the effect's Duration to Diameter, he could make two shields with the same effect, but it would take him longer to finish.*
 
-Finally, the character may craft objects that already contain raw vis into magical devices with lesser enchantments (see ArM5, page 96, Lesser Enchantments). The vis must be part of the enchanted object, and again, this does not require a season, but rather a crafted effect as above. Use
-
-
-### Design and Inscription Bonuses
-
-Characters with the Craft Magic Virtue can add designs and inscriptions to their crafted effects, giving them a type of enchantment bonus in addition to those for shape and material. Magi who have this Virtue may also incorporate design and inscription bonuses into other objects they make in the lab, such as invested devices, longevity rituals, or talismans. Note that the total bonus gained from shape, material, design, and inscription is still limited to the magus's Magic Theory score (or an applicable Craft score).
-
-**Portraits:** Portraits usually depict a famous ruler, saint, or person, and the character may gain an additional +1 bonus if the figure pictured is particularly recognizable as great, or is particularly appropriate to the effect. *Bonuses: +2 authority, +2 affect subject, +2 affect saint's patronage, +1 protection*
-
-**Writing:** For a writing bonus, the inscription must spell out what the caster wishes the effect to achieve, perhaps calling upon mystic forces or specific entities. An additional +1 is added if the writing names the target or the caster. *Bonuses: +3 use restricted to a list of people, +1 control, +1 affect wearer*
-
-**Seal or Symbol:** The item receives a bonus if it includes an official seal or symbol. This might be for a particular craft guild, a Hermetic House, an individual's family, or even the Order. It could also be used to represent people from a specific kingdom or religion. If the symbol is obviously very old, is recognizable, or comes from a distant and exotic location, the item gets an additional +1 bonus. *Bonuses: +3 use restricted to members, +1 authority, +1 secrecy*
-
-**Image:** A design can incorporate an image of any shape found on the Shape and Material Bonuses table. This gives a design bonus of half the bonus that shape would usually contribute, rounded down. For example, an item depicting a bell (+5 warning) would add a +2 design bonus to a warning effect in the device. *Bonus: + (half the image's shape bonus)*
-
-the character's Casting Total in place of his Lab Total, but if this invests a Supernatural Ability into the device, this result only needs to be greater than or equal to the level of the effect, not twice that value as with spell effects. Also, the level of the invested effect cannot exceed five times the number of pawns of vis in the object. (This differs from Hermetic magic in that magi use less vis, and the vis they use does not have to be part of the object to be enchanted.)
+Finally, the character may craft objects that already contain raw vis into magical devices with lesser enchantments (see ArM5, page 96, Lesser Enchantments). The vis must be part of the enchanted object, and again, this does not require a season, but rather a crafted effect as above. Use the character's Casting Total in place of his Lab Total, but if this invests a Supernatural Ability into the device, this result only needs to be greater than or equal to the level of the effect, not twice that value as with spell effects. Also, the level of the invested effect cannot exceed five times the number of pawns of vis in the object. (This differs from Hermetic magic in that magi use less vis, and the vis they use does not have to be part of the object to be enchanted.)
 
 *Example: A tanner with Enchanting Music and Craft Magic obtains the pelt of a magical beast containing 3 pawns of vis. He fashions this into a large drum, and enchants it with an effect that causes those who hear it to become very afraid. He does not need to play the drum to produce the effect, and instead enchants it while he is making it. His Communication is +2 and his Enchanting Music is 5. His Craft Tanner is at least 2, so he may add +2 for the Drum shape and material bonus (+2 cause fear). He must roll to ensure he does not botch, but if he succeeds, he produces an enchanted instrument that anyone can activate for an Enchanting Music effect with a Casting Total of 9.*
 
 Magi with this Virtue should be highly sought after by Mystagogues of House Verditius, as the power of Craft Magic complements their House Mysteries exceptionally well. However, the philosophy of their House is fundamentally at odds with the magic of the Rusticani, the former being driven by pride and desire for artistry that the latter group generally finds repugnant. Because of this essential difference in their outlook, should a rustic magus ever try to join House Verditius, he loses his Craft Magic Virtue during his Initiation ceremony (perhaps because of the spell *The Embrace of Boethius*, as described in *Houses of Hermes: Mystery Cults*). No one has ever done this as far as anyone knows, and Verditius magi most likely consider Mechanicals to be cheap impostors, if they have heard anything of them at all.
+
+> ### Design and Inscription Bonuses
+> 
+> Characters with the Craft Magic Virtue can add designs and inscriptions to their crafted effects, giving them a type of enchantment bonus in addition to those for shape and material. Magi who have this Virtue may also incorporate design and inscription bonuses into other objects they make in the lab, such as invested devices, longevity rituals, or talismans. Note that the total bonus gained from shape, material, design, and inscription is still limited to the magus's Magic Theory score (or an applicable Craft score).
+> 
+> **Portraits:** Portraits usually depict a famous ruler, saint, or person, and the character may gain an additional +1 bonus if the figure pictured is particularly recognizable as great, or is particularly appropriate to the effect. *Bonuses: +2 authority, +2 affect subject, +2 affect saint's patronage, +1 protection*
+> 
+> **Writing:** For a writing bonus, the inscription must spell out what the caster wishes the effect to achieve, perhaps calling upon mystic forces or specific entities. An additional +1 is added if the writing names the target or the caster. *Bonuses: +3 use restricted to a list of people, +1 control, +1 affect wearer*
+> 
+> **Seal or Symbol:** The item receives a bonus if it includes an official seal or symbol. This might be for a particular craft guild, a Hermetic House, an individual's family, or even the Order. It could also be used to represent people from a specific kingdom or religion. If the symbol is obviously very old, is recognizable, or comes from a distant and exotic location, the item gets an additional +1 bonus. *Bonuses: +3 use restricted to members, +1 authority, +1 secrecy*
+> 
+> **Image:** A design can incorporate an image of any shape found on the Shape and Material Bonuses table. This gives a design bonus of half the bonus that shape would usually contribute, rounded down. For example, an item depicting a bell (+5 warning) would add a +2 design bonus to a warning effect in the device. *Bonus: + (half the image's shape bonus)*
+
 
 #### Minor Hermetic Virtue: Spell Foci
 
@@ -5802,21 +5377,17 @@ Rustic magi usually carry many small tools and arcane objects that can be used a
 
 ### Major Hermetic Flaw: Weak Spontaneous Magic
 
-Because of their need to craft their spells, the Rusticani associate their power with their own strength of will, tied directly to their hearts and minds. The magic comes naturally to them, like breathing or work-
+Because of their need to craft their spells, the Rusticani associate their power with their own strength of will, tied directly to their hearts and minds. The magic comes naturally to them, like breathing or working, and they cannot exert themselves to make it more potent. Thus, they cannot fatigue themselves when using spontaneous magic, and so they all have the Weak Spontaneous Magic Flaw. This makes them much more dependent upon formulaic spells and advance preparation than other magi, and so when they do perform magic spontaneously, it is typically done in their laboratory or workshop, producing a charged item that they may take with them or give to another. This still requires that they divide their Casting Score by 5 to determine their Casting Total, unless it is done as a seasonal laboratory activity, in which case they may use their full Lab Total as normal.
 
-
-ing, and they cannot exert themselves to make it more potent. Thus, they cannot fatigue themselves when using spontaneous magic, and so they all have the Weak Spontaneous Magic Flaw. This makes them much more dependent upon formulaic spells and advance preparation than other magi, and so when they do perform magic spontaneously, it is typically done in their laboratory or workshop, producing a charged item that they may take with them or give to another. This still requires that they divide their Casting Score by 5 to determine their Casting Total, unless it is done as a seasonal laboratory activity, in which case they may use their full Lab Total as normal.
-
-# Hermetic Sahirs
+## Hermetic Sahirs
 
 According to the Qur'an, *sihr* (magic) was taught to mankind by two fallen angels named Harut and Marut, to tempt them away from the straight path of Islam. Those they taught passed the knowledge on through successive generations. In some cases the knowledge became corrupted under the influence of outsiders, and in other cases it was forgotten, leaving only snippets of information. However, there is one tradition who claim to practice the magic in its pure form. These wizards are the sahirs (feminine sahira). Legends among Hermetic magi talk of an Order of Suleiman (Solomon), an organization of Islamic magi who are rivals in power to the Order. What the aims of this order are, and whether it actually exists, is a matter of great debate, particularly in the southern Tribunals of the Order.
 
 ### Key Facts
 
-**Favored Tribunals:** Iberia, almost exclusively. The Hermetic Sahirs are uncommon in the Levant, where their non-Hermetic cousins are still to be found; the Almohads of Iberia practice a variant of Islam that is not acceptable to the 'Abbasids who control the Levant (See *Realms of Power: The Divine*, Chapter 5:
+**Favored Tribunals:** Iberia, almost exclusively. The Hermetic Sahirs are uncommon in the Levant, where their non-Hermetic cousins are still to be found; the Almohads of Iberia practice a variant of Islam that is not acceptable to the 'Abbasids who control the Levant (See *Realms of Power: The Divine*, Chapter 5: Mythic Islam for more information).
 
-Mythic Islam for more information). **Major Non-Hermetic Virtue:** Sihr (an Accelerated Ability , described below)
-
+**Major Non-Hermetic Virtue:** Sihr (an Accelerated Ability , described below)
 
 **Minor Hermetic Virtue:** Minor Magical Focus (jinn). This focus applies to only jinn, not to other spiritual creatures of the Magic, Faerie, and Infernal realms.
 
@@ -5828,10 +5399,7 @@ In the Umayyad Emirate of the Iberian Peninsula, the sahirs who had caused the d
 
 ### Culture
 
-This tradition is firmly rooted in the southern half of the Iberian peninsula, and is only rarely found outside of these lands. Ancient pacts made by the pre-Hermetic ancestors of the sahirs allow them to summon the spirits of natural features — called the jinn — which inhabit the lands occupied by the Muslims, from Cordoba to North Africa, Egypt, and the Holy Land. Sahirs who stray beyond these lands can still exercise their unique magic to summon spirits, but the *genii loci* who answer such summons in Christian lands are foreign to the sahirs, and the magus finds it harder to make pacts with them. All Hermetic sahirs are at least nominally Muslims, which does not win them very many friends within the Order of Hermes, particularly among the Flambeau who still pursue a centuriesold feud with the sahirs. Naturally, sahirs
-
-
-form covenants with other magi who have accepted Mohammed as the Prophet. Sahirs have a strong unity as a tradition due to their common enemy, and often assist each other in times of need. However, because of their demand for limited resources (the jinn themselves and the vis needed to bargain with them), they do not often live in close proximity to each other.
+This tradition is firmly rooted in the southern half of the Iberian peninsula, and is only rarely found outside of these lands. Ancient pacts made by the pre-Hermetic ancestors of the sahirs allow them to summon the spirits of natural features — called the jinn — which inhabit the lands occupied by the Muslims, from Cordoba to North Africa, Egypt, and the Holy Land. Sahirs who stray beyond these lands can still exercise their unique magic to summon spirits, but the *genii loci* who answer such summons in Christian lands are foreign to the sahirs, and the magus finds it harder to make pacts with them. All Hermetic sahirs are at least nominally Muslims, which does not win them very many friends within the Order of Hermes, particularly among the Flambeau who still pursue a centuriesold feud with the sahirs. Naturally, sahirs form covenants with other magi who have accepted Mohammed as the Prophet. Sahirs have a strong unity as a tradition due to their common enemy, and often assist each other in times of need. However, because of their demand for limited resources (the jinn themselves and the vis needed to bargain with them), they do not often live in close proximity to each other.
 
 A sahir often develops a good relationship with those jinn who occupy the landscape around his home, and powerful jinn are often treated as companions, friends, or even family. Weaker jinn are given the respect accorded to a valuable servant or grog. It is a foolish sahir indeed who treats a jinni harshly if there is any possibility that he might wish to call upon its services again, for a surly jinni might twist the intent of his master's commands, and once freed, may plot against him in revenge.
 
@@ -5851,18 +5419,13 @@ The non-Hermetic sahirs have much greater control over the jinn. Rather than rel
 
 All Hermetic sahirs are Muslim, in name if nothing else. More information about Islam, and Virtues appropriate to Muslim characters, can be found in *Realms of Power: The Divine*. If the saga is set outside of Islamic Iberia, then the Judged Unfairly Flaw is highly recommended, to represent the prejudice that other magi hold against Muslims (the same effect is present in mundanes, but it pales in comparison to the negative effects of The Gift). A sahir character is also likely to have the Feud Flaw, representing the enmity of House Flambeau for his lineage; this is particularly true for sagas set in Iberia, where the hatred still runs deep.
 
-Certain Virtues prove very useful to Hermetic sahirs, particularly Second Sight; in addition, more than a few are Elementalists, and Student of (Realm) is
+Certain Virtues prove very useful to Hermetic sahirs, particularly Second Sight; in addition, more than a few are Elementalists, and Student of (Realm) is very common, as is Puissant Bargain or Affinity with Bargain. Botched dealings with jinn during apprenticeship might cause Supernatural Nuisance, Plagued by Supernatural Entity, or a Malediction (Greater or Lesser). Occasionally, a jinni might decide to accompany a sahir of its own free will, granting a variant of the Faerie Friend Flaw (although the jinni may have Magic rather than Faerie Might).
 
-### The Jinn
-
-When God made the world, he made three groups of being endowed with intelligence. The angels he made from light, the jinn were made from raw elemental matter (called "the smokeless fire," or aether), and mankind was formed from clay. A jinni (masculine singular, the feminine form is jinniyya) is a spiritual reflection of man; like him they are capable of both salvation and damnation. Some jinn display (or at least feign) a lack of interest in mankind; this kind shows no inclination towards aping human behavior, and are usually pagan. Such jinn draw their power from the Magic realm. Other jinn seem incapable of preventing themselves from meddling in the lives of mortals. They live in close proximity to them, and often profess their desire for salvation by adopting human religion, usually Islam. This group is akin to Arabic faeries. There is a third type, those jinn who seem bent upon the destruction of mankind, known to the rest of the world as demons.
-
-Jinn are a variety of *genii loci* (the spirits of a place), and as such they possess both a spiritual form and a material form made of elemental matter. The spiritual form inhabits a landscape feature, such as a sand dune, a boulder, or a pool of water. The jinni of a mountain is likely to have a higher Might than that of a boulder; typically Mights range from 5–40.The physical form is basically human, but has a size appropriate to the physical feature, and is usually composed of the same material as the abode. If this form is slain, the spirit can reform it after it has regenerated the Might points spent to create it; the jinni is very likely to exact vengeance on its slayer. Jinn need not eat or drink and do not age. They all possess the Ways of the Land and Second Sight Virtues.
-
-very common, as is Puissant Bargain or Affinity with Bargain. Botched dealings with jinn during apprenticeship might cause Supernatural Nuisance, Plagued by Supernatural Entity, or a Malediction (Greater or Lesser). Occasionally, a jinni
-
-
-might decide to accompany a sahir of its own free will, granting a variant of the Faerie Friend Flaw (although the jinni may have Magic rather than Faerie Might).
+> ## The Jinn
+> 
+> When God made the world, he made three groups of being endowed with intelligence. The angels he made from light, the jinn were made from raw elemental matter (called "the smokeless fire," or aether), and mankind was formed from clay. A jinni (masculine singular, the feminine form is jinniyya) is a spiritual reflection of man; like him they are capable of both salvation and damnation. Some jinn display (or at least feign) a lack of interest in mankind; this kind shows no inclination towards aping human behavior, and are usually pagan. Such jinn draw their power from the Magic realm. Other jinn seem incapable of preventing themselves from meddling in the lives of mortals. They live in close proximity to them, and often profess their desire for salvation by adopting human religion, usually Islam. This group is akin to Arabic faeries. There is a third type, those jinn who seem bent upon the destruction of mankind, known to the rest of the world as demons.
+> 
+> Jinn are a variety of *genii loci* (the spirits of a place), and as such they possess both a spiritual form and a material form made of elemental matter. The spiritual form inhabits a landscape feature, such as a sand dune, a boulder, or a pool of water. The jinni of a mountain is likely to have a higher Might than that of a boulder; typically Mights range from 5–40.The physical form is basically human, but has a size appropriate to the physical feature, and is usually composed of the same material as the abode. If this form is slain, the spirit can reform it after it has regenerated the Might points spent to create it; the jinni is very likely to exact vengeance on its slayer. Jinn need not eat or drink and do not age. They all possess the Ways of the Land and Second Sight Virtues.
 
 #### Major Supernatural Virtue: Sihr
 
@@ -5872,54 +5435,50 @@ Sihr is used to summon a jinni, and provide mystic power to the bargain that pla
 
 **Discern Might: Intelligence + Realm Lore + stress die vs. Ease Factor 9**
 
-### Example Jinni: Wahhab
+> ## Example Jinni: Wahhab
+> 
+> **Magic Might:** 15 (Ignem)
+> 
+> **Characteristics:** Int –1, Per +2, Pre +2, Com 0, Str +3, Sta +2, Dex +1, Qik 0
+> 
+> **Size**: +2
+> 
+> **Confidence Score:** 1 (3 points)
+> 
+> **Virtues and Flaws:** Way of the Dunes; Second Sight, Skinchanger; Avaricious
+> 
+> **Personality Traits:** Greedy +5, Brave +3, Proud +2
+> 
+> **Combat:**
+> 
+> Great sword: Init +2, Attack +10, Defense +6, Damage +12
+> 
+> **Soak**: +6
+> 
+> **Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+)
+> 
+> **Abilities:** Arabic 4 (negotiation), Athletics 3 (leaping), Great Weapon 3 (great sword), Penetration 4 (heat), Second Sight 4 (jinni)
+> 
+> #### Powers:
+> 
+> *Crafter of Fire*, 1–3 points, Init 0, Ignem: duplicates any non-Ritual Creo Ignem or Muto Ignem spell less than or equal to 15th level at a cost of 1 Might point per magnitude of the effect.
+> 
+> *Incorporeal,* 0 points, Init Constant, Mentem: Wahhab is naturally both invisible and intangible, and cannot be influenced by the physical world. Magic may only directly target him if the caster can sense his existence. In this form he has no physical statistics or combat scores. Without taking a corporeal form, Wahhab's physical characteristics are only used when dealing with other incorporeal creatures.
+> 
+> *Donning the Corporeal Veil*, 2 points, Init +1, Corpus: Wahhab can form the physical body described under Appearance to house his spiritual form; when doing so he acquires the physical characteristics, size, combat statistics, and Wound levels listed above. His arms and armor are also created with this power. He cannot become fatigued. This body lasts until he decides he no longer needs it. Killing the body does not kill Wahhab.
+> 
+> *Presence*, 0 points, constant, Mentem: Wahhab is aware of everything that goes on within his haunt. This power needs to Penetrate to perceive beings with a Magic Resistance.
+> 
+> **Vis:** 1 pawn of Ignem vis can be collected every year from his haunt, in the form of a lambent flame which appears on the cracked altar. If slain in physical form, his body will yield 3 pawns of Ignem vis.
+> 
+> **Appearance**: Wahhab appears as a giant muscled man with coppery red skin and black hair. He carries an immense curved sword and wears an armored shirt (partial scale armor), every one of the copper scales is in the shape of a tongue of fire. When in physical form, he can use his Skinchanger Virtue to adopt the shape of a desert hawk.
+> 
+> Wahhab is a jinni who inhabits the ancient ruins of a fane to a forgotten god, which dates to before Christianity or Islam came to Iberia. He is a spirit of fire, relishing the baking heat of his desert home. He is passionate, brave, vain, and loves the reflected glow of flames on precious metals and gems, which he is amassing in a secret cache.
+> 
+> Wahhab can be used as a template to create other types of jinn; full rules for creating spirits will appear in a later book for **Ars Magica Fifth Edition**. All jinn can mimic Hermetic spells related to their element (see Wahhab's Crafter of Fire Power), but cannot create an effect whose level is greater than their Might. More powerful jinn may have more Powers, such as instant transportation or the creation of wealth. Since they are spirits of a place, the physical location haunted by a jinni acts as an Arcane Connection that provides a +1 bonus to the Penetration Multiplier; more potent Arcane Connections can only be obtained from a jinni who has taken corporeal form.
+> 
 
-**Magic Might:** 15 (Ignem)
-
-**Characteristics:** Int –1, Per +2, Pre +2, Com 0, Str +3, Sta +2, Dex +1, Qik 0
-
-**Size**: +2
-
-**Confidence Score:** 1 (3 points)
-
-**Virtues and Flaws:** Way of the Dunes; Second Sight, Skinchanger; Avaricious
-
-**Personality Traits:** Greedy +5, Brave +3, Proud +2
-
-**Combat:**
-
-Great sword: Init +2, Attack +10, Defense +6, Damage +12
-
-**Soak**: +6
-
-**Wound Penalties**: –1 (1–7), –3 (8–14), –5 (15–21), Incapacitated (22–28), Dead (29+)
-
-**Abilities:** Arabic 4 (negotiation), Athletics 3 (leaping), Great Weapon 3 (great sword), Penetration 4 (heat), Second Sight 4 (jinni)
-
-#### Powers:
-
-*Crafter of Fire*, 1–3 points, Init 0, Ignem: duplicates any non-Ritual Creo Ignem or Muto Ignem spell less than or equal to 15th level at a cost of 1 Might point per magnitude of the effect.
-
-*Incorporeal,* 0 points, Init Constant, Mentem: Wahhab is naturally both invisible and intangible, and cannot be influenced by the physical world. Magic may only directly target him if the caster can sense his existence. In this form he has no physical statistics or combat scores. Without taking a corporeal form, Wahhab's physical characteristics are only used when dealing with other incorporeal creatures.
-
-*Donning the Corporeal Veil*, 2 points, Init +1, Corpus: Wahhab can form the physical body described under Appearance to house his spiritual form; when doing so he acquires the physical characteristics, size, combat statistics, and Wound levels listed above. His arms and armor are also created with this power. He cannot become fatigued. This body lasts until he decides he no longer needs it. Killing the body does not kill Wahhab.
-
-*Presence*, 0 points, constant, Mentem: Wahhab is aware of everything that goes on within his haunt. This power needs to Penetrate to perceive beings with a Magic Resistance.
-
-**Vis:** 1 pawn of Ignem vis can be collected every year from his haunt, in the form of a lambent flame which appears on the cracked altar. If slain in physical form, his body will yield 3 pawns of Ignem vis.
-
-**Appearance**: Wahhab appears as a giant muscled man with coppery red skin and black hair. He carries an immense curved sword and wears an armored shirt (partial scale armor), every one of the copper scales is in the shape of a tongue of fire. When in physical form, he can use his Skinchanger Virtue to adopt the shape of a desert hawk.
-
-Wahhab is a jinni who inhabits the ancient ruins of a fane to a forgotten god, which dates to before Christianity or Islam came to Iberia. He is a spirit of fire, relishing the baking heat of his desert home. He is passionate, brave, vain, and loves the reflected glow of flames on precious metals and gems, which he is amassing in a secret cache.
-
-Wahhab can be used as a template to create other types of jinn; full rules for creating spirits will appear in a later book for **Ars Magica Fifth Edition**. All jinn can mimic Hermetic spells related to their element (see Wahhab's Crafter of Fire Power), but cannot create an effect whose level is greater than their Might. More powerful jinn may have more Powers, such as instant transportation or the creation of wealth. Since they are spirits of a place, the physical location haunted by a jinni acts as an Arcane Connection that provides a +1 bonus to the Penetration Multiplier; more potent Arcane Connections can only be obtained from a jinni who has taken corporeal form.
-
-**Summoning Jinn:** Once discerned, the sahir may summon the jinni and bind it into service. This summons must take
-
-place in the physical presence of the jinni or at its home; the latter is most common because it provides an Arcane Connection
-
-
-to the spirit. Once begun, the jinni may attempt to interfere with the summons (although most do not), so it is wise to erect a Hermetic ward to keep the spirit at bay. The summons makes the spirit assume its material form, and takes at least 15 minutes to perform. The sahir chants the words of command encoded by Solomon, while making the prescribed ritual motions and drawing Arabic figures on the ground. The summons also requires vis of a Form appropriate to the jinni being summoned. The standard cost of a summons is one pawn for every magnitude of Might of the jinni, but the sahir can chose to spend less (with a minimum of 1 pawn) or more (with a maximum equal to the Sihr score). Note that the sahir only has his estimate of the jinni's Might (assuming he has attempted to discern the jinni prior to the summons), so may unwittingly spend less or more than the standard amount. The amount of vis spent does not affect the summoning, but plays an important role in the bargaining that follows.
+**Summoning Jinn:** Once discerned, the sahir may summon the jinni and bind it into service. This summons must take place in the physical presence of the jinni or at its home; the latter is most common because it provides an Arcane Connection to the spirit. Once begun, the jinni may attempt to interfere with the summons (although most do not), so it is wise to erect a Hermetic ward to keep the spirit at bay. The summons makes the spirit assume its material form, and takes at least 15 minutes to perform. The sahir chants the words of command encoded by Solomon, while making the prescribed ritual motions and drawing Arabic figures on the ground. The summons also requires vis of a Form appropriate to the jinni being summoned. The standard cost of a summons is one pawn for every magnitude of Might of the jinni, but the sahir can chose to spend less (with a minimum of 1 pawn) or more (with a maximum equal to the Sihr score). Note that the sahir only has his estimate of the jinni's Might (assuming he has attempted to discern the jinni prior to the summons), so may unwittingly spend less or more than the standard amount. The amount of vis spent does not affect the summoning, but plays an important role in the bargaining that follows.
 
 The sahir generates a Summoning Total based on his Sihr Ability . A successful summons that manages to penetrate the jinni's Magic Resistance forces the jinni to take physical form before the sahir. Calculate the Summoning Strength, which is the amount by which the sahir's Casting Total exceeds the Ease Factor. A botched Sihr roll results in the appearance of an infuriated jinni, or a spirit wholly different to than the one intended.
 
@@ -5943,49 +5502,46 @@ A sahir can spend **extra time** on his summons; every extra 15 minutes causes a
 
 The Ease Factor has a Bargain Modifier, which depends on what the sahir is asking from the jinni, and what he offers in return.
 
-A failed bargain roll results in a failure to make a bargain, and the jinni is not compelled to remain. A botch results in the sahir acquiring either Supernatural Nuisance (for a weak jinni) or Plagued by Jinni (for a moderate or powerful jinni) for at least a month. A successful bargain binds the jinni to the beck and call of the sahir for the duration of the bargain. He can ask it to perform any task within its power, although when a jinni expends its last Might point in the service of the sahir, then the bargain ends, regardless of the length of service remain-
-
-| Bargain Modifiers                                                                         |          |
-|-------------------------------------------------------------------------------------------|----------|
-| Provision                                                                                 | Modifier |
-| Terms are general in<br>scope ("Follow me<br>around and do as I say")                     | +3       |
-| Term are specific in<br>scope ("Help me find the<br>Emerald of Al-Andalus")               | +0       |
-| Terms constitute a single<br>task ("Get me safely<br>across the Straits of<br>Gibraltar") | –3       |
-| Service to last 1 day                                                                     | –3       |
-| Service to last 1 week                                                                    | 0        |
-| Service to last 1 month                                                                   | +3       |
-| Service to last 1 season                                                                  | +6       |
-| Service to last 1 year                                                                    | +9       |
-| Sahir accepts a simple<br>duty                                                            | –3       |
-| Sahir accepts an onerous<br>duty                                                          | –6       |
-| Sahir spent less vis than<br>the standard cost                                            | +2*      |
-| Sahir spent more vis than<br>the standard cost                                            | –2*      |
-| * Modifier is per pawn under or over                                                      |          |
-
-ing. The jinni cannot renege on any solemn oaths it has made prior to the summons; this includes, for jinni who have adopted a religion, disobeying the tenets of that faith. The jinni cannot swear any new oaths during its service without permission from the sahir. A jinni who is in service for a season or more may be used as a source of knowledge on Sihr, the appropriate Hermetic Form, or either Faerie, Magic, or Infernal Lore (as appropriate). A jinni can only instruct a sahir once for each Ability or Art. A sahir can have a number of jinn in service to him at any one time equal to his Leadership score, although all sahirs can command at least one jinni.
-
-the standard cost.
+A failed bargain roll results in a failure to make a bargain, and the jinni is not compelled to remain. A botch results in the sahir acquiring either Supernatural Nuisance (for a weak jinni) or Plagued by Jinni (for a moderate or powerful jinni) for at least a month. A successful bargain binds the jinni to the beck and call of the sahir for the duration of the bargain. He can ask it to perform any task within its power, although when a jinni expends its last Might point in the service of the sahir, then the bargain ends, regardless of the length of service remaining. The jinni cannot renege on any solemn oaths it has made prior to the summons; this includes, for jinni who have adopted a religion, disobeying the tenets of that faith. The jinni cannot swear any new oaths during its service without permission from the sahir. A jinni who is in service for a season or more may be used as a source of knowledge on Sihr, the appropriate Hermetic Form, or either Faerie, Magic, or Infernal Lore (as appropriate). A jinni can only instruct a sahir once for each Ability or Art. A sahir can have a number of jinn in service to him at any one time equal to his Leadership score, although all sahirs can command at least one jinni.
 
 **Source Quality of a Jinni: 3 x magnitude of Might**
 
 **Maximum Number of Jinni: equal to Leadership (minimum 1)**
 
+> ## Bargain Modifiers
+> 
+> | Provision | Modifier |
+> |-----------|:--------:|
+> | Terms are general in scope ("Follow me around and do as I say") | +3 |
+> | Terms are specific in scope ("Help me find the Emerald of Al-Andalus") | +0 |
+> | Terms constitute a single task ("Get me safely across the Straits of Gibraltar") | –3 |
+> | Service to last 1 day | –3 |
+> | Service to last 1 week | 0 |
+> | Service to last 1 month | +3 |
+> | Service to last 1 season | +6 |
+> | Service to last 1 year | +9 |
+> | Sahir accepts a simple duty | –3 |
+> | Sahir accepts an onerous duty | –6 |
+> | Sahir spent less vis than the standard cost | +2\* |
+> | Sahir spent more vis than the standard cost | –2\* |
+> 
+> \* Modifier is per pawn under or over the standard cost.
 
-### Typical Duties for Sahirs
+> ## Typical Duties for Sahirs
+> 
+> **Simple Duties:** Cleansing or protecting the jinni's home, guarding a human family to whom the jinni has become attached, retrieving stolen wealth, writing a poem in praise of the jinn, providing rare commodities such as frankincense or rubies.
+> 
+> **Onerous Duties:** Fighting wizards who seek to enslave jinn, freeing slaves from captivity, playing a jest on an important local figure, delivering the heart of an enemy, procuring a unique item such as a book written in Solomon's own hand.
 
-**Simple Duties:** Cleansing or protecting the jinni's home, guarding a human family to whom the jinni has become attached, retrieving stolen wealth, writing a poem in praise of the jinn, providing rare commodities such as frankincense or rubies.
-
-**Onerous Duties:** Fighting wizards who seek to enslave jinn, freeing slaves from captivity, playing a jest on an important local figure, delivering the heart of an enemy, procuring a unique item such as a book written in Solomon's own hand.
-
-### Sahirs in the Saga
-
-Having a sahir character in the saga poses some different challenges compared to other magi. A sahir's work is all done up front; summoning jinn and binding them to service before heading off to complete a task. However, his non-Hermetic magic is critically dependent on the amount of vis available in the saga, for this determines his capacity to summon jinn. Further, a sahir is best on his home turf where he has fully investigated the local jinn, and knows their capabilities well. The storyguide should consider creating several jinn from the region around the covenant, and allowing other players to run them as secondary characters during stories. A jinni must obey the bargain between itself and the sahir, but need not do so slavishly. Different jinn have different personalities; some might be friendly and willing to help, others might be hostile and attempt to twist the bargain that was made. Remember also that as a sahir gains in power, he will desire to summon more powerful jinn, so the storyguide should ensure the area has a range of spirits, or that the sahir meets such entities in his travels.
+> ## Sahirs in the Saga
+> 
+> Having a sahir character in the saga poses some different challenges compared to other magi. A sahir's work is all done up front; summoning jinn and binding them to service before heading off to complete a task. However, his non-Hermetic magic is critically dependent on the amount of vis available in the saga, for this determines his capacity to summon jinn. Further, a sahir is best on his home turf where he has fully investigated the local jinn, and knows their capabilities well. The storyguide should consider creating several jinn from the region around the covenant, and allowing other players to run them as secondary characters during stories. A jinni must obey the bargain between itself and the sahir, but need not do so slavishly. Different jinn have different personalities; some might be friendly and willing to help, others might be hostile and attempt to twist the bargain that was made. Remember also that as a sahir gains in power, he will desire to summon more powerful jinn, so the storyguide should ensure the area has a range of spirits, or that the sahir meets such entities in his travels.
 
 #### Hermetic Magic
 
 Sahirs tend to excel at the elemental Forms, because of their ability to learn from the jinn whom they summon. Sahirs should always know spells that will protect them against a jinn in the event of a failed bargain, and cautious sahirs erect a ward around themselves before beginning a summons. Hermetic magic lacks the distinction to ward against the jinn specifically, and because of their bias towards the elemental Forms, sahirs are usually capable of creating stronger wards against specific jinn (jinn of the waters, jinn of the earth, and so forth), despite needing to know separate variants of these spells for Faerie, Magic, and Infernal jinn. Apotropaic magics — those which strip a spirit of its Might — are typically part of the arsenal of a sahir.
 
-**Suleiman's Wrath on the Oath-Forsaken Jinni**
+##### Suleiman's Wrath on the Oath-Forsaken Jinni
 
 PeVi Gen
 
@@ -5995,17 +5551,19 @@ This spell weakens and possibly destroys a creature with Magic Might. If the spe
 
 (Base effect, +2 Voice)
 
-# Seirenes
+## Seirenes
 
 This tradition is comprised of a group of magae who practice a form of lyrical magic taught to their founder by the sirens of legend. The music of the Seirenes allows them to influence the thoughts and actions of their listeners and is especially effective when performed in a trio.
 
 ### Key Facts
 
-**Favored Tribunal:** The Seirenes are predominantly located in the Thebes,
+**Favored Tribunal:** The Seirenes are predominantly located in the Thebes, Roman, and Provencal Tribunals and favor covenants near the Mediterranean Sea, but they travel extensively throughout Mythic Europe and can be encountered anywhere.
 
-Roman, and Provencal Tribunals and favor covenants near the Mediterranean Sea, but they travel extensively throughout Mythic Europe and can be encountered anywhere. **Major Non-Hermetic Virtue:** Siren Song **Minor Hermetic Virtue:** Minor Magical
+**Major Non-Hermetic Virtue:** Siren Song
 
-Focus (Mentem – an emotion) **Major Hermetic Flaw:** Necessary Condition (all spells must be sung) **Miscellaneous:** The Seirenes only select females as apprentices.
+**Minor Hermetic Virtue:** Minor Magical Focus (Mentem – an emotion)
+
+**Major Hermetic Flaw:** Necessary Condition (all spells must be sung) **Miscellaneous:** The Seirenes only select females as apprentices.
 
 ### History
 
@@ -6015,50 +5573,37 @@ Before Thelxiope could be discovered, the ship traveled near the island of the s
 
 Thelxiope told her story to the sirens, who took pity on her for foolishly falling in love with a sailor. They cared for Thelxiope and eventually taught her the secrets of their magic. Although the sirens preached their hatred of men to Thelxiope, she did not initially adopt it.
 
-Before the voyage to retrieve the Golden Fleece, Chiron warned Jason that he and his Argonauts would be lost at sea unless Orpheus accompanied them. Chiron's prophecy was fulfilled when the Argo approached the island of the sirens. As the sirens' song drew the Argonauts toward the rocks, Orpheus began playing his lyre and the beauty of his music overcame the lure of their song. The sirens
+Before the voyage to retrieve the Golden Fleece, Chiron warned Jason that he and his Argonauts would be lost at sea unless Orpheus accompanied them. Chiron's prophecy was fulfilled when the Argo approached the island of the sirens. As the sirens' song drew the Argonauts toward the rocks, Orpheus began playing his lyre and the beauty of his music overcame the lure of their song. The sirens became filled with a jealous rage when they heard Orpheus's music. They could not suffer defeat at the hands of a mere man and threw themselves into the sea and turned to stone. To this day, the Seirenes are hostile toward the members of the Cult of Orpheus.
 
-
-became fi lled with a jealous rage when they heard Orpheus's music. They could not suffer defeat at the hands of a mere man and threw themselves into the sea and turned to stone. To this day, the Seirenes are hostile toward the members of the Cult of Orpheus.
-
-Thelxiope bitterly left the island forever, intent on exacting revenge on the world of men. She traveled Europe using her magical powers to punish any cruel or unfaithful man she encountered. These petty acts left Thelxiope unfulfi lled. It was only when she encountered an orphaned girl and adopted her as her ward that Thelxiope's life took on meaning. The young girl possessed The Gift and had been ostracized by her village because of it. Thelxiope trained her in magic, and the
-
-two traveled across Europe searching for other Gifted
-
-girls to save.
+Thelxiope bitterly left the island forever, intent on exacting revenge on the world of men. She traveled Europe using her magical powers to punish any cruel or unfaithful man she encountered. These petty acts left Thelxiope unfulfilled. It was only when she encountered an orphaned girl and adopted her as her ward that Thelxiope's life took on meaning. The young girl possessed The Gift and had been ostracized by her village because of it. Thelxiope trained her in magic, and the two traveled across Europe searching for other Gifted girls to save.
 
 ### Culture
 
-Thelxiope discovered and trained many young women on her travels. After she retired, her pupils continued the search. The Seirenes continue to place an emphasis on recruiting apprentices to their tradition. Because a Seirene often identifi es a Gifted women before she is able to train her adequately, the Seirenes have developed a custom of sending their apprentices to begin training in Music and Siren Song with their parentes. After her gauntlet and before she joins a covenant, a Seirene usually spends time traveling with two other Seirenes. When combined with the joint early training that Seirenes have, these practices have created a very tight-knit tradition.
+Thelxiope discovered and trained many young women on her travels. After she retired, her pupils continued the search. The Seirenes continue to place an emphasis on recruiting apprentices to their tradition. Because a Seirene often identifies a Gifted women before she is able to train her adequately, the Seirenes have developed a custom of sending their apprentices to begin training in Music and Siren Song with their parentes. After her gauntlet and before she joins a covenant, a Seirene usually spends time traveling with two other Seirenes. When combined with the joint early training that Seirenes have, these practices have created a very tight-knit tradition.
 
 The Seirenes do not only seek women with The Gift. They readily recruit any female with Supernatural Abilities, or any with a damaged Gift, who might be capable of learning Siren Song. The Seirenes treat these unGifted members as equals in all aspects; however, the Order does not grant them the voting rights of true magae.
 
-The Seirenes' search to discover Gifted women defi nes their tradition. The Seirenes believe that the conditions for women, especially Gifted ones, are intolerable in the male-dominated society of Mythic Europe. Thelxiope's followers know that changing society is a slow process, but they take small steps where they can. When a Seirene discovers a woman ruling her own lands, running her own business,
+The Seirene's search to discover Gifted women defines their tradition. The Seirenes believe that the conditions for women, especially Gifted ones, are intolerable in the male-dominated society of Mythic Europe. Thelxiope's followers know that changing society is a slow process, but they take small steps where they can. When a Seirene discovers a woman ruling her own lands, running her own business, or performing any role traditionally limited to men, she surreptitiously assists the woman or hinders her male rivals.
 
-> or performing any role traditionally limited to men, she surreptitiously assists the woman or hinders her male rivals.
+The Seirenes also attempt to make their covenants more egalitarian. To do this, Seirenes ensure that their covenants recruit exceptional women wherever they find them. They also encourage female grogs and covenfolk to perform traditional male roles whenever they show any aptitude. Seirenes are not virulently anti-male, merely vigorously pro-female.
 
-> > The Seirenes also attempt to make their covenants more egalitarian. To do this, Seirenes ensure that their covenants recruit exceptional women wherever they fi nd them. They also encourage female grogs and covenfolk to perform traditional male roles whenever they show any aptitude. Seirenes are not virulently anti-male, merely vigorously pro-female.
+The Seirenes entered the Order relatively early in its history. Although their magic was powerful against mundane men, a magus of only moderate power or anyone familiar with the tale of Odysseus could easily defeat it. The Seirenes realized this and accepted the offer of membership in the Order for access to Bonisagus's versatile magic and the protection of the Parma Magica. The Seirenes also recognized that the Order was essentially a meritocracy where all members were given an equal voice.
 
-The Seirenes entered the Order relatively early in its history. Although their magic was powerful against mundane men, a magus of only moderate power or anyone familiar with the tale of Odysseus could easily defeat it. The Seirenes realized this and accepted the offer of membership in the Order for access to Bonisagus's versatile
+At Tribunal, the Seirenes tend to vote at the direction of their leadership. This practice is not followed as rigidly as it is by House Tremere, and each member retains her own sigil. The leadership of the tradition is determined every 12 years at a grand competition. All Seirenes compete for the titles of First Singer, First Lyrist, and First Flautist. The winners are chosen by vote of all members present at the grand competition, which is held at the covenant of the reigning First Singer. Other than this honor, the three Firsts are treated equally and have equal authority. Although someone without The Gift has never won the competition, the possibility exists.
 
-### Islands of the Sirens
+> ### Islands of the Sirens
+> 
+> The legends list several possible islands where the sirens made their home. These include Anthemoessa, between Sicily and the Italian Peninsula; Cape Peloris; Capri; and Sirenum Scopuli. The island that was the final home of the sirens is unknown. It is said to be white with the bleached bones of sailors who were drawn to their deaths by the sirens. It is likely to posses a Magic aura or possibly a regio.
+> 
+> The sirens were powerful magical creatures and the stone remains of their bodies are a treasure trove of vis. If the Seirenes ever discover that someone has harvested those remains, that person gains a very dedicated enemy. When the sirens died, they also left behind their magical instruments. Legend tells that the trio was comprised of a vocalist accompanied by sirens playing the lyre and the flute. Their instruments were allegedly made from the bones of dead sailors. Not only would these instruments have great historical value to a member of the Seirenes tradition, but they are also powerful magical devices.
+> 
+> *Story. Seed*: A town is overrun with vermin when a colorfully dressed man offers his assistance. He promises to clear the town of its rats in exchange for a generous sum of money. The man plays a sweet melody and the rats blindly follow into a nearby lake to drown, but the town refuses to pay. On the next feast day, the man returns and plays another sweet melody. All of the children of the town follow him into a nearby mountain where they disappear forever. Is a Seirene, disguised as a man, extorting from towns throughout Mythic Europe? Or did some man discover the lost island of the sirens of legend?
 
-The legends list several possible islands where the sirens made their home. These include Anthemoessa, between Sicily and the Italian Peninsula; Cape Peloris; Capri; and Sirenum Scopuli. The island that was the fi nal home of the sirens is unknown. It is said to be white with the bleached bones of sailors who were drawn to their deaths by the sirens. It is likely to posses a Magic aura or possibly a regio.
-
-The sirens were powerful magical creatures and the stone remains of their bodies are a treasure trove of vis. If the Seirenes ever discover that someone has harvested those remains, that person gains a very dedicated enemy. When the sirens died, they also left behind their magical instruments. Legend tells that the trio was comprised of a vocalist accompanied by sirens playing the lyre and the fl ute. Their instruments were allegedly made from the bones of dead sailors. Not only would these instruments have great historical value to a member of the Seirenes tradition, but they are also powerful magical devices.
-
-*Story. Seed*: A town is overrun with vermin when a colorfully dressed man offers his assistance. He promises to clear the town of its rats in exchange for a generous sum of money. The man plays a sweet melody and the rats blindly follow into a nearby lake to drown, but the town refuses to pay. On the next feast day, the man returns and plays another sweet melody. All of the children of the town follow him into a nearby mountain where they disappear forever. Is a Seirene, disguised as a man, extorting from towns throughout Mythic Europe? Or did some man discover the lost island of the sirens of legend?
-
-magic and the protection of the Parma Magica. The Seirenes also recognized that the Order was essentially a meritocracy where all members were given an equal voice.
-
-At Tribunal, the Seirenes tend to vote at the direction of their leadership. This practice is not followed as rigidly as it is by House Tremere, and each member retains
-
-### Seirenes in Your Saga
-
-With a little effort, the Seirenes can play a role in any saga, even if no player elects to play one as a maga. The Seirenes act as a natural counterpart to the Cult of Orpheus. Because of Orpheus's role in the death of the sirens of legend, the Seirenes could serve as antagonists to anyone seeking initiation into the Cult of Orpheus. Likewise, the Seirenes possess a remnant of the lyrical magic that the Orphics have lost. A *magos* of the Cult might try to rebuild the magic of Orpheus by attempting to learn Siren Song. The Seirenes are not a Mystery Cult, but they do not willingly teach their secrets to males. Should the leadership of the Seirenes discover that a male has learned of their magic, they would likely vow to kill him and start a Wizard's War against his teacher. If the student is either a follower of Orpheus, or the Cult offers him protection, the conflict between the Seirenes and Orphics could cause widespread disruption. The characters might get involved if the leaders of their Tribunal attempt to broker a peace.
-
-**Story Seed:** Although the sirens who trained Thelxiope died, they were not the last sirens. Sirens live on certain islands in the Mediterranean where they use their beautiful music to lure sailors to their doom. Some Seirenes have aligned themselves with these creatures and live with them away from the world of men. Other Seirenes travel to these islands to learn from the creatures or trade for the magical instruments they can create.
-
-her own sigil. The leadership of the tradition is determined every 12 years at a grand competition. All Seirenes compete for the titles of First Singer, First Lyrist, and First Flautist. The winners are chosen by vote of all members present at the grand competition, which is held at the covenant of the reigning First Singer. Other than this honor, the three Firsts are treated equally and have equal authority. Although someone without The Gift has never won the competition, the possibility exists.
+> ### Seirenes in Your Saga
+> 
+> With a little effort, the Seirenes can play a role in any saga, even if no player elects to play one as a maga. The Seirenes act as a natural counterpart to the Cult of Orpheus. Because of Orpheus's role in the death of the sirens of legend, the Seirenes could serve as antagonists to anyone seeking initiation into the Cult of Orpheus. Likewise, the Seirenes possess a remnant of the lyrical magic that the Orphics have lost. A *magos* of the Cult might try to rebuild the magic of Orpheus by attempting to learn Siren Song. The Seirenes are not a Mystery Cult, but they do not willingly teach their secrets to males. Should the leadership of the Seirenes discover that a male has learned of their magic, they would likely vow to kill him and start a Wizard's War against his teacher. If the student is either a follower of Orpheus, or the Cult offers him protection, the conflict between the Seirenes and Orphics could cause widespread disruption. The characters might get involved if the leaders of their Tribunal attempt to broker a peace.
+> 
+> **Story Seed:** Although the sirens who trained Thelxiope died, they were not the last sirens. Sirens live on certain islands in the Mediterranean where they use their beautiful music to lure sailors to their doom. Some Seirenes have aligned themselves with these creatures and live with them away from the world of men. Other Seirenes travel to these islands to learn from the creatures or trade for the magical instruments they can create.
 
 ### Characters
 
@@ -6078,22 +5623,19 @@ If a group of musicians performs together, the Music scores of the other members
 
 A victim's resistance roll is modified based on the same factors as the Entrancement Ability.
 
-| Command                 | Example                           | Target's<br>Bonus |
-|-------------------------|-----------------------------------|-------------------|
-| Innocuous               | Listen to my song                 | +0                |
-| Questionable Come to me |                                   | +3                |
-| Dangerous               | Follow me out of<br>town          | +6                |
-| Heinous                 | Kill your fellows                 | +9                |
-| Suicidal                | Crash your ship<br>upon the rocks | +12               |
+| Command      | Example                    | Target's Bonus |
+|--------------|----------------------------|----------------|
+| Innocuous    | Listen to my song          | +0             |
+| Questionable | Come to me                 | +3             |
+| Dangerous    | Follow me out of town      | +6             |
+| Heinous      | Kill your fellows          | +9             |
+| Suicidal     | Crash your ship upon the rocks | +12        |
 
 **Specialties**: Men, children, rats. (Supernatural)
 
 Although Siren Song is a more powerful Virtue than Enchanting Music, the two Virtues may be used in combination. Unlike the Enchanting Music Ability, which creates an emotion in a person and can influence individuals on a long-term basis, Siren Song actually controls the mind of the person while he listens to the music. When a character uses both Virtues, her initial command made with Siren Song can be reinforced by an appropriate emotion provided by the Enchanting Music Virtue. The combination can continue to influence the victim after the music has ceased. For the Abilities to be combined, the character must successfully overcome the victim's Stamina on both rolls. If other Seirenes accompany the character in performing, their Enchanting Music scores may be added to the leader's roll. The same restrictions and benefits from the Siren Song Virtue apply to a group performing with the Enchanting Music Ability.
 
-
-### Appendix
-
-# Agencies
+# Appendix: Agencies
 
 Magi often maintain networks of mundane contacts, which they call agencies. Agents pursue the goals of the magus while ensuring that he cannot be implicated in meddling with mundane politics. The following sections describe how agents may be recruited, used, and managed.
 
@@ -6119,10 +5661,10 @@ Indirectly controlled people serve a useful role under Hermetic law. They enable
 
 It is not necessary for players to design the character sheets of their characters' agents, but a handful of statistics are required, to quantify the usefulness of each agent. Each agent should have:
 
-- A name •
-- A Social Status Virtue or Flaw •
-- A Bond , which is a Personality Trait that expresses the reason that the agent is subordinate to the principal •
-- A list of resources useful to the principal, like Abilities, wealth, social influence, or membership in a social circle •
+- A name
+- A Social Status Virtue or Flaw
+- A Bond , which is a Personality Trait that expresses the reason that the agent is subordinate to the principal
+- A list of resources useful to the principal, like Abilities, wealth, social influence, or membership in a social circle
 
 *Example: Carolus has many agents drawn from the criminal underworld of a large city. His player Mark details two of these contacts as follows:*
 
@@ -6130,15 +5672,11 @@ It is not necessary for players to design the character sheets of their characte
 
 *Godfroi: Merchant; Temporal Influence; Bond: Fear of Carolus +2. Godfroi handles stolen goods, and Carolus supplies him with merchandise. Godfroi is influential in local government, and the Merchant Guild.*
 
-Agents may be controlled by principals they consider their inferiors only through coercion. A principal who recruits an agent of higher social standing acquires the effects
+Agents may be controlled by principals they consider their inferiors only through coercion. A principal who recruits an agent of higher social standing acquires the effects of the Difficult Underlings Story Flaw for dealings with this character, to represent the attempts of the agent to win free from the controlling influence of the principal. The coercion of the agent is represented by a Flaw (such as Blackmail, Dark Secret, and so forth). Thus, a merchant may control a bishop through financial favors, but the bishop hates it. A priest may control a knight with blackmail, but the knight loathes him for it. The exception to this rule is magi, who stand outside the social hierarchy of Mythic Europe and can potentially recruit any individuals they meet as their agents. This problem with social standing is why many magi prefer to deal with their agents directly rather than employing a factor, who often have low social status.
 
-#### Societates
-
-### Partial Adoption
-
-Some troupes prefer to not define the agents that characters receive due to Virtues and Flaws, instead only accounting for those gained during play. If, in your own saga, your players feel it is more convenient for a person with the Social Contacts Virtue to be assured of knowing somewhere wherever he goes, or your storyguide likes being able to add obscure cousins with a talent for finding trouble to the family tree of characters with Close Family Ties, then there's no need to convert these into fully described agencies.
-
-of the Difficult Underlings Story Flaw for dealings with this character, to represent the attempts of the agent to win free from the controlling influence of the principal. The coercion of the agent is represented by a Flaw (such as Blackmail, Dark Secret, and so forth). Thus, a merchant may control a bishop through financial favors, but the bishop hates it. A priest may control a knight with blackmail, but the knight loathes him for it. The exception to this rule is magi, who stand outside the social hierarchy of Mythic Europe and can potentially recruit any individuals they meet as their agents. This problem with social standing is why many magi prefer to deal with their agents directly rather than employing a factor, who often have low social status.
+> ## Partial Adoption
+> 
+> Some troupes prefer to not define the agents that characters receive due to Virtues and Flaws, instead only accounting for those gained during play. If, in your own saga, your players feel it is more convenient for a person with the Social Contacts Virtue to be assured of knowing somewhere wherever he goes, or your storyguide likes being able to add obscure cousins with a talent for finding trouble to the family tree of characters with Close Family Ties, then there's no need to convert these into fully described agencies.
 
 #### Recruiting Agents at Character Creation
 
@@ -6166,28 +5704,25 @@ A magus uses his agents by setting one or more of them a task. Agents must, at t
 
 **Persuasion Roll: Communication + Charm, Intrigue, or Leadership + Bond Strength – social penalty of The Gift + stress die vs. Ease Factor (see table under Tasks for Agents)**
 
-
 Assuming the agent accepts the task, the storyguide may choose to resolve the task with a die roll against an appropriate Ability of the agent's (using the Easy, Hard, or Impressive Ease Factor from the Tasks for Agents insert). Alternatively, the storyguide can run a side story, with the player taking on the character of the agent, and other players taking on antagonistic roles. This latter suggestion can prove disruptive to troupe-style play, and should only be used for important plot exposition. All agents are assumed to have contacts, which they use without prompting, to fulfill requests from the principal.
 
 The most common use for an agent is as a source of **information**; well-placed agents in the right places can feed back useful information to their principals almost passively with little effort. The agent may also be used in an active manner, seeking a specific piece of information, at possible risk and/or cost to themselves. It must be possible that an agent knows the requested information, or can obtain it with minor effort. If this is not true, then the character is asking for assistance from her agent (see below), rather than information.
 
 A principal should not ask for substantial information from each of her contacts more than once per season, else the contact considers the principal an unwelcome burden and looks for ways to loosen her hold. Of course, this restriction does not apply to simple gossip, scuttlebutt, or general information known to many people, just to information which is sensitive, or to which the contact is privy and has intrinsic value.
 
-Agents may also be called upon for **assistance**. By cashing in past favors, or applying pressure or incentive on an agent, a principal can induce that contact to use his individual skills or knowledge in the service of his employer. Once again, the assistance requested must be appropriate to the agent — a priest cannot be asked to break into a castle at night to steal a lock of hair from the duke's daughter; this is a task for a criminal practiced in stealth and climbing. Most characters have only two "free" seasons a year, and since this time is spread throughout the year rather than occurring in discrete blocks, an agent cannot always spare the time. Characters with Social Status Virtues may have more time to devote to their principal, but the incen-
-
-### Resistance of Agents
-
-A newly contacted agent has a Resistance Strength, which represents his reluctance to serve the principal. The more powerful and skilled the agent, the greater this Resistance is, as determined by the table on the next page. The character reduces this Resistance Strength using the methods given in the Recruiting Agents sections. When the potential agent's Resistance Strength reaches zero, he falls under the influence of the principal, who must then develop a Bond Strength of at least +1 to start using the agent. The principal may continue to improve the Bond score using the methods given under Maintaining Agents, below, to a maximum of +6, representing a fanatically dedicated agent. The examples given in this table account only for Virtues and Flaws given in **Ars Magica Fifth Edition**. Supplements often contain new Virtues and Flaws, which troupes cost at their discretion.
-
-Agents created on this table do not need to balance their Virtues and Flaws. Players should only account for resources the agent will use in play. Characters with many valuable features are so rare that a player character could not realistically seek them out. Storyguides may introduce such characters, as targets for recruitment, as a reward for skilled play.
-
-Hermetic magi are never agents.
-
-tive must be good, for time is valuable. Agents with Social Status Flaws might be unavailable for long periods of time as they hide from the authorities or spend time in jail (see Confounding Factors, below).
+Agents may also be called upon for **assistance**. By cashing in past favors, or applying pressure or incentive on an agent, a principal can induce that contact to use his individual skills or knowledge in the service of his employer. Once again, the assistance requested must be appropriate to the agent — a priest cannot be asked to break into a castle at night to steal a lock of hair from the duke's daughter; this is a task for a criminal practiced in stealth and climbing. Most characters have only two "free" seasons a year, and since this time is spread throughout the year rather than occurring in discrete blocks, an agent cannot always spare the time. Characters with Social Status Virtues may have more time to devote to their principal, but the incentive must be good, for time is valuable. Agents with Social Status Flaws might be unavailable for long periods of time as they hide from the authorities or spend time in jail (see Confounding Factors, below).
 
 *Example: Carolus needs to borrow the signet ring of a mayor, which he intends to enchant with a minor effect. He therefore approaches Tom the Cutpurse, one of his agents with a Bond of Gratitude +3. The favor he is asking is a hard task that incurs moderate risk to Tom, so Mark (Carolus's player) needs a persuasion roll of 9 or more to persuade his agent to do this favor.*
 
 *Assuming this roll is successful (probably through the expenditure of Confidence Points), to resolve the theft itself the storyguide pits Tom's Dexterity + Legerdemain against an Ease Factor of 12, on a stress die with three botch dice. If this succeeds, Carolus will need Tom's services again in a season's time to replace the ring.*
+
+> ## Resistance of Agents
+> 
+> A newly contacted agent has a Resistance Strength, which represents his reluctance to serve the principal. The more powerful and skilled the agent, the greater this Resistance is, as determined by the table on the next page. The character reduces this Resistance Strength using the methods given in the Recruiting Agents sections. When the potential agent's Resistance Strength reaches zero, he falls under the influence of the principal, who must then develop a Bond Strength of at least +1 to start using the agent. The principal may continue to improve the Bond score using the methods given under Maintaining Agents, below, to a maximum of +6, representing a fanatically dedicated agent. The examples given in this table account only for Virtues and Flaws given in **Ars Magica Fifth Edition**. Supplements often contain new Virtues and Flaws, which troupes cost at their discretion.
+> 
+> Agents created on this table do not need to balance their Virtues and Flaws. Players should only account for resources the agent will use in play. Characters with many valuable features are so rare that a player character could not realistically seek them out. Storyguides may introduce such characters, as targets for recruitment, as a reward for skilled play.
+> 
+> Hermetic magi are never agents.
 
 #### Confounding Situations
 
@@ -6199,90 +5734,92 @@ A character who begins play with an agency due to a Virtue or Flaw may take the 
 
 Agencies are not static things. Death is an inevitable part of life in Mythic Europe, and agents may be lost due to story events or to events outside the control of the principal. Having an agency is therefore similar to having a Story Flaw, in that characters who possess them may find themselves having to become involved in stories to maintain them. For example:
 
-- An agent who is regularly pressed for sensitive information may acquire a reputation as a snitch, which will reduce his overall effectiveness. •
-- An agent recruited through blackmail might call the bluff of a principal. •
-- An agent might be accused of a crime that will result in his death if he is found guilty. •
-
-
-
-### Resistance of Agents Table
-
-| Social Status                                 | Resistance | Examples                                                                                                            |
-|-----------------------------------------------|------------|---------------------------------------------------------------------------------------------------------------------|
-| Major Social Virtue                           | 3          | Landed Noble*, Magister et Artibus, Redcap                                                                          |
-| Minor Social Virtue                           | 1          | Clerk, Custos, Failed Apprentice, Gentleman/woman, Knight, Mendicant Friar,<br>Mercenary Captain*, Priest, Wise One |
-| Free Social Virtue (except<br>Hermetic Magus) | 0          | Covenfolk, Craftsman, Merchant, Peasant, Wanderer                                                                   |
-| Minor Social Status Flaws                     | –1         | Branded Criminal, Outcast, Outlaw Leader*                                                                           |
-| Major Social Status Flaws                     | –3         | Outlaw, Outsider                                                                                                    |
-|                                               |            |                                                                                                                     |
-
-<sup>\*</sup> Must also take useful underlings, below
-
-#### Modifiers
-
-*The agent is easily suborned if he has . . .*
-
-| Circumstance                                                 | Modifier | Examples                                                                                                                           |
-|--------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------|
-| Major Flaws likely to inconve<br>nience principal            | –3       | Enemies, Feud, Lycanthrope, Plagued by Supernatural Entity                                                                         |
-| Minor Flaws likely to inconve<br>nience principal            | –1       | Black Sheep, Dark Secret, Dependant, Diabolic Past, Favors, Infamous                                                               |
-| Minor Flaw used by the player<br>character to dominate agent | –6*      | Principal has hostage (Dependent or True Love), is Blackmailing using Dark Secret,<br>Diabolic Past, or other leverage (Blackmail) |
-
-<sup>\*</sup>Agent hates principal, which inflicts Difficult Underlings Flaw for this agent only
-
-#### Resources
-
-| Resource                                             | Modifier | Examples                                                                                   |
-|------------------------------------------------------|----------|--------------------------------------------------------------------------------------------|
-| Extraordinary skill: Main Ability score is 6 or more | +1       |                                                                                            |
-| Exceptional skill: Main ability score 8 or more      | +3       |                                                                                            |
-| Minor General or Supernatural Virtue                 | +1       | Gossip, Magic Sensitivity, Protection, Skinchanger, Social<br>Contacts, Temporal Influence |
-| Major General or Supernatural Virtue                 | +3       | Entrancement, True Faith, Wealthy                                                          |
-| Serves Rival Covenant                                | +9       |                                                                                            |
-| Underlings                                           | +1       | Up to a half-dozen people, including agents and hirelings                                  |
-| Many Underlings                                      | +3       | Up to two dozen people, including agents and hirelings                                     |
-| Useful Minor Flaw                                    | +1       | Busybody, Faerie Friend, Magical Animal Companion, Mentor                                  |
-| Has more than three resources in this list           | +6       |                                                                                            |
-| Has more than six resources in this list             | +9       |                                                                                            |
-
-#### Minimum
-
-A potential agent's Resistance cannot be less than 1.
-
-#### Examples
-
-Aelfric, as an Outlaw Leader with a half-dozen underlings, has a Resistance Strength of 0. Godfroi is a Merchant, costing 0 points, so his Temporal Influence makes his Resistance Strength +1.
-
-An agent might die, but his brother or son might seek the same deal with his principal.
-
-• Depending upon how these stories are resolved, the Bond Strength of the agent involved might decline by one or more points, and should a Bond Strength decline below zero, the agent ceases to work for the principal. Bond Strengths can only
-
-
-
-### Modifiers to Persuasion Roll Ease Factors
-
-| Timeframe                                                                           | Modifer  |                                                      |
-|-------------------------------------------------------------------------------------|----------|------------------------------------------------------|
-| Within a few weeks                                                                  | +0       |                                                      |
-| Within a few days                                                                   | +1       |                                                      |
-| Within a day                                                                        | +3       |                                                      |
-| Personal Risk                                                                       | Modifier | Example                                              |
-| No risk to self (simple die)                                                        | +0       | Deliver a package to a<br>merchant                   |
-| Risk of embarrassment or reputation<br>(attempt requires a stress die, 1 botch die) | +1       | Deliver a prostitute to a<br>merchant                |
-| Risk of injury or imprisonment (attempt<br>requires a stress die, 3 botch dice)     | +3       | Deliver a threat to a rich<br>merchant               |
-| Risk of death (attempt requires a stress die,<br>5 botch dice)                      | +6       | Deliver a threat to the<br>bishop, in his own palace |
-
-increase through active participation of the principal, and there are two main methods: favors and money.
+- An agent who is regularly pressed for sensitive information may acquire a reputation as a snitch, which will reduce his overall effectiveness.
+- An agent recruited through blackmail might call the bluff of a principal.
+- An agent might be accused of a crime that will result in his death if he is found guilty.
+- Depending upon how these stories are resolved, the Bond Strength of the agent involved might decline by one or more points, and should a Bond Strength decline below zero, the agent ceases to work for the principal. Bond Strengths can only increase through active participation of the principal, and there are two main methods: favors and money.
 
 **Favors** are an effective way of cultivating an agent and increasing his Bond Strength. The player of the principal must conceive a way in which her character can assist the agent, perhaps with advice from the storyguide. Once the story has been played out, the storyguide awards Adventure experience points in the usual fashion, and an equal number of agency experience points are applied directly to the strength of the Bond, using the same progression as Arts on the Advancement Table (ArM5, page 31). Such stories can focus heavily on one character, so the storyguide may wish to conduct these stories separately from the main game night, or involve the other players as antagonists (or even protagonists).
 
-*Example: Bandits are regularly stealing Godfroi's supplies, so Carolus uses mind-reading spells to find out which of the merchant's employees*
-
-### The Other Side of the Coin
-
-It is possible for a player character to be an agent rather than a principal. This usually entails the Favors Story Flaw, but a Mentor may also consider your character to be part of his agency. Your character's principal or his factor will contact your character on an irregular basis and request information or assistance. You should consider what hold the principal has over your character, and what the consequences are of refusing to help him.
-
-*has been selling the caravan's routes to the bandits, and then arranges an ambush. This earns the magus three Adventure experience points. The magus spends the three points normally, but the ruthless manner in which he dealt with the issue has also earned three agency experience points toward Godfroi's Bond Strength, which is enough to raise his Fear (Carolus) +2 to +3.*
+*Example: Bandits are regularly stealing Godfroi's supplies, so Carolus uses mind-reading spells to find out which of the merchant's employees has been selling the caravan's routes to the bandits, and then arranges an ambush. This earns the magus three Adventure experience points. The magus spends the three points normally, but the ruthless manner in which he dealt with the issue has also earned three agency experience points toward Godfroi's Bond Strength, which is enough to raise his Fear (Carolus) +2 to +3.*
 
 **Money** can be used to increase the Bond Strength of an agent, but agents are not generally employees, and only so much loyalty can be bought. To certain types of agents, this might seem suspiciously like bribery, and a principal must tread lightly if he has such individuals as part of his agency. One Mythic Pound's worth of material goods can take the place of 5 agency experience points (or 4 shillings per point) without need for a story. The exchange rate of money for agency points may vary according to the wealth of the agent: for example, hard cash might be twice as effective for an impoverished agent, but half as effective for a rich one. However, Bond Strength can never rise above +3 by the application of money. If using the Wealth and Poverty rules from *Covenants* (see Chapter 5: Wealth and Poverty), a troupe may wish to impose a regular minor upkeep cost for agents; it is suggested that 10 points of Bond Strength divided between one or more agents incur the same cost to maintain as a single nonspecialist servant of the covenant.
 
+> ### The Other Side of the Coin
+> 
+> It is possible for a player character to be an agent rather than a principal. This usually entails the Favors Story Flaw, but a Mentor may also consider your character to be part of his agency. Your character's principal or his factor will contact your character on an irregular basis and request information or assistance. You should consider what hold the principal has over your character, and what the consequences are of refusing to help him.
+
+> ## Resistance of Agents Table
+> 
+> | Social Status | Resistance | Examples |
+> |---------------|:----------:|----------|
+> | Major Social Virtue | 3 | Landed Noble\*, Magister et Artibus, Redcap |
+> | Minor Social Virtue | 1 | Clerk, Custos, Failed Apprentice, Gentleman/woman, Knight, Mendicant Friar, Mercenary Captain\*, Priest, Wise One |
+> | Free Social Virtue (except Hermetic Magus) | 0 | Covenfolk, Craftsman, Merchant, Peasant, Wanderer |
+> | Minor Social Status Flaws | –1 | Branded Criminal, Outcast, Outlaw Leader\* |
+> | Major Social Status Flaws | –3 | Outlaw, Outsider |
+> 
+> \* Must also take useful underlings, below
+> 
+> #### Modifiers
+> 
+> *The agent is easily suborned if he has . . .*
+> 
+> | Circumstance | Modifier | Examples |
+> |--------------|:--------:|----------|
+> | Major Flaws likely to inconvenience principal | –3 | Enemies, Feud, Lycanthrope, Plagued by Supernatural Entity |
+> | Minor Flaws likely to inconvenience principal | –1 | Black Sheep, Dark Secret, Dependant, Diabolic Past, Favors, Infamous |
+> | Minor Flaw used by the player character to dominate agent | –6\* | Principal has hostage (Dependent or True Love), is blackmailing using Dark Secret, Diabolic Past, or other leverage (Blackmail) |
+> 
+> \*Agent hates principal, which inflicts Difficult Underlings Flaw for this agent only
+> 
+> #### Resources
+> 
+> | Resource | Modifier | Examples |
+> |----------|:--------:|----------|
+> | Extraordinary skill: Main Ability score is 6 or more | +1 | |
+> | Exceptional skill: Main ability score 8 or more | +3 | |
+> | Minor General or Supernatural Virtue | +1 | Gossip, Magic Sensitivity, Protection, Skinchanger, Social Contacts, Temporal Influence |
+> | Major General or Supernatural Virtue | +3 | Entrancement, True Faith, Wealthy |
+> | Serves Rival Covenant | +9 | |
+> | Underlings | +1 | Up to a half-dozen people, including agents and hirelings |
+> | Many Underlings | +3 | Up to two dozen people, including agents and hirelings |
+> | Useful Minor Flaw | +1 | Busybody, Faerie Friend, Magical Animal Companion, Mentor |
+> | Has more than three resources in this list | +6 | |
+> | Has more than six resources in this list | +9 | |
+> 
+> #### Minimum
+> 
+> A potential agent's Resistance cannot be less than 1.
+> 
+> #### Examples
+> 
+> Aelfric, as an Outlaw Leader with a half-dozen underlings, has a Resistance Strength of 0. Godfroi is a Merchant, costing 0 points, so his Temporal Influence makes his Resistance Strength +1.
+> 
+> An agent might die, but his brother or son might seek the same deal with his principal.
+
+> ## Tasks for Agents
+> 
+> | Task | Ease Factor for Persuasion Roll | Example |
+> |------|:-------------------------------:|---------|
+> | Provide common information, which is easily obtained | 3 | Relay what the gossips are saying about yesterday’s events in the town square |
+> | Provide sensitive information, which is difficult to obtain | 6 | Discover the address of the bishop’s mistress |
+> | Provide secret information, known to a select few | 9 | Uncover which other nobles are members of the duke’s diabolic cabal |
+> | Perform an Easy task (Ease Factor 6) | 3 | Persuade a merchant to give passage to a magus with The Blatant Gift |
+> | Perform a Hard task (Ease Factor 12) | 6 | Steal a ring from a lady’s finger |
+> | Perform an Impressive task (Ease Factor 18) | 9 | Arrange a fatal accident for the prince |
+
+> ## Modifiers to Persuasion Roll Ease Factors
+> 
+> | Timeframe         | Modifier |
+> |-------------------|:--------:|
+> | Within a few weeks | +0 |
+> | Within a few days  | +1 |
+> | Within a day       | +3 |                                                   |
+> 
+> | Personal Risk | Modifier | Example |
+> |---------------|:--------:|---------|
+> | No risk to self (simple die) | +0 | Deliver a package to a merchant |
+> | Risk of embarrassment or reputation (attempt requires a stress die, 1 botch die) | +1 | Deliver a prostitute to a merchant |
+> | Risk of injury or imprisonment (attempt requires a stress die, 3 botch dice) | +3 | Deliver a threat to a rich merchant |
+> | Risk of death (attempt requires a stress die, 5 botch dice) | +6 | Deliver a threat to the bishop, in his own palace |


### PR DESCRIPTION
This PR adds and cleans up the Markdown version of *Houses of Hermes: Societates*.

Main work included:

* reconstruction and normalization of the table of contents
* cleanup of OCR issues and formatting inconsistencies across the text
* reconstruction and normalization of multiple tables (some was missing)
* inclusion of official errata
* general Markdown cleanup for readability and project consistency