### PR TITLE
Ars Magica 5e - Houses of Hermes - True Lineages

### DIFF
--- a/wip/Ars Magica 5e - Houses of Hermes - True Lineages.md
+++ b/wip/Ars Magica 5e - Houses of Hermes - True Lineages.md
@@ -1,18 +1,31 @@
+# Houses of Hermes: True Lineages
+A sourcebook for Ars Magica 5th Edition.
 
+> *Open License Markdown version by applejuice1965 & OriginalMadman, https://github.com/OriginalMadman/Ars-Magica-Open-License*
+> 
+> *[Completion state: Text manually fixed, all official Errata included.]*
+> 
+> *Based on the material for Ars Magica, ©1993–2024,  licensed by Trident, Inc. d/b/a Atlas Games®, under [Creative Commons Attribution-ShareAlike 4.0 International license 4.0](https://creativecommons.org/licenses/by-sa/4.0/) ("CC-BY-SA 4.0"). Order of Hermes, Tremere, Doissetep, and Grimgroth are trademarks of Paradox Interactive AB and are used with permission.*
 
-**AUTHORS:** Erik Dahl (Mercere), Timothy Ferguson (Tremere), Matt Ryan (Bonisagus), David Woods (Guernicus)
+The True Lineages are the backbone of the Order of Hermes. In these four Hermetic Houses, each magus was taught by a magus of the House, and that master-apprentice relationship goes back to the founders. This sourcebook details the four True Lineages, including rules for original research, unique forms of magic, and new Virtues and Flaws.
 
-**EDITING AND PROJECT MANAGEMENT:** David Chart **COVER ILLUSTRATION:** Grey Thornberry
+**House Bonisagus** descends from the two magi who created the Order, and continues to supply knowledge and leadership. They explore the theoretical applications of magic, delving deeper into its arcane secrets. And they advocate peace and cooperation among the Houses, searching for other wizards who might contribute to the community of magi. **House Guernicus** upholds and enforces the Code of Hermes as the official judges and investigators of the Order. Its Quaesitores believe they stand against the wheel of fate, slowing it as best they can. By the efforts of its magi, the basic structures of Hermetic society have remained intact for over four hundred years. **House Mercere** holds the magi of Mythic Europe together by facilitating communication, encouraging trade, and aiding their sodales. Its heralds, heroes, mercenaries, and merchants reflect the contractictions of their House: it is exotic, but traditional; loyal, but self-centered; proud, but humble. **House Tremere** provides the strength of the Order. It controls events and prepares for coming battles, gathering influence and resources to respond to crises as they draw near. Tremere are pragmatic, dutiful, and courageous magi who know that Mythic Europe is a chaotic and dangerous place.
 
-**INTERIOR ILLUSTRATIONS:** O. Brausewetter, Alphonse de Neuville, Kelly Hensing, J. F. Horrabin, Tyler Jenkins, William Maskell, Jeff Menges, Howard Pyle, Dom Reardon
+These are the True Lineages. Without them all, the Order of Hermes would surely fall.
 
-**ART COORDINATION, LAYOUT AND PROOFREADING:** John Nephew
+**Authors:** Erik Dahl (Mercere), Timothy Ferguson (Tremere), Matt Ryan (Bonisagus), David Woods (Guernicus)
 
-**5TH EDITION TRADE DRESS:** J. Scott Reeves
+**Editing and Project Management:** David Chart **COVER ILLUSTRATION:** Grey Thornberry
 
-**PLAYTESTERS:** Chris Jensen-Romer, Peter Hiley, Kevin Sides, Luke Price, Lloyd Graney; Erik Dahl, Jerry Braverman, Kim Braverman, Thomas L. Scott; Samuel Bidal, Anne-Gaëlle Darmont, Jérôme Darmont, Gilles Marcvincent, Miguel Peca, Didier Rabour; Alexander Bader, Tanja Bader, Stefan Ehret, MaPhi Werner; Matthew L. Seidl, Soraya Ghiasi; Camo Coffey, Roddy Hale, Mark Shirley, Andrew Smith, Andrew Walton; Neil Taylor, Sheila Thomas
+**Interior Illustrations:** O. Brausewetter, Alphonse de Neuville, Kelly Hensing, J. F. Horrabin, Tyler Jenkins, William Maskell, Jeff Menges, Howard Pyle, Dom Reardon
 
-**PUBLISHER'S SPECIAL THANKS:** Jerry Corrick and the gang at the Source
+**Art Coordination, Layout and Proofreading:** John Nephew
+
+**5Th Edition Trade Dress:** J. Scott Reeves
+
+**Playtesters:** Chris Jensen-Romer, Peter Hiley, Kevin Sides, Luke Price, Lloyd Graney; Erik Dahl, Jerry Braverman, Kim Braverman, Thomas L. Scott; Samuel Bidal, Anne-Gaëlle Darmont, Jérôme Darmont, Gilles Marcvincent, Miguel Peca, Didier Rabour; Alexander Bader, Tanja Bader, Stefan Ehret, MaPhi Werner; Matthew L. Seidl, Soraya Ghiasi; Camo Coffey, Roddy Hale, Mark Shirley, Andrew Smith, Andrew Walton; Neil Taylor, Sheila Thomas
+
+**Publisher'S Special Thanks:** Jerry Corrick and the gang at the Source
 
 ### About the Authors
 
@@ -41,182 +54,166 @@ October 2005
 
 **Digital Edition Version 1.0**
 
+# Table of Contents
 
-### Table of
+**Chapter One: House Bonisagus**<br>
+&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;Famous Figures<br>
+&emsp;History<br>
+&emsp;&emsp;The Founder Bonisagus<br>
+&emsp;&emsp;The Founder Trianoma<br>
+&emsp;&emsp;The Formative Years<br>
+&emsp;&emsp;The Founders' End<br>
+&emsp;&emsp;The Schism War<br>
+&emsp;House Organization in 1220<br>
+&emsp;&emsp;The Gender of the Lineages<br>
+&emsp;&emsp;House Nomenclature<br>
+&emsp;&emsp;The Ranks of Magi Bonisagi<br>
+&emsp;&emsp;The Inner Circles<br>
+&emsp;&emsp;Colentes Arcanorum<br>
+&emsp;&emsp;Tenentes Occultorum<br>
+&emsp;&emsp;Colloquium Delectorum<br>
+&emsp;&emsp;Primus<br>
+&emsp;&emsp;Seekers<br>
+&emsp;The Magi of House Bonisagus<br>
+&emsp;&emsp;Common Virtues and Flaws<br>
+&emsp;&emsp;Apprentices<br>
+&emsp;&emsp;Magi Bonisagi<br>
+&emsp;&emsp;Magi Trianomae<br>
+&emsp;House Utilities<br>
+&emsp;&emsp;House Acclaim<br>
+&emsp;&emsp;Folios<br>
+&emsp;&emsp;Intrigue<br>
+&emsp;&emsp;New Virtues and Flaws<br>
+&emsp;Original Research<br>
+&emsp;Example Discoveries<br>
+&emsp;&emsp;Arma Magica<br>
+&emsp;&emsp;Parmulae<br>
+&emsp;&emsp;Figurine Magic<br>
+&emsp;&emsp;Realm-Aligned Spells<br>
+<br>
+**Chapter Two: House Guernicus**<br>
+&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;Famous Figures<br>
+&emsp;&emsp;Chapter Structure<br>
+&emsp;History<br>
+&emsp;&emsp;Before the Order<br>
+&emsp;&emsp;The Order Forms<br>
+&emsp;&emsp;The Quaesitores<br>
+&emsp;&emsp;The Life of Guernicus<br>
+&emsp;&emsp;Fenicil<br>
+&emsp;&emsp;Duresca Scrolls<br>
+&emsp;&emsp;Schism War<br>
+&emsp;&emsp;Traditionalists/Transitionalist<br>
+&emsp;Organization<br>
+&emsp;&emsp;Population<br>
+&emsp;&emsp;Domus Magna<br>
+&emsp;&emsp;Prima<br>
+&emsp;&emsp;The Magvillus Council<br>
+&emsp;&emsp;Assignments<br>
+&emsp;The Code of Hermes<br>
+&emsp;&emsp;Origins<br>
+&emsp;&emsp;Forfeit Immunity<br>
+&emsp;&emsp;The Hermetic Oath<br>
+&emsp;&emsp;High and Low Crimes<br>
+&emsp;&emsp;The Peripheral Code<br>
+&emsp;Tribunal Procedures<br>
+&emsp;&emsp;Preparing a Case<br>
+&emsp;&emsp;Presenting the Case<br>
+&emsp;&emsp;Acquittal<br>
+&emsp;&emsp;Conviction<br>
+&emsp;Penalties<br>
+&emsp;&emsp;Determining Penalties<br>
+&emsp;&emsp;Wizard's March<br>
+&emsp;&emsp;Punishments<br>
+&emsp;Quaesitorial Duties and Powers<br>
+&emsp;&emsp;Quaesitor in Good Standing<br>
+&emsp;&emsp;Investigation Duties<br>
+&emsp;&emsp;Cooperation<br>
+&emsp;&emsp;Investigation Immunity<br>
+&emsp;&emsp;Compensation<br>
+&emsp;&emsp;Calling a Wizard's March<br>
+&emsp;&emsp;Consultation and Arbitration<br>
+&emsp;&emsp;Tribunal Duties<br>
+&emsp;Guernicus Magi<br>
+&emsp;&emsp;Apprentices<br>
+&emsp;&emsp;Playing a Guernicus Magus<br>
+&emsp;&emsp;Being a Quaesitor<br>
+&emsp;&emsp;Being a Hoplite<br>
+&emsp;&emsp;Being an Advocate<br>
+&emsp;&emsp;Being a Magical Investigation Specialist<br>
+&emsp;&emsp;Being a Terrae-Magus<br>
+&emsp;&emsp;Guernicus Politics and Advancement<br>
+&emsp;Running Stories for a Quaesitor<br>
+&emsp;Allies<br>
+&emsp;&emsp;Hoplites<br>
+&emsp;&emsp;Redcaps<br>
+&emsp;&emsp;Custos<br>
+&emsp;Quaesitorial Magic<br>
+&emsp;&emsp;Acute Sense<br>
+&emsp;&emsp;Spell Traces and Sigils<br>
+&emsp;&emsp;Spells and Guidelines<br>
+&emsp;Fenicil's Rituals<br>
+&emsp;&emsp;Greater Rituals<br>
+&emsp;&emsp;Lesser Rituals<br>
+<br>
+**Chapter Three: House Mercere**<br>
+&emsp;Mercere the Founder<br>
+&emsp;Redcaps<br>
+&emsp;&emsp;Messengers and Heralds<br>
+&emsp;&emsp;Merchants and Bankers<br>
+&emsp;&emsp;Mercenaries and Guardians<br>
+&emsp;&emsp;Minstrels and Wanderers<br>
+&emsp;Magical Merceres<br>
+&emsp;&emsp;Mercurian Magi<br>
+&emsp;&emsp;Mutantes<br>
+&emsp;&emsp;Other Specialties<br>
+&emsp;Laboratory Rules<br>
+&emsp;&emsp;Mastered Spell Special Abilities<br>
+&emsp;&emsp;Mercere's Portals<br>
+&emsp;Magic Rules<br>
+&emsp;&emsp;Mutantum Magic<br>
+&emsp;Spells<br>
+&emsp;&emsp;Mutantum Spells<br>
+&emsp;&emsp;Other Spells<br>
+&emsp;Virtues and Flaws<br>
+&emsp;&emsp;Virtues<br>
+&emsp;&emsp;Flaws<br>
+<br>
+**Chapter Four: House Tremere**<br>
+&emsp;&emsp;Key Facts<br>
+&emsp;&emsp;Famous Figures<br>
+&emsp;Symbols<br>
+&emsp;History<br>
+&emsp;&emsp;Before the Order<br>
+&emsp;&emsp;The Final Founder<br>
+&emsp;&emsp;The House After Tremere<br>
+&emsp;&emsp;Mortal Affairs<br>
+&emsp;&emsp;Coeris<br>
+&emsp;The House in 1220<br>
+&emsp;&emsp;Pragmatic Attitude<br>
+&emsp;&emsp;Military Ethos<br>
+&emsp;&emsp;Reverence for Order<br>
+&emsp;&emsp;Extent<br>
+&emsp;&emsp;Political Priorities<br>
+&emsp;Structure<br>
+&emsp;&emsp;Vexillations<br>
+&emsp;Promotion by Force<br>
+&emsp;Designing Magi of House Tremere<br>
+&emsp;&emsp;Arts and Spells<br>
+&emsp;&emsp;Virtues and Flaws<br>
+&emsp;&emsp;Abilities<br>
+&emsp;&emsp;Magical Items Popular in the House<br>
+&emsp;&emsp;Specialist Roles<br>
+&emsp;Dueling<br>
+&emsp;&emsp;Styles of Certamen<br>
+&emsp;New Spells<br>
+&emsp;Shape and Material Bonus Table Additions<br>
+&emsp;New Virtues<br>
+<br>
+**Timeline**<br>
 
-# Contents
-
-| House Bonisagus4                  |  |
-|-----------------------------------|--|
-| Key Facts5                        |  |
-| Famous Figures5                   |  |
-| History4                          |  |
-| The Founder Bonisagus4            |  |
-| The Founder Trianoma6             |  |
-| The Formative Years7              |  |
-| The Founders' End8                |  |
-| The Schism War9                   |  |
-| House Organization in 12209       |  |
-| The Gender of the Lineages10      |  |
-| House Nomenclature10              |  |
-| The Ranks of Magi Bonisagi10      |  |
-| The Inner Circles10               |  |
-| Colentes Arcanorum10              |  |
-| Tenentes Occultorum12             |  |
-| Colloquium Delectorum13           |  |
-| Primus13                          |  |
-| Seekers15                         |  |
-| The Magi of House Bonisagus16     |  |
-| Common Virtues and Flaws16        |  |
-| Apprentices16                     |  |
-| Magi Bonisagi18                   |  |
-| Magi Trianomae20                  |  |
-| House Utilities21                 |  |
-| House Acclaim21                   |  |
-| Folios22                          |  |
-| Intrigue24                        |  |
-| New Virtues and Flaws25           |  |
-| Original Research26               |  |
-| Example Discoveries30             |  |
-| Arma Magica30                     |  |
-| Parmulae32                        |  |
-| Figurine Magic33                  |  |
-| Realm-Aligned Spells34            |  |
-|                                   |  |
-| House Guernicus35                 |  |
-|                                   |  |
-| Key Facts36                       |  |
-| Famous Figures36                  |  |
-| Chapter Structure35               |  |
-| History36                         |  |
-| Before the Order37                |  |
-| The Order Forms37                 |  |
-| The Quaesitores38                 |  |
-| The Life of Guernicus38           |  |
-| Fenicil39                         |  |
-| Duresca Scrolls40                 |  |
-| Schism War40                      |  |
-| Traditionalists/Transitionalist41 |  |
-| Organization42                    |  |
-| Population42                      |  |
-| Domus Magna43                     |  |
-
-| Prima43                                      |  |
-|----------------------------------------------|--|
-| The Magvillus Council44                      |  |
-| Assignments44                                |  |
-| The Code of Hermes45                         |  |
-| Origins45                                    |  |
-| Forfeit Immunity45                           |  |
-| The Hermetic Oath46                          |  |
-| High and Low Crimes46                        |  |
-| The Peripheral Code54                        |  |
-| Tribunal Procedures56                        |  |
-| Preparing a Case56                           |  |
-| Presenting the Case57                        |  |
-| Acquittal58                                  |  |
-| Conviction58                                 |  |
-| Penalties59                                  |  |
-| Determining Penalties59                      |  |
-| Wizard's March60                             |  |
-| Punishments60                                |  |
-| Quaesitorial Duties and Powers61             |  |
-| Quaesitor in Good Standing61                 |  |
-| Investigation Duties62                       |  |
-| Cooperation62                                |  |
-| Investigation Immunity62                     |  |
-| Compensation63                               |  |
-| Calling a Wizard's March63                   |  |
-| Consultation and Arbitration63               |  |
-| Tribunal Duties64                            |  |
-| Guernicus Magi66                             |  |
-| Apprentices66                                |  |
-| Playing a Guernicus Magus66                  |  |
-| Being a Quaesitor67                          |  |
-| Being a Hoplite67                            |  |
-| Being an Advocate67                          |  |
-| Being a Magical Investigation Specialist .67 |  |
-| Being a Terrae-Magus68                       |  |
-| Guernicus Politics and Advancement68         |  |
-| Running Stories for a Quaesitor69            |  |
-| Allies70                                     |  |
-| Hoplites70                                   |  |
-| Redcaps70                                    |  |
-| Custos70                                     |  |
-| Quaesitorial Magic70                         |  |
-| Acute Sense71                                |  |
-| Spell Traces and Sigils71                    |  |
-| Spells and Guidelines72                      |  |
-| Fenicil's Rituals76                          |  |
-| Greater Rituals76                            |  |
-| Lesser Rituals77                             |  |
-|                                              |  |
-| House Mercere78                              |  |
-| Mercere the Founder78                        |  |
-| Redcaps81                                    |  |
-|                                              |  |
-
-| Merchants and Bankers84                     |  |
-|---------------------------------------------|--|
-| Mercenaries and Guardians89                 |  |
-| Minstrels and Wanderers91                   |  |
-| Magical Merceres94                          |  |
-| Mercurian Magi95                            |  |
-| Mutantes96                                  |  |
-| Other Specialties98                         |  |
-|                                             |  |
-| Laboratory Rules99                          |  |
-| Mastered Spell Special Abilities99          |  |
-| Mercere's Portals100                        |  |
-| Magic Rules101                              |  |
-| Mutantum Magic101                           |  |
-| Spells101                                   |  |
-| Mutantum Spells101                          |  |
-| Other Spells103                             |  |
-| Virtues and Flaws103                        |  |
-| Virtues104                                  |  |
-| Flaws108                                    |  |
-|                                             |  |
-| House Tremere110                            |  |
-|                                             |  |
-| Key Facts110                                |  |
-| Famous Figures110                           |  |
-| Symbols110                                  |  |
-| History112                                  |  |
-| Before the Order112                         |  |
-| The Final Founder112                        |  |
-| The House After Tremere113                  |  |
-| Mortal Affairs114                           |  |
-| Coeris115                                   |  |
-| The House in 1220116                        |  |
-| Pragmatic Attitude116                       |  |
-| Military Ethos116                           |  |
-| Reverence for Order116                      |  |
-| Extent116                                   |  |
-| Political Priorities117                     |  |
-| Structure118                                |  |
-| Vexillations121                             |  |
-| Promotion by Force123                       |  |
-| Designing Magi of House Tremere125          |  |
-| Arts and Spells125                          |  |
-| Virtues and Flaws131                        |  |
-| Abilities131                                |  |
-|                                             |  |
-| Magical Items Popular in the House132       |  |
-| Specialist Roles132                         |  |
-| Dueling134                                  |  |
-| Styles of Certamen135                       |  |
-| New spells139                               |  |
-| Shape and Material Bonus Table Additions139 |  |
-| New Virtues141                              |  |
-| Timeline144                                 |  |
-
-
-Messengers and Heralds..........................82
-
-### Chapter One
-
-# House Bonisagus
+# Chapter One: House Bonisagus
 
 *"Brothers and Sisters, I bring you the potion that will cure our sorrows and bind our wounds. No longer need we conspire against each other; for now we stand together on the common ground that this knowledge has provided, and we can make peace. May all of you and all your filii use what I will teach you wisely."*
 
@@ -232,49 +229,39 @@ founders. Members of the House maintain the goals of the original pair. Magi Bon
 
 Throughout history wizards have aspired to the same goal: to understand nature's secrets and gain power over them. The magi of House Bonisagus have similar aspirations; the differences are their community orientation and the firm idea that only peace offers the stability necessary for such discoveries. Of all the Hermetic Houses, House Bonisagus is most pleased with the Order of Hermes, finding it a safe community that allows for their personal goals. No one has ever heard a magus Bonisagi gainsay the Order.
 
-The following pages detail House Bonisagus, beginning with its Founders and its history before explaining the House's organization in the thirteenth century. This section also includes information about the Seekers, an informal group of magi exploring the mystical past, who
-
-> search out legendary and magical sites. Details for the magi of the House follow, beginning with apprentices before explaining the two branches of the House. The House Utilities section contains two systems exclusive to House Bonisagus, House Acclaim and folios, as well as more information on the social skill Intrigue. This section ends with new Virtues and Flaws applicable to House Bonisagus magi. Rules for original research are next, useful for any magus character, followed by example
-
-Hermetic discoveries.
-
+The following pages detail House Bonisagus, beginning with its Founders and its history before explaining the House's organization in the thirteenth century. This section also includes information about the Seekers, an informal group of magi exploring the mystical past, who search out legendary and magical sites. Details for the magi of the House follow, beginning with apprentices before explaining the two branches of the House. The House Utilities section contains two systems exclusive to House Bonisagus, House Acclaim and folios, as well as more information on the social skill Intrigue. This section ends with new Virtues and Flaws applicable to House Bonisagus magi. Rules for original research are next, useful for any magus character, followed by example Hermetic discoveries.
 
 ## History
 
 ### The Founder Bonisagus
 
-Bonisagus was born in Florence in 690. Unsettled by his potent Gift, his parents sent him to live with his uncle, a deacon in the church Or San Michele, hoping that his soothing presence might cure the boy. His uncle realized
+Bonisagus was born in Florence in 690. Unsettled by his potent Gift, his parents sent him to live with his uncle, a deacon in the church Or San Michele, hoping that his soothing presence might cure the boy. His uncle realized Bonisagus's nature, and instead of suppressing the boy's inclinations, encouraged them. Outspoken and charismatic, Bonisagus spent his early years reading through his uncle's library and listening to the wandering speakers who preached from the steps of the church.
 
-
-
-
-### Key Facts
-
-**Population:** 81 (52 magi Bonisagi, 29 magi Trianomae)
-
-**Domus Magna:** Durenmar in the Rhine tribunal.
-
-**Prima:** The archmage Murion. An unscrupulous schemer and staunch conservative, Murion leads the House along an ambitious path that will, if successful, re-establish House Bonisagus's power among the Houses.
-
-**Favored Tribunals:** The Rhine and Roman Tribunals, followed by the Iberian and Provencal.
-
-### Famous Figures
-
-**Bonisagus,** inventor of the Parma Magica and Hermetic magic theory, Founder of the House.
-
-**Trianoma,** visionary responsible for the Order of Hermes, Founder of the House.
-
-**Lucian,** Trianoma's first apprentice, the first Seeker **Viea,** Trianoma's twin, enemy of the Order.
-
-**Notatus,** first Primus, apprentice of Bonisagus, inventor of the *Aegis of the Hearth.*
-
-**Thamus Collis,** Primus during the Schism War. **Jovius,** last apprentice of Bonisagus, Marched by his parens.
-
-### Durenmar: Domus Magna
-
-The domus magna of House Bonisagus is Durenmar, located in the Black Forest in the Holy Roman Empire (modern day Germany). Built on the ruins of a Mercurian temple, it is the site where the Twelve Founders swore allegiance to the Order of Hermes in 767. It consists of three towers, a forum and several outlying buildings standing in one of the forest's few valleys. The three towers are named after the three most important magi of House Bonisagus. The Tower of Bonisagus houses the Great Library, an unequaled collection of books. The Tower of Notatus contains the living quarters of the resident magi Bonisagi, including the Prima Murion. The Tower of Trianoma is home to the magi Trianomae, Redcaps, and other magi not of House Bonisagus. The Forum of Hermes is where the Rhine Tribunal meetings and the Grand Tribunals are held. Much more information about Durenmar can be found in *Guardians of the Forests: The Rhine Tribunal*.
-
-Bonisagus's nature, and instead of suppressing the boy's inclinations, encouraged them. Outspoken and charismatic, Bonisagus spent his early years reading through his uncle's library and listening to the wandering speakers who preached from the steps of the church.
+> ## Key Facts
+> 
+> **Population:** 81 (52 magi Bonisagi, 29 magi Trianomae)
+> 
+> **Domus Magna:** Durenmar in the Rhine tribunal.
+> 
+> **Prima:** The archmage Murion. An unscrupulous schemer and staunch conservative, Murion leads the House along an ambitious path that will, if successful, re-establish House Bonisagus's power among the Houses.
+> 
+> **Favored Tribunals:** The Rhine and Roman Tribunals, followed by the Iberian and Provencal.
+> 
+> ## Famous Figures
+> 
+> **Bonisagus,** inventor of the Parma Magica and Hermetic magic theory, Founder of the House.
+> 
+> **Trianoma,** visionary responsible for the Order of Hermes, Founder of the House.
+> 
+> **Lucian,** Trianoma's first apprentice, the first Seeker **Viea,** Trianoma's twin, enemy of the Order.
+> 
+> **Notatus,** first Primus, apprentice of Bonisagus, inventor of the *Aegis of the Hearth.*
+> 
+> **Thamus Collis,** Primus during the Schism War. **Jovius,** last apprentice of Bonisagus, Marched by his parens.
+> 
+> ## Durenmar: Domus Magna
+> 
+> The domus magna of House Bonisagus is Durenmar, located in the Black Forest in the Holy Roman Empire (modern day Germany). Built on the ruins of a Mercurian temple, it is the site where the Twelve Founders swore allegiance to the Order of Hermes in 767. It consists of three towers, a forum and several outlying buildings standing in one of the forest's few valleys. The three towers are named after the three most important magi of House Bonisagus. The Tower of Bonisagus houses the Great Library, an unequaled collection of books. The Tower of Notatus contains the living quarters of the resident magi Bonisagi, including the Prima Murion. The Tower of Trianoma is home to the magi Trianomae, Redcaps, and other magi not of House Bonisagus. The Forum of Hermes is where the Rhine Tribunal meetings and the Grand Tribunals are held. Much more information about Durenmar can be found in *Guardians of the Forests: The Rhine Tribunal*.
 
 Florence was governed by the Lombards, an invading Germanic tribe, notorious for killing outcasts, indigents, and anyone they felt threatened by. Fearing that Bonisagus might draw such attention, his uncle took him to Iozheza, a wizard living in the Florentine countryside. Iozheza was a conjurer of considerable skill. He searched for other wizards, greedy for their magical secrets and willing to kill for them. He readily accepted Bonisagus and taught him his first spells. The pair explored the Italian coasts, hunting through the rubble of the Roman Empire for remnants of the lost Cults of Mercury, Dionysus, and Mithras. Bonisagus bore grim witness to several of Iozheza's evil acts.
 
@@ -284,12 +271,7 @@ Bonisagus continued the search for lost cults and isolated magi. Rather than spe
 
 Teaching himself some of the minor rituals, he discovered commonalities with his own spells, those of the cult of Osiris and others from the temple of Diana. He believed he could create a system of magic that would encompass all of theses types of magic. Funded by his uncle, Bonisagus began a passionate search for more magical texts, roaming the Aegean basin and deep into Persia to retrieve many legendary tomes and magical papyri. His early library was immense, including memoirs of Cappadocian wizards, the secret lore of the Chaldeans, Gnostic, Christian, and Jewish mysteries, and even the magical writings of Moses and Solomon.
 
-Bonisagus also discovered many powerful magi during his travels. His first few meetings were disastrous and
-
-
-
-
-one encounter nearly killed him. Paradoxically, this same magus would later become one of the Twelve Founders. Bonisagus decided to invent some form of magical resistance to protect him. His efforts were delayed by robbers, who stole a satchel full of his books on his return trip to Rome. Bonisagus followed them to their secret lair, a cave in the Southern Alps, and retrieved his property. Chasing the thieves away, Bonisagus realized that the cave had been a shrine to Hermes before becoming the bandits' lair. He thought it an ideal place for his research, being both private and maintaining a magical aura. Within a year he had installed his library and laboratory. He began the duel task of formulating a universal magic theory and creating some type of magic resistance. He was not heard from again for ten years.
+Bonisagus also discovered many powerful magi during his travels. His first few meetings were disastrous and one encounter nearly killed him. Paradoxically, this same magus would later become one of the Twelve Founders. Bonisagus decided to invent some form of magical resistance to protect him. His efforts were delayed by robbers, who stole a satchel full of his books on his return trip to Rome. Bonisagus followed them to their secret lair, a cave in the Southern Alps, and retrieved his property. Chasing the thieves away, Bonisagus realized that the cave had been a shrine to Hermes before becoming the bandits' lair. He thought it an ideal place for his research, being both private and maintaining a magical aura. Within a year he had installed his library and laboratory. He began the duel task of formulating a universal magic theory and creating some type of magic resistance. He was not heard from again for ten years.
 
 ### The Founder Trianoma
 
@@ -299,22 +281,19 @@ One night Trianoma dreamt a terrible nightmare. She and her sister had been figh
 
 A year later Trianoma and her sister found Bonisagus's hide-away. Following Viea's advice, the sisters immediately attacked, their long hair loosed and woven with poisonous snakes. Trianoma's incantations and Viea's enchanted arrows failed to pierce Bonisagus's magical protection, and the magus easily defeated the sisters. Bonisagus imprisoned the women, threatening them with slavery if they did not teach him their song-magic. Viea balked at the offer but Trianoma craftily agreed.
 
-### Story Seed: Legends of the Founder
-
-Many legends surround Bonisagus and Trianoma, and these are only a few of the fantastic stories attributed to the pair. Investigating these legends would make excellent adventures.
-
-Some find it oddly coincidental that Bonisagus's Aventine Hill home in Rome was located so close to the well that contained several lost Mercurian spells. One legend proposes that Bonisagus's uncle left the spells there for his curious nephew to find. The story goes that he was following the command of Pope Gregory II, one of the first popes entrusted with the care of the papal library, who filtered some of the Vatican's more curious texts to the ingenious young magus. Perhaps he hoped that Bonisagus' theory would lead to the creation of an order of magi loyal to the Church, much as the Cult of Mercury was loyal to the Roman emperor. Is there a link between the Church and the Order of Hermes?
-
-The story of Trianoma's trip to the Dragon is well known, and yet no one has been able to retrace a single footstep of this mythic journey. Who was this Dragon she awoke, and how did it know the location of Bonisagus, working in isolation? Many suspect it was one of the Old Ones, the great beings of the primordial age who directed the sorceress. If this was true it could mean the Order is merely a pawn of these creatures. Some have tried to retrace the sisters' journey and failed, but perhaps a new expedition will find the truth?
-
-Both Trianoma and Bonisagus developed Longevity Rituals late in their life. During their stay in the Alpine cave the pair conceived a son. The mixing of their magic bloodlines produced a strange boy, strong with the Gift but psychologically fragile. At five years of age he fled in the night, resisting efforts to be found by his seeking parents. Some say this is why Bonisagus left the cave and went to the Black Forest; he could no longer view the contents of his home without painful emotions. The cave has never been discovered. Some magi think the boy returned there, to what fell purpose no one knows.
-
-Bonisagus' rough-shod magic theory, still in its infancy, easily incorporated the twin's spells. As he formulated his theory, he taught it to the sisters. Sharing magical secrets changed the relationship between the wizard and the witches, most notably Trianoma, who started to view the Bonisagus differently. Rather than a threat, he seemed a kind, open-hearted, inquisitive man. As he learned their
-
-
-spells, Bonisagus taught both women some simple formulaic spells, invented under his new system of magic. Still, both yearned for the secret of the Parma Magica. As Trianoma's ardor grew, Veia became jealous of their relationship. The sisters argued, and after a particularly vicious quarrel Veia left the cave, fleeing in the night with several of Bonisagus's valuable books.
+Bonisagus' rough-shod magic theory, still in its infancy, easily incorporated the twin's spells. As he formulated his theory, he taught it to the sisters. Sharing magical secrets changed the relationship between the wizard and the witches, most notably Trianoma, who started to view the Bonisagus differently. Rather than a threat, he seemed a kind, open-hearted, inquisitive man. As he learned their spells, Bonisagus taught both women some simple formulaic spells, invented under his new system of magic. Still, both yearned for the secret of the Parma Magica. As Trianoma's ardor grew, Veia became jealous of their relationship. The sisters argued, and after a particularly vicious quarrel Veia left the cave, fleeing in the night with several of Bonisagus's valuable books.
 
 The magus was furious but Trianoma forbade any revenge. She was reminded of her dream that had started this journey. She believed hunting down her sister would drive the world of wizards to a horrible end. Instead, she used her sister's pilfering to suggest a new order of magi, where theft and murder would not be necessary. Bonisagus was reluctant, but Trianoma spoke of a society of magicians unlike any he had ever seen. He acquiesced and accepted her as his full apprentice, beginning her studies in earnest. Within a year she had learned his Hermetic theory and finally the Parma Magica.
+
+> ## Story Seed: Legends of the Founder
+> 
+> Many legends surround Bonisagus and Trianoma, and these are only a few of the fantastic stories attributed to the pair. Investigating these legends would make excellent adventures.
+> 
+> Some find it oddly coincidental that Bonisagus's Aventine Hill home in Rome was located so close to the well that contained several lost Mercurian spells. One legend proposes that Bonisagus's uncle left the spells there for his curious nephew to find. The story goes that he was following the command of Pope Gregory II, one of the first popes entrusted with the care of the papal library, who filtered some of the Vatican's more curious texts to the ingenious young magus. Perhaps he hoped that Bonisagus' theory would lead to the creation of an order of magi loyal to the Church, much as the Cult of Mercury was loyal to the Roman emperor. Is there a link between the Church and the Order of Hermes?
+> 
+> The story of Trianoma's trip to the Dragon is well known, and yet no one has been able to retrace a single footstep of this mythic journey. Who was this Dragon she awoke, and how did it know the location of Bonisagus, working in isolation? Many suspect it was one of the Old Ones, the great beings of the primordial age who directed the sorceress. If this was true it could mean the Order is merely a pawn of these creatures. Some have tried to retrace the sisters' journey and failed, but perhaps a new expedition will find the truth?
+> 
+> Both Trianoma and Bonisagus developed Longevity Rituals late in their life. During their stay in the Alpine cave the pair conceived a son. The mixing of their magic bloodlines produced a strange boy, strong with the Gift but psychologically fragile. At five years of age he fled in the night, resisting efforts to be found by his seeking parents. Some say this is why Bonisagus left the cave and went to the Black Forest; he could no longer view the contents of his home without painful emotions. The cave has never been discovered. Some magi think the boy returned there, to what fell purpose no one knows.
 
 ### The Formative Years
 
@@ -326,10 +305,9 @@ As the Order grew, Bonisagus and Trianoma decided they needed help overseeing th
 
 House Bonisagus responded unevenly to the early conflicts that threatened the Order of Hermes. Magi Bonisagi barely took notice of the calamities, preferring their personal research over any organized reaction. They deemed the Order sufficiently capable of handling events without their specific participation. Bonisagus was often accused of being self-centered and unaware of the world around him, and this perception clung to his lineage. Magi Trianomae launched themselves into these early problems, thinking every conflict could be resolved through peaceful negotiations and dextrous politicking. They realized their mistake with Damhan-Allaidh, who cared little for negotiations and preferred beheading magi to befriending them. They may have fared better in the other early crises, but since Trianoma's lineage followed her behavior of acting without recognition, their exact involvement is unknown. Those in the Order fond of conspiracy theories claim that magi Trianomae were behind House Tremere's "Sundering", although magi Trianomae publicly deny any such claim.
 
-### Story Seed: The Lost Diary of Polus
-
-Polus was a powerful magus living in the ninth century, who kept diaries of his life as a magus Trianomae. Several of his diaries still exist, residing in the Great Library of Durenmar. Recently one of his missing diaries has been found, containing specific information about his and other magi Triamonae's involvement in the Sundering. Besides claiming responsibility, the dairies clearly show how magi Trianomae repeatedly broke their Hermetic Oath by spying on Tremere magi. If this missing diary came to the Order's attention, it would seriously discredit House Bonisagus and its Trianoma lineage. Player characters are asked to discover whether this diary is genuine or a forgery.
-
+> ## Story Seed: The Lost Diary of Polus
+> 
+> Polus was a powerful magus living in the ninth century, who kept diaries of his life as a magus Trianomae. Several of his diaries still exist, residing in the Great Library of Durenmar. Recently one of his missing diaries has been found, containing specific information about his and other magi Triamonae's involvement in the Sundering. Besides claiming responsibility, the dairies clearly show how magi Trianomae repeatedly broke their Hermetic Oath by spying on Tremere magi. If this missing diary came to the Order's attention, it would seriously discredit House Bonisagus and its Trianoma lineage. Player characters are asked to discover whether this diary is genuine or a forgery.
 
 ### The Founder's End
 
@@ -337,13 +315,11 @@ Bonisagus continued teaching Hermetic magic throughout the eighth century, teach
 
 Trianoma continued traveling from covenant to covenant — usually domus magnae — throughout the eighth and early ninth centuries. She always had an apprentice in tow, always accepting another as soon as her current charge took the Oath. She too attended the Grand Tribunal of 832, sharing a meal with her master. After supper, she retired to her private suite and died in her sleep.
 
-### Story Seed: The Founders' End
-
-Viea was never found, nor was the property she took ever recovered. Some believe that the stolen volumes contained lost details of Bonisagus's theory, and that their recovery could repair some of the failings of Magic Theory. They claim Viea fled back to Thessaly and began a line of sorceresses whose magic could surpass the limits of Hermetic magic. Bonisagus's purpose at the Thebes Tribunal in 836 was to raise a band of adventures to find his enemy. Player characters could be recruited to explore the Greek islands looking for Bonisagus's lost books and, perhaps, his grave.
-
-Trianoma did not die peacefully in her sleep during the Grand Tribunal of 832. Knowing the power that those who die before their time leave upon the earth, Trianoma insisted that her mentor murder her, hoping this ultimate sacrifice would increase the magical aura of Durenmar. Bonisagus flatly refused, and Trianoma forced her apprentice to perpetuate the grisly deed. This succeeded in permanently increasing the Magic Aura of the valley, but it also imprisoned Trianoma's ghost within her tower. The top two stories were destroyed in an attempt to remove her spirit, which now haunts the surrounding Black Forest.
-
-
+> ## Story Seed: The Founders' End
+> 
+> Viea was never found, nor was the property she took ever recovered. Some believe that the stolen volumes contained lost details of Bonisagus's theory, and that their recovery could repair some of the failings of Magic Theory. They claim Viea fled back to Thessaly and began a line of sorceresses whose magic could surpass the limits of Hermetic magic. Bonisagus's purpose at the Thebes Tribunal in 836 was to raise a band of adventures to find his enemy. Player characters could be recruited to explore the Greek islands looking for Bonisagus's lost books and, perhaps, his grave.
+> 
+> Trianoma did not die peacefully in her sleep during the Grand Tribunal of 832. Knowing the power that those who die before their time leave upon the earth, Trianoma insisted that her mentor murder her, hoping this ultimate sacrifice would increase the magical aura of Durenmar. Bonisagus flatly refused, and Trianoma forced her apprentice to perpetuate the grisly deed. This succeeded in permanently increasing the Magic Aura of the valley, but it also imprisoned Trianoma's ghost within her tower. The top two stories were destroyed in an attempt to remove her spirit, which now haunts the surrounding Black Forest.
 
 ### The Schism War
 
@@ -353,18 +329,15 @@ Still, neither branch of House Bonisagus was prepared when the Schism War broke 
 
 In 1011, magi Trianomae convinced the Primus of House Guernicus to call an emergency Grand Tribunal instead of the Regular Tribunal meetings to deal with the situation. The Primi of House Bonisagus and House Mercere readily agreed. House Mercere offered its aid to quickly reach all the Primi and escort them to Magvillus. The summons went to as many covenants as the Redcaps could safely reach. The specifics of this emergency meeting can be found in the Guernicus chapter. The end result was the Renunciation of House Diedne and all its members. This decision caused many magi of House Bonisagus to resent their fellows. Destroying one of the founding Houses was hardly a model of cooperation and peaceful community. It was a heavy decision Bonisagus Primus Thamus Collis had to make, and once decided he abdicated his position — the only Primus to ever do so.
 
-### Story Seed: A Pair in Isolation
-
-Before the events of the Schism War, a Bonisagus and a Diedne magus isolated themselves from the rest of the Order to collaborate on magical research. Their hiding place was so remote that they missed the events of the Schism War entirely. Growing older, they each acquired and trained an apprentice in the twelfth century, to finish their research once they slipped into Final Twilight. The apprentices continued their master's efforts, neither one ever leaving their isolated valley, never attending any of the regular meetings of the Order, waiting until their research was complete before their triumphal return.
-
-Now they have returned, only to find their masters' covenant destroyed long ago, and one of the pair an enemy of the Order. They have invented a staff that can perform spontaneous magic, adding its magical ability to the wielder's for spectacular results. They can react with the player characters in a variety of ways, depending on the nature of the saga; they may ask for help or be instant antagonists.
+> ## Story Seed: A Pair in Isolation
+> 
+> Before the events of the Schism War, a Bonisagus and a Diedne magus isolated themselves from the rest of the Order to collaborate on magical research. Their hiding place was so remote that they missed the events of the Schism War entirely. Growing older, they each acquired and trained an apprentice in the twelfth century, to finish their research once they slipped into Final Twilight. The apprentices continued their master's efforts, neither one ever leaving their isolated valley, never attending any of the regular meetings of the Order, waiting until their research was complete before their triumphal return.
+> 
+> Now they have returned, only to find their masters' covenant destroyed long ago, and one of the pair an enemy of the Order. They have invented a staff that can perform spontaneous magic, adding its magical ability to the wielder's for spectacular results. They can react with the player characters in a variety of ways, depending on the nature of the saga; they may ask for help or be instant antagonists.
 
 ## House Organization in 1220
 
 House Bonisagus is one of the smaller Houses of the Order of Hermes. Many of its members work independently, and the House has developed organizations to meet its magi's needs. House Bonisagus has only three levels of hierarchy. The Primus stands at the top of the hierarchy, naturally, and holds considerable power and influence. Beneath him are two Inner Circles, the Colentes Arcanorum and the Tenentes Occultorum, two groups of equal status charged with maintaining the specific interests of the House's two sides. The rest of the House consists of regular magi Bonisagi and magi Trianomae. Magi Bonisagi have invented ranks among themselves based on their research achievements, levels of prestige with accompanying titles. Magi Trianomae view themselves as equals. The Seekers are a group of magi intent on discovering the secrets of the Old Ones. They are a recognized group within House Bonisagus, but since they accept magi of other Houses, they sit somewhat outside the regular structure of the House.
-
-
-
 
 ### The Gender of the Lineage
 
@@ -388,35 +361,30 @@ The House has two councils of magi charged with maintaining the smooth functioni
 
 ### Colentes Arcanorum
 
-The Colentes Arcanorum ('Colens Arcanorum' singular) are five magi Bonisagi responsible for disseminating the recent research of the House to the other lineages. Rather than make each maga responsible for personally sharing her research, the Colentes exist to accomplish this task. A Colens Arcanorum serves for seven years, from one Tribunal to the next. The council members are chosen at random by the Primus. The name of every magus Bonisagi who has attained the rank of *cannophori* is inscribed on a clay coin and placed in a leather pouch. At some point during the Rhine Tribunal, the Primus draws five names from the pouch, the names of the next members of the Colentes Arcanorum. Redcap messengers are sent to tell these magi the news. It is possible — and has indeed happened — for a Colens to serve consecutive terms through this random process. This practice has been criticized by other Houses, especially the Tremere, who claim that the randomization of applicants minimizes the committee's quality. House Bonisagus feels the opposite is true; that random selection forces all magi Bonisagi of rank to remain up to date on important Hermetic pro-
-
-
-
-### Story Seed: The Lost Lance
-
-During the tenth century, Cerularius Bonisagi of the Normandy Tribunal developed the Lancea Magica, a magical attack that could pierce a magus' Parma Magica and deliver an unresisted lethal attack. Its efficiency was frightening, and the Colentes decided that it should be destroyed. Cerularius burned his Laboratory Texts and vowed to never investigate a similar effect.
-
-However, recent reports from the Normandy Tribunal suggest that the Lancea Magica still exists, and has been used to slay another magus. The player characters are charged with determining if Cerularius, long passed into Final Twilight, did indeed destroy his discovery. If not, who is using this forbidden lore? If so, is there a new magic that can overcome the Parma Magica?
-
-jects. It also means that every *cannophori* must prepare for the chance of selection, which makes the entire House wiser and responsible to its fellows. The Colentes Arcanorum is not a council of elders but a committee of equals.
+The Colentes Arcanorum ('Colens Arcanorum' singular) are five magi Bonisagi responsible for disseminating the recent research of the House to the other lineages. Rather than make each maga responsible for personally sharing her research, the Colentes exist to accomplish this task. A Colens Arcanorum serves for seven years, from one Tribunal to the next. The council members are chosen at random by the Primus. The name of every magus Bonisagi who has attained the rank of *cannophori* is inscribed on a clay coin and placed in a leather pouch. At some point during the Rhine Tribunal, the Primus draws five names from the pouch, the names of the next members of the Colentes Arcanorum. Redcap messengers are sent to tell these magi the news. It is possible — and has indeed happened — for a Colens to serve consecutive terms through this random process. This practice has been criticized by other Houses, especially the Tremere, who claim that the randomization of applicants minimizes the committee's quality. House Bonisagus feels the opposite is true; that random selection forces all magi Bonisagi of rank to remain up to date on important Hermetic projects. It also means that every *cannophori* must prepare for the chance of selection, which makes the entire House wiser and responsible to its fellows. The Colentes Arcanorum is not a council of elders but a committee of equals.
 
 The chance that a magi Bonisagus character is a Colens Arcanorum is dependent upon the number of *cannophori* in any particular saga. Normally, half of the magi Bonisagi of a saga have reached this rank or higher. Thus, in a "regular" saga, there are 25 magi Bonisagi eligible for the position, and a player character who has achieved the rank of *cannophori* has a 1 in 5 chance of being selected. If you wish to begin play with a Colens character, you must select the new Minor Hermetic Virtue: Colens Arcanorum, described at the end of the Bonisagus chapter.
 
 During the seven years of the Colentes Arcanorum's service, they receive Laboratory Texts and Tractatus from fellow magi Bonisagi, usually delivered by Redcaps but sometimes in person. A Colens reads the material, searching for innovative research that she thinks merits sharing with the Order. This continues throughout her term of office, at the end of which she meets with her fellow Colentes. As a group, the Colentes decide which are the most important Lab Texts and Tractatus and compile a volume of this material for distribution. The research is judged primarily on originality and usefulness, but the reputation and rank of the authoring magus are also factors. These volumes are called **folios**, and rules detailing them can be found in the House Utilities section.
 
-Only the best material is used. Unimaginative or routine Lab Texts are passed over, as are low Quality
-
+Only the best material is used. Unimaginative or routine Lab Texts are passed over, as are low Quality Tractatus or those written on uninteresting subjects. A third case exists: dangerous research. As they review the material, the Colentes sometimes decide that a discovery is too dangerous to spread. This decision does not come lightly and the Colentes antagonize over each case. If it looks like the material should be banned, the presiding Bonisagus Quaesitor is asked to make the ﬁnal decision. If he decides the research is too dangerous for release, the inventor is ordered to destroy his discovery. Failure to comply will result in a Wizard’s March.
 
 Besides the dissemination of research, the Colentes Arcanorum have two bureaucratic functions. The first is the ability to rescind individual research commands made by the Primus. Any maga Bonisagi who has been instructed by the Primus to undertake specific research may request the Colentes to relieve her of this duty. If a majority of the Colentes agree, she may ignore the Primus's directive. More importantly, they have the power to change the Primus of the House. They may decide that the House would be better served by a new Primus and can demand the current Primus to abdicate his position. Cause must be presented for such an unprecedented act by a magus Bonisagi of at least the *cannophori* rank. After hearing the charges, the Colentes must unanimously agree to force the Primus's resignation. They then select his replacement, determining the new Primus by majority vote. This has never happened in the history of House Bonisagus. Both of these functions occur during the Colloquium Delectorum (see below).
 
-#### SUBMITTED TEXTS
+> ## Story Seed: The Lost Lance
+> 
+> During the tenth century, Cerularius Bonisagi of the Normandy Tribunal developed the Lancea Magica, a magical attack that could pierce a magus' Parma Magica and deliver an unresisted lethal attack. Its efficiency was frightening, and the Colentes decided that it should be destroyed. Cerularius burned his Laboratory Texts and vowed to never investigate a similar effect.
+> 
+> However, recent reports from the Normandy Tribunal suggest that the Lancea Magica still exists, and has been used to slay another magus. The player characters are charged with determining if Cerularius, long passed into Final Twilight, did indeed destroy his discovery. If not, who is using this forbidden lore? If so, is there a new magic that can overcome the Parma Magica?
+
+
+#### Submitted Texts
 
 A Colens Arcanorum receives from 15 to 30 submitted Lab Texts and tractatus during their seven year term, averaging about 4 submissions a year. These submissions are usually translations of an author's original Lab Text or copies of her tractatus; they are rarely the original text. Lab Texts must be translated from the author's shorthand. The Colens are primarily interested in original research, and look for Lab Texts that include experimentation. Well-written tractatus are also sought, but a Colens would rather include a Lab Text over a tractatus. New spells and magic items are certainly interesting, but the emphasis is on knowledge that pushes the boundaries of Hermetic magic.
 
 It takes a day for Colens Arcanorum to briefly scan a submitted text and determine its value. The most valuable will be taken to the Colloquium Delectorum and spread throughout the Order. The other submissions become the property of the receiving Colens.
 
-
-
+### Tenentes Occultorum
 
 Initially Trianoma alone took care of marshaling the formation and cooperation of tribunals. As the Order grew the task became overwhelming and Trianoma appointed a few of her followers as assistants, dividing Mythic Europe into smaller, manageable areas for them to oversee. Responsibility for relations between tribunals and magi was soon assumed by House Guernicus, and it was redundant for the Trianomae to do what the Quaesitores did so efficiently. Trianoma and her filii began patrolling the borders of the Order, making sure the secrets of House Bonisagus stayed well within it. Several early situations lead to the formation of the Tenentes Occultorum, the 'Tenders of Secret Lore.'
 
@@ -424,10 +392,9 @@ The Tenentes Occultorum (singular 'Tenens Occultorum') are four magi Trianomae a
 
 Symmetry is an essential ingredient in many Hermetic practices, and the four Tenentes represent the seasons, each one symbolically mirroring the position he occupies. The Spring Tenens is a magus chosen immediately after his gauntlet; the Summer, Autumn, and Winter Tenentes each have more experience respectively. The Primus chooses from the entire line of the magi Trianomae, doing his best to match experienced magi to each position. Sometimes his decision is based on the present location of magi Trianomae, since each season's Tenens is responsible for a specific area.
 
-### Story Seed: The Belligerent Benedictines
-
-A tractatus on Parma Magica is missing. Sent from a magus Bonisagi to a Colens Arcanorum using a mundane messenger, it has gone missing near an abbey suspected of harboring "forbidden" books. The Autumn Tenens asks the player characters to investigate the abbey and its abbot, known for his resentment towards the Order, and search for the lost tractatus. Since a character's Gift will certainly upset the situation, the Tenens asks a group of companions to undertake this quest.
-
+> ## Story Seed: The Belligerent Benedictines
+> 
+> A tractatus on Parma Magica is missing. Sent from a magus Bonisagi to a Colens Arcanorum using a mundane messenger, it has gone missing near an abbey suspected of harboring "forbidden" books. The Autumn Tenens asks the player characters to investigate the abbey and its abbot, known for his resentment towards the Order, and search for the lost tractatus. Since a character's Gift will certainly upset the situation, the Tenens asks a group of companions to undertake this quest.
 
 The four areas are based on a Roman conception of Mythic Europe, arbitrarily fashioned after an earlier model of the Tribunals. The Spring Tenens operates in Britannia, the Hibernia, Loch Leglean, and Stonehenge Tribunals, a place where an inexperienced Tenens's mistakes won't do lasting harm. The Summer Tenens is responsible for Iberian Provinces — initially the Iberian and Provencal Tribunals and later adding the Normandy Tribunal. The Roman provinces are overseen by the Autumn Tenens and include the Roman and Rhine Tribunals and the Tribunal of the Greater Alps. This is the greatest concentration of magi Bonisagi and interested mundanes and demands an most experienced Tenens. The remaining Tribunals, Transylvania, Thebes, Levant, and the Novgorod, are the responsibility of the Winter Tenens, the most senior magus of the four.
 
@@ -439,10 +406,9 @@ The Tenentes's primary responsibility is to keep magical secrets out of the hand
 
 The Tenentes also seek information concerning mundanes exploring arcane mysteries. They have accumulated notes recording the activity of the mundane universities, chapel schools and noble families. Of particular interest are individuals who have sought secret knowledge in the past and possess The Gift. Men of this ilk are closely watched. A Tenens may ask a maga Trianomae to intervene, using either their skills of intrigue to convince the man that he is better off not seeking arcane secrets or by more overt methods.
 
-
 The Tenentes Occultorum meet at the end of their term of service at the Colloquium Delectorum. The group combines their notes of the House's magi and troublesome individuals and institutions. These notes are compiled and sent to Durenmar, along with the Colentes Arcanorum's folio. The Tenentes then relinquish their duties and head back to their covenant, either the one they have been recently stationed in or their original home.
 
-#### TABULA GEOGRAPHICA MAGICA
+#### Tabula Geographica Magica
 
 Even more fascinating than their directory of magi Bonisagi is the Tabula Geographica Magica, the Gazetteer of Magic, a catalogue of magical sites and regiones discovered in their area. This information is gathered from magi Trianomae, who seek out ancient and powerful sites, and from the Seekers, those dedicated exclusively to this pursuit. At each Colloquium the Tenentes add to the Gazetteer, including newly discovered sites and more information on sites already found. Some of these sites are sources of vis, but the primary intent in gathering this information is to provide a better knowledge of Europe and her magical secrets. The Gazetteer is brought from Durenmar to the location of the Colloquium by a magus Trianomae or a trusted Redcap, and is returned there once the Tenentes finish their updates.
 
@@ -450,8 +416,7 @@ This resource is reluctantly shared; House Bonisagus feels that its contained kn
 
 ### Colloquium Delectorum
 
-Every seven years the Colentes Arcanorum and the Tenentes Occultorum hold a meeting called the Colloquium Delectorum, 'Conference of the Committees', or Colloquium for short. The Colloquium is a traveling conference held at regular Tribunal meetings of one of the thirteen Tribunals. The location of the Colloquium is decided by the nine council members — five Colentes and four Tenentes — at the start of their appointment, each offering their preferred location (usually their home Tribunal), and the decision made by majority agreement. Since the council members don't meet until the end of
-
+Every seven years the Colentes Arcanorum and the Tenentes Occultorum hold a meeting called the Colloquium Delectorum, 'Conference of the Committees', or Colloquium for short. The Colloquium is a traveling conference held at regular Tribunal meetings of one of the thirteen Tribunals. The location of the Colloquium is decided by the nine council members — five Colentes and four Tenentes — at the start of their appointment, each offering their preferred location (usually their home Tribunal), and the decision made by majority agreement. Since the council members don't meet until the end of their service, this decision can take a few years, and the Tenentes have been known to inﬂuence the Colentes through their mastery of Intrigue. If a decision isn’t reached within ﬁve years, the Primus chooses the location.
 
 The Colloquium is a week-long conference held after the regular proceeding of the Tribunal hosting it. Much of it is a closed session, with only the Colentes and the Tenentes attending. Both the Primus and the Bonisagus Quaesitor are permitted to attend, although this generally only happens when the Colloquium is held at the Rhine Tribunal. The Tenentes compile their information about fellow House magi, meddlesome mundanes, and magical sites. The Colentes present the research they have received over the previous seven years, comparing Lab Texts and tractatus and deciding which research should be disseminated to the Order. The included authors receive recognition and their status increases among magi Bonisagi. The Colentes include a list of the authors who submitted research, as well. After the Colentes have reached an agreement, they remain at the location and compile the research into a folio. This takes a season, during which the Colentes work closely together editing the material into a single volume. Rules to create a folio can be found in the House Utilities section.
 
@@ -461,72 +426,73 @@ The council of Colentes can be called on by magi Bonisagi, either to remove the 
 
 The Primus of House Bonisagus is an auspicious position, the head of the House and the shoulders which bear the weight of the Order, symbolically if not legally. First and foremost, he is the Praeco of the both the regular Rhine Tribunals and the Grand Tribunal held every 33 years. Like other Praecos at other Tribunals, the Primus has the power to set the event's agenda and silence, even eject magi. The Primus uses these powers to unfold the Tribunal in accordance with his premeditated political intentions.
 
-Internally, the Primus is responsible for steering the course of the House, directing those members who might need direction and allowing the general whole to enjoy all the rights and privileges a magus of the House expects. It is his duty to randomly select the Colentes Arcanorum. He also appoints four magi as the Tenentes Occultorum, one to represent each of the four seasons. He can direct an individual maga Bonisagi's research, requesting she abandon her current endeavors and pursue specified
-
-
-
-
-### Glaucon, magus Trianomae and Seeker
-
-**Characteristics:** Int +3, Per +3, Pre 0, Com +1, Str 0, Sta
-
-+1, Dex -1, Qik 0
-
-**Size:** 0 **Age:** 29 (6 years past apprenticeship)
-
-**Decrepitude:** 0 **Warping Score:** 0 (2) **Confidence Score:** 1 (4)
-
-**Virtues and Flaws:** The Gift; Hermetic Magus; Gentle Gift; Affinity with Intellego, Improved Characteristics (x2), Personal vis source, Puissant Intrigue (Free Virtue), Second Sight, Strong-Willed, Study Bonus; Enemies, Painful Magic; Disorientating Magic, Infamous, Palsied Hands, Seeker
-
-**Personality Traits:** Curious +3, Persistent +3, Selfish +2 **Reputation:** Grave Robber 4 (Tribunal of the Greater Alps)
-
-**Combat:** Dodging: Init +0, Attack n/a, Defense +3, Damage n/a
-
-**Soak:** 1
-
-**Fatigue levels:** OK, 0, –1, –3, –5, Unconscious
-
-**Wound Penalties:** –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20)
-
-**Abilities:** Athletics 3 (spelunking), Artes Liberales 1 (Geometry), Awareness 2 (ambushes), Brawl 2 (dodging), Concentration 1 (when wounded), Faerie Lore 1 (mountain faeries), Guile 2 (hiding past activities), Intrigue 2 (+2) (detecting other's interests), Kingdom of Aragon Lore 2 (mountains), Latin 4 (cartographical terms), Parma Magica 3 (Mentem), Penetration 3 (Mentem), Magic Lore 2 (Mercurian temples), Magic Theory 3 (inventing spells), Ride 1 (distances), Second Sight 1 (ghosts), Spanish 5 (flowery speech), Survival 2 (mountains)
-
-**Arts:** Cr 0, In 9, Mu 2, Pe 8, Re 3; An 0, Aq 0, Au 0, Co 6, He 0, Ig 1, Im 1, Me 10, Te 0, Vm 7
-
-**Twilight Scars:** None
-
-**Encumbrance:** 0 (0) **Spells Known:**
-
-*Preternatural Growth and Shrinking* (MuCo 15) +9
-
-*Rise of the Feathery Body* (ReCo 10) +10
-
-*Palm of Flame* (CrIg 5) +2
-
-*Reveal the Lingering Spirit* (InMe 20) +20 *Trust of Childlike Faith* (ReMe 10) +14 *Lay to Rest the Haunting Spirit* (PeMe 15) +19 *Lay to Rest the Haunting Spirit* (PeMe 25) +19
-
-*Pierce the Faerie Veil* (InVi 20) +17 *Pierce the Magic Veil* (InVi 20) +17 *The Invisible Eye Revealed* (InVi 20) +17
-
-**Notes:** Glaucon is a Seeker who specializes in scouring mountainous areas looking for ancient Mercurian temples. Casting spells is painful for Glaucon, and he believes that finding an older source of magic will help him understand the excruciating nature of his Gift. Glaucon shuns other magi of his House, hoping to avoid the regular responsibilities of magi Trianomae. The Tenentes Occultorum are annoyed at Glaucon because he is reluctant to reveal the specific locations of his travels, particular the location of his secret vis source.
-
-### NEW INTELLEGO MENTEM SPELL
-
-**REVEAL THE LINGERING SPIRIT**
-
-**R:** Per, **D:** Conc, **T:** Vision, **Level 20**
-
-This spell allows you to see invisible ghosts. If the spell penetrates the ghost's magic resistance, you can see it. This spell does not force the ghost to become visible to others.
-
-(Base 3, +1 Conc, +4 Vision)
-
-research. This request is dependent upon the magus's rank in the House. Requested magi do have some recourse if they don't wish to comply with the Primus's orders, and a majority vote of the Colentes Arcanorum will release a maga from this duty.
+Internally, the Primus is responsible for steering the course of the House, directing those members who might need direction and allowing the general whole to enjoy all the rights and privileges a magus of the House expects. It is his duty to randomly select the Colentes Arcanorum. He also appoints four magi as the Tenentes Occultorum, one to represent each of the four seasons. He can direct an individual maga Bonisagi's research, requesting she abandon her current endeavors and pursue specified research. This request is dependent upon the magus's rank in the House. Requested magi do have some recourse if they don't wish to comply with the Primus's orders, and a majority vote of the Colentes Arcanorum will release a maga from this duty.
 
 The Primus also appoints his successor, who holds the position for life. There have been seven Primi since the founder, each chosen by his predecessor to continue the direct line of leadership since Bonisagus himself. A Primus can step down from his position, which has happened only once, when Primus Thamus Collis abdicating his position after Renouncing House Diedne. The House has given the Colentes Arcanorum a method for removing a Primus who is abusing his power (see Colentes Arcanorum).
 
-A prospective Primus must meet several qualifications. First, he must be a magus Bonisagi, since no magus Trianomae would ever dream of overtly leading the House. It is customary for the Primus to be an archmage (see *Guardians of the Forests: The Rhine Tribunal*), but not necessary. He must have successfully trained an apprentice, personally sharing his knowledge with someone else. He must also be a *dendrophori*, the highest level of status a magus Bonisagus can achieve. Finally, a prospective
+A prospective Primus must meet several qualifications. First, he must be a magus Bonisagi, since no magus Trianomae would ever dream of overtly leading the House. It is customary for the Primus to be an archmage (see *Guardians of the Forests: The Rhine Tribunal*), but not necessary. He must have successfully trained an apprentice, personally sharing his knowledge with someone else. He must also be a *dendrophori*, the highest level of status a magus Bonisagus can achieve. Finally, a prospective Primus must have served as a Colens Arcanorum to experience the House's organization and bureaucracy. In 1220 there are a half dozen or so magi Bonisagi qualified to be Primus of the House.
 
-
-
-Primus must have served as a Colens Arcanorum to experience the House's organization and bureaucracy. In 1220 there are a half dozen or so magi Bonisagi qualified to be Primus of the House.
+> ## Glaucon, magus Trianomae and Seeker
+> 
+> **Characteristics:** Int +3, Per +3, Pre 0, Com +1, Str 0, Sta
+> 
+> +1, Dex -1, Qik 0
+> 
+> **Size:** 0 **Age:** 29 (6 years past apprenticeship)
+> 
+> **Decrepitude:** 0 **Warping Score:** 0 (2) **Confidence Score:** 1 (4)
+> 
+> **Virtues and Flaws:** The Gift; Hermetic Magus; Gentle Gift; Affinity with Intellego, Improved Characteristics (x2), Personal vis source, Puissant Intrigue (Free Virtue), Second Sight, Strong-Willed, Study Bonus; Enemies, Painful Magic; Disorientating Magic, Infamous, Palsied Hands, Seeker
+> 
+> **Personality Traits:** Curious +3, Persistent +3, Selfish +2 **Reputation:** Grave Robber 4 (Tribunal of the Greater Alps)
+> 
+> **Combat:** Dodging: Init +0, Attack n/a, Defense +3, Damage n/a
+> 
+> **Soak:** 1
+> 
+> **Fatigue levels:** OK, 0, –1, –3, –5, Unconscious
+> 
+> **Wound Penalties:** –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20)
+> 
+> **Abilities:** Athletics 3 (spelunking), Artes Liberales 1 (Geometry), Awareness 2 (ambushes), Brawl 2 (dodging), Concentration 1 (when wounded), Faerie Lore 1 (mountain faeries), Guile 2 (hiding past activities), Intrigue 2 (+2) (detecting other's interests), Kingdom of Aragon Lore 2 (mountains), Latin 4 (cartographical terms), Parma Magica 3 (Mentem), Penetration 3 (Mentem), Magic Lore 2 (Mercurian temples), Magic Theory 3 (inventing spells), Ride 1 (distances), Second Sight 1 (ghosts), Spanish 5 (flowery speech), Survival 2 (mountains)
+> 
+> **Arts:** Cr 0, In 9, Mu 2, Pe 8, Re 3; An 0, Aq 0, Au 0, Co 6, He 0, Ig 1, Im 1, Me 10, Te 0, Vm 7
+> 
+> **Twilight Scars:** None
+> 
+> **Encumbrance:** 0 (0) **Spells Known:**
+> 
+> *Preternatural Growth and Shrinking* (MuCo 15) +9
+> 
+> *Rise of the Feathery Body* (ReCo 10) +10
+> 
+> *Palm of Flame* (CrIg 5) +2
+> 
+> *Reveal the Lingering Spirit* (InMe 20) +20
+>
+>*Trust of Childlike Faith* (ReMe 10) +14
+>
+>*Lay to Rest the Haunting Spirit* (PeMe 15) +19
+>
+>*Lay to Rest the Haunting Spirit* (PeMe 25) +19
+> 
+> *Pierce the Faerie Veil* (InVi 20) +17
+>
+>*Pierce the Magic Veil* (InVi 20) +17
+>
+*The Invisible Eye Revealed* (InVi 20) +17
+> 
+> **Notes:** Glaucon is a Seeker who specializes in scouring mountainous areas looking for ancient Mercurian temples. Casting spells is painful for Glaucon, and he believes that finding an older source of magic will help him understand the excruciating nature of his Gift. Glaucon shuns other magi of his House, hoping to avoid the regular responsibilities of magi Trianomae. The Tenentes Occultorum are annoyed at Glaucon because he is reluctant to reveal the specific locations of his travels, particular the location of his secret vis source.
+> 
+> ### New Intellego Mentem Spell
+> 
+> ##### Reveal the Lingering Spirit
+> 
+> **R:** Per, **D:** Conc, **T:** Vision, **Level 30**
+> 
+> This spell allows you to see invisible ghosts. If the spell penetrates the ghost's magic resistance, you can see it. This spell does not force the ghost to become visible to others.
+> 
+> (Base 5, +1 Conc, +4 Vision)
 
 ### Seekers
 
@@ -538,51 +504,51 @@ A magus from any House may be a Seeker. They are nominally under the control of 
 
 In 1220 there are approximately 25 Seekers; five of them are magi of House Bonisagus, the highest concentration from any single lineage.
 
+> ## Common Virtues and Flaws
+> 
+> Every magi Bonisagi has the free General, Minor Virtue: **Puissant Magic Theory**. Other common Virtues and Flaws are:
+> 
+> **Adept Laboratory Student**. Your parens never left the lab.
+> 
+> **Affinity with Art**. Your parens encouraged this specialty in you, and you are expected by other magi Bonisagi to make good on his efforts.
+> 
+> **Flexible Formulaic Magic**. This is ideal for a dabbler, who delights in Range, Duration, and Target changes.
+> 
+> **Hermetic Prestige**. Your parens was so well-known that his reputation extended outside of the House. **Inventive Genius**.
+> 
+> **Secondary Insight**. You innately understand the Hermetic connections between the Arts.
+> 
+> **Skilled Parens**. Magi Bonisagi are interested in spreading their knowledge to their apprentices and focus on this activity.
+> 
+> **Blatant Gift**.
+> 
+> **Book Learner**.
+> 
+> **Deficient Technique** and **Deficient Form**. Two unfortunate side-affects of a parens overspecializing in Arts that interest him or that the apprentice is exceptionally good at.
+> 
+> **Driven**. You strive to be the expert in your field of specialized research.
+> 
+> Every magi Trianomae has the free General, Minor Virtue: **Puissant Intrigue**. Other common Virtues and Flaws are:
+> 
+> **Apt Student**. Most of your learning was taught to you by people, not books.
+> 
+> **Deft Form**. Your apprenticeship offered many opportunities to develop greater control over one of your Arts.
+> 
+> **Gentle Gift**. You were chosen by your parens because you could interact with mundanes easily.
+> 
+> **Linguist.** Your itinerant apprenticeship made you comfortable learning languages
+> 
+> **Long-winded**. Constant travel with your parens increased your endurance.
+> 
+> **Well-traveled**.
+> 
+> **Enemies**. The constant political interactions of your parens had consequences.
+> 
+> **Favors**. Another political consequence of your parens's meddling.
+> 
+> **Weak Scholar**. Time spent on the road lessened your book learning potential.
 
-
-
-Every magi Bonisagi has the free General, Minor Virtue: **Puissant Magic Theory**. Other common Virtues and Flaws are:
-
-**Adept Laboratory Student**. Your parens never left the lab.
-
-**Affinity with Art**. Your parens encouraged this specialty in you, and you are expected by other magi Bonisagi to make good on his efforts.
-
-**Flexible Formulaic Magic**. This is ideal for a dabbler, who delights in Range, Duration, and Target changes.
-
-**Hermetic Prestige**. Your parens was so well-known that his reputation extended outside of the House. **Inventive Genius**.
-
-**Secondary Insight**. You innately understand the Hermetic connections between the Arts.
-
-**Skilled Parens**. Magi Bonisagi are interested in spreading their knowledge to their apprentices and focus on this activity.
-
-**Blatant Gift**.
-
-**Book Learner**.
-
-**Deficient Technique** and **Deficient Form**. Two unfortunate side-affects of a parens overspecializing in Arts that interest him or that the apprentice is exceptionally good at.
-
-**Driven**. You strive to be the expert in your field of specialized research.
-
-Every magi Trianomae has the free General, Minor Virtue: **Puissant Intrigue**. Other common Virtues and Flaws are:
-
-**Apt Student**. Most of your learning was taught to you by people, not books.
-
-**Deft Form**. Your apprenticeship offered many opportunities to develop greater control over one of your Arts.
-
-**Gentle Gift**. You were chosen by your parens because you could interact with mundanes easily.
-
-**Linguist.** Your itinerant apprenticeship made you comfortable learning languages
-
-**Long-winded**. Constant travel with your parens increased your endurance.
-
-**Well-traveled**.
-
-**Enemies**. The constant political interactions of your parens had consequences.
-
-**Favors**. Another political consequence of your parens's meddling.
-
-**Weak Scholar**. Time spent on the road lessened your book learning potential.
-
+## The Magi of House Bonisagus
 
 Magi of House Bonisagus search for knowledge. Magi Bonisagi focus on their individual efforts and use their results as a foundation for more research. Magi Trianomae focus on the Order of Hermes, viewing knowledge as the glue that binds the Houses together. Magi Bonisagi prefer their privacy, living in safe, isolated covenants where they can follow their magical pursuits without interruption. Magi Trianomae prefer the community as a whole, living in more gregarious environments and enjoying the interplay of Hermetic politics.
 
@@ -594,26 +560,19 @@ Bonisagus designed Magic Theory to be easily accessible to students. His first t
 
 House Bonisagus sees training apprentices as a solemn duty rather than a selfish benefit. Magi of the House believe they honor their Founders with every new magus sworn into the House. It is very rare for a magus of House Bonisagus to depart this world without training at least one apprentice, and common for them to train two or more.
 
-Typical House Bonisagus apprentices begin their training when young. The House displays a bit of snobbery in choosing apprentices, preferring young, bright children to carry on its regal lineage. Otherwise, House Bonisagus follows the standard practices for training apprentices. Once a child has been accepted as an apprentice, the parens notifies his House by sending a letter or messenger to the committee that oversees his branch of the lineage. This procedure is bureaucratic, meant to pla-
+Typical House Bonisagus apprentices begin their training when young. The House displays a bit of snobbery in choosing apprentices, preferring young, bright children to carry on its regal lineage. Otherwise, House Bonisagus follows the standard practices for training apprentices. Once a child has been accepted as an apprentice, the parens notifies his House by sending a letter or messenger to the committee that oversees his branch of the lineage. This procedure is bureaucratic, meant to placate the worrisome Tenentes Occultorum. Hermetic training lasts fifteen years, with the apprentice being taught magic by her parens at least one season out of each year, after which she must pass a gauntlet to become a true maga of the House.
 
-
-
-cate the worrisome Tenentes Occultorum. Hermetic training lasts fifteen years, with the apprentice being taught magic by her parens at least one season out of each year, after which she must pass a gauntlet to become a true maga of the House.
-
-Each branch of the House presents a specific gauntlet for the apprentice. Magi Bonisagi all must pass the Theoretical Interview, an excruciatingly long verbal examination. It is performed by a magus Bonisagi other than an apprentice's parens. Parens and apprentice travel to an elder magus Bonisagi's covenant, where the apprentice undertakes the day-long examination. The Interview is based on Magic Theory and the Arts, and does not including the casting of any spells, focusing instead on a deeper understanding of Hermetic magic. Most apprentices pass their Theoretical Interview, those who don't return to their covenant and undergo a personal interview with their parens. This second interview is repeated until the apprentice passes the exam.
+Each branch of the House presents a specific gauntlet for the apprentice. Magi Bonisagi all must pass the Theoretical Interview, an excruciatingly long verbal examination. It is performed by a magus Bonisagi other than an apprentice's parens. Parens and apprentice travel to an elder magus Bonisagi's covenant, where the apprentice undertakes the day-long examination. The Interview is based on Magic Theory and the Arts, and does not include the casting of any spells, focusing instead on a deeper understanding of Hermetic magic. Most apprentices pass their Theoretical Interview, those who don't return to their covenant and undergo a personal interview with their parens. This second interview is repeated until the apprentice passes the exam.
 
 Magi Trianomae send their apprentices on a solo journey for their gauntlet. Once an apprentice has finished his Hermetic training to the satisfaction of his parens, he is sent to another magus Trianomae, traveling to a distant covenant by himself. This journey ideally takes two seasons to complete, and proves that the apprentice can survive the challenges of solo travel. Once at his destination, the apprentice is proclaimed a magus and chooses a name for himself. Those who fail return to their parens, shamefaced and defeated, and must attempt the same gauntlet at a later date. There have been apprentices who have never returned from being sent off.
 
-### ANOTHER MAGUS'S APPRENTICE
+#### Another Magus's Apprentice
 
-Unique among the Lineages, magi of House Bonisagus may take another Hermetic magus's apprentice. Reminiscent of Mercere's initial promise to give his future apprentices to Bonisagus, this practice was adopted during meetings of the First Tribunal to grant the magi of House Bonisagus the right to take others' apprentices. This was in appreciation for both Bonisagus's theoretical work, as well as Trianoma's political maneuverings that constructed the Order. Both magi had spent considerable effort on others, and the other Founders thought giving them the right to take apprentices was ample compensation.
+Unique among the Lineages, magi of House Bonisagus may take another Hermetic magus’s apprentice. Reminiscent of Mercere’s initial promise to give his future apprentices to Bonisagus, this practice was adopted during meetings of the First Tribunal to grant the magi of House Bonisagus the right to take others’ apprentices. This was in appreciation for both Bonisagus’s theoretical work, as well as Trianoma’s political maneuverings that constructed the Order. Both magi had spent considerable effort on others, and the other Founders thought giving them the right to take apprentices was ample compensation. 
 
-Theoretically, the magi of House Bonisagus use this privilege to get the best and brightest apprentices of the Order. In reality, the magi of the House have a variety of reasons for taking another's apprentice. Some are lazy and prefer the hard work of finding and initially training an apprentice to be left to others. Some are covetous and seek to plunder the better apprentices from their fellows. Not all motivations are base; some magi of the House take
+Theoretically, the magi of House Bonisagus use this privilege to get the best and brightest apprentices of the Order. In reality, the magi of the House have a variety of reasons for taking another’s apprentice. Some are lazy and prefer the hard work of ﬁnding and initially training an apprentice to be left to others. Some are covetous and seek to plunder the better apprentices from their fellows. Not all motivations are base; some magi of the House take apprentices from abusive parens, and others will take a neglected or tormented apprentice.
 
-
-Both magi Bonisagi and magi Trianomae have the privilege of taking another magus's apprentice. The former are more prone to exercise this right than the latter.
-
-Certain guidelines have developed since the ninth century surrounding this right. While no formal rules exist, magi Bonisagi and Trianomae have learned the hard way that over-exercising this prerogative can lead to trouble. "Apprentice snatching", as it is sometimes called, is rarely received favorably by the maga loosing her apprentice. To soften the blow, the House has formed suggested rules for its members to follow.
+Certain guidelines have developed since the ninth century surrounding this right. While no formal rules exist, magi Bonisagi and Trianomae have learned the hard way that over-exercising this prerogative can lead to trouble. "Apprentice snatching", as it is sometimes called, is rarely received favorably by the maga losing her apprentice. To soften the blow, the House has formed suggested rules for its members to follow.
 
 - A magus of House Bonisagus who has an apprentice should not take a second apprentice from a magus.
 - A magus of House Bonisagus should never take more than one apprentice from any single magus.
@@ -624,15 +583,13 @@ Magi who abuse this privilege may find themselves charged with a low crime depen
 
 Magi Bonisagi of rank have an easier time finding an apprentice than their colleagues. See the House Acclaim section in the House Utilities section.
 
-#### MULTIPLE APPRENTICES
+#### Multiple Apprentices
 
-There is nothing to say that a Hermetic magus can not have more than one apprentice at a time. Legally, a parens is required to spent a season a year teaching his apprentice. The Arts can only be taught one on one, so a magus could have four apprentices at the most and still abide by the rulings of the Peripheral Code. Of course, such a magus will have no time for his own research. This is the main reason why most magi Bonisagi only have one apprentice at a time.
+There is nothing to say that a Hermetic magus can not have more than one apprentice at a time. Legally, a parens is required to spend a season a year teaching his apprentice. The Arts can only be taught one on one, so a magus could have four apprentices at the most and still abide by the rulings of the Peripheral Code. Of course, such a magus will have no time for his own research. This is the main reason why most magi Bonisagi only have one apprentice at a time.
 
 Some magi Bonisagi will have more than one apprentice at a time. Because of their natural affinity in the laboratory, magi Bonisagi can always successfully use a second lab assistant (see Working Together). If a maga Bonisagi has two apprentices, both can assist her in the laboratory. This means that half of her time is spent teaching her two charges. Still, this situation is satisfactory to many magi Bonisagi, and the second lab assistant's help offsets the time spent out of the lab.
 
-
-
-#### FOSTERING
+#### Fostering
 
 A successful maga Bonisagi needs to be highly trained. She will need scores in several Abilities besides Magic Theory to realize her true potential. Profession: Scribe is necessary for the copious amounts of writing and copy she will do, and a high Latin score is required to read and write books. Teaching is also a valuable Ability and most magi Bonisagi have a score in this as well. Since there are so many important skills, the House has developed a system of **fosterage** to help train apprentices. This practice has proved more useful than finding mundane academic scholars interested in working with Gifted students.
 
@@ -640,52 +597,41 @@ Magi Bonisagi can agree to **foster** each other's apprentices, a common but not
 
 After this initial teaching the apprentices are exchanged again, this time to help the reciprocating parens in the laboratory. Since both parens took a year to train the apprentices, they are rewarded by having both of their help in the lab for a year (see Working Together). Depending on the distance between magi Bonisagi, sometimes an apprentice will travel to a covenant and stay two years — one being taught and one assisting in the lab before returning home with the other magus's apprentice in tow, who will then stay two years fulfilling his half of the fosterage bargain.
 
-This practice holds a small amount of danger for the apprentice, since he is under the control of a magus other than his parens. Because of this, fostering is not entered into lightly. Magi Bonisagi find it a privilege to exchange apprentices in this way, and tend not to abuse this practice. Because of the risk, however, they are not interested in extending this privilege to magi outside their direct lineage. Fostering is not practiced by magi Trianomae, who do not confine themselves to the laboratory like their House brethren. They do encourage its use, however,
+This practice holds a small amount of danger for the apprentice, since he is under the control of a magus other than his parens. Because of this, fostering is not entered into lightly. Magi Bonisagi find it a privilege to exchange apprentices in this way, and tend not to abuse this practice. Because of the risk, however, they are not interested in extending this privilege to magi outside their direct lineage. Fostering is not practiced by magi Trianomae, who do not confine themselves to the laboratory like their House brethren. They do encourage its use, however, since it builds communal ties and further increases the interdependence of House Bonisagus.
 
-
-### Optional Rule: Continuous Research
-
-Magi who manage to avoid outside distractions and remain working in their laboratory on a single project — "lab rats" — can slowly gain an advantage over time. Continuous Research is a way for storyguides to reward players who manage to stay sheltered within their laboratory, forsaking all else and remaining dedicated to their research project. This is most evident in larger projects, those that require many seasons of laboratory work.
-
-Continual Research is a beneficial modifier that you can add to your Lab Total while you remain working on a single project. For each uninterrupted season of lab work spent on your project, you accrue one point of Continual Research. Continual Research builds like an Ability. Once you have spent five seasons on a project, accruing five Continual Research points, you may add 1 to your Lab Total. You may add this modifier for as long as you continue working on the same project. After fifteen seasons spent in Continuous Research the modifier increases to +2. The advantage continues to grow as long as you do not change research subjects or interrupt your seasonal lab work (see **ArM5**'s Laboratory chapter, "Distractions from Lab Work", page 103).
-
-This optional rule has different effects in different sagas. In a slow saga (see **ArM5**'s Saga chapter, page 218) magi will have to delicately manage their time so that seasonal interruptions can be accomplished without disrupting research. In a fast saga this rule will encourage magi to work on larger projects.
-
-since it builds communal ties and further increases the interdependence of House Bonisagus.
+> ## Optional Rule: Continuous Research
+> 
+> Magi who manage to avoid outside distractions and remain working in their laboratory on a single project — "lab rats" — can slowly gain an advantage over time. Continuous Research is a way for storyguides to reward players who manage to stay sheltered within their laboratory, forsaking all else and remaining dedicated to their research project. This is most evident in larger projects, those that require many seasons of laboratory work.
+> 
+> Continual Research is a beneficial modifier that you can add to your Lab Total while you remain working on a single project. For each uninterrupted season of lab work spent on your project, you accrue one point of Continual Research. Continual Research builds like an Ability. Once you have spent five seasons on a project, accruing five Continual Research points, you may add 1 to your Lab Total. You may add this modifier for as long as you continue working on the same project. After fifteen seasons spent in Continuous Research the modifier increases to +2. The advantage continues to grow as long as you do not change research subjects or interrupt your seasonal lab work (see **ArM5**'s Laboratory chapter, "Distractions from Lab Work", page 103).
+> 
+> This optional rule has different effects in different sagas. In a slow saga (see **ArM5**'s Saga chapter, page 218) magi will have to delicately manage their time so that seasonal interruptions can be accomplished without disrupting research. In a fast saga this rule will encourage magi to work on larger projects.
 
 ### Magi Bonisagi
 
-Magi Bonisagi tend to be reclusive, eschewing the company of others as they work uninterrupted in their labs. Even a magus Bonisagi fresh from apprenticeship exhibits this behavior, viewing research as the ultimate method of unearthing the secrets of magic. He is at home in his laboratory, surrounded by tomes, and immersed among bubbling beakers and gurgling pots, the quintessential wizard, incorporating all aspects of magical possibilities and every arcane activity in his laboratory. Nothing magical disinterests him, whether that is familiar binding, item creation, longevity rituals, vis distillation
-
-
-
-and extraction, or the wide range of spell invention and research. He would rather be surrounded by his formulas and Lab Texts than anywhere else.
+Magi Bonisagi tend to be reclusive, eschewing the company of others as they work uninterrupted in their labs. Even a magus Bonisagi fresh from apprenticeship exhibits this behavior, viewing research as the ultimate method of unearthing the secrets of magic. He is at home in his laboratory, surrounded by tomes, and immersed among bubbling beakers and gurgling pots, the quintessential wizard, incorporating all aspects of magical possibilities and every arcane activity in his laboratory. Nothing magical disinterests him, whether that is familiar binding, item creation, longevity rituals, vis distillation and extraction, or the wide range of spell invention and research. He would rather be surrounded by his formulas and Lab Texts than anywhere else.
 
 Preferring their privacy, individual magi Bonisagi rarely meet. While they may be expected to attend Tribunal meetings, especially the Grand Tribunal, nothing mandates their attendance. Time spent traveling is time away from the laboratory. Magi Bonisagi have learned to interact with each other through written messages, notes delivered by Redcaps or itinerant magi Trianomae, although the later sometimes refuse to carry mere messages.
 
-Bonisagi magi receive infrequent visits from magi Trianomae, who are curious about the magi's research. The whole House benefits knowing the subject of each magus's research, so few magi Bonisagi refuse these minor interruptions. Submitting folios to the Colentes Arcanorum increases a maga's rank, and the safest way to ensure the deliver of folio submission is to placing it in the care of a magus Trianomae.
+Bonisagi magi receive infrequent visits from magi Trianomae, who are curious about the magi's research. The whole House benefits knowing the subject of each magus's research, so few magi Bonisagi refuse these minor interruptions. Submitting folios to the Colentes Arcanorum increases a maga's rank, and the safest way to ensure the delivery of a folio submission is to place it in the care of a magus Trianomae.
 
-#### TYPES OF MAGI BONISAGI
+#### Types of Magi Bonisagi
 
 There are three overall types of magi Bonisagi. These are not official distinctions within the House, but are merely paths that many magi Bonisagi follow. A **traditionalist** constantly works to refine Magic Theory, thinking this was Bonisagus's primary motivation. He pushes against the limits of Hermetic magic, searching for ways to break through many of the lesser limits that still inhibit Bonisagus's system. A **dabbler** is a magus who enjoys playing with Hermetic magic, using the system to build odd spells and quirky enchanted items. He researches magic for creative combinations of Ranges, Durations, and Targets, enjoying the symmetry of the categories created by his founder. A **harmonizer** believes that every type of magic can be integrated into Bonisagus's theory. She enjoys bending other supernatural abilities to Bonisagus's rule.
 
-These propensities for magi Bonisagi can be used by a character as specializations in their Magic Theory Ability. You may choose traditionalist, dabbler, or harmonizer as a specialization for your Magic Theory (see Specializations in the Abilities chapter of **ArM5**, page 62). As a traditionalist, each time your research attempts to break a Hermetic Limit of Magic, you may add 1 to your Magic Theory score (see Original Research below). If you are a dabbler, you may apply your specialization each time you invent a spell or magical affect with a changed Range, Duration, or Target that differs from the standard version. As a harmonizer you may apply your specialization each time you invent a spell or enchant an item that mimics a supernatural ability. This applies to
+These propensities for magi Bonisagi can be used by a character as specializations in their Magic Theory Ability. You may choose traditionalist, dabbler, or harmonizer as a specialization for your Magic Theory (see Specializations in the Abilities chapter of **ArM5**, page 62). As a traditionalist, each time your research attempts to break a Hermetic Limit of Magic, you may add 1 to your Magic Theory score (see Original Research below). If you are a dabbler, you may apply your specialization each time you invent a spell or magical affect with a changed Range, Duration, or Target that differs from the standard version. As a harmonizer you may apply your specialization each time you invent a spell or enchant an item that mimics a supernatural ability. This applies to original research as well. Your storyguide will be the ultimate arbitrator, deciding if your specialization applies to your research. These new specializations are only permissible for magi Bonisagi characters.
 
+> ## Story Seed: The Land of Women
+> 
+> A magus Trianomae visits the characters' covenant seeking assistance. He says he has discovered distant Amazonia, a fabled land inhabited only by women. He has a captive with him as evidence, a woman whose right breast has been removed. Her mind is addled and impenetrable to Mentem spells, a consequence of him magically defeating her, he says. He believes the Amazons' island kingdom is ruled by powerful sorceresses and asks the characters to return with him. Something about his manner is unsettling, reminding the characters that magi Trianomae are masters of intrigue and possible duplicity. Has he found the Land of the Amazons or is some evil afoot?
 
-A magus Trianomae visits the characters' covenant seeking assistance. He says he has discovered distant Amazonia, a fabled land inhabited only by women. He has a captive with him as evidence, a woman whose right breast has been removed. Her mind is addled and impenetrable to Mentem spells, a consequence of him magically defeating her, he says. He believes the Amazons' island kingdom is ruled by powerful sorceresses and asks the characters to return with him. Something about his manner is unsettling, reminding the characters that magi Trianomae are masters of intrigue and possible duplicity. Has he found the Land of the Amazons or is some evil afoot?
-
-original research as well. Your storyguide will be the ultimate arbitrator, deciding if your specialization applies to your research. These new specializations are only permissible for magi Bonisagi characters.
-
-#### WORKING TOGETHER
+#### Working Together
 
 Magi Bonisagi are not as interested in working together in the lab as other magi generally think. The main bone of contention is that a magus would much rather be the primary researcher than the assistant, since the primary researcher gains all the notoriety of the research and the assistant only gains exposure experience and minor House recognition. After the *daduchos* House rank, no magi Bonisagi wants to be considered an "assistant" any longer. Bonisagus is remembered for Magic Theory and Parma Magica, not for assisting Tremere in inventing certamen. While magi Bonisagi don't mind sharing finished Lab Texts and tractatus, they are hesitant to commit to another's research in a perceived subservient role.
 
 Two exceptions exist: newly-gauntleted magi Bonisagi who have not yet achieved any House rank, and magi returning to their parens's lab. These magi will work with a more experienced magi Bonisagi, forfeiting personal endeavors for the slow accumulation of House status and exposure experience points. Newly-gauntleted magi are expected to lead their own research by the time they have achieved the rank of *daduchos*. Magi can work with their parens up to the rank of *cannophori* without shame, but at that point they should be pursuing their own research. Magi who were fostered can include their fostering maga in this second category (see Fostering Apprentices).
 
-
-
-
-When magi Bonisagi do decide to collaborate, they work well together. Their natural affinity for the laboratory helps them, and they find they can overcome many of the constraints of a shared lab space that other magi find limiting. Their practice of fostering apprentices adds to their ability with multiple assistants. Because of this natural proclivity, magi Bonisagi can always have one more lab assistant then the normal **ArM5** rules would allow a magus character to have. This only applies to magi Bonisagi, their apprentices, and their familiars. For example, without a score in Leadership a maga Bonisagi can have two laboratory assistants besides her familiar.
+When magi Bonisagi do decide to collaborate, they work well together. Their natural affinity for the laboratory helps them, and they find they can overcome many of the constraints of a shared lab space that other magi find limiting. Their practice of fostering apprentices adds to their ability with multiple assistants. Because of this natural proclivity, magi Bonisagi can always have one more lab assistant than the normal **ArM5** rules would allow a magus character to have. This only applies to magi Bonisagi, their apprentices, and their familiars. For example, without a score in Leadership a maga Bonisagi can have two laboratory assistants besides her familiar.
 
 ### Magi Trianomae
 
@@ -697,7 +643,7 @@ Many followers of Trianoma lead itinerant lives, exhibiting the same wanderlust 
 
 Magi Trianomae have left Mythic Europe, seeking distant wizards and their magical knowledge, all in an effort to expand the model of a peaceful community of wizards. They serve as Hermetic emissaries, carrying the ideals of the Order to the farthest corners of the world, and have undertaken expeditions to Mythic Cathay, India and Africa. By 1220, no emissaries have reported any degree of success, either through failed efforts or by not returning at all.
 
-#### THE POLITICS OF TRIANOMA
+#### The Politics of Trianoma
 
 Magi Trianomae are expected to continue the political agenda of their founder. Not all do; some use their training to advance their own careers and ambitions. Those that do adhere to the founder's plan follow these major political concerns.
 
@@ -711,13 +657,9 @@ Magi Trianomae are expected to continue the political agenda of their founder. N
 
 **Keep the Houses bickering.** Trianoma learned early on that a certain amount of squabbling is good for the Order. It keeps the members engaged with each other, even if that engagement seems harsh at times. Squabbles also prevent two or more Houses from permanently joining, which would upset the balance of the Order.
 
-#### THE CIPHER OF TRIANOMA
+#### The Cipher of Trianoma
 
-During the early days of the Order, Trianoma found it very useful to send messages to her filii written in code, so that if these notes were intercepted they would not prematurely reveal any of her political plans. The easiest way to do this was to teach her filii her personal shorthand, the abbreviations she used when creating Lab Texts. This tradition continues with magi Trianomae
-
-
-
-using similar shorthand for their Lab Texts as they do for the clandestine notes they send each other. This script is not exact; individual magi do have slight variations of the cipher.
+During the early days of the Order, Trianoma found it very useful to send messages to her filii written in code, so that if these notes were intercepted they would not prematurely reveal any of her political plans. The easiest way to do this was to teach her filii her personal shorthand, the abbreviations she used when creating Lab Texts. This tradition continues with magi Trianomae using similar shorthand for their Lab Texts as they do for the clandestine notes they send each other. This script is not exact; individual magi do have slight variations of the cipher.
 
 Magi Trianomae use this code to send messages to each other and to the Tenentes Occultorum. Sometimes these messages are individual parchments. Other times they are notes inscribed at the end of Lab Texts or books. The most common method is to include a coded message in the margins of a magus Bonisagus's Lab Text that is in their possession at the time. This is then sent to another magus Trianomae along the regular routes. Magi Trianomae are trained to look for these coded messages.
 
@@ -731,7 +673,7 @@ The second and harder method is to decode a secret note. Decoding a note takes a
 
 ### House Acclaim: Status in House Bonisagus
 
-Magi Bonisagi have developed a system of recognition within their branch of House Bonisagus to indicate the accumulated rewards of their research efforts. Magi advance through the ranks of this system based on their finished research efforts. This system of rank is called **House Acclaim**, and each type of laboratory activity is worth certain amount.
+Magi Bonisagi have developed a system of recognition within their branch of House Bonisagus to indicate the accumulated rewards of their research efforts. Magi advance through the ranks of this system based on their finished research efforts. This system of rank is called **House Acclaim**, and each type of laboratory activity is worth a certain amount.
 
 House Acclaim is a free Reputation that every magus Bonisagi character receives at character generation. Only magi Bonisagi are actually interested in this Reputation. Magi Trianomae understand that it is a measure of their brethren's status, but aren't overly concerned with it. Magi of other Houses have differing opinions. Some find it overly pedantic, an arrogant practice by an already pretentious lineage, while others think it a practical device that encourages original research, from which the entire Order benefits. Outside the House it has little relevance; inside House Bonisagus, many magi Bonisagi are obsessive about it, measuring themselves against their fellows by their rank within the House.
 
@@ -739,146 +681,108 @@ House Acclaim is increased by Acclaim points. Different types of laboratory rese
 
 ### Research and Acclaim Points
 
-| Type of Research<br>Acclaim Points                |
-|---------------------------------------------------|
-| Write an Art tractatusQuality/2                   |
-| Write an Art summaLevel/2                         |
-| Invent an original spell1/magnitude of spell      |
-| Invent an original spell using                    |
-| experimentation<br>2/magnitude of spell           |
-| Create a Talisman2                                |
-| Bind a familiarMagic Might of familiar/5          |
-| Train an apprentice3                              |
-| Assist a magus of higher rank in the lab1/project |
-| Stabilize a breakthrough3/magnitude of spell      |
-| Achieve a minor breakthrough15                    |
-| Achieve a major breakthrough30                    |
-|                                                   |
+| Type of Research                         | Acclaim Points            |
+|------------------------------------------|---------------------------|
+| Write an Art tractatus                   | Quality/2                 |
+| Write an Art summa                       | Level/2                   |
+| Invent an original spell                 | 1/magnitude of spell      |
+| Invent an original spell using experimentation | 2/magnitude of spell |
+| Create a Talisman                        | 2                         |
+| Bind a familiar                          | Magic Might of familiar/5 |
+| Train an apprentice                      | 3                         |
+| Assist a magus of higher rank in the lab | 1/project                 |
+| Stabilize a Breakthrough                 | 3/magnitude of spell      |
+| Achieve a Minor Breakthrough             | 15                        |
+| Achieve a Major Breakthrough             | 30                        |
 
 There are four ranks of magi Bonisagi. In order, they are the *boukoloi* ("cowherds"), the *daduchos* ("torch-bearers"), the *cannophori* ("reed-bearers"), and the *dendrophori* ("tree-bearers"). Magi Bonisagi fresh from their gauntlet have no rank, and the Primus is above the ranks. These ranks and their responsibilities are explained in the Magi Bonisagi section.
 
-The House uses this system of rank to determine who is above who, a snobbish pecking order of magi. Much like the noble status of the feudal mundanes, the rankings of magi Bonisagi determine the relationships between the reclusive Hermetic scholars. Magi will only foster their apprentices with magi of equal rank. Furthermore, magi
+The House uses this system of rank to determine who is above who, a snobbish pecking order of magi. Much like the noble status of the feudal mundanes, the rankings of magi Bonisagi determine the relationships between the reclusive Hermetic scholars. Magi will only foster their apprentices with magi of equal rank. Furthermore, magi Bonisagi would prefer to have their apprentice gauntleted by a magus of a higher rank than themselves.
 
+## House Acclaim Points and Score
 
+| Acclaim Score | Acclaim Points to reach | Acclaim point to increase to | Title       |
+|---------------|-------------------------|------------------------------|-------------|
+| 1             | 5                       | 5                            | Boukoloi    |
+| 2             | 15                      | 10                           | Daduchos    |
+| 3             | 30                      | 15                           | Cannophori  |
+| 4             | 50                      | 20                           | Dendrophori |
+| 5             | n/a                     | n/a                          | Primus      |
 
-### House Acclaim Points and Score
-
-|       | Acclaim Acclaim Points Acclaim point |                |             |  |
-|-------|--------------------------------------|----------------|-------------|--|
-| Score | to reach                             | to increase to | Title       |  |
-| 1     | 5                                    | 5              | Boukoloi    |  |
-| 2     | 15                                   | 10             | Daduchos    |  |
-| 3     | 30                                   | 15             | Cannophori  |  |
-| 4     | 50                                   | 20             | Dendrophori |  |
-| 5     | n/a                                  | n/a            | Primus      |  |
-|       |                                      |                |             |  |
-
-Bonisagi would prefer to have their apprentice gauntleted by a magus of a higher rank than themselves.
-
-A magus Bonisagi may add his House
-
-Acclaim score to any social skill roll that involves interacting with another magus of House Bonisagus, including magi Trianomae. A good rule of thumb is to add a character's House Acclaim score to any roll that involves her Presence characteristic. This advantage is only added when the magi involved are from House
-
-Bonisagus; magi of other lineages are not as influenced by Bonisagus status as House members are. Magi Trianomae find it harder to influence magi Bonisagi of rank than those of lesser status, and a magus Bonisagi may add his House Acclaim score to any Intrigue or Guile roll used to resist a maga Trianomae's influence.
+A good rule of thumb is to add a character’s House Acclaim score to any social skill roll involving her Presence characteristic when interacting with another magus of House Bonisagus, including magi Trianomae. This advantage is only added when the magi involved are from House Bonisagus; magi of other lineages are not as influenced by Bonisagus status as House members are. Magi Trianomae find it harder to influence magi Bonisagi of rank than those of lesser status, and a magus Bonisagi may add his House Acclaim score to any Intrigue or Guile roll used to resist a maga Trianomae’s influence.
 
 House Acclaim does not add to a magus's Presence during bouts of Certamen, a method rarely used to settle disagreements among members of House Bonisagus.
 
-A magus Bonisagi of rank has an easier time finding an apprentice. You may add your Acclaim score to your roll to find an apprentice (see **ArM5**, Laboratory chapter, Apprentices, page 106). If the result is 12+, you find one as normal. If you fail this roll, you still find one, taking an apprentice from another magus as is your right. If your roll fails by 5 or more points, you have antagonized a fellow magus who will need some form of compensation to be placated. If you botch this roll your enemy is
-
-so vehement that you gain the Major Story Flaw: Enemies.
+A magus Bonisagi of rank has an easier time finding an apprentice. You may add your Acclaim score to your roll to find an apprentice (see **ArM5**, Laboratory chapter, Apprentices, page 106). If the result is 12+, you find one as normal. If you fail this roll, you still find one, taking an apprentice from another magus as is your right. If your roll fails by 5 or more points, you have antagonized a fellow magus who will need some form of compensation to be placated. If you botch this roll your enemy is so vehement that you gain the Major Story Flaw: Enemies.
 
 ### Folios
 
-Folios are collections of Laboratory Texts and tractatus compiled by the Colentes Arcanorum the season after the close of the Colloquium Delectorum. They are thick volumes containing many pages of parchment, and at a glace can be confused with a weighty summa. Rather than an encyclopedic examination of a single topic however, folios contain information about a variety of topics. Having received submitted texts from other magi Bonisagi
+Folios are collections of Laboratory Texts and tractatus compiled by the Colentes Arcanorum the season after the close of the Colloquium Delectorum. They are thick volumes containing many pages of parchment, and at a glance can be confused with a weighty summa. Rather than an encyclopedic examination of a single topic however, folios contain information about a variety of topics. Having received submitted texts from other magi Bonisagi during the last seven years, the Colentes select the best submissions to include in the folio. Folios also include a smattering of information about the various authors, as well as the Colentes's insights and opinions. Coveted by magi throughout the Order, folios provide a wealth of information in a single binding.
 
-> during the last seven years, the Colentes select the best submissions to include in the folio. Folios also include a smattering of information about the various authors, as well as the Colentes's insights and opinions. Coveted by magi throughout the Order, folios provide a wealth of infor-
+Once the Colentes have decided on the exact material to be included in a folio, they spend the next season compiling it, staying on at the covenant that held the Colloquium Delectorum. Folios are titled by the year in which they were made, 'The Folio of 1123', for example. Once completed the folio is taken to Durenmar, where it is copied three times. The first copy is made for House Guernicus and sent to Magvillus in an overt display of House Bonisagus sharing its research. The second copy goes to the covenant that housed the Colentes during their season spent compiling, as reimbursement for their hospitality. The third copy is sent to Harco, domus magna of House Mercere. This copy circulates throughout the Order, carried from covenant to covenant by the Redcaps, along a predetermined route. Each covenant negotiates with House Mercere for their position on this waiting list, as well as for the length of time the folio stays. Naturally, the Redcaps charge for this service.
 
-> > mation in a single binding.
-
-Once the Colentes have decided on the exact material to be included in a folio, they spend the next season compiling it, staying on at the covenant that held the Colloquium Delectorum. Folios are titled by the year in which they were made, 'The Folio of 1123', for example. Once completed the folio is taken to Durenmar, where it is copied three times. The first copy is made for House Guernicus and sent to Magvillus in an overt display of House Bonisagus sharing its research. The second copy goes to the covenant that housed the Colentes during their season spent compiling, as reimbursement for their hospitality. The third copy is sent to Harco, domus magna of House Mercere. This copy circulates throughout the Order, carried from covenant to covenant by the Redcaps, along a predetermined route. Each covenant negotiates with House Mercere for their position on this waiting list, as well as for the length of time the folio stays. Naturally, the Redcaps charge for this service
-
-
-
-
-#### WRITING FOLIOS
+#### Writing Folios
 
 It takes a season to create a folio. The Colentes Arcanorum's combined Magic Theory scores are the maximum total of Lab Text magnitudes and tractatus Qualities that can be included in a single volume. For example, if the 5 Colentes have a Magic Theory score of 7 each (including their Puissant Magic Theory Ability), the folio can have a total of 35 magnitudes of Lab Texts or tractatus Qualities.
 
-#### Folios: Colentes combined Magic Theory = Sum of Lab Text magnitudes and/or tractatus Qualities
+**Folios: Colentes combined Magic Theory = Sum of Lab Text magnitudes and/or tractatus Qualities**
 
 Once the total number of allowable items has been determined, individual texts are copied to the folio. The regular rules for copying Lab Texts and tractatus apply. Lab Texts are always submitted to the Colentes with the author's abbreviations and shortcuts omitted, so that they are written understandably. An individual Colens may either copy Lab Texts or tractatus. A Colens may copy 12 magnitudes of Lab Texts per point in Profession: Scribe into a folio. A Colens copying tractatus may copy them carefully or quickly, depending on the number of tractatus included. Since quick copying reduces the tractatus' Quality by one, this is rarely done.
 
 The Colentes Arcanorum receive Exposure experience for the season spent creating the folio, which can be placed in Magic Theory or Profession: Scribe.
 
-#### EXAMPLE FOLIO
+#### Example Folio
 
-Five Colentes have decided which items will go into a folio. Their combined Magic Theory score is 35. Their final choices are a tractatus on Herbam Quality 8, a tractatus on Magic Lore Quality 10, a Lab Text for *Stone Tell of the Mind that Sits* (magnitude 6), a Lab Text for *Ball of Abysmal Flame* (magnitude 7), and a Lab Text for *Veil of Invisibility* (magnitude 4). The Lab Texts were chosen because the inventing magi used experimentation, and each spell has a beneficial side-affect. One of the Colens has a Profession: Scribe score high enough to copy all of the Lab Texts into the folio herself, and two other Colentes can copy the tractatus. The remaining two stay to assist their colleagues.
+Five Colentes have decided which items will go into a folio. Their combined Magic Theory score is 35. Their final choices are a tractatus on Herbam Quality 8, a tractatus on Magic Lore Quality 10, a Lab Text for *Stone Tell of the Mind that Sits* (magnitude 6), a Lab Text for *Ball of Abysmal Flame* (magnitude 7), and a Lab Text for *Veil of Invisibility* (magnitude 4). The Lab Texts were chosen because the inventing magi used experimentation, and each spell has a beneficial side-effect. One of the Colens has a Profession: Scribe score high enough to copy all of the Lab Texts into the folio herself, and two other Colentes can copy the tractatus. The remaining two stay to assist their colleagues.
 
-#### READING FOLIOS
+#### Reading Folios
 
-Essentially, a folio is nothing more than a collection of Lab Texts and tractatus, and the same rules used to read those materials still apply. Having a folio provides you with a handful of choices for your personal study. Each
-
-
-Magi Bonisagi do not always readily agree on what submitted texts should be included in a folio, and disagreements are hotly debated. One magus will argue to include a text, while one or more of his fellows may resist. Space in a folio is limited, and arguments occur more often than not. These are sometimes settled politically. One magus may decline to push for his text if another agrees to foster his apprentice, for example. The Colentes Arcanorum make these decisions in a closed session of the Colloquium, so they are not shy about making petty arguments that may seem beneath their station.
-
-If character magi are involved in such a decision, the storyguide may ask the characters to make stress rolls against each other to see who wins the argument. Characters may choose to loudly shout down a disagreeing opponent or eloquently counter their opponent with a crafty argument for a text's inclusion. Loud characters may make a Presence + Leadership stress roll. Crafty characters may make a Communication + Artes Liberales stress roll. Both types of arguers may add their House Acclaim score to their roll. The character with the higher total wins the argument.
-
-individual Lab Text or tractatus must be read for an entire season, just as if it was a stand alone text.
+Essentially, a folio is nothing more than a collection of Lab Texts and tractatus, and the same rules used to read those materials still apply. Having a folio provides you with a handful of choices for your personal study. Each individual Lab Text or tractatus must be read for an entire season, just as if it was a stand alone text.
 
 The Colentes Arcanorum include biographical data on the author as well as brief accounts of their opinion of the text. Once you have finished a particular item included in a folio, you receive one experience point in Order of Hermes Lore.
 
-#### COPYING FOLIOS
+> ## Editorial Disagreements
+> 
+> Magi Bonisagi do not always readily agree on what submitted texts should be included in a folio, and disagreements are hotly debated. One magus will argue to include a text, while one or more of his fellows may resist. Space in a folio is limited, and arguments occur more often than not. These are sometimes settled politically. One magus may decline to push for his text if another agrees to foster his apprentice, for example. The Colentes Arcanorum make these decisions in a closed session of the Colloquium, so they are not shy about making petty arguments that may seem beneath their station.
+> 
+> If character magi are involved in such a decision, the storyguide may ask the characters to make stress rolls against each other to see who wins the argument. Characters may choose to loudly shout down a disagreeing opponent or eloquently counter their opponent with a crafty argument for a text's inclusion. Loud characters may make a Presence + Leadership stress roll. Crafty characters may make a Communication + Artes Liberales stress roll. Both types of arguers may add their House Acclaim score to their roll. The character with the higher total wins the argument.
+
+#### Copying Folios
 
 Folios are combined copies of Lab Texts and tractatus, organized and edited by the Colentes. Once combined, they are easier to copy than their individual parts. Copying a folio is very much like copying a summa, and can be done carefully or quickly. If a scribe is copying a folio carefully, he accumulates points equal to 6 + his Profession: Scribe score in a season. Once his accumulated points equal the combined Magic Theory score of the Colentes Arcanorum who created the folio, the folio is copied. If he copies the folio quickly, he gains 18 + 3 times his Profession: Scribe score in accumulated points per season. Quickly copying a folio will reduce the Quality of every included tractatus by 1 and delete the additional Order of Hermes Lore experience points. It will not affect the Lab Texts.
-
-
-
 
 Magi Trianomae begin play with the free Virtue: Puissant Intrigue, the time-honored method of scheming and plotting. This Ability is defined in the core rules of **ArM5**, but character magi might require more information. The following rules detail when an Intrigue roll is called for and exactly what a successful result means.
 
 Whenever a character magus Trianomae seeks to influence a non-player character, they may make a Presence + Intrigue roll. If they are seeking information they may make a Communication + Intrigue roll. The social consequences of The Gift affect this roll, penalizing it by –3, –6 if the maga has the Blatant Gift. Ignore this penalty if both parties are under the protection of a Parma Magica. Because of the nature of suspicion and deceit, this roll should always be a stress roll. The necessary Ease Factors for success are listed on the following chart.
 
-**Influence a non-player character: Presence + Intrigue vs. variable Ease Factor**
+> **Influence a non-player character: Presence + Intrigue vs. variable Ease Factor**
+> 
+> **Interrogate a non-player character: Communication + Intrigue vs. variable Ease Factor**
+> 
+> | Intrigue Ease Factor | Situation |
+> |-------------|-----------|
+> | 6+  | Accurately ascertain someone's overt political goal; make a person continue a political course they are currently following |
+> | 9+  | Determine a person's political allies; arouse suspicion in a person; delay a person's current course of action; make a person agree to meet with a rival |
+> | 12+ | Determine a person's unstated political agenda; turn ambivalent allies against each other; alter a person's course of action; help antagonists settle minor disputes |
+> | 15+ | Determine a person's silent partners; sever an alliance between trusted allies; turn a person to a course of action ultimately detrimental to their interests; help antagonists settle major disputes |
+ 
+Politics is rarely a static arena, and sometimes a magus Trianomae character must make Intrigue rolls against another active participant, either a player or non-player character. In such a case, the magus Trianomae rolls Presence + Intrigue + a stress die against the target's Communication + Intrigue + stress die. The target may elect to use her Guile Ability instead of her Intrigue Ability. Success is determined by the situation and the amount by which the victor's total exceeds the loser's.
 
-**Interrogate a non-player character: Communication + Intrigue vs. variable Ease Factor**
-
-#### Intrigue
-
-#### Ease
-
-#### Factor Situation
-
-- 6+ Accurately ascertain someone's overt political goal; make a person continue a political course they are currently following
-- 9+ Determine a person's political allies; arouse suspicion in a person; delay a person's current course of action; make a person agree to meet with a rival
-- 12+ Determine a person's unstated political agenda; turn ambivalent allies against each other; alter a person's course of action; help antagonists settle minor disputes
-- 15+ Determine a person's silent partners; sever an alliance between trusted allies; turn a person to a course of action ultimately detrimental to their interests; help antagonists settle major disputes
-
-Politics is rarely a static arena, and sometimes a magus Trianomae character must make Intrigue rolls against another active participant, either a player or non-player character. In such a case, the magus Trianomae rolls Presence + Intrigue + a stress die against the target's Communication + Intrigue + stress die. The target may
-
-
-elect to use her Guile Ability instead of her Intrigue Ability. Success is determined by the situation and the amount by which the victor's total exceeds the loser's.
-
-#### Victor
-
-#### wins by Result
-
-- 3+ Determine if the person is a possible ally or antagonist; encourage a person to continue a course of action
-- 6+ Rattle a person's composure; force a minor secret to be divulged; influence opponent to a new course of action
-- 9+ Purposefully embarrass a person in public; force a major secret to slip; force opponent to betray an ambivalent alliance
-- 12+ Completely expose any secrets the opponent may hold; force the opponent to betray a trusted alliance
-- 15+ Force a magus to act against the best interests of his House
-
-Intrigue contests are not rapid events, and the course of an exchange may continue throughout dinner, a day's joint activity, or even an entire Tribunal. As the exchange nears its end, the Storyguide should call for an Intrigue roll.
+Intrigue contests are not rapid events, and the course of an exchange may continue throughout dinner, a day’s joint activity, or even an entire Tribunal. As the exchange nears its end, the Storyguide should call for an Intrigue roll.
 
 For example, Glaucon Trianomae visits the covenant of Semita Errabunda and dines with Moratamis of House Guernicus. Moratamis suspects that Glaucon snatched the golden rabbit, one of the covenant's vis sources. Glaucon hopes to allay Moratamis's suspicions by suggesting that someone else abducted the rabbit. As the meal ends, the storyguide asks both players to make an Intrigue roll. She determines that Glaucon needs to roll a 6+ advantage to succeed in changing Moratamis's mind. Glaucon's Presence (0) + Intrigue (4) is 4 and Moratamis's Communication (+1) + Intrigue (3) is 4: an even match. Unfortunately for Glaucon, their stress die rolls also match, and he fails in his attempt to change the Quaesitor's mind. Moratamis suggests they continue the subject at the next Tribunal.
 
-#### FOLK KEN AND GUILE
+> | Victor wins by | Result |
+> |----------------|--------|
+> | 3+  | Determine if the person is a possible ally or antagonist; encourage a person to continue a course of action |
+> | 6+  | Rattle a person's composure; force a minor secret to be divulged; influence opponent to a new course of action |
+> | 9+  | Purposefully embarrass a person in public; force a major secret to slip; force opponent to betray an ambivalent alliance |
+> | 12+ | Completely expose any secrets the opponent may hold; force the opponent to betray a trusted alliance |
+> | 15+ | Force a magus to act against the best interests of his House |
 
-Social skills can be used to complement roleplaying rather an as a substitute for it. Whenever a player character interacts with an important non-player character the storyguide may make a secret Per + Folk Ken roll. From this roll the storyguide should give the player appropriate commentary on the subject's behavior. A roll of 6+ allows for basic insights, the subject's general character. A roll of
+#### Folk Ken and Guile
 
-
-
-9+ allows for more specific insights, the player can be told if the character appears not entirely honest or acting out of character. A 12+ allows the player to know which statements are likely to be deceptive. Higher rolls allow more surety of impression.
+Social skills can be used to complement roleplaying rather than as a substitute for it. Whenever a player character interacts with an important non-player character the storyguide may make a secret Per + Folk Ken roll. From this roll the storyguide should give the player appropriate commentary on the subject's behavior. A roll of 6+ allows for basic insights, the subject's general character. A roll of 9+ allows for more specific insights, the player can be told if the character appears not entirely honest or acting out of character. A 12+ allows the player to know which statements are likely to be deceptive. Higher rolls allow more surety of impression.
 
 Folk Ken can be countered with the Guile skill. A character attempting to deceive rolls Com + Guile. A Guile roll of 9+ allows the deceiver to put on a reasonable front, the character can lie without being obvious. If 12+, the deception appears near perfect, but a higher Folk Ken roll will reveal the cracks. A guile roll of 15+ is perfect, unless the observer knows someone is lying he will not be able to tell. Just because a character rolls well on a Guile test, does not mean the opponent believes what he is told. Folk Ken impressions are important, but the wise do not rely on them exclusively; they may not believe someone who tells them that grass is blue, even if they cannot tell that he is lying from his demeanor.
 
@@ -888,32 +792,29 @@ Folk Ken and Intrigue are complementary. The former allows the character to judg
 
 Over the years House Bonisagus has included many members with particular Virtues and Flaws. Since the House can select other magi's apprentices, youths who exhibit these powers are often adopted into the House. However, this does not mean that Bonisagi are the sole recipients of these boons. Virtues and Flaws marked with an asterisk depend on the structure of House Bonisagus, and so are exclusive to the House. Others are not.
 
-### MINOR HERMETIC VIRTUES
+#### Minor Hermetic Virtues
 
-**Colens Arcanorum\*:** You are a member of one of the inner circles of House Bonisagus, the Collectors of Secrets. You begin the game with the House Bonisagus rank *cannophori.* During your seven year tenure you will receive Lab Texts and tractatus from other magi Bonisagi, which you may keep. At the end of your service you must attend the Colloquium Delectorum and decide which of these submitted text will be included in a folio. You must also contribute to the folio's construction. This Virtue is
+**Colens Arcanorum\*:** You are a member of one of the inner circles of House Bonisagus, the Collectors of Secrets. You begin the game with the House Bonisagus rank *cannophori.* During your seven year tenure you will receive Lab Texts and tractatus from other magi Bonisagi, which you may keep. At the end of your service you must attend the Colloquium Delectorum and decide which of these submitted text will be included in a folio. You must also contribute to the folio's construction. This Virtue is not appropriate for magi Bonisagi fresh from their gauntlet; you should have passed your apprentice’s gauntlet at least ten years ago.
 
+**Tenens Occultorum**: You are a member of one of the inner circles of House Bonisagus, the Tenders of Secret Knowledge. You have been chosen by the Primus to occupy one of the four Tenentes Occultorum positions. Your exact position is depending on your experience, judged by the numbers of seasons since your gauntlet. If you are a younger magus you will be the Spring Tenens. Certain responsibilities accompany this Virtue.
 
-**Tenens Occultorum\***: You are a member of one of the inner circles of House Bonisagus, the Tenders of Secret Knowledge. You have been chosen by the Primus to occupy one of the four Tenentes Occultorum positions. Your exact position is depending on your experience, judged by the numbers of seasons since your gauntlet. If you are a younger magus you will be the Spring Tenens. Certain responsibilities accompany this Virtue.
-
-#### MINOR SUPERNATURAL VIRTUE
+#### Minor Supernatural Virtue
 
 **Figurine Magic.** You have been taught the art of Figurine Magic, which allows you to construct small wax or wood figurines of power, whose benefits may assist you or others. You may either be a Gifted magus or a non-Gifted practitioner. Taking this Virtue confers the Ability Figurine Magic 1. See the optional example in the Example Discoveries section for more information.
 
-### MINOR GENERAL VIRTUE
+### Minor General Virtue
 
 **Linguist.** You are extremely proficient learning new languages. All Study Totals for any Language are increased by a quarter, as any experience points you put into any language at character generation. Both Living and Dead languages are augmented with this Virtue.
 
-#### MINOR HERMETIC FLAW
+#### Minor Hermetic Flaw
 
 **Stockade Parma Magica:** Because of your restricted understanding of Parma Magica, you cannot suppress your Parma once it is erected. Any friendly spell or magical affect must penetrate your Parma Magica to affect you, just as if it were a hostile spell.
 
-#### MINOR PERSONALITY FLAW
+#### Minor Personality Flaw
 
 **Seeker:** You are a self-proclaimed member of the Seekers, a loose organization of competitive magi searching for ancient magic and arcane artifacts. Much of your life is spent in pursuit of these items. Your interests may occasionally clash with other interests of your House.
 
-
-
-### MINOR STORY FLAW
+#### Minor Story Flaw
 
 **Fostered Apprentice\*:** You were fostered as an apprentice, briefly serving another magus in his laboratory. You have a lasting relationship with this magus, similar to the relationship you have with your parens. You also have a connection to another magi Bonisagi that you trained with. Either of these people may ask favors of you, which you feel obligated to perform.
 
@@ -925,35 +826,28 @@ Of all the Hermetic Houses, House Bonisagus is the most compelled to augment the
 
 A magus may begin original research at any time in his career. Some wait, increasing their knowledge of the Arts to bolster their Lab Total, while others begin as soon as they leave apprenticeship. There are no minimum Art or Ability requirements for undertaking original research and the process is the same whether the magus is a wizened archmagus or a fresh-eyed youth. Bear in mind that you will eventually teach others any Breakthrough you have achieved, either through individual instruction or written tractatus, so a high Language or Teach Ability may be useful.
 
-#### BREAKTHROUGHS
+#### Breakthroughs
 
 By undertaking original research you are attempting to achieve some goal that has not been reached previously by Hermetic magic. These achievements are called **Breakthroughs** and there are three types: Minor, Major, and Hermetic.
 
-
 A **Minor Breakthrough** is something that is immediately usable and teachable in the existing framework of Hermetic magic. A new spell Range or Duration is a good example of a Minor Breakthrough. In many sagas, Minor Breakthroughs happen often enough that a maga can expect to achieve this goal once or twice during her lifetime. Minor Breakthroughs could be more common, but are few because most magi Bonisagi have loftier goals. Why invent a new Range when you can attempt to break a Hermetic Limit? Grandiosity usually propels magi toward harder projects.
 
-A **Major Breakthrough** pushes the limits of Magic Theory without actually breaking them. These sorts of Breakthroughs are often Hermetic Virtues that can be taught to the Gifted. Incorporating types of non-hermetic spell casting into Hermetic magic is another example of a Major Breakthrough; these then becoming teachable
-
-
-
-Supernatural Virtues. A Major Breakthrough can also allow you to adapt a standard application of a Hermetic idea in a variable way. Notatus' development of the *Aegis of the Hearth* was a Major Breakthrough, a variable spell based on Bonisagus' Parma Magica. Major Breakthroughs make a magus famous. With persistence, a troupe playing in a fast speed saga could realistically see a player make a Major Breakthrough.
+A **Major Breakthrough** pushes the limits of Magic Theory without actually breaking them. These sorts of Breakthroughs are often Hermetic Virtues that can be taught to the Gifted. Incorporating types of non-hermetic spell casting into Hermetic magic is another example of a Major Breakthrough; these then becoming teachable Supernatural Virtues. A Major Breakthrough can also allow you to adapt a standard application of a Hermetic idea in a variable way. Notatus' development of the *Aegis of the Hearth* was a Major Breakthrough, a variable spell based on Bonisagus' Parma Magica. Major Breakthroughs make a magus famous. With persistence, a troupe playing in a fast speed saga could realistically see a player make a Major Breakthrough.
 
 A **Hermetic Breakthrough** is a new Arcane Ability or the breaking of a Lesser Limit. Nearly anything is possible; this is magic in its most uncharted state. A new Arcane Ability could be the practice of sending mental images from the mind of one magus to another (crude telepathy) or the ability to walk through different levels of regiones without the use of spells. Breaking the Lesser Limits of Hermetic magic is also a viable goal. Depending on the sensibilities of the troupe, any of the Lesser Limits could be violated, which would definitely change the shape of magic in your saga. In a canonical **Ars Magica** setting, the Parma Magica is the only Hermetic Breakthrough that has occurred in the 450 years of the Order of Hermes.
 
 It is important to discuss your idea and the specific Breakthrough you are attempting with your troupe. Does the group want a Lesser Limit broken, for example, or will a teachable Hermetic Virtue upset the nature of the game? If the Limit of Creation is broken, then magi will be creating permanent items out of thin air, without the necessity for vis, which could undermine many of the storyguide's upcoming stories.
 
-### SEEKING THE UNKNOWN
-
+#### Seeking the Unknown
 Once you have determined what sort of Breakthrough you would like to accomplish, you must invent something Hermetically that somehow incorporates your idea. This can be a spell or a magical enchantment, either a lesser enchantment or a charged item. Detail the effect fully, as per the normal rules found in the Laboratory chapter of **Ars Magica** Fifth Edition. Since you are searching for clues aimed at surpassing regular Hermetic theories, you must experiment, using the rules found in the Arcane Experimentation section of the Laboratory chapter, including choosing a risk modifier for your experiment and rolling on the Extraordinary Results Chart.
 
-For your original research to be fruitful you must roll the Discovery result on the Extraordinary Results Chart. Fortune plays a large roll in the research process. However, you can hedge your bet with original research in a way that you can not with regular experimentation. Instead of calculating your risk modifier into your Lab Total during the season, you use that modifier to adjust
+For your original research to be fruitful you must roll the Discovery result on the Extraordinary Results Chart. Fortune plays a large roll in the research process. However, you can hedge your bet with original research in a way that you can not with regular experimentation. Instead of calculating your risk modifier into your Lab Total during the season, you use that modifier to adjust your roll on the Extraordinary Results Chart. The risk modiﬁer still runs the range of +1 to +3, but you are restricted in your choice by your Magic Theory score. For every ﬁve points or fraction thereof of Magic Theory (including Puissant Magic Theory) you may choose a risk modiﬁer of 1. Thus, to chose a risk modiﬁer of +2 your Magic Theory must be 6 or higher, and a risk modiﬁer of +3 requires a Magic Theory of 11+. 
 
+**Risk Modifier: +1 per 5 points of Magic Theory or fraction thereof, up to +3**
 
-#### Risk Modifier: +1 per 5 points of Magic Theory or fraction thereof, up to +3
+Consult the Extraordinary Results Chart as normal to determine the effect on your spell. However, you may also add or subtract all or part of your Risk Modifier in order to get a Discovery in addition to the normal effect of experimentation. Thus, if you had a Risk Modifier of +3, and rolled an 8, you would get a Modified Effect. You could also subtract 1 to get a Discovery in addition. The effect of the spell is still modified. You cannot use the Risk Modifier to get a supplementary result other than a Discovery.
 
-Consult the Extraordinary Results Chart and add or subtract the risk modifier from a stress die roll. You must do one or the other, but this gives you a slight choice in your result. You do not have to use the whole modifier. If you choose a +3 risk modifier, for example, and it is more advantageous to use a +2 modifier, you may. If you roll a 0 on the stress die you must still check for a botch, rolling an additional botch die for each level of risk modifier you chose.
-
-#### Breakthrough: roll Discovery on the Extraordinary Results Chart during a season of Arcane Experimentation
+**Breakthrough: roll Discovery on the Extraordinary Results Chart during a season of Arcane Experimentation**
 
 **Risk Modifier: Do not add risk modifier into Lab Total. Add or Subtract risk modifier from the stress die rolled on the Extraordinary Results Chart**
 
@@ -961,14 +855,11 @@ You are hoping for a Discovery. If you do not roll a Discovery, your spell or it
 
 If your spell or enchanted item research takes more than a single season to complete you must continue to roll on the Extraordinary Results Chart for each season. Having deciding how you will use your risk modifier in a previous season, you must continue to use it in the same manner for consecutive seasons. If you subtracted 1 from your initial roll on the Extraordinary Results Chart in your first season, for example, you must subtract 1 from every additional roll on the Extraordinary Results Chart in additional seasons until the item or spell is completed. You may accrue odd and weird results as your research progresses, but may continue to experiment providing you don't receive a Complete Failure or Disaster result.
 
-
-
-
 If you do achieve a Discovery during your experimentation then the original research was a success. Ignore the Discovery sub-chart of the Extraordinary Results Chart; that chart applies to those not investigating the deeper mystery of Hermetic magic, instead discovering something more intimate about their personal connection to magic and the Arts. You, however, have found that elusive element of magic that you started your original research searching for. Now you must stabilize that experimental process to better understand your discovery.
 
 Each spell or magical enchantment can only lead to one discovery. You may continually invent the same spell or enchantment experiment until a discovery is rolled, even if the experiment was a success. Thus, you may accumulate many usable versions of the same spell in process of your research. However, once a specific experiment yields a Discovery, you may no longer explore that spell or magical enchantment for further discoveries.
 
-### STABILIZING THE UNKNOWN
+#### Stabilizing the Unknown
 
 After you have achieved your Discovery, you must stabilize that process through exact repetition. You must repeat the experimentation, continuing for the same number of seasons and using the exact Lab Total and risk modifier that you used to find your Discovery. If you used vis during your process you must repeat the amount used. You must roll again on the Extraordinary Results Chart, and you must modify your roll in the same direction as you did to make the Discovery. This means that if you added your risk modifier to your roll your must add it again; if you subtracted your risk modifier from your roll you must subtract it this second time.
 
@@ -976,29 +867,25 @@ During the stabilization season you do not need to roll a Discovery to succeed. 
 
 Original research is the process of accumulating stabilized discoveries until a Breakthrough is achieved. If your stabilization season succeeds, you gain a point per magnitude of the invented Hermetic spell or enchanted item that you may use towards your Breakthrough. You also create a Laboratory Text that explains your discovery. When these points reach a certain threshold number, you succeed; your research has achieved a Breakthrough.
 
-> **Magnitudes of Stabilized Discovery equal Breakthrough points**
+**Magnitudes of Stabilized Discovery equal Breakthrough points**
 
-As a side affect to this stabilization process, you receive Warping Points from your attempts to understand this new magic. The number of Warping Points gained is the magnitude of the effect — a simple die. If you gain more than 2 Warping Points you must roll to avoid Wizard's Twilight, as explained in the Wizard's Twilight section of **Ars Magica** 5th Edition's Hermetic Magic chapter (page 88). You can obviously mitigate the chance of gaining Warping Points by experimenting with lower magnitude effects. However, this lengthens your original research process, since it is your accumulated effect magnitudes that ultimately add up to your Breakthrough. Experimenting with higher magnitude spells hastens you toward your Breakthrough and increases your risk of Wizard's Twilight.
+As a side affect to this stabilization process, you receive Warping Points from your attempts to understand this new magic. The number of Warping Points gained is the magnitude of the effect — a simple die. IIf you gain 2 or more Warping Points you must roll to avoid Wizard's Twilight, as explained in the Wizard's Twilight section of **Ars Magica** 5th Edition's Hermetic Magic chapter (page 88). You can obviously mitigate the chance of gaining Warping Points by experimenting with lower magnitude effects. However, this lengthens your original research process, since it is your accumulated effect magnitudes that ultimately add up to your Breakthrough. Experimenting with higher magnitude spells hastens you toward your Breakthrough and increases your risk of Wizard's Twilight.
 
 #### Warping Points gained: the Magnitude of the Stabilized Discovery minus a simple die
 
 You receive Warping Points whether you succeed or fail at stabilizing your discovery. If your stabilization attempt fails, you may spend another season and try it again. You may continue to stabilize your discovery until you succeed, providing you spend consecutive seasons until you succeed and you do not suffer some dire event along the way.
 
-### SURPASSING THE LIMITS
+#### Surpassing the Limits
 
 Once the accumulated points of your stabilized discoveries reach a certain number, you succeed and invent a Breakthrough. A rough rule of thumb is 30 points are needed for a Minor Breakthrough, 45 for a Major and 60 for a true Hermetic Breakthrough. This is only a guide, however, and your storyguide will set the exact number of magnitudes necessary for your Breakthrough.
 
 It is vitally important that the player not know the number of points necessary for her Breakthrough success. The reasons for this are twofold. First, this long process is fraught with disappointment and failure, and only the truly passionate will continue once repeated seasons spent in the laboratory fail to yield a Discovery. Not knowing the target number of needed magnitudes reflects the uncertainties that lie within original research.
 
-Secondly, this allows the storyguide to minutely adjust the target number off the cuff, as you work through your original research towards completion. If she feels that you are nearing your Breakthrough too quickly, she can raise the target number a little. Conversely, she may also lower the target number, if success would increase the pleasure of the game or add an interesting turn of events to the saga. This slight recalculation should be used for the overall benefit of the saga, and not as a tool to reward
-
-
-
-or punish players. The intent of the original research rules is that Breakthroughs are difficult and take a long time to achieve.
+Secondly, this allows the storyguide to minutely adjust the target number off the cuff, as you work through your original research towards completion. If she feels that you are nearing your Breakthrough too quickly, she can raise the target number a little. Conversely, she may also lower the target number, if success would increase the pleasure of the game or add an interesting turn of events to the saga. This slight recalculation should be used for the overall benefit of the saga, and not as a tool to reward or punish players. The intent of the original research rules is that Breakthroughs are difficult and take a long time to achieve.
 
 Original research is long and arduous and does not have to be done during consecutive seasons. You may work at a Breakthrough for a while and then stop, returning to it when you are reinvigorated or better learned in the Arts. Each individual experiment must be worked through to completion, and if a Discovery occurs you must proceed directly into the stabilization phase. You may certainly take breaks between experiments.
 
-#### MULTIPLE LABORATORY TEXTS
+#### Multiple Laboratory Texts
 
 There is nothing in the original research process that stops multiple magi from working together on a Breakthrough. Some small hindrances present themselves; the magi must be willing to share and each must be able to read the wizardly script of the others' Laboratory Texts (see the Translating Laboratory Texts section of the Hermetic Magic chapter in **Ars Magica** 5th Edition, page 102). Rather, it is usually personality conflicts, selfishness, and self-centeredness that keep magi from working together on Breakthroughs. Even in House Bonisagus, which has an atypically high level of intra-House cooperation, magi are reluctant to share original research notes.
 
@@ -1006,8 +893,9 @@ Bear in mind that cooperation is not the only way to gain someone's stabilized L
 
 If you are lucky enough to have another maga's Laboratory Texts, and they concern the same Breakthrough you are exploring, you may incorporate them into the accumulated points necessary for your research. You must successfully break the author's code and spend a season reading the Laboratory Texts and following the experiment, requiring a Hermetic laboratory. You accumulate points equal to your Lab Total in the Arts concerned. Once your points equal the level of the Lab Text's described experiment, you may add the magnitude of the effect to your total points. In effect, each researcher has a total accumulation of points. The Breakthrough will not happen until a single practitioner amasses enough points to reach its target number. Thus, if two or more magi are researching the same Breakthrough, the first to reach the target number makes the actual Breakthrough.
 
+A magus does not gain Warping Points by reading another maga’s original research Laboratory Text. This is another powerful incentive to gain these valuable notes. 
 
-#### BREAKTHROUGHS IN PLAY
+#### Breakthroughs in Play
 
 Once you have accumulated enough points from your original research, you complete your task and invent a Breakthrough. If you have created a Minor Breakthrough, it is instantly usable and understandable by Hermetic magi. You may incorporate it into your next invented spell or magical enchantment, and this is the usual path of transmission to your fellow magi. For example, magus Tillitus invents a new Range 'Horizon'. He then invents a spell using Horizon as the Range and offers the Laboratory Texts of this spell to the Order. Those reading the Laboratory Texts both learn the spell and understand the new Range at the same time. They can then use this new Range in exactly the same way they can use any spell Range.
 
@@ -1017,30 +905,25 @@ Learning a Major Breakthrough is similar to learning a supernatural ability, wit
 
 A Hermetic Breakthrough is a legendary event and its transmission depends on the nature of the Breakthrough. If it is an Arcane Ability, like the Parma Magica, then it must be taught just like any regular ability. If the Breakthrough exceeds one of the Hermetic limits of magi, then it must be taught like a Major Breakthrough, either through personal instruction or a written tractatus.
 
-#### HERMETIC INTEGRATION
+#### Hermetic Integration
 
-Ultimately, a magus researcher wants to completely integrate his Breakthrough into Hermetic theory. A perfect system of magic would let every practitioner perform every type of magical act without any necessary Virtues
-
-
-
-
-### Exempli Gratia: Original Research
-
-Fresh from his gauntlet and newly installed in the covenant of Semita Errabunda, Tillitus Bonisagi decides he wants to break the Limit of Vis, which states that Hermetic magic cannot change the Art to which raw vis is attuned. The storyguide and the troupe decide that this is essentially a Muto Vis operation, and agree that any experimentation in these Arts, as well as Intellego, may lead to this discovery. Eagar for fame, Tillitus begins immediately.
-
-Since there are so many general magnitude Muto Vim spells, Tillitus decides to invent them all, one at a time of course, experimenting along the way. This works well with his generalist nature. His first attempt is to invent *Wizard's Reach* for the Art of Animal at level 5. His Lab Total is 20 (Intelligence +5 + Magic Theory 3 + Puissant Ability [+2] + Muto 5 + Vim 5). He chooses a risk modifier of +1 to influence his roll on the Extraordinary Results Chart; his Magic Theory isn't high enough to allow a larger risk modifier.
-
-Tillitus' Lab Total easily doubles the spell level and he invents his first *Wizard's Reach* spell. He rolls a 5 on the Extraordinary Results Chart, which he can reduce by 1 (his risk factor) to a 4 for 'no extraordinary effects.' Cursing his ill-luck, Tillitus continues through the Forms, inventing *Wizard's Reach* level 5 for each. He could keep inventing the same spell, but he would rather have several variations of *Wizard's Reach*. He keeps the same Lab Total and uses a +1 risk modifier throughout, adjusting it up or down to suit his needs. Finally, during his experimentation with the spell for Ignem, he rolls a 9 on the Extraordinary Results Chart, which he can move to a 10 for a discovery.
-
-He spends the very next season repeating the experiment hoping to stabilize his discovery. Using the Lab Total and risk modifier, he must roll again on the Extraordinary Results Chart. His stress die rolls 1 and then 4, for an 8: Complete Failure. He must apply the risk modifier in the same manner as he did during his experimentation season, which changes his 8 to a 9, saving him from the Complete Failure and stabilizing his discovery. He has achieved an important first step towards his ultimate goal.
-
-During the stabilization season, Tillitus must roll a simple die and possibly collect Warping Points. His pedestrian approach is fairly safe, at these small magnitudes, and he has little to fear; a magnitude 1 spell any result on the simple die will not yield Warping Points at this stage. After seven seasons of experimentation, Tillitus has produced a stabilized discovery of magnitude 1. He can't believe his good luck!
-
-or Supernatural Abilities. This is easily accomplished with Minor Breakthroughs, but more difficult with Major Breakthroughs. Hermetic Breakthroughs represent their own problems of integration.
+Ultimately, a magus researcher wants to completely integrate his Breakthrough into Hermetic theory. A perfect system of magic would let every practitioner perform every type of magical act without any necessary Virtues or Supernatural Abilities. This is easily accomplished with Minor Breakthroughs, but more difficult with Major Breakthroughs. Hermetic Breakthroughs represent their own problems of integration.
 
 Minor Breakthroughs, by definition, work within Hermetic parameters and are instantly integrated into Bonisagus' theory of magic. Major Breakthroughs create Hermetic Virtues, which must be learned, granting the use of the Virtue with an accompanying Ability. Breakthroughs may be further researched to allow a magus access to the Virtue without learning an Ability. Thus, making a Major Breakthrough on an existing Major Breakthrough will change the nature of Hermetic magic.
 
 For example, a maga achieves a Major Breakthrough and invents the Hermetic Virtue Life Boost. She can teach this ability to other magi, granting each the Hermetic Virtue Life Boost once they learn it. A second Major Breakthrough would integrate Life Boost into regular Hermetic magic, meaning that every practitioner taught Magic Theory using this new technique would be able to use Life Boost.
+
+> ## Exempli Gratia: Original Research
+> 
+> Fresh from his gauntlet and newly installed in the covenant of Semita Errabunda, Tillitus Bonisagi decides he wants to break the Limit of Vis, which states that Hermetic magic cannot change the Art to which raw vis is attuned. The storyguide and the troupe decide that this is essentially a Muto Vis operation, and agree that any experimentation in these Arts, as well as Intellego, may lead to this discovery. Eager for fame, Tillitus begins immediately.
+> 
+> Since there are so many general magnitude Muto Vim spells, Tillitus decides to invent them all, one at a time of course, experimenting along the way. This works well with his generalist nature. His first attempt is to invent *Wizard's Reach* for the Art of Animal at level 5. His Lab Total is 20 (Intelligence +5 + Magic Theory 3 + Puissant Ability [+2] + Muto 5 + Vim 5). He chooses a risk modifier of +1 to influence his roll on the Extraordinary Results Chart; his Magic Theory isn't high enough to allow a larger risk modifier.
+> 
+> Tillitus' Lab Total easily doubles the spell level and he invents his first *Wizard's Reach* spell. He rolls a 5 on the Extraordinary Results Chart.' Cursing his ill-luck, Tillitus continues through the Forms, inventing *Wizard's Reach* level 5 for each. He could keep inventing the same spell, but he would rather have several variations of *Wizard's Reach*. He keeps the same Lab Total and uses a +1 risk modifier throughout, adjusting it up or down to suit his needs. Finally, during his experimentation with the spell for Ignem, he rolls a 9 on the Extraordinary Results Chart, which he can move to a 10 for a discovery.
+> 
+> He spends the very next season repeating the experiment hoping to stabilize his discovery. Using the Lab Total and risk modifier, he must roll again on the Extraordinary Results Chart. His stress die rolls 1 and then 4, for an 8: Complete Failure. He must apply the risk modifier in the same manner as he did during his experimentation season, which changes his 8 to a 9, saving him from the Complete Failure and stabilizing his discovery. He has achieved an important first step towards his ultimate goal.
+> 
+> During the stabilization season, Tillitus must roll a simple die and possibly collect Warping Points. His pedestrian approach is fairly safe, at these small magnitudes, and he has little to fear; a magnitude 1 spell any result on the simple die will not yield Warping Points at this stage. After seven seasons of experimentation, Tillitus has produced a stabilized discovery of magnitude 1. He can't believe his good luck!
 
 ## Example Discoveries
 
@@ -1050,27 +933,17 @@ The following four discoveries are examples of original research. Storyguides ma
 
 The Arma Magica, or 'magical defenses', are based upon Bonisagus's unique Parma Magica ritual. Bonisagus discovered that the Parma Magica could be stretched to protect others. This thins the protective energies of the shield and weakens its overall resistance, but is an excellent way to protect companions and apprentices. Arma Magica uses Parma Magica in similar ways, pressed back or "folded" the field of resistance upon itself for a variety of effects, called **folds**. Each fold is a Major Breakthrough, since each creates a new way of using an already existing Hermetic effect. There are six Parma Magica folds; inventing one is a grand accomplishment and inventing all six would make a magus legendary.
 
-A magus may know a number of folds equal to his Parma Magica score. The first fold learned is always the
+A magus may know a number of folds equal to his Parma Magica score. The first fold learned is always the basic encompassing of another. Additional folds must be taught by a teacher, who may a teach a single fold to a number of students equal to her Teach Ability. She may always teach a single student a single fold even if she has no score in Teach. Magi Bonisagi would willingly teach these Parma folds, some even declining offers of compensation.
 
+#### Parma Magica Folds
 
-*31*
+Many of these new defenses alter the magus' Parma Magica score. Some reduce it, usually by half, while others augment it or diminish it by a specific amount. To determine the magic resistance of a magus using these new folds, always change the original Parma Magica (rounding up) before multiplying it by 5 and adding specific Form bonuses. Despite subtraction and division, a reduced Parma Magica can never fall below 0. A magus always receives his Form bonus against magical attacks.
 
-
-basic encompassing of another. Additional folds must be taught by a teacher, who may a teach a single fold to a number of students equal to her Teach Ability. She may always teach a single student a single fold even if she has no score in Teach. Magi Bonisagi would willingly teach these Parma folds, some even declining offers of compensation.
-
-### PARMA MAGICA FOLDS
-
-Many of these new defenses alter the magus' Parma Magica score. Some reduce it, usually by half, while others augment it or diminish it by a specific amount. To determine the magic resistance of a magus using these new folds, always change the original Parma Magica (rounding down) before multiplying it by 5 and adding specific Form bonuses. Despite subtraction and division, a reduced Parma Magica can never fall below 0. A magus always receives his Form bonus against magical attacks.
-
-Note that the typical Parma Magica takes two minutes to perform and lasts until sunrise or sunset, which ever comes first. Except for the Parma Ablativa, all of the Parma folds follow this procedure. A magus may suppress his Parma, not cancel it, so in most cases the same Parma Magica fold initially performed stays active until the ritual itself expires, or is dispelled. A magus can not change folds as the need arises. Extending the Parma Magica to other characters is one exception, and the Parma Restricta (see below) is another. Since performing a Parma Magica is an essential part of being a Hermetic magus, it becomes a routine act at every sunrise and sunset.
+Note that the typical Parma Magica takes two minutes to perform and lasts until sunrise or sunset, whichever comes first. Except for the Parma Ablativa, all of the Parma folds follow this procedure. A magus may suppress his Parma, not cancel it, so in most cases the same Parma Magica fold initially performed stays active until the ritual itself expires, or is dispelled. A magus can not change folds as the need arises. Extending the Parma Magica to other characters is one exception, and the Parma Restricta (see below) is another. Since performing a Parma Magica is an essential part of being a Hermetic magus, it becomes a routine act at every sunrise and sunset.
 
 **Parma Ablativa**: The 'ablative shield' creates a much more powerful shield that weakens over time. Double a magus's Parma Magica score when calculating magic resistance. However, Penetration totals of resisted spells must be subtracted from the resistance. For example, if a magus's Parma Ablativa magic resistance was 40 and resisted a spell or magical effect with a Penetration of 10, his magic resistance would be reduced to 30. Designed for combat, this fold offers a stronger initial protection than regular Parma Magica. This fold takes ten minutes to perform, longer than the two minutes it takes to perform a regular Parma Magica. If the Parma Ablativa's resistance is completely destroyed — magic resistance falls to zero the magus may perform another Parma Magica fold. This is the sole exception to the rule of only one Parma per sunrise/sunset.
 
-**Parma Absorbea:** The 'swallowing shield' accepts incoming spell attacks and traps them in a mystical pocket that holds the magical energy for a single combat round, just long enough for the magus to use that energy to empower one of his own spells. Divide the magus's Parma Magica in half (round up) to calculate magic resis-
-
-
-
-tance. Incoming spells that are resisted are held briefly. A magus may use this trapped energy to increase the casting total of his next spell. If the magus makes a Stamina + Concentration stress roll higher than the Penetration value of the trapped spell, he adds one half of that spell's Penetration to his next spell's casting total. If his next spell is the exact Technique and Form as the imprisoned spell, including requisites, he may add the entire Penetration value to his next casting total.
+**Parma Absorbea:** The 'swallowing shield' accepts incoming spell attacks and traps them in a mystical pocket that holds the magical energy for a single combat round, just long enough for the magus to use that energy to empower one of his own spells. Divide the magus's Parma Magica in half (round up) to calculate magic resistance. Incoming spells that are resisted are held briefly. A magus may use this trapped energy to increase the casting total of his next spell. If the magus makes a Stamina + Concentration stress roll higher than the Penetration value of the trapped spell, he adds one half of that spell's Penetration to his next spell's casting total. If his next spell is the exact Technique and Form as the imprisoned spell, including requisites, he may add the entire Penetration value to his next casting total.
 
 **Parma Condensa**: The 'thick shield' protects a magus against a particular Form, chosen when casting it. Double the Parma Magica score against the specified Form, but divide it by two (round up) against all others. This can be particularly effective against known enemies or in specific Realms. The magus must have a score of at least double his Parma Magica in the Art he chooses.
 
@@ -1086,15 +959,11 @@ The Order has long sought a means of protecting its mundane members from magic. 
 
 A Parmula is a lesser enchanted device that will provide the wearer with a magic resistance of 30. To make a Parmula a magus must spend an entire season in the laboratory, instilling the magic within an appropriate vessel, typically a silver brooch or other jewelry. Its base level of effect is Rego Vim 30. Its effect requires constant use, which adds two magnitudes and four levels to the final level of effect, for an total effective level of 44. As with all lesser enchanted items, it must be constructed in a single season; the creator's Rego Vim lab total must double the level of the effect. The magus receives a +4 from the Shape and Material Bonuses Table for instilling the effect within a piece of jewelry. It costs five pawns of Rego or Vim vis to enchant a Parmula. Once completed, the Parmula offers Magic Resistance of 30. Possessing a Lab Text describing the creation of a Parmula would be helpful for the inventing magus.
 
-#### Parmulae: Lesser Enchanted Device that provides a magic resistance of 30. Total level of effect is 44.
+**Parmulae: Lesser Enchanted Device that provides a magic resistance of 30. Total level of effect is 44.**
 
 This sounds too good to be true, and it is. A Parmula only lasts a year before its protective magic dissipates, and experimentation hasn't been able to alter this temporal limit. Secondly, a more powerful device has not yet been invented; the original research provides for only this level of magic resistance from a Parmula. These limitations have not been adequately accounted for, and seem an anomaly of the process. A Parmula would be considered a Minor Breakthrough. They are based on the Rego Vim work done by Notatus, the first Primus of House Bonisagus, and his Major Breakthrough, *The Aegis of the Hearth.* Changing their length of duration or the level of magic resistance would require a Major Breakthrough.
 
-You should discuss Parmulae with your troupe before allowing them into your saga. Parma Magica is the only type of universal magic resistance known in 1220, giving Hermetic magi a decisive edge in monopolizing the magical landscape of Mythic Europe. It could be safely argued that Parma Magica is the primary reason the Order of Hermes has been so successful. Including Parmulae in a saga would diminish the dominate position of Parma Magica, and the Order might hesitate to circulate devices that could loosen their monopolistic control. A troupe
-
-
-
-must consider the impact of these protective devices upon their view of Mythic Europe before allow Parmulae into a saga.
+You should discuss Parmulae with your troupe before allowing them into your saga. Parma Magica is the only type of universal magic resistance known in 1220, giving Hermetic magi a decisive edge in monopolizing the magical landscape of Mythic Europe. It could be safely argued that Parma Magica is the primary reason the Order of Hermes has been so successful. Including Parmulae in a saga would diminish the dominate position of Parma Magica, and the Order might hesitate to circulate devices that could loosen their monopolistic control. A troupe must consider the impact of these protective devices upon their view of Mythic Europe before allow Parmulae into a saga.
 
 ### Figurine Magic
 
@@ -1106,31 +975,28 @@ Constructing a figurine takes a month for a wax figurine or two for a wood figur
 
 The better the figurine the stronger the magical attachment, so extreme care is taken constructing a figure. As the process begins, the magus must succeed with a Dexterity + Craft: Sculptor + stress roll against an Ease Factor of 6 for a wax figurine or 9 for a wood figurine. Failing this roll means the figurine is too crude to represent the target and the time spent constructing the figure is wasted. Botching this roll means the magus inadvertently constructed this figurine for someone else. He will not realize her mistake until the item fails to affect the target at the completion of the construction.
 
-> **Making a figure: Dexterity + Craft: Sculptor + Stress die**
+**Making a figure: Dexterity + Craft: Sculptor + Stress die**
 
 **Ease Factor: 6 for a wax figurine, 9 for a wood figure**
 
+Remember that if a character does not have a score in Craft: Sculptor she may still make a roll, treating it as if she had a score of zero in the Ability and rolling three extra botch dice if necessary.
 
 Once the figure is carved it may be imbued with magic. Hermetic magi may enchant the figurines with Hermetic spells. They may also enchant the figurine with Minor General or Supernatural Virtues. The original practice only allows the enchantment of Minor Virtues. Integrating Figurine Magic into Hermetic magic allows the enchantment of Hermetic spells as well as the Virtues. The magus decides what sort of power the figurine will have at the beginning of the process. At the end of the figure's construction time, the magus rolls an Intelligence + Figurine Magic + Aura Modifier + stress die roll against an Ease Factor based on the magic imbued.
 
-| Enchanting a figure: Intelligence + Figurine Magic +<br>Aura Modifier |              |
-|-----------------------------------------------------------------------|--------------|
-| Imbued Power                                                          | Ease Factor  |
-| Base                                                                  | 9            |
-| Minor General Virtue                                                  | +3           |
-| Minor Supernatural Virtue                                             | +6           |
-| Hermetic Spell                                                        | +1/magnitude |
+> **Enchanting a figure: Intelligence + Figurine Magic +Aura Modifier**
+> |                                                                       |              |
+> |-----------------------------------------------------------------------|--------------|
+> | Imbued Power                                                          | Ease Factor  |
+> | Base                                                                  | 9            |
+> | Minor General Virtue                                                  | +3           |
+> | Minor Supernatural Virtue                                             | +6           |
+> | Hermetic Spell                                                        | +1/magnitude |
 
 Figurines imbued with a Supernatural Ability that requires a score, like Premonitions or Second Sight, allow the Figurine bearer to act as if she had a 1 in the specific Ability, which is then modified by any certain Characteristics according to the Virtue's description. Some General Virtues from the core **ArM5** rules are inappropriate; they include Educated, Faerie Blood, Gossip, Improved Characteristic, Large, Latent Magic Ability, Privileged Upbringing, Protection, Relic, Skinchanger, Social Contacts, Student of (Realm), Troupe Upbringing, True Love (PC), Warrior, and Well-Traveled.
 
 Hermetic spells installed within an Figurine must have a range of Touch and a Target of Individual. The Duration of Sun is required, which is extended to constant use in the enchantment process, much like in the regular Laboratory rules section. The magus must be able to cast the desired spell he wishes to install within the figurine. Unlike a normal lesser enchanted item, the enchantment is not permanent. The figurine will hold the enchantment for a length of time dependent upon the material of the item, and the magic will eventually cease operating.
 
-Magi who can perform Figurine Magic prefer it to lesser enchanted items for three reasons. First, these creations do not require Vis to construct, merely time and effort. A magus' magical resources are not depleted when creating figurines. Secondly, they are quick to construct,
-
-
-
-
-requiring only a month instead of the usual season of laboratory time. Lastly, though they can be potent, they are an ephemeral magic, short-lived and fleeting. They are too weak to pester a magus, whose Parma Magica protects him from the figurine's magic. Enchanted figurines have a penetration total of zero.
+Magi who can perform Figurine Magic prefer it to lesser enchanted items for three reasons. First, these creations do not require Vis to construct, merely time and effort. A magus' magical resources are not depleted when creating figurines. Secondly, they are quick to construct, requiring only a month instead of the usual season of laboratory time. Lastly, though they can be potent, they are an ephemeral magic, short-lived and fleeting. They are too weak to pester a magus, whose Parma Magica protects him from the figurine's magic. Enchanted figurines have a penetration total of zero.
 
 It would be interesting to move Figurine Magic out of the Supernatural Ability category and firmly incorporate it into Hermetic practices, allowing magi to simply make figurines without needing a corresponding Ability. Such an event would be a Major Discovery, inventing a degree of enchanted item lower than a Lesser Enchantment.
 
@@ -1150,6 +1016,17 @@ Realm-aligned spells can be cast in Realms other than which they were created fo
 
 For example, Glaucon the Seeker wants to invent a realm-aligned version of *Sight of the Transparent Motive* flavored for the Faerie Realm. His Magic Theory of 3 is reduced by his Faerie Lore of only 1. He still easily invents the spell in a single season. his player makes a note that this spell is a faerie realm-aligned spell with –1 botch die in a faerie aura or regio.
 
+> ## Realm-Aligned Spell Interaction Table
+> 
+> **Realm-Aligned Spell**
+> 
+> | Aura Type | Magic          | Faerie         | Infernal      |
+> |-----------|----------------|----------------|---------------|
+> | Magic     | no bonus       | + (1/2 aura)   | – aura        |
+> | Divine    | – (3 x aura)   | – (4 x aura)   | – (5 x aura)  |
+> | Faerie    | + (1/2 aura)   | no bonus       | – aura        |
+> | Infernal  | – aura         | – (2 x aura)   | no bonus      |
+
 ## Bibliography
 
 Burkert, Walter. *Ancient Mystery Cults.* Massachusetts: Harvard University Press, 1987.
@@ -1160,25 +1037,15 @@ Meyer, Marvin W., ed. *The Ancient Mysteries.* San Francisco: Harper & Row, 1987
 
 Tweet, Jonathan. *The Order of Hermes.* Lion Rampant, 1990.
 
-### Realm-Aligned Spell Interaction Table Realm-Aligned Spell Aura Type Magic Faerie Infernal Magic no bonus + (1/2 aura) – aura Divine – (3 x aura) – (4 x aura) – (5 x aura) Faerie + (1/2 aura) no bonus – aura Infernal – aura – (2 x aura) no bonus
-
-*34*
-
-### Chapter Two
-
-# House Guernicus
+# Chapter Two:  House Guernicus
 
 *"If we are to have an Order to regulate and command our behavior, let there be no question about it. Let there be no weakness in the law, let there be no exceptions for those who feel they are above the Code. If we are to have an Order of Hermes, we will give it the order of law."*
 
-> — Guernicus, Founder of the House, at the First Tribunal
+— Guernicus, Founder of the House, at the First Tribunal
 
-tigate individuals and covenants suspected of breaking the Code of Hermes.
+**Motto:** *Lex super voluntate* (The law above the will.)
 
-To aid their task, they have uncovered the roots of Hermetic magic in Rome, Greece and ancient Egypt. This gives them strength of tradition and access to powerful, secret rituals, which they guard in their domus magna.
-
-This chapter should prove useful to all players, as it gives the legal framework of the Order. Non-Guernicus player characters may aspire to become Quaesitors themselves or simply act as an investigator once or twice.
-
-**Symbol:** The scales of justice balanced on a sword. **Motto:** *Lex super voluntate* (The law above the will.)
+**Symbol:** The scales of justice balanced on a sword. 
 
 Without Guernicus and his wisdom the Order would have floundered within the lifetime of the Founders. Without the firm hand of his descendants, magi would be living under the yoke of tyranny; lower in dignity and circumstance than before even the Founding. So say the Quaesitores, and who could doubt them?
 
@@ -1188,10 +1055,13 @@ nothing of hardship, trade their inheritance for petty gain; thus its ideals fal
 
 House Guernicus believes it stands against the wheel of fate, slowing it as best it can. By the efforts of its magi the basic structures of Hermetic society have remained intact for over four hundred years.
 
-The majority of Guernicus magi hold the office of Quaesitor, named after the magistrates of the Roman Republic. The Quaesitores are the official judges and investigators of the Order. They oversee Tribunals and ensure they uphold the Code. If a magus is to be punished, it is a Quaesitor who sets the penalty. They inves-
+The majority of Guernicus magi hold the office of Quaesitor, named after the magistrates of the Roman Republic. The Quaesitores are the official judges and investigators of the Order. They oversee Tribunals and ensure they uphold the Code. If a magus is to be punished, it is a Quaesitor who sets the penalty. They investigate individuals and covenants suspected of breaking the Code of Hermes.
 
+To aid their task, they have uncovered the roots of Hermetic magic in Rome, Greece and ancient Egypt. This gives them strength of tradition and access to powerful, secret rituals, which they guard in their domus magna.
 
-## Chapter Structure
+This chapter should prove useful to all players, as it gives the legal framework of the Order. Non-Guernicus player characters may aspire to become Quaesitors themselves or simply act as an investigator once or twice.
+
+### Chapter Structure
 
 This chapter is split into ten main headings, listed below.
 
@@ -1209,21 +1079,27 @@ This chapter is split into ten main headings, listed below.
 
 **Running Stories for a Quaesitor:** Advice on how investigation stories may be constructed and run for a troupe.
 
-**Allies:** Those who commonly aid the Quaesitores it their work.
-
-
-
-### Key Facts
-
-**Population:** 98 (plus 41 non-Guernicus Quaesitors). **Domus magna:** Magvillus in the Rome Tribunal. **Prima:** The Archmaga Bilera. Known for her investigative and negotiation skills, Bilera was appointed Prima to help heal the rift between the Traditionalists and the Transitionalists.
-
-### Famous Figures
-
-**Guernicus,** Founder of the House. **Fenicil,** researcher into ancient magical traditions. **Simprim,** founder of the Transitionalist movement.
+**Allies:** Those who commonly aid the Quaesitores in their work.
 
 **Quaesitorial Magic:** Spells commonly employed by Quaesitors in investigations and trials.
 
 **Fenicil's Rituals:** The secret rituals of House Guernicus.
+
+> ## Key Facts
+> 
+> **Population:** 98 (plus 41 non-Guernicus Quaesitors).
+> 
+> **Domus magna:** Magvillus in the Rome Tribunal.
+> 
+> **Prima:** The Archmaga Bilera. Known for her investigative and negotiation skills, Bilera was appointed Prima to help heal the rift between the Traditionalists and the Transitionalists.
+> 
+> ## Famous Figures
+> 
+> **Guernicus,** Founder of the House.
+> 
+> **Fenicil,** researcher into ancient magical traditions.
+> 
+> **Simprim,** founder of the Transitionalist movement.
 
 ## History
 
@@ -1247,14 +1123,13 @@ If he found a wizard suffering unjust persecution he would aid them. His honor, 
 
 With these allies he eventually he tracked his man down. The murderer was trapped in an underground chamber with the grimoires he had wished to steal. With no food, no water and only a single candle, learning the earth magic needed to escape was an impossible task.
 
-
-### The Thief's Tomb
-
-Guernicus never revealed where he entombed his prey. Although much of Guernicus's original earth magic was incorporated into Hermetic magic, Mercurian grimoires would still be valuable. Some think the suspicious Guernicus would have held back secrets from Bonisagus and that these grimoires would revolutionize Terram magic. Rumor has it that one tome dated back to the Cult of Mercury and held five of the original thirty-eight spells.
-
-Over the years many magi have sought out clues to the location of the thief's tomb. None succeeded, but many came close and wrote of their investigations. If a magus were to gather these tracts and piece the clues together, he might be able to discover the tomb. However, to claim the prize he must contend with an angry ghost.
-
-Guernicus never wanted the tomb to be found, so many members of his House would feel disturbing it to be an insult to their Founder's memory. Although not illegal, such an act will antagonize many Quaesitors. Any tomb raiders would be advised to keep their future activities strictly legal.
+> ## The Thief's Tomb
+> 
+> Guernicus never revealed where he entombed his prey. Although much of Guernicus's original earth magic was incorporated into Hermetic magic, Mercurian grimoires would still be valuable. Some think the suspicious Guernicus would have held back secrets from Bonisagus and that these grimoires would revolutionize Terram magic. Rumor has it that one tome dated back to the Cult of Mercury and held five of the original thirty-eight spells.
+> 
+> Over the years many magi have sought out clues to the location of the thief's tomb. None succeeded, but many came close and wrote of their investigations. If a magus were to gather these tracts and piece the clues together, he might be able to discover the tomb. However, to claim the prize he must contend with an angry ghost.
+> 
+> Guernicus never wanted the tomb to be found, so many members of his House would feel disturbing it to be an insult to their Founder's memory. Although not illegal, such an act will antagonize many Quaesitors. Any tomb raiders would be advised to keep their future activities strictly legal.
 
 ### The Order Forms
 
@@ -1262,28 +1137,21 @@ As Trianoma sought out wizards to join the Order, she heard of Guernicus. His re
 
 Although Guernicus was happy to live in peace, he could not believe other wizards could. Although he acknowledged exceptions, he thought immorality intrinsic to the Gifted nature. He would swear an oath and keep it, but had no faith others would. Given that Trianoma was promising to teach Parma Magica to any who join her Order, Guernicus accepted, so he would not be disadvantaged when it inevitably fell. He agreed to share his knowledge with Bonisagus, again so he would not be disadvantaged in the ensuing chaos.
 
-When the form of the Hermetic Oath was debated, Guernicus argued that all members should have the same voting weight at Tribunals; that not even the Founders should be given precedence in voting. The Founders
-
-
-
-
+When the form of the Hermetic Oath was debated, Guernicus argued that all members should have the same voting weight at Tribunals; that not even the Founders should be given precedence in voting. The Founders could rule their followers, but not the Tribunals. This was agreed and the system of Houses and Primi was settled.
 
 Even after Bonisagus had taught them Hermetic magic, Guernicus and Trianoma argued constantly over the viability of the Order. Guernicus contended that only though a strictly enforced Code could the Order survive. In the early years he was constantly looking for examples of magi breaking the spirit of the Oath, challenging magi to settle ambiguities in its interpretation. He also looked for offenses not covered by the Oath that might lead to discord. Diedne was Guernicus's staunchest ally in this and other matters.
 
-Magi of House Diedne held their ritual sites sacred to their religion. Diedne complained that other magi were desecrating her members' sacred places with intrusions. Criamon also found the privacy of his Mystery threatened. In response Guernicus, Criamon and Diedne demanded that the privacy of sanctums was protected. This and other proposals were agreed and soon a body of Tribunal rulings were formed, clarifying, expanding and embellishing the Code — the Peripheral Code. Satisfied with the result, Guernicus revised his estimate on the
-
-### Polybius and the Order
-
-Polybius (202-122 BC) was a Greek from Arcadia (a district of Greece). In his youth his was an officer in the Achaean League, which sought to keep the Peloponnesus region independent of Rome. However, he was arrested and sent to Italy to await trial for conspiracy. Fortune smiled on him and he was befriended by an influential Roman family. With their patronage he became a respected historian. He witnessed the destruction of both Carthage and Corinth, in 146 B. C. and is credited with helping the Greeks accept the inevitability of Roman rule.
-
-Polybius made an insightful analysis of Roman government. He showed how its mix of monarchy, aristocracy and democracy helped prevent any of the three falling into corruption. Whereas a simpler form of government would quickly decay into a tyranny, oligarchy or mob rule, a balance of the three was more stable.
-
-Guernicus had read Polybius's histories and argued the Order should follow a similarly mixed government. The three arms of the Order would be the Primi, Tribunals and the Quaesitores. The Quaesitores and the Tribunals would guard the Primi from tyranny. The Quaesitores and Primi would guard the Tribunals from mob rule. The Tribunals and the Primi would guard the Quaesitores from oligarchy.
-
-
-lifespan of the Order to, "Three score years and ten — or perhaps few more thanks to longevity potions."
+Magi of House Diedne held their ritual sites sacred to their religion. Diedne complained that other magi were desecrating her members' sacred places with intrusions. Criamon also found the privacy of his Mystery threatened. In response Guernicus, Criamon and Diedne demanded that the privacy of sanctums was protected. This and other proposals were agreed and soon a body of Tribunal rulings were formed, clarifying, expanding and embellishing the Code — the Peripheral Code. Satisfied with the result, Guernicus revised his estimate on the lifespan of the Order to, "Three score years and ten — or perhaps few more thanks to longevity potions."
 
 Exasperated, Trianoma asked what more was needed. Guernicus replied that the Order needed a magus dedicated to the task of keeping the peace, exposing transgression and ensuring the law was kept, yet it had none. Trianoma challenged Guernicus to be that magus and he accepted.
+
+> ## Polybius and the Order
+> 
+> Polybius (202-122 BC) was a Greek from Arcadia (a district of Greece). In his youth his was an officer in the Achaean League, which sought to keep the Peloponnesus region independent of Rome. However, he was arrested and sent to Italy to await trial for conspiracy. Fortune smiled on him and he was befriended by an influential Roman family. With their patronage he became a respected historian. He witnessed the destruction of both Carthage and Corinth, in 146 B. C. and is credited with helping the Greeks accept the inevitability of Roman rule.
+> 
+> Polybius made an insightful analysis of Roman government. He showed how its mix of monarchy, aristocracy and democracy helped prevent any of the three falling into corruption. Whereas a simpler form of government would quickly decay into a tyranny, oligarchy or mob rule, a balance of the three was more stable.
+> 
+> Guernicus had read Polybius's histories and argued the Order should follow a similarly mixed government. The three arms of the Order would be the Primi, Tribunals and the Quaesitores. The Quaesitores and the Tribunals would guard the Primi from tyranny. The Quaesitores and Primi would guard the Tribunals from mob rule. The Tribunals and the Primi would guard the Quaesitores from oligarchy.
 
 ### The Quaesitores
 
@@ -1297,29 +1165,26 @@ Guernicus spent most of his years trying to guide the growing Peripheral Code as
 
 His last victory was in helping the Tytalus Prima Hariste prevent a war on Pralix's 'Order of Miscellany'. Trianoma negotiated the creation of House Ex Miscellanea and the Grand Tribunal agreed to it after a narrow vote.
 
-Guernicus's last public appearance was at the Grand Tribunal of 817 AD. Against his strident objection the meeting passed the ruling instituting certamen as 'decisive
-
-
-
-
-Although no magus can enter House Guernicus unless apprenticed to a Guernicus master, other magi can become Quaesitors. In some Tribunals non-Guernicus Quaesitors are seen as essential to the maintenance of the Hermetic peace. Although the role requires a significant commitment of time, such magi gain great respect in both their Tribunal and their own House.
-
-Promising candidates are monitored by local Quaesitors. Those that embark on successful independent investigations are most likely to be offered a Quaesitorial title. In essence a magus who wishes to become a Quaesitor needs to act as one.
-
-A candidate does not need a spotless record. Transgressions of ignorance, youthful misjudgment or reasonable legal disputes can be forgiven. Magi that show a general disrespect for the law are excluded. Candidates should show the sort of honorable good character expected of a Quaesitor.
-
-If recommended by a senior Quaesitor, a candidate is invited to Magvillus to meet the Primus. If the Primus is impressed, he will offer the magus Quaesitorial training. If the candidate accepts he is assigned to an experienced Quaesitor. The pair spends a number of years journeying between Tribunals responding to requests by overburdened Quaesitors. During this period the mentor grills the candidate on the Code, logical puzzles and other investigation skills.
-
-If the mentor is satisfied with the candidate's performance he issues a favorable report to the Primus, who then bestows the title of Quaesitor.
-
-In game terms this gives the candidate training and exposure to, Code of Hermes, Hermes Lore, Awareness, Folk Ken and Intrigue. The mentor often teaches the candidate spells useful for investigations, although not yet the Quaesitorial spells (see below).
-
-in all disputes'. Guernicus retreated to his Magvillus fortress, claiming the ruin of the Order was at hand.
+Guernicus's last public appearance was at the Grand Tribunal of 817 AD. Against his strident objection the meeting passed the ruling instituting certamen as 'decisive in all disputes'. Guernicus retreated to his Magvillus fortress, claiming the ruin of the Order was at hand.
 
 Rumor has it that Guernicus later foreswore his Arts and undertook a pilgrimage to Rome. When his Longevity Ritual failed, he refused all offers to enact another. Without Parma and with senility setting in, he shunned all contact with magi without the Gentle Gift. He claimed Parma hid magi's true character from each other. These tales may have been a ruse; all that is publicly known is that Guernicus spent his final years in seclusion at Magvillus, communicating only through his favored filius Fenicil.
 
 
 Fenicil became Primus in 832 AD, but the fate of Guernicus was never revealed. Wild rumors suggested that Guernicus found a way to cheat both age and Twilight. They claim that he sleeps beneath the earth, waiting for the day the Order falls; just to witness his prediction with grim satisfaction.
+
+> ## Becoming a Quaesitor
+> 
+> Although no magus can enter House Guernicus unless apprenticed to a Guernicus master, other magi can become Quaesitors. In some Tribunals non-Guernicus Quaesitors are seen as essential to the maintenance of the Hermetic peace. Although the role requires a significant commitment of time, such magi gain great respect in both their Tribunal and their own House.
+> 
+> Promising candidates are monitored by local Quaesitors. Those that embark on successful independent investigations are most likely to be offered a Quaesitorial title. In essence a magus who wishes to become a Quaesitor needs to act as one.
+> 
+> A candidate does not need a spotless record. Transgressions of ignorance, youthful misjudgment or reasonable legal disputes can be forgiven. Magi that show a general disrespect for the law are excluded. Candidates should show the sort of honorable good character expected of a Quaesitor.
+> 
+> If recommended by a senior Quaesitor, a candidate is invited to Magvillus to meet the Primus. If the Primus is impressed, he will offer the magus Quaesitorial training. If the candidate accepts he is assigned to an experienced Quaesitor. The pair spends a number of years journeying between Tribunals responding to requests by overburdened Quaesitors. During this period the mentor grills the candidate on the Code, logical puzzles and other investigation skills.
+> 
+> If the mentor is satisfied with the candidate's performance he issues a favorable report to the Primus, who then bestows the title of Quaesitor.
+> 
+> In game terms this gives the candidate training and exposure to, Code of Hermes, Hermes Lore, Awareness, Folk Ken and Intrigue. The mentor often teaches the candidate spells useful for investigations, although not yet the Quaesitorial spells (see below).
 
 ### Fenicil
 
@@ -1331,36 +1196,29 @@ His researches and those of his followers were fruitful. On the basis of this re
 
 Although many magi raised their eyebrows at Fenicil's announcements and commented wryly on his scholarship, no one opposed him. As time passed, more and more magi simply accepted Fenicil's views as fact.
 
-Besides discovering evidence of previous magical orders, Fenicil gathered together as many Mercurian texts as he could find or have copied. In addition, he found texts of ancient Egyptian, Greek and Babylonian rituals. Most of these rituals depended on a large and devoted following, not on the power of individuals. Working in secret his followers translated these rituals into a form they could learn and cast. Thanks to this work, the
-
-
-
-
-Quaesitores have powerful, secret magic (see Fenicil's Rituals for details).
+Besides discovering evidence of previous magical orders, Fenicil gathered together as many Mercurian texts as he could find or have copied. In addition, he found texts of ancient Egyptian, Greek and Babylonian rituals. Most of these rituals depended on a large and devoted following, not on the power of individuals. Working in secret his followers translated these rituals into a form they could learn and cast. Thanks to this work, the Quaesitores have powerful, secret magic (see Fenicil's Rituals for details).
 
 In addition to the ancient writings, Fenicil and his supporters brought a great many ancient magical artifacts to Magvillus. The powers of these objects were thoroughly investigated. Like the ritual magic Fenicil discovered and adapted, the Order as a whole has no idea what any of these items did or still do.
 
 It is rumored that one item has the power to scry on any magus in the Order without fear of detection. This was born of a gossip's over-active imagination. However, it might be true; only the inner council of Magvillus knows for sure.
 
-The Fenicil collection may now be the most extensive source on ancient magics within the Order. However, the extent of the collection is known only to the inner coun-
+The Fenicil collection may now be the most extensive source on ancient magics within the Order. However, the extent of the collection is known only to the inner council. All solicitations by Hermetic scholars to study or take copies of any text have been politely rejected.
 
-### Double Edged Sword
-
-Fenicil intended his work to unify the Order, however not everyone used it for this goal. From its creation the Order was primarily a society of Latin wizards. Only two of the Founders were non-Latin, Diedne and Bjornaer. Of these two, House Diedne was by far the most powerful and numerous; it was in fact the most powerful House in the Order. This sat uneasily with many Latin magi. The unity and power of House Diedne was found particular irksome by magi of House Tremere, who coveted their position.
-
-House Diedne's insular and secretive ways allowed others to foster hostility and distrust against it. They argued that the Order of Hermes was destined to be an Order of Greco-Roman wizards; Celtic wizardry was not part of this. House Diedne stubbornly refused to conform to the Latin tradition, so they had no right to be members and endangered the Order. By implication this argument applied to Bjornaer and most Ex Miscellanea magi, but Diedne was the first target. So when Tremere magi made claims about House Diedne, they were readily believed by many.
-
-The Schism war killed off the most vocal agitators for a Latin-only Order. Most survivors had little stomach for another war anyway. However, in 1220 memories of the Schism have faded. With more and more non-Latin wizards joining House Ex Miscellanea, the dominance of the Latin traditions may seem under threat again. Perhaps the time is right for a new movement to purge the Order of non-Latin magi?
-
-This would be a real test for the Quaesitores. They failed suppress such zealots in the prelude to the first Schism, can they prevent a second? Will the blood of House Bjornaer end up on House Guernicus's hands?
-
-cil. All solicitations by Hermetic scholars to study or take copies of any text have been politely rejected.
+> ## Double Edged Sword
+> 
+> Fenicil intended his work to unify the Order, however not everyone used it for this goal. From its creation the Order was primarily a society of Latin wizards. Only two of the Founders were non-Latin, Diedne and Bjornaer. Of these two, House Diedne was by far the most powerful and numerous; it was in fact the most powerful House in the Order. This sat uneasily with many Latin magi. The unity and power of House Diedne was found particularly irksome by magi of House Tremere, who coveted their position.
+> 
+> House Diedne's insular and secretive ways allowed others to foster hostility and distrust against it. They argued that the Order of Hermes was destined to be an Order of Greco-Roman wizards; Celtic wizardry was not part of this. House Diedne stubbornly refused to conform to the Latin tradition, so they had no right to be members and endangered the Order. By implication this argument applied to Bjornaer and most Ex Miscellanea magi, but Diedne was the first target. So when Tremere magi made claims about House Diedne, they were readily believed by many.
+> 
+> The Schism war killed off the most vocal agitators for a Latin-only Order. Most survivors had little stomach for another war anyway. However, in 1220 memories of the Schism have faded. With more and more non-Latin wizards joining House Ex Miscellanea, the dominance of the Latin traditions may seem under threat again. Perhaps the time is right for a new movement to purge the Order of non-Latin magi?
+> 
+> This would be a real test for the Quaesitores. They failed to suppress such zealots in the prelude to the first Schism, can they prevent a second? Will the blood of House Bjornaer end up on House Guernicus's hands?
 
 ### Duresca Scrolls
 
-In the l0th century, documents were discovered at the covenant of Duresca in Iberia. These documents appeared to be a set of letters written between Guernicus and his filii. Within this correspondence the secret agenda of House Guernicus was described; to dominate first the Order and then the world. These letters became known as the Duresca scrolls and they caused quite a stir in the Order.
+In the 10th century, documents were discovered at the covenant of Duresca in Iberia. These documents appeared to be a set of letters written between Guernicus and his filii. Within this correspondence the secret agenda of House Guernicus was described; to dominate first the Order and then the world. These letters became known as the Duresca scrolls and they caused quite a stir in the Order.
 
-The Duresca scrolls were presented at the next Iberian Tribunal, but they were officially declared fraudulent and destroyed. As the ruling was based primarily on evidence given by the Presiding Quaesitor, this ruling did not satisfy everyone in the Order. Later in the l0th century, the purging of House Tytalus distracted the Order's interest from the Duresca scrolls.
+The Duresca scrolls were presented at the next Iberian Tribunal, but they were officially declared fraudulent and destroyed. As the ruling was based primarily on evidence given by the Presiding Quaesitor, this ruling did not satisfy everyone in the Order. Later in the 10th century, the purging of House Tytalus distracted the Order's interest from the Duresca scrolls.
 
 A number of secret copies of the documents remain and occasionally a magus circulates new copies. The Quaesitores have little patience with such magi and charge them with endangering the Order by spreading known lies.
 
@@ -1370,11 +1228,7 @@ As the conflict between House Tremere and Diedne slid towards open war, House Gu
 
 The full council of Magvillus was summoned, including the Diedne representative. It was determined that there would be an emergency Grand Tribunal to resolve the crisis. All the Primi apart from those of Tremere and Diedne were to attend, as well as many high ranking magi from each Tribunal that could be found, with as many proxy sigils as could be gathered. House Tremere and Diedne would be represented solely by their Quaesitorial House representatives. Antonius had consistently made public his desire for a peaceful settlement of the crisis. He was trusted by the leaders of House Diedne and so they accepted the call.
 
-Word went out via the Presiding Quaesitors, the House representatives, and the Mercere. Members of the outer council used their enchanted devices to bring groups to the reception house outside Magvillus. Each
-
-
-
-group was greeted by a heavy guard of experienced Hoplites and escorted to the meeting chamber. None were given casting tokens. Others arrived by their own means.
+Word went out via the Presiding Quaesitors, the House representatives, and the Mercere. Members of the outer council used their enchanted devices to bring groups to the reception house outside Magvillus. Each group was greeted by a heavy guard of experienced Hoplites and escorted to the meeting chamber. None were given casting tokens. Others arrived by their own means.
 
 Unfortunately the Ex Miscellanea Primus decided to travel mundanely. He set out with a great number of proxy sigils. These votes could have dramatically altered the cause of Order history, but he never arrived.
 
@@ -1382,7 +1236,7 @@ At this meeting the war between Tremere and Diedne was debated. The Diedne and T
 
 Magi from many other Houses joined the battle, which became the Order against House Diedne. Even with this, the war hung in the balance. At times it seemed as if the Order would be defeated by House Diedne. Considering this possibility the inner Magvillus Council made a fateful decision. A ritual Fenicil had discovered offered a chance to deal House Diedne a crippling blow. However, the requirements of the ritual were abhorrent, a human sacrifice.
 
-House Tremere's principle accusation against House Diedne was human sacrifice. The irony of House Guernicus performing that act in support of the war against Diedne was not lost on the council. Neither was the betrayal of the trust Diedne and Guernicus had shared. Still, the situation was dire and the decision was made. Antonius led the ritual and wielded the knife, murdering the Diedne representative. Shortly after there was a turn in House Diedne's fortunes and most participants were convinced it was their doing. All the participants were sworn to utter secrecy.
+House Tremere's principal accusation against House Diedne was human sacrifice. The irony of House Guernicus performing that act in support of the war against Diedne was not lost on the council. Neither was the betrayal of the trust Diedne and Guernicus had shared. Still, the situation was dire and the decision was made. Antonius led the ritual and wielded the knife, murdering the Diedne representative. Shortly after there was a turn in House Diedne's fortunes and most participants were convinced it was their doing. All the participants were sworn to utter secrecy.
 
 House Diedne fell, but House Guernicus rose stronger than ever. The Order had seen a general war between Hermetic magi and the destruction shocked everyone. The Quaesitores claimed that they could have prevented or ended the war earlier if they had had more authority and the traumatized Order gave them more; extending investigation immunity and the requirements for cooperation.
 
@@ -1390,11 +1244,11 @@ House Diedne fell, but House Guernicus rose stronger than ever. The Order had se
 
 Under Guernicus's influence the Code was framed to ensure the peace and the freedoms of individual magi. Guernicus constantly argued against any proposal that would unnecessarily restrict their freedoms or impose burdens. Therefore, traditionally there is great resistance to any proposal that would do so.
 
-### Tribunals
-
-Originally there was only one Tribunal in the Order. However, in 773 AD this Tribunal constituted the regional Tribunals and the Grand Tribunal. Scholars of the Code of Hermes refer to the original Tribunal as the First Tribunal. The First Tribunal met in 767 AD to form the Order and in 773 AD to form the regional Tribunals and the Grand Tribunal. The distinction between the First Tribunal and the Grand Tribunal is a legally important one.
-
-However, this importance is lost on many magi. It is common practice to count the meetings of the Grand Tribunal from the earliest First Tribunal, rather than the meeting of 799 AD. Quaesitors who take issue with this are often accused of semantic pedantry.
+> ## Tribunals
+> 
+> Originally there was only one Tribunal in the Order. However, in 773 AD this Tribunal constituted the regional Tribunals and the Grand Tribunal. Scholars of the Code of Hermes refer to the original Tribunal as the First Tribunal. The First Tribunal met in 767 AD to form the Order and in 773 AD to form the regional Tribunals and the Grand Tribunal. The distinction between the First Tribunal and the Grand Tribunal is a legally important one.
+> 
+> However, this importance is lost on many magi. It is common practice to count the meetings of the Grand Tribunal from the earliest First Tribunal, rather than the meeting of 799 AD. Quaesitors who take issue with this are often accused of semantic pedantry.
 
 The first rulings clarifying the Hermetic Oath were made before the formation of the regional and Grand Tribunals. The original Tribunal that made these clarifications is now referred to as the First Tribunal. Traditionalist Quaesitors consider the Hermetic Oath and the clarifying rulings of the First Tribunal to be the foundation stones of the Order.
 
@@ -1402,19 +1256,15 @@ Traditionally a Tribunal has authority to contradict its own rulings with new ru
 
 In 1148 a well-respected Quaesitor, Simprim, began openly advocating that the Code be revised. To Simprim and his followers a law incapable of adaptation doomed the Order rather than helped preserve it. In a number of Tribunals the loss of vis sources and magic auras due to mundane encroachment was becoming an acute issue. In these Tribunals many magi felt the strict prohibition against mundane interference should be relaxed to allow the defense of magic resources. Simprim argued that if the Code demanded that magi sit idle as their magical resources were destroyed, they would be forced to defy it; lawlessness would follow.
 
-In addition, he claimed that the Order had outgrown Guernicus's vision of a loose society of freemen. Simprim maintained that corruption had beset many local Tribunals and action against them was too difficult under the existing system. The traditional rights of magi hindered investigations and trials too much. In times of gen-
+In addition, he claimed that the Order had outgrown Guernicus's vision of a loose society of freemen. Simprim maintained that corruption had beset many local Tribunals and action against them was too difficult under the existing system. The traditional rights of magi hindered investigations and trials too much. In times of general conflict, a Tribunal meeting every seven years was simply inadequate to keep the peace; a new schism was inevitable.
 
-
-
-### Lore of the Order: Transitionalist
-
-*"As Quaesitors of the Order, we carry a heavy burden. It is our duty to judge our brethren, always trying our best to be fair and impartial in all we decide. Fortunately, we have a great tool to aid us in this task — the Code of Hermes — carefully handed down to us from the original rulings to the most recent decisions of the Grand Tribunal. For ages we have made our decisions based upon strict interpretations of these rulings, and this always seemed enough.*
-
-*"Now I must most humbly suggest this is no longer the case. The world has changed dramatically in the past centuries. Many of the First Tribunal rulings have become outdated. It has become clear to many of us within the Quaesitores that any law or tradition incapable of changing is a burden rather than a blessing. The time has come to accept new ideas, to again use the Code as a tool to help magi, not to bind them or deny them justice. In the coming years, we must begin to interpret the Oath in ways appropriate to changing times. If we do not, I fear we shall slowly die, a victim of stagnant decline, much like the empire that ruled this peninsula a millennium ago."*
-
+> ## Lore of the Order: Transitionalist
+> 
+> *"As Quaesitors of the Order, we carry a heavy burden. It is our duty to judge our brethren, always trying our best to be fair and impartial in all we decide. Fortunately, we have a great tool to aid us in this task — the Code of Hermes — carefully handed down to us from the original rulings to the most recent decisions of the Grand Tribunal. For ages we have made our decisions based upon strict interpretations of these rulings, and this always seemed enough.*
+> 
+> *"Now I must most humbly suggest this is no longer the case. The world has changed dramatically in the past centuries. Many of the First Tribunal rulings have become outdated. It has become clear to many of us within the Quaesitores that any law or tradition incapable of changing is a burden rather than a blessing. The time has come to accept new ideas, to again use the Code as a tool to help magi, not to bind them or deny them justice. In the coming years, we must begin to interpret the Oath in ways appropriate to changing times. If we do not, I fear we shall slowly die, a victim of stagnant decline, much like the empire that ruled this peninsula a millennium ago."*
+> 
 > — Simprim of House Guernicus, speech to the inner council of Magvillus
-
-eral conflict, a Tribunal meeting every seven years was simply inadequate to keep the peace; a new schism was inevitable.
 
 Simprim suggested more powers be given to the Quaesitores and Tribunals. He called for the Grand Tribunal to have the authority to amend the First Tribunal rulings as it desired and that local Tribunals be given reasonable scope to set policies on mundane interference.
 
@@ -1444,13 +1294,11 @@ There are ninety-eight Guernicus magi in the Order and about thirteen apprentice
 
 On average a Tribunal will have three non-Guernicus Quaesitors. Therefore an average Tribunal will have eleven or twelve Quaesitors available to share the work of investigations, arbitrations etc. Of course, no Tribunal is average and the Magvillus Council assigns new Quaesitors to Tribunals based on perceived need. So the exact numbers in a Tribunal are for individual sagas to determine.
 
-
-
 ### Domus Magna
 
 The domus magna of House Guernicus is Magvillus, in the Roman Tribunal. It lies on the southern portion of the Apennine mountain range in the Kingdom of Sicily. Magvillus is located on a peak around nine miles north of the town of Potenza.
 
-This highly secretive covenant has nothing to do with local Hermetic politics, except through normal legal channels. Unless invited, only Quaesitors and Recaps are allowed in. Magi turning up at the gate will be given shelter in the reception house outside the walls while their request is considered. The inner buildings are strictly for Guernicus magi only.
+This highly secretive covenant has nothing to do with local Hermetic politics, except through normal legal channels. Unless invited, only Quaesitors and Redcaps are allowed in. Magi turning up at the gate will be given shelter in the reception house outside the walls while their request is considered. The inner buildings are strictly for Guernicus magi only.
 
 Born from the pessimism of Guernicus, the defenses of Magvillus are extreme. Its remote mountain location and defensible position alone would make it virtually invulnerable to mundane attack. However, the fortress was conjured from bedrock of solid granite; its tall seamless construction is clearly not the work of human hands. Even if Magvillus was located on level ground, it would challenge the best siege engines of the day. Magvillus's water is supplied magically and has enough magically preserved food to last years.
 
@@ -1462,10 +1310,7 @@ The power of Magvillus's *Aegis of the Hearth* ritual is a secret, but it is com
 
 In addition to the structures above ground, the keep gives access to many vast underground chambers; also covered by the *Aegis of the Hearth*. Even if the fortress was breached, the defenders can retreat into these highly defensible structures.
 
-
-heirs. Even during the Schism War, Magvillus was never assaulted and so the actual efficacy of its defenses remains untested.
-
-earth elementals; allies of Guernicus and still loyal to his
+During the four centuries of its existence, Magvillus has acquired many items of Hermetic enchantment. The turb of Magvillus has access to many enchanted weapons and suits of armor. The elite guard carries potent enchanted devices, capable of penetrating the Parma of many magi. Perhaps the most impressive Hermetic enchantments are the automata, provided by Verditius Quaesitors. Beyond this, the entire mountain on which it is perched is thought to be the home to many powerful earth elementals; allies of Guernicus and still loyal to his heirs.
 
 Within the fortress there is a small chapel to serve the spiritual needs of the magi and grogs. It is dedicated to Nicholas of Myra, known for generosity to the poor, protector of the innocent and wronged. He raised to life three young boys who had been murdered and pickled in a barrel of brine to hide the crime. The altar of the chapel houses a shard of this barrel. Within the chapel a strong Divine aura overcomes the site's magical aura. However, this does not extend outside (normally at least).
 
@@ -1473,18 +1318,13 @@ Within the fortress there is a small chapel to serve the spiritual needs of the 
 
 The current Primus is the Archmage Bilera. She was chosen for both her record and her apparent neutrality in the Traditionalist/Transitionalist debate.
 
-In many ways Bilera is the archetypical Guernicus Primus. Before taking office her life was one of quiet service to the Order. Bilera's magical interest lies in horticulture and the architecture of gardens. By careful cultivation
+In many ways Bilera is the archetypical Guernicus Primus. Before taking office her life was one of quiet service to the Order. Bilera's magical interest lies in horticulture and the architecture of gardens. By careful cultivation and arrangement in a magical aura, Bilera has managed to create gardens of surpassing beauty that also yield a regular (if usually modest) harvest of vis. Before becoming Primus, Bilera would travel throughout the Order looking for suitable sites for her gardens. If a covenant agreed, she would both plant a garden and tutor a magus in its maintenance. To Bilera, the pleasure of creating a new garden was its own reward, but she also takes tithes from each that produces vis. Many of her investigations began while working on these gardens.
 
-### The Imperfect Defense
-
-For the two hours prior to sunrise on Good Friday, a strong Divine aura envelops the entire Magvillus fortress and the *Aegis of the Health* is suppressed. This may correspond to the trial of Jesus by the Sanhedrin. Guernicus thought it was God's reminder to House Guernicus of the fallibility of human justice. This is a great secret, known only to members of the inner council. Initially the council considered moving the chapel outside the fortress, but Guernicus urged the council to accept God's test of their faith (there was no knowing if it would have worked in any case).
-
-Although would-be attackers might win the battle if they attacked at this time, what fate would they suffer on Easter day, when the victories of evil were undone?
-
-
-
-
-and arrangement in a magical aura, Bilera has managed to create gardens of surpassing beauty that also yield a regular (if usually modest) harvest of vis. Before becoming Primus, Bilera would travel throughout the Order looking for suitable sites for her gardens. If a covenant agreed, she would both plant a garden and tutor a magus in its maintenance. To Bilera, the pleasure of creating a new garden was its own reward, but she also takes tithes from each that produces vis. Many of her investigations began while working on these gardens.
+> ## The Imperfect Defense
+> 
+> For the two hours prior to sunrise on Good Friday, a strong Divine aura envelops the entire Magvillus fortress and the *Aegis of the Hearth* is suppressed. This may correspond to the trial of Jesus by the Sanhedrin. Guernicus thought it was God's reminder to House Guernicus of the fallibility of human justice. This is a great secret, known only to members of the inner council. Initially the council considered moving the chapel outside the fortress, but Guernicus urged the council to accept God's test of their faith (there was no knowing if it would have worked in any case).
+> 
+> Although would-be attackers might win the battle if they attacked at this time, what fate would they suffer on Easter day, when the victories of evil were undone?
 
 Her ability to unravel the most complex intrigues was not widely noted at first. Her small frame and soft-spoken manner led many to underestimate her. In actuality she was shrewd and sharp-eyed with an intuitive acumen second to none. With her keen insight, Bilera seldom had any need to resort to magical methods. Even after exposure, Bilera would lead the effort for a swift and discreet private settlement. Thus many of her most successful cases passed unnoted. Bilera never did anything to advertise her accomplishments and her itinerant lifestyle led many to think she was not even an active Quaesitor.
 
@@ -1512,7 +1352,6 @@ Newly gauntleted Guernicus magi are voluntarily assigned to Tribunals based on n
 
 Having a Quaesitor in a covenant is a mixed blessing. In conflicts with mundanes and other magi, a Quaesitor will seldom condone actions that step outside the law. However, they will pursue investigations against illegal activities against their own covenant with particular vigor. Young Quaesitors are often placed with spring covenants in areas where older covenants are known to be hostile.
 
-
 ## The Code of Hermes
 
 The following section relates to a generally agreed interpretation of the Code. These basic interpretations were formed from the First Tribunal rulings. Traditionalists accept that they can be further clarified and expanded by later Tribunal rulings, but wish to maintain this core.
@@ -1521,18 +1360,15 @@ A Transitionalist sees these interpretations as subject to fundamental revision 
 
 ### Origins
 
-When Guernicus decided what legal system the Order should adopt, most thought of Roman law. However, Guernicus dismissed the suggestion. Magi had been lawless barbarians for three hundred years; a barbarian law was the best that could be hope for. Thus
+When Guernicus decided what legal system the Order should adopt, most thought of Roman law. However, Guernicus dismissed the suggestion. Magi had been lawless barbarians for three hundred years; a barbarian law was the best that could be hope for. Thus Guernicus took the Germanic and Nordic tribal laws and re-cast them to suit the Order.
 
-### The Law in Your Saga
-
-For readability and brevity the following section mostly describes how Traditionalist Quaesitors would like Tribunals to interpret the Code. Whether magi of a Tribunal generally accept this interpretation or respect the Code at all is an open question. How lawful or lawless the Order is rests entirely at the discretion of troupes. In some, the Order may barely exist as an organization, with all Tribunals chaotic and their decisions dictated by the most powerful groups even on criminal matters. In others the law will show neither fear nor favor, with hedge wizards receiving equal legal protection with Archmagi. In some there will only be the Oath and personal judgment. Others will have formally written laws, with magi fighting cases over technicalities and wording like modern lawyers.
-
-How strong the Traditionalists or Transitionalists are has also been left an open question. Individual troupes should come to their own decision. In some sagas, Transitionalists will be a small fringe group, looked upon as misguided but so marginalized that they are unthreatening. In others they will have already instituted their proposals in many Tribunals and will be pressing the Grand Tribunal.
-
-How uniform the Order is in its organization is also open. Within the same saga different Tribunals may cross the spectrum on all axes.
-
-
-Guernicus took the Germanic and Nordic tribal laws and re-cast them to suit the Order.
+> ## The Law in Your Saga
+> 
+> For readability and brevity the following section mostly describes how Traditionalist Quaesitors would like Tribunals to interpret the Code. Whether magi of a Tribunal generally accept this interpretation or respect the Code at all is an open question. How lawful or lawless the Order is rests entirely at the discretion of troupes. In some, the Order may barely exist as an organization, with all Tribunals chaotic and their decisions dictated by the most powerful groups even on criminal matters. In others the law will show neither fear nor favor, with hedge wizards receiving equal legal protection with Archmagi. In some there will only be the Oath and personal judgment. Others will have formally written laws, with magi fighting cases over technicalities and wording like modern lawyers.
+> 
+> How strong the Traditionalists or Transitionalists are has also been left an open question. Individual troupes should come to their own decision. In some sagas, Transitionalists will be a small fringe group, looked upon as misguided but so marginalized that they are unthreatening. In others they will have already instituted their proposals in many Tribunals and will be pressing the Grand Tribunal.
+> 
+> How uniform the Order is in its organization is also open. Within the same saga different Tribunals may cross the spectrum on all axes.
 
 ### Forfeit Immunity
 
@@ -1540,10 +1376,7 @@ The key form of defense from Hermetic charges is to claim the victim had forfeit
 
 Normally a magus is under the protected of the law. In other words he is immune to attack. However, in certain circumstances he might step outside the protection of Hermetic Law, either partially or totally.
 
-Wizard War is one example of this. A combatant in a Wizard War is not legally protected against attacks from the other combatant (or combatants). This lack of legal protection is called forfeit immunity. A magus is also under forfeit immunity while committing, preparing to commit, or shortly after committing a crime. By his criminal act his legal protection is forfeit. While forfeit other magi may act against him, but the response should be proportional. As with most aspects of Hermetic Law, forfeit
-
-
-
+Wizard War is one example of this. A combatant in a Wizard War is not legally protected against attacks from the other combatant (or combatants). This lack of legal protection is called forfeit immunity. A magus is also under forfeit immunity while committing, preparing to commit, or shortly after committing a crime. By his criminal act his legal protection is forfeit. While forfeit other magi may act against him, but the response should be proportional. As with most aspects of Hermetic Law, forfeit immunity is a matter of degree. In some cases a response may be seen as justiﬁed and in others it will not.
 
 Thus a magus may claim his attack on another magus was legal, as the victim's immunity was forfeit at the time. The Tribunal will weigh up any claim of forfeit immunity in the light of the actions of both parties.
 
@@ -1574,12 +1407,13 @@ A clear and direct breach of the Code is designated a high crimes. These are:
 - Attacking an Ally of the Order
 - Aiding an Enemy of the Order
 
+\* *One directly made against the magus.*
 
 A detailed discussion on each of these potential offenses is given below. If the case is a high crime, the prosecution can call for a Wizard's March, otherwise he cannot. Tribunals always have discretion to set a penalty they find appropriate, but to call a Wizard's March it must be a high crime.
 
 All other offenses are low crimes. The magus can still be Marched if they refuse to abide by the Tribunal ruling made against them, as this is a high crime. Thus, if a magus fails to agree to the punishment, he faces a March.
 
-### DEPRIVATION OF MAGICAL POWER
+#### Deprivation of Magical Power
 
 **"I will not deprive nor attempt to deprive a member of their magical power."**
 
@@ -1589,7 +1423,7 @@ Any physical injury that restricts the ability to speak, gesture or general mobi
 
 Beyond this, a covenant's mundane resources, including personnel, are also protected to a degree as these are required for study. However, attacks on mundane assets are normally brought as low crimes (see below).
 
-### SLAYING
+### Slaying
 
 **"I will not slay, nor attempt to slay a member of the Order, except in a properly declared Wizard War."**
 
@@ -1599,20 +1433,7 @@ If the other magus was engaged or preparing to engage in an act that seriously t
 
 A magus who slays another (outside a Wizard's March or War) must always come before the Tribunal for judgment. In some cases this is a formality, but it ensures the entire Tribunal is fully informed and involved in the process.
 
-By an early First Tribunal ruling, being within another's sanctum automatically confers forfeit immunity with
-
-
-*<sup>\*</sup> One directly made against the magus.*
-
-
-
-Most magi have no contact with their mundane family. Many have weak emotional ties to parentes and magical siblings.
-
-In response, magi frequently develop strong friendships with other magi, usually covenant sodales. Magi who are particularly close swear an oath of friendship. These magi then refer to each other as amicus (friend). In Hermetic society this implies a strong moral (not legal) duty to support the other. This bond is often more reliable than the bonds of lineage and House. If there is a need to avenge an amicus, the magus is not expected to break the law or throw his life away on a gesture, but the duty to avenge never expires. Payback can occur decades later.
-
-Before declaring a Wizard War, a wise magus considers who their opponent's amici are and how close they are to parens, filii or mystae. Extended bloody feuds are not unknown in some Tribunals.
-
-respect to the owner of the sanctum. In this circumstance the sanctum owner can make lethal attacks legally, but any aggressive response by the intruder is usually illegal.
+By an early First Tribunal ruling, being within another's sanctum automatically confers forfeit immunity with respect to the owner of the sanctum. In this circumstance the sanctum owner can make lethal attacks legally, but any aggressive response by the intruder is usually illegal.
 
 Petty spells or petty physical attacks are insufficient to justify a lethal response. However, casting humiliating magics on other magi or physically assaulting them is clearly provocative and goes to mitigation.
 
@@ -1624,10 +1445,18 @@ Gravis of House Flambeau was charged with slaying Talus of House Merinita. Gravi
 
 *A.A. 1030 (A.D. 891), Rome Tribunal*
 
-Dominicus of House Jerbiton was charged with the slaying of Gravis of House Flambeau. Dominicus claimed forfeit immunity applied. Gravis had thrown a *Ball of Abyssal Flame* at him after a council discussion had become 'heated'. Witnesses testified that Gravis had made the first attack, with only verbal provocation. Although his Parma was penetrated, Dominicus was barely injured and replied with *Clenching Hand of the Crushed Heart*, instantly slaying Gravis. A member of Dominicus's covenant claimed that
+Dominicus of House Jerbiton was charged with the slaying of Gravis of House Flambeau. Dominicus claimed forfeit immunity applied. Gravis had thrown a *Ball of Abyssal Flame* at him after a council discussion had become 'heated'. Witnesses testified that Gravis had made the first attack, with only verbal provocation. Although his Parma was penetrated, Dominicus was barely injured and replied with *Clenching Hand of the Crushed Heart*, instantly slaying Gravis. A member of Dominicus's covenant claimed that Dominicus, an amicus of Talus, had taken a powerful potion that morning. This potion made his ﬂesh impervious to ﬁre; he then orchestrated the confrontation. Dominicus did not dispute this, but maintained that Gravis had attempted to kill him, forfeiting his immunity. The Presiding Quaesitor pronounced that Dominicus’s intention did not excuse Gravis’s action and he was acquitted. However, Dominicus was later convicted of breaching his covenant charter and was exiled from the Tribunal.
+
+> ## Amici
+> 
+> Most magi have no contact with their mundane family. Many have weak emotional ties to parentes and magical siblings.
+> 
+> In response, magi frequently develop strong friendships with other magi, usually covenant sodales. Magi who are particularly close swear an oath of friendship. These magi then refer to each other as amicus (friend). In Hermetic society this implies a strong moral (not legal) duty to support the other. This bond is often more reliable than the bonds of lineage and House. If there is a need to avenge an amicus, the magus is not expected to break the law or throw his life away on a gesture, but the duty to avenge never expires. Payback can occur decades later.
+> 
+> Before declaring a Wizard War, a wise magus considers who their opponent's amici are and how close they are to parens, filii or mystae. Extended bloody feuds are not unknown in some Tribunals.
 
 
-### WIZARD WAR
+### Wizard War
 
 Tribunal.
 
@@ -1635,7 +1464,7 @@ Tribunal.
 
 For a fee, a Redcap can ensure the declaration of war is delivered within the appropriate time. He then reports back the successful delivery to the sender. This Redcap also acts as a legal witness to the declaration. This means that hostile magi do not meet each other beforehand and ensures there is no dispute over the legality of the declaration. This procedure is not considered a core interpretation of the Code and so some Tribunals may have more elaborate procedures.
 
-The core interpretation is that the recipient of the declaration has a lunar mouth to prepare and then the war lasts for a lunar month. During a Wizard War both parties can attack each other's life and property without fear of prosecution. However, they still may be held to account for any collateral damage. A magus cannot legally attack property in which his opponent has shared ownership, such as covenant buildings, vis sites and covenant books.
+The core interpretation is that the recipient of the declaration has a lunar month to prepare and then the war lasts for a lunar month. During a Wizard War both parties can attack each other's life and property without fear of prosecution. However, they still may be held to account for any collateral damage. A magus cannot legally attack property in which his opponent has shared ownership, such as covenant buildings, vis sites and covenant books.
 
 If a combatant endangers the property or lives of other magi, they forfeit their immunity with respect to those magi. Many covenant sodales are extremely quick to exploit such an opportunity.
 
@@ -1643,12 +1472,7 @@ A combatant is free to enter his opponent's sanctum and destroy its contents. An
 
 The prohibition against retribution is interpreted as complete legal immunity from charges for the slaying. It also forbids other magi from persecuting the victor for the slaying. However, this immunity is granted in all Wizard Wars. In general, a magus cannot be prosecuted for declaring Wizard War.
 
-However, in one extreme case this has been challenged. The Rhine Tribunal charged the magus Hernis
-
-
-
-
-with endangering the Order by excessive and unjustified use of Wizard War. By calculated use of Wizard War he sought to achieve political domination of the Tribunal through terror. The Presiding Quaesitor pronounced that if Hernis's actions had endangered the Order, this would not be covered by the Wizard War immunity. The Tribunal found Hernis guilty of endangering the Order.
+However, in one extreme case this has been challenged. The Rhine Tribunal charged the magus Hernis with endangering the Order by excessive and unjustified use of Wizard War. By calculated use of Wizard War he sought to achieve political domination of the Tribunal through terror. The Presiding Quaesitor pronounced that if Hernis's actions had endangered the Order, this would not be covered by the Wizard War immunity. The Tribunal found Hernis guilty of endangering the Order.
 
 Hernis refused to cooperate with the Tribunal and so they had only one course available. A group of powerful magi hunted Hernis down; two were slain in the process. This case is still seen as exceptional.
 
@@ -1656,7 +1480,7 @@ Hernis refused to cooperate with the Tribunal and so they had only one course av
 
 Dominicus of House Jerbiton was charged with seeking retribution after an amicus of his was slain in a Wizard War, by declaring Wizard War on the victor. Dominicus claimed the charge was invalid, as it sought retribution for his own Wizard War and the Code protected him from such charges. The Presiding Quaesitor pointed out that founder Flambeau proposed this provision of the Code for the express purpose of seeking vengeance; therefore the defense was sound. On this advice, the Tribunal acquitted him.
 
-#### ABIDE BY TRIBUNAL DECISIONS
+#### Abide by Tribunal Decisions
 
 **"I will abide by the decisions made by fair vote at Tribunal."**
 
@@ -1666,31 +1490,29 @@ Traditionalists maintain that even Grand Tribunal rulings should not conflict di
 
 However, regional or Grand Tribunals can create other provisions, like restricting the magical production of silver or how many official sanctums a magus may have. For the most part the Grand Tribunal does not try to define every detail of Hermetic life. Local Tribunals are left with great control over important details like property and inheritance law. They also have a good deal of scope in interpreting Grand Tribunal rulings. A Presiding Quaesitor will only step in with a veto (see below) if the Tribunal is clearly and unambiguously conflicting with any reasonable interpretation of the Oath, First or Grand Tribunal ruling. By these local rulings, a great deal of variation exists between Tribunals.
 
-### Proxy Voting
-
-A magus's right to vote holds even if they do not attend. A magus can give his sigil to an attending magus who agrees to act as proxy. In order to be legal the proxy needs to cast the vote according to the will of the owner. This is done in two principle ways.
-
-A directed proxy involves the sigil owner composing a list of voting directions. Most magi find exercising a proxy like this tedious and a little demeaning. Usually Redcaps are paid to act as directed proxies.
-
-A free proxy involves the sigil owner declaring that it is his will that his vote be cast with the proxy's. Magi are normally happy to act as proxies on this basis. Alternatively the proxy may be a mixture of directed and free. Many magi will accept a proxy with one or two directions.
-
-After the Tribunal the proxy is required to detail how he used the owner's sigil. On a directed proxy this should match the instructions. Not following the instructions is a high crime. On a free proxy the owner can disown any decisions he does not agree with. This divests the owner of legal responsibility for the vote, but is very insulting to the proxy holder.
-
-The Tremere practice of holding the sigils of filii is a free proxy. Therefore under Hermetic Law the decision of a Tremere magus to make his parens (or whomever) his proxy is entirely legal. In principle a Tremere magus can demand his sigil back at any time. However, membership of House Tremere is not a Hermetic right and the leadership of the House can cast out any member they choose for whatever reason. Therefore, Tremere magi who demand their sigil's return are effectively leaving the House.
-
-Of course, a magus can only proxy his vote to be used in his residential Tribunal or the Grand Tribunal. This applies equally to Tremere magi.
-
-*A.A. 912 (A.D. 773), Durenmar*
-
-The founder Tremere was accused of failing to respect the votes of others by demanding the control of the sigils of his filii. In his defense Tremere's filii testified that their choice of proxy was out of respect for their parens and that it was their right to do this. The Tribunal found in Tremere's favor, but reaffirmed that Tremere magi have the right to reclaim their sigils at any time. Tremere added that members of his House were respectful of their parentes and so no worthy member would feel the need to reclaim their sigil before it was the will of their parens.
-
-
-
 Regional Tribunals can revise or reverse their own rulings at they please. However, most are inherently conservative and require compelling arguments to clearly contradict earlier decisions. A Tribunal that regularly makes contradictory rulings opens itself to the derision of neighboring Tribunals and admonishment by their Presiding Quaesitor. However, occasional changes to local provisions are expected.
 
-All rulings should is some way relate back to a provision of the Oath. In essence all rulings should simply clarify, expand or embellish the Oath. By these Tribunal rulings the Peripheral Code is formed (see page 54).
+All rulings should in some way relate back to a provision of the Oath. In essence all rulings should simply clarify, expand or embellish the Oath. By these Tribunal rulings the Peripheral Code is formed (see page 54).
 
-#### VOTING RIGHTS
+> ## Proxy Voting
+> 
+> A magus's right to vote holds even if they do not attend. A magus can give his sigil to an attending magus who agrees to act as proxy. In order to be legal the proxy needs to cast the vote according to the will of the owner. This is done in two principle ways.
+> 
+> A directed proxy involves the sigil owner composing a list of voting directions. Most magi find exercising a proxy like this tedious and a little demeaning. Usually Redcaps are paid to act as directed proxies.
+> 
+> A free proxy involves the sigil owner declaring that it is his will that his vote be cast with the proxy's. Magi are normally happy to act as proxies on this basis. Alternatively the proxy may be a mixture of directed and free. Many magi will accept a proxy with one or two directions.
+> 
+> After the Tribunal the proxy is required to detail how he used the owner's sigil. On a directed proxy this should match the instructions. Not following the instructions is a high crime. On a free proxy the owner can disown any decisions he does not agree with. This divests the owner of legal responsibility for the vote, but is very insulting to the proxy holder.
+> 
+> The Tremere practice of holding the sigils of filii is a free proxy. Therefore under Hermetic Law the decision of a Tremere magus to make his parens (or whomever) his proxy is entirely legal. In principle a Tremere magus can demand his sigil back at any time. However, membership of House Tremere is not a Hermetic right and the leadership of the House can cast out any member they choose for whatever reason. Therefore, Tremere magi who demand their sigil's return are effectively leaving the House.
+> 
+> Of course, a magus can only proxy his vote to be used in his residential Tribunal or the Grand Tribunal. This applies equally to Tremere magi.
+> 
+> *A.A. 912 (A.D. 773), Durenmar*
+> 
+> The founder Tremere was accused of failing to respect the votes of others by demanding the control of the sigils of his filii. In his defense Tremere's filii testified that their choice of proxy was out of respect for their parens and that it was their right to do this. The Tribunal found in Tremere's favor, but reaffirmed that Tremere magi have the right to reclaim their sigils at any time. Tremere added that members of his House were respectful of their parentes and so no worthy member would feel the need to reclaim their sigil before it was the will of their parens.
+
+#### Voting Rights
 
 **"I will have one vote at Tribunal and I will use it prudently. I will respect as equal the votes of all others at Tribunal."**
 
@@ -1702,43 +1524,11 @@ Most Tribunals impose some formal residency requirements, sometimes in an attemp
 
 Magi who wander between Tribunals still need an official residence. It is their responsibility to maintain enough contact with the Mercere to ensure they are informed about cases against them.
 
-Tribunal borders are often vague. For instance, magi of a covenant near the border between England and Scotland might declare for either Stonehenge or Loch
-
+Tribunal borders are often vague. For instance, magi of a covenant near the border between England and Scotland might declare for either Stonehenge or Loch Leglean. Most Quaesitors supports this freedom and oppose moves for strict border deﬁnitions.
 
 If a Tribunal has residency requirements, a magus can fall delinquent of them; this is for the Presiding Quaesitor to judge and declare. Such a magus has seven years to meet the requirements or join another Tribunal. If he does not he can be charged with vagrancy (see below).
 
-This section guarantees all magi the right cast their single vote, according to their will, on all issues brought before their residential Tribunal and the Grand Tribunal. Implicit in this is the right to attend, although the Praeco can exclude magi who misbehave. Theoretically every magus has the right to attend the Grand Tribunal, but virtually all choose to free proxy (see the insert) their vote to representatives. The journey to Durenmar is often long
-
-### Vagrancy
-
-Social pressure and threats of Wizard War aside, the only power backing up the authority of a Primus is the ability to expel members. By a First Tribunal ruling, magi are legally required to have a House. House vagrancy can therefore lead to a Wizard's March.
-
-In order to prevent Primi becoming tyrants, the ability to move House is legally possible, but not guaranteed. Most magi are very proud of their House and would only consider leaving in the most extreme circumstances. Individual Houses have different expectations of how demanding a Primus should be. Only if those expectations are grossly exceeded might a Primus risk mass desertion.
-
-Magi who renounce their House membership or are expelled have one year to obtain membership in another. After this period they can be charged with vagrancy. This is low crime and the Presiding Quaesitor demands the magus find another House before the next Tribunal. Failure to comply with a Tribunal judgment is a high crime and can result in a Wizard's March.
-
-Magi can enter a new House through a sponsor. Members of true lineages never offer such sponsorship, but others might. The Primus has the right to veto admissions, but finding a sponsor is usually enough to gain entrance. If no other House will accept them, Ex Miscellanea will normally do so. In many Tribunals, vagrants are simply assumed to have joined House Ex Miscellanea if they fail to find a more respectable one within a year.
-
-Magi can also be charged with vagrancy if they are without a residential Tribunal or residing in a Tribunal without meeting its residency requirements. Anyone can bring a vagrancy case.
-
-
-
-
-### The Rhine Corruption
-
-Early in the Order's history magi of the Rhine Tribunal began perverting the intention of proxy voting to acquire multiple votes. By agreement, an elder magus would grant proxy rights to another whenever they were not present at Tribunal and allow the proxy to transfer these rights as they wished. When the elder magus passed into Final Twilight or otherwise disappeared, his passing would not be recognized or reported. By this means extra votes began to accumulate within the elder ranks of Rhine magi.
-
-By the time this practice came to the attention of the region's Quaesitors, the Rhine's elder magi had already established a significant advantage. They also secured the support of younger magi by offering possession of one or more of these votes. Initially the Quaesitores brought charges of vagrancy against the sigil ghosts (as they called them). The sigil ghosts could neither defend their case nor legally appoint an advocate. Their failure to defend the case was clear evidence for the prosecution. However, the Rhine Tribunal voted to acquit them anyway. The prosecution principles faced considerable hostility and a number were driven from the Tribunal with threats of Wizard War.
-
-The Magvillus Council judged that ending the practice at regional level was not possible at that time; the Grand Tribunal was required. At the time the Rhine was still seen as the heart of the Order. If the Quaesitores had forced the issue to Grand Tribunal they faced possible defeat, leading to the practice being legalized Order-wide.
-
-The Magvillus Council decided to contain the problem. Presiding Quaesitors outside the Rhine are now extremely watchful. If the Presiding Quaesitor suspects that a sigil might belong to a magus who has passed on, he will quiz the proxy holder. If the Presiding Quaesitor is unconvinced he will hold the absent magus a non-resident. If the magus in question is alive, he needs to prove it by attending next time.
-
-It is theoretically possible that a magus could find himself unable to attend Tribunal for an extended period of time, appoint a proxy in anticipation of this, and be ruled non-resident by the Presiding Quaesitor. In such a situation, the magus would have a strong case for claiming that the Presiding Quaesitor had committed a high crime by depriving him of his vote. The Quaesitores are well aware of this, and are very careful about ruling magi non-resident.
-
-Many Quaesitors believe the time may be right to bring the Rhine Tribunal into line; it no longer enjoys the reverence it once had with the rest of the Order. However, the Magvillus Council is waiting for a significant number of Rhine magi to publicly object to the corrupt voting practice. If the majority of the Rhine magi are happy with the status quo, the Magvillus Council will leave them to it. However, if the Council thought a majority wished to free itself of the corruption, the Quaesitores would act quickly. The continuation of the Rhine corruption therefore depends on the majority of Rhine magi accepting it.
-
-and few magi care to attend simply as voting observers. Magi can pay a Redcap to be a directed proxy, but this is expensive. Although the Tribunal chamber at Durenmar only seats a hundred and twenty, in practice this has always been sufficient.
+This section guarantees all magi the right to cast their single vote, according to their will, on all issues brought before their residential Tribunal and the Grand Tribunal. Implicit in this is the right to attend, although the Praeco can exclude magi who misbehave. Theoretically every magus has the right to attend the Grand Tribunal, but virtually all choose to free proxy (see the insert) their vote to representatives. The journey to Durenmar is often long and few magi care to attend simply as voting observers. Magi can pay a Redcap to be a directed proxy, but this is expensive. Although the Tribunal chamber at Durenmar only seats a hundred and twenty, in practice this has always been sufficient.
 
 The provision also demands that magi use their vote prudently. Traditionalists interpret this as a duty to vote strictly according to an honest legal judgment. Voting to convict or acquit against a magus's better legal judgment is a high crime. Anyone exposed as having accepted a bribe or other deal for his vote may be charged. The rigor with which this provision is enforced varies greatly.
 
@@ -1746,19 +1536,43 @@ Even in strict Tribunals, corruption can still happen. Allies tend to vote for a
 
 A magus can always choose to abstain if he wishes and magi are free to trade votes as they please outside of criminal cases.
 
-#### ENDANGERMENT
+> ## Vagrancy
+> 
+> Social pressure and threats of Wizard War aside, the only power backing up the authority of a Primus is the ability to expel members. By a First Tribunal ruling, magi are legally required to have a House. House vagrancy can therefore lead to a Wizard's March.
+> 
+> In order to prevent Primi becoming tyrants, the ability to move House is legally possible, but not guaranteed. Most magi are very proud of their House and would only consider leaving in the most extreme circumstances. Individual Houses have different expectations of how demanding a Primus should be. Only if those expectations are grossly exceeded might a Primus risk mass desertion.
+> 
+> Magi who renounce their House membership or are expelled have one year to obtain membership in another. After this period they can be charged with vagrancy. This is low crime and the Presiding Quaesitor demands the magus find another House before the next Tribunal. Failure to comply with a Tribunal judgment is a high crime and can result in a Wizard's March.
+> 
+> Magi can enter a new House through a sponsor. Members of true lineages never offer such sponsorship, but others might. The Primus has the right to veto admissions, but finding a sponsor is usually enough to gain entrance. If no other House will accept them, Ex Miscellanea will normally do so. In many Tribunals, vagrants are simply assumed to have joined House Ex Miscellanea if they fail to find a more respectable one within a year.
+> 
+> Magi can also be charged with vagrancy if they are without a residential Tribunal or residing in a Tribunal without meeting its residency requirements. Anyone can bring a vagrancy case.
 
-#### "I will not endanger the Order through my actions."
+> ## The Rhine Corruption
+> 
+> Early in the Order's history magi of the Rhine Tribunal began perverting the intention of proxy voting to acquire multiple votes. By agreement, an elder magus would grant proxy rights to another whenever they were not present at Tribunal and allow the proxy to transfer these rights as they wished. When the elder magus passed into Final Twilight or otherwise disappeared, his passing would not be recognized or reported. By this means extra votes began to accumulate within the elder ranks of Rhine magi.
+> 
+> By the time this practice came to the attention of the region's Quaesitors, the Rhine's elder magi had already established a significant advantage. They also secured the support of younger magi by offering possession of one or more of these votes. Initially the Quaesitores brought charges of vagrancy against the sigil ghosts (as they called them). The sigil ghosts could neither defend their case nor legally appoint an advocate. Their failure to defend the case was clear evidence for the prosecution. However, the Rhine Tribunal voted to acquit them anyway. The prosecution principles faced considerable hostility and a number were driven from the Tribunal with threats of Wizard War.
+> 
+> The Magvillus Council judged that ending the practice at regional level was not possible at that time; the Grand Tribunal was required. At the time the Rhine was still seen as the heart of the Order. If the Quaesitores had forced the issue to Grand Tribunal they faced possible defeat, leading to the practice being legalized Order-wide.
+> 
+> The Magvillus Council decided to contain the problem. Presiding Quaesitors outside the Rhine are now extremely watchful. If the Presiding Quaesitor suspects that a sigil might belong to a magus who has passed on, he will quiz the proxy holder. If the Presiding Quaesitor is unconvinced he will hold the absent magus a non-resident. If the magus in question is alive, he needs to prove it by attending next time.
+> 
+> It is theoretically possible that a magus could find himself unable to attend Tribunal for an extended period of time, appoint a proxy in anticipation of this, and be ruled non-resident by the Presiding Quaesitor. In such a situation, the magus would have a strong case for claiming that the Presiding Quaesitor had committed a high crime by depriving him of his vote. The Quaesitores are well aware of this, and are very careful about ruling magi non-resident.
+> 
+> Many Quaesitors believe the time may be right to bring the Rhine Tribunal into line; it no longer enjoys the reverence it once had with the rest of the Order. However, the Magvillus Council is waiting for a significant number of Rhine magi to publicly object to the corrupt voting practice. If the majority of the Rhine magi are happy with the status quo, the Magvillus Council will leave them to it. However, if the Council thought a majority wished to free itself of the corruption, the Quaesitores would act quickly. The continuation of the Rhine corruption therefore depends on the majority of Rhine magi accepting it.
+
+#### Endangerment
+
+**"I will not endanger the Order through my actions."**
 
 This is the most fundamental provision. Any act which risks the peace and security of other magi can be used to justify a charge. This provision is generally held as the most important, thus it can in extreme cases be used to justify contradicting another provision. However, this judgment is normally made only by a Tribunal, with the Presiding Quaesitor vetoing any abuse of the principle.
 
 A defendant might claim the endangerment was trivial or only personal. The prosecution needs to show that magi other than the defendant were endangered.
 
-
-
 Intention on behalf of the defendant is important in mitigation, as is any negligence or recklessness. If convicted, the penalty will take account of both the culpability of the defendant and the degree of endangerment.
 
-#### MUNDANE INTERFERENCE
+#### Mundane Interference
 
 **"I will not interfere with the affairs of mundanes and thereby bring ruin upon my sodales"**
 
@@ -1772,17 +1586,15 @@ Conflict may arise directly between a magus and a particular noble or clergyman.
 
 Over this provision there is much debate both within the Order and House Guernicus. In some Tribunals it is virtually ignored, and on this issue much of the Traditionalist/Transitionalist disagreement occurs. The Transitionalists argue that provision is already effectively unenforceable; it should be recast to suit the times. A new provision could be enforced, the abuses punished and the benign activities legalized. In the current situation both are ignored. Traditionalists disagree, of course.
 
-#### DEALS WITH DEVILS
+#### Deals with Devils
 
 **"I will not deal with devils, lest I imperil my soul and the souls of my sodales as well."**
 
 This provision is the most strictly enforced of all high crimes. Magi are absolutely forbidden from knowingly making an agreement with an infernal agent.
 
-The infernal is seen as the greatest threat to the security of the Order. Even the most seemingly benign agreements will almost certainly result in a Wizard's March. The only possible defense is ignorance that the creature was a demon. Even an agreement to mutually avoid contact with a demon has been punished by a Wizard's March. Faced with a known demon a magus should agree to nothing. In general his only legal choice would be to
+The infernal is seen as the greatest threat to the security of the Order. Even the most seemingly benign agreements will almost certainly result in a Wizard's March. The only possible defense is ignorance that the creature was a demon. Even an agreement to mutually avoid contact with a demon has been punished by a Wizard's March. Faced with a known demon a magus should agree to nothing. In general his only legal choice would be to defend himself or flee.
 
 Seeking out demons in order to slay them is generally legal, unless the demon then focuses its attention on the Order. This might result in a charge of endangerment.
-
-defend himself or flee.
 
 Intelligent and subtle demons might attack other magi in order to get their real enemy into trouble. In such a case, the magus who started the conflict may be punished in proportion to the damage suffered by others.
 
@@ -1794,7 +1606,7 @@ Many magi are of the opinion that all demons are a danger to the Order, reasonin
 
 Rudophus of Durenmar, through his actions, had attracted the attention of a major demon. Although he attempted for over a decade to kill this demon, he was unsuccessful. The demon began systematic attacks against the Redcaps of the Tribunal. The senior Mercere brought a case against Rudophus for endangering the Order. The Tribunal convicted Rudophus and he was commanded to provide House Mercere with some magical means of protecting themselves from the depredations of demons.
 
-#### MOLESTING THE FAY
+#### Molesting the Fay
 
 **"I will not molest the fay, least their vengeance catch my sodales as well."**
 
@@ -1804,16 +1616,13 @@ The term 'molest' suggests that the conflict would have to be provoked by the de
 
 *A.A. 1311 (A.D. 1172), Normandy Tribunal*
 
-
-
-
 Guardinia of Merinita accused Berenguer of Tytalus molesting the fay. Berenguer claimed in his defense that the faeries had stolen his apprentice, and therefore he had every right to take steps to return the child to his care. The Tribunal upheld Berenguer's defense, but the Praeco admonished him for being heavy-handed in his rescue.
 
-### SCRYING
+#### Scrying
 
 **"I will not use magic to scry upon members of the Order of Hermes, nor shall I use it to peer into their affairs."**
 
-Criamon insisted on this provision to protect his tradition's magical secrets. Thus attempts to discover magical secrets via magic are considered the most serious. However, any use of magic (not just Intellego spells) to spy or aid spying into a magus's legal affairs is considered an offense. As always the penalty will depend on the harm done or intended.
+Verditius insisted on this provision to protect his tradition's magical secrets. Thus attempts to discover magical secrets via magic are considered the most serious. However, any use of magic (not just Intellego spells) to spy or aid spying into a magus's legal affairs is considered an offense. As always the penalty will depend on the harm done or intended.
 
 The key point is 'legal affairs'. Many covenants have spells and items specifically designed to reveal scrying attempts. These magics are acknowledged as legal. Theoretically such magics might reveal a legal act. For instance, a visitor might use a scrying spell to innocently communicate with his covenant. However, using such magics in another's covenant and then complaining if these are detected, is seen as petty, an abuse of hospitality, and is unlikely to receive any support.
 
@@ -1821,7 +1630,7 @@ Magi are unlikely to bring a successful case for being spotted while invisible o
 
 When using scrying spells in mundane society cautious magi usually cast without Penetration (see Forceless Casting insert). In this way even if a magus is accidentally caught within a target, his privacy is usually protected. However, this is not absolutely safe. Redcaps have no magic resistance and they enjoy the full protection of the Code. In fact, the privacy of Redcaps is particularly sensitive as they often know a great many secrets of other magi. If a Redcap is caught by a scrying spell, the Tribunal will presume intent and the caster would need to convince them otherwise. If there was no intent, but secrets were revealed, damages will be awarded. If there was no intent or secrets revealed the case is trivial.
 
-#### APPRENTICES
+#### Apprentices
 
 **"I will train apprentices who will swear to this Code, and should any of them turn against the Order and my sodales I will be the first to strike them. No apprentice of mine shall be called magus until he or she first swears to uphold this Code."**
 
@@ -1829,29 +1638,27 @@ To officially claim an apprentice a magus must initiate them into Hermetic magic
 
 In most Tribunals is a low crime to keep a Gifted child merely as a lab assistant. In order to protect the future of the Order, an unclaimed Gifted child can be taken by the first magus who makes a formal and witnessed offer to teach them the Hermetic Arts. The new master is legally obliged to take the child to his sanctum with all reasonable haste and begin Hermetic initiation as soon as practicable. A similar method can also be used if a master is delinquent in training; instead of initiation, a season's tuition is given.
 
-
-
-
-### Blood Rights
-
-Seven years ago a young maga gave birth to a Gifted child. As the child grew up, the maga diligently studied her Arts in preparation for the child's apprenticeship. At the age of six the child spoke Latin as his first language and already knew his letters. It was common knowledge in the covenant that the maga planned his initiation for the summer season.
-
-However, a week before the spring equinox, a magus visited the covenant and lay claim to the child by a formal offer of Hermetic initiation. The maga refused to give up her son and hid him in her sanctum. The magus charged the maga with depriving him of his magical property.
-
-The prosecution case is simple and strong. The maga had not started her son's Hermetic initiation and so the boy was unclaimed. The defense case may attract a lot of emotive support, but on what basis can a legal argument be made? The standard interpretation makes clear that an undeclared Gifted child is claimable.
-
-The defense might make a direct emotive appeal to the Tribunal's sense of justice. They could argue that the maga's claim to the child was inherent to her parenthood and that this issue was not addressed by any prior rulings on apprentices. Thus an acquittal ruling would not conflict with higher rulings. Her delay in initiating the child was simply a matter of age. She had every intention to properly apprentice the child and that the Tribunal should recognize her blood rights with a new ruling (one to acquit). The Presiding Quaesitor should agree that an acquittal ruling is within the power of the Tribunal. The decision is entirely at the discretion of the Tribunal magi.
-
-This situation might make an interesting moral dilemma for player characters (if they are given to moral dilemmas). The maga might belong to a hostile covenant and the would-be master a member of an allied covenant. The player characters may hold the deciding votes.
-
 Apprentices taken as children spend fifteen or more years as the property of their master before passing a gauntlet and joining the Order in a formal ceremony. This is not the case with wizards who seek to join the Order as adults. A Gifted person who has already developed significant magical power cannot be initiated into Hermetic magic in the normal way. Initiation rituals might be developed to allow such wizards to become Hermetic, but in any case, such wizards are unsuitable for an apprenticeship and should be offered membership directly.
 
+Non-hermetic wizards do not need to pass a gauntlet to be recognized as magi, they simply swear the Oath (having been invited). They have a year to ﬁnd a sponsor and gain membership in a House to avoid a possible vagrancy charge (see above). However, some Tribunals simply assume they are members of Ex Miscellanea.
 
 After swearing the Hermetic Oath, the wizard can be legally taught Parma and this is normally done by their sponsor. This sponsor becomes their Hermetic parens with all its associated responsibilities and benefits (inheritance rights).
 
 As membership of House Ex Miscellanea has no required standard, such magi normally end up there. House Ex Miscellanea will readily accept wizards who cannot learn Hermetic magic.
 
-### DUTY OF THE PARENS
+> ## Blood Rights
+> 
+> Seven years ago a young maga gave birth to a Gifted child. As the child grew up, the maga diligently studied her Arts in preparation for the child's apprenticeship. At the age of six the child spoke Latin as his first language and already knew his letters. It was common knowledge in the covenant that the maga planned his initiation for the summer season.
+> 
+> However, a week before the spring equinox, a magus visited the covenant and lay claim to the child by a formal offer of Hermetic initiation. The maga refused to give up her son and hid him in her sanctum. The magus charged the maga with depriving him of his magical property.
+> 
+> The prosecution case is simple and strong. The maga had not started her son's Hermetic initiation and so the boy was unclaimed. The defense case may attract a lot of emotive support, but on what basis can a legal argument be made? The standard interpretation makes clear that an undeclared Gifted child is claimable.
+> 
+> The defense might make a direct emotive appeal to the Tribunal's sense of justice. They could argue that the maga's claim to the child was inherent to her parenthood and that this issue was not addressed by any prior rulings on apprentices. Thus an acquittal ruling would not conflict with higher rulings. Her delay in initiating the child was simply a matter of age. She had every intention to properly apprentice the child and that the Tribunal should recognize her blood rights with a new ruling (one to acquit). The Presiding Quaesitor should agree that an acquittal ruling is within the power of the Tribunal. The decision is entirely at the discretion of the Tribunal magi.
+> 
+> This situation might make an interesting moral dilemma for player characters (if they are given to moral dilemmas). The maga might belong to a hostile covenant and the would-be master a member of an allied covenant. The player characters may hold the deciding votes.
+
+### Duty of the Parens
 
 **". . . should any of them turn against the Order and my sodales I will be the first to strike them."**
 
@@ -1859,16 +1666,11 @@ The Oath demands the parens be the first to attack an outcast magus. If the pare
 
 The exact inheritance chain is actually the province of regional Tribunals. Many allow covenants to inherit the estate. However, it is rare that the inheritor strikes down the outcast. This leaves them liable to prosecution. The slayer can charge the inheritor with failing in their lawful duty and settle the case by acquiring the inheritance rights. In 1220 this convention is so established that no one normally bothers with any legal formality. The inheritor also inherits any debts the outcast had. So if the Presiding Quaesitor awarded the outcast's victim damages, the inheritor must pay from the inherited estate.
 
-### BONISAGUS RIGHTS AND DUTIES
+### Bonisagus Rights and Duties
 
 **"I shall further the knowledge of the Order and share with my sodales all that I find in my search for wisdom and power."**
 
-Sworn by members of House Bonisagus, this provision requires members of the House to make available all finished discoveries. It can also be applied to all Lab Texts and books in general. The magus is required to give access to these texts to all who request it. The Lab Texts do not have to be fully written up and can be in the magus's normal shorthand. Magi who wish to copy these texts are not
-
-
-
-
-allowed to take them away and must provide their own materials. A covenant can charge the magus for his board and lodgings while he is scribing.
+Sworn by members of House Bonisagus, this provision requires members of the House to make available all finished discoveries. It can also be applied to all Lab Texts and books in general. The magus is required to give access to these texts to all who request it. The Lab Texts do not have to be fully written up and can be in the magus's normal shorthand. Magi who wish to copy these texts are not allowed to take them away and must provide their own materials. A covenant can charge the magus for his board and lodgings while he is scribing.
 
 To avoid these demands a Bonisagus magus can send a copy to the library of Durenmar. Once it is in this library, the Bonisagus can refer any enquiries there.
 
@@ -1884,13 +1686,13 @@ In the seven years since the last Tribunal, Helvennia of Bonisagus had exercised
 
 Helvennia claimed another apprentice in the following year. On the night of the following new moon seven declarations of Wizard War were delivered to her. Despite attempts at arbitration, none of the seven agreed to withdrawn their declaration. Helvennia fled into hiding but was found and slain with the aid of her new apprentice.
 
-### CASTING OUT
+### Casting Out
 
 **"I request that should I break this Oath, I be cast out of the Order. If I am cast out, I ask my sodales to find me and slay me that my life may not continue in degradation and infamy."**
 
 If taken literally, all convictions should lead to a Wizard's March. In practice the Presiding Quaesitor normally offers the magus a lesser punishment. However, if the magus refuses this offer the magus is cast out.
 
-### ENEMIES AND ALLIES
+### Enemies and Allies
 
 **"The enemies of the Order are my enemies. The friends of the Order are my friends. The allies of the Order are my allies. Let us work as one and grow strong."**
 
@@ -1902,37 +1704,33 @@ A prosecution can be made for attacks against the friends and allies of individu
 
 The Hermetic Oath is clarified, embellished and expanded by Tribunal rulings. These rulings are collectively known as the Peripheral Code. There are two types of Tribunal ruling, case and proposed. Case rulings result from convictions or acquittals in criminal cases. Proposal rulings are simply proposed for debate and the Tribunal decides to agree to it or not.
 
-#### CASE RULINGS
+#### Case Rulings
 
 Previous case rulings are often used by the prosecution or defense. If a Tribunal voted to convict a magus in similar circumstances they will be inclined to convict again. The prosecution will try to highlight the similarities and the defense the differences. If the defense can find a case of an acquittal the same arguments will run in reverse. Most local Tribunals hold their own rulings as superior to other local Tribunals. In fact it might be a blunder to use a ruling from a rival Tribunal, as parochial magi may be less inclined to vote the same way.
 
 Even if there is no prior ruling or provision of the Code that might apply, a prosecution can be brought. The Tribunal will then hear the evidence and debate whether the action should be ruled illegal or not. If successful this form of case ruling often encourages prosecutions on similar grounds.
 
-As cases often rest on intent and reasonableness, prior case rulings are often of dubious relevance. However, there are cases which have established widely accepted
+As cases often rest on intent and reasonableness, prior case rulings are often of dubious relevance. However, there are cases which have established widely accepted legal principle; many of these are taken to the Grand Tribunal.
 
+> ## The Legality of Certamen
+> 
+> In the early days of the Order the culture of distrust and violence was still strong. Many would not accept that a less powerful magus could defy them. They often rejected the equality of Tribunal justice and declared Wizard War on their opponents. These wars sometimes developed into bloody feuds between groups. To Guernicus this was to be expected, born of the flaw Flambeau had insisted on. Some of Guernicus's filii speculated that the situation would correct itself; after this bloody period magi would understand that Wizard War risked a spiraling cycle of killings. This risk would only increase as social connections deepened with later generations.
+> 
+> However, others were dismayed with the situation and sought an immediate solution. Tremere and Bonisagus presented their certamen ritual as this solution. This dueling magic would allow magi to settle disputes via a test of their magical power. Guernicus was alarmed. Although he did not object to the ritual having some function, he insisted that it be limited in scope, lest it render the Tribunal process irrelevant. However, as there were no restrictions on Wizard War, Tremere and others argued that any restriction on certamen would undermine its purpose.
+> 
+> It was argued that the cycles of Wizard Wars were threatening the Order and a radical answer was required. Unrestricted certamen was the only one presented. Despite Guernicus's objection the ruling was passed. For the first and only time in Order history Guernicus exercised his veto, but the Primi overruled it. After this defeat, Guernicus retreated to Magvillus never to venture out again.
+> 
+> For a while the ruling appeared successful. However, history showed that it was a key piece of Tremere's bid for domination. This ended in the Sundering of 848 AD. The council of Primi that followed retracted their objection to Guernicus's veto and certamen ceased to have any legal force for twenty years.
+> 
+> At the Grand Tribunal of 868 AD, after much consultation with House Guernicus, the certamen ruling was amended and reinstated. Certamen could not be used to defy a Tribunal judgment, make a magus break the Code or ignore a Code violation.
+> 
+> If a magus believed he had been challenged to certamen over a Code protected issue, he might refuse it. This would technically forfeit the dispute, but if the challenge was illegal it would be unenforceable. If the challenger believed the challenge was legal, he could publish a case for failing to respect a certamen result. If the Tribunal ruled the challenge legal, the Presiding Quaesitor would enforce the result, adding damages, fines and punishments as appropriate.
+> 
+> For example, if a magus's ownership of a vis source is uncontestable by a Tribunal's rules of ownership, an opponent cannot legally demand certamen to take ownership from him. However, if the ownership is in reasonable doubt, rival claimants can challenge each other to certamen to resolve it. The reasonable doubt transforms the case from criminal theft, to a non-criminal dispute. In deciding whether to issue or accept a challenge, a magus needs to consider if their Tribunal would judge it a criminal matter or not.
+> 
+> If a challenge is mutually accepted no Tribunal appeal is possible.
 
-
-### The Legality of Certamen
-
-In the early days of the Order the culture of distrust and violence was still strong. Many would not accept that a less powerful magus could defy them. They often rejected the equality of Tribunal justice and declared Wizard War on their opponents. These wars sometimes developed into bloody feuds between groups. To Guernicus this was to be expected, born of the flaw Flambeau had insisted on. Some of Guernicus's filii speculated that the situation would correct itself; after this bloody period magi would understand that Wizard War risked a spiraling cycle of killings. This risk would only increase as social connections deepened with later generations.
-
-However, others were dismayed with the situation and sought an immediate solution. Tremere and Bonisagus presented their certamen ritual as this solution. This dueling magic would allow magi to settle disputes via a test of their magical power. Guernicus was alarmed. Although he did not object to the ritual having some function, he insisted that it be limited in scope, lest it render the Tribunal process irrelevant. However, as there were no restrictions on Wizard War, Tremere and others argued that any restriction on certamen would undermine its purpose.
-
-It was argued that the cycles of Wizard Wars were threatening the Order and a radical answer was required. Unrestricted certamen was the only one presented. Despite Guernicus's objection the ruling was passed. For the first and only time in Order history Guernicus exercised his veto, but the Primi overruled it. After this defeat, Guernicus retreated to Magvillus never to venture out again.
-
-For a while the ruling appeared successful. However, history showed that it was a key piece of Tremere's bid for domination. This ended in the Sundering of 848 AD. The council of Primi that followed retracted their objection to Guernicus's veto and certamen ceased to have any legal force for twenty years.
-
-At the Grand Tribunal of 868 AD, after much consultation with House Guernicus, the certamen ruling was amended and reinstated. Certamen could not be used to defy a Tribunal judgment, make a magus break the Code or ignore a Code violation.
-
-If a magus believed he had been challenged to certamen over a Code protected issue, he might refuse it. This would technically forfeit the dispute, but if the challenge was illegal it would be unenforceable. If the challenger believed the challenge was legal, he could publish a case for failing to respect a certamen result. If the Tribunal ruled the challenge legal, the Presiding Quaesitor would enforce the result, adding damages, fines and punishments as appropriate.
-
-For example, if a magus's ownership of a vis source is uncontestable by a Tribunal's rules of ownership, an opponent cannot legally demand certamen to take ownership from him. However, if the ownership is in reasonable doubt, rival claimants can challenge each other to certamen to resolve it. The reasonable doubt transforms the case from criminal theft, to a non-criminal dispute. In deciding whether to issue or accept a challenge, a magus needs to consider if their Tribunal would judge it a criminal matter or not.
-
-If a challenge is mutually accepted no Tribunal appeal is possible.
-
-legal principle; many of these are taken to the Grand Tribunal.
-
-### PROPOSAL RULINGS
+#### Proposal Rulings
 
 A magus can simply propose that the Tribunal pass a new ruling. A traditionalist would insist that all rulings need to be based on some part of the Oath. Tribunals should only clarify, expand and embellish the Code, not create wholly novel provisions.
 
@@ -1942,14 +1740,9 @@ If a Tribunal rules in favor of a proposal, prosecutions or proposals on the sam
 
 The rulings of the First and Grand Tribunal are seen as authoritative in all Tribunals. For example, the First Tribunal made rulings on sancta, apprentices, the power of the Quaesitores and certamen. These rulings and their interpretation are standard throughout the Order.
 
-#### THE DETAIL
+#### The Detail
 
-It would be neither practical nor desirable to detail all of the Peripheral Code. Storyguides are free to create any Tribunal ruling they desire. However, unless the
-
-
-
-
-Transitionalists hold sway such rulings should not rewrite the Oath or seriously undermine any of the Order's core membership rights.
+It would be neither practical nor desirable to detail all of the Peripheral Code. Storyguides are free to create any Tribunal ruling they desire. However, unless the Transitionalists hold sway such rulings should not rewrite the Oath or seriously undermine any of the Order's core membership rights.
 
 In general, these rulings cover matters favorable to the peace and stability of the Order. For example, physical or magical assaults that do not threaten a magus's life or magic, breaching a contract, perjury at Tribunal, attempting to deceive a Quaesitor conducting an investigation, and failure to cooperate with a legally conducted Quaesitorial investigation. Many of these rulings rest on the endangerment provision.
 
@@ -1961,7 +1754,7 @@ Sooner or later player character magi will need to prosecute or defend a case. T
 
 ### Preparing a Case
 
-### DETERMINING THE PRINCIPLES
+#### Determining the Principles
 
 Each case must have a prosecution and defense principle. In cases where there is a living victim, they become the prosecution principle. If the victim has been slain the case may be brought by anyone, although a relation is preferred. If more than one magus volunteers within three months of the Tribunal, the principle is determined by order of precedence. In descending order these are: parens, filius, amicus, covenant sodales and then any other magus. Candidates at the same level of relation take precedence by seniority.
 
@@ -1971,46 +1764,41 @@ Quaesitors prefer to remain impartial, but if no one volunteers to be prosecutio
 
 The accused automatically begins as the defense principle.
 
-#### DETERMINING THE TRIBUNAL
+#### Determining the Tribunal
 
 A case is normally heard in the Tribunal where the actions that led to the charge took place. If the location is in a border region and the defendant is a resident on one side, the case should be brought there. If the location is in a border region and only the prosecutor is a resident of either, the case should be brought to the prosecutor's Tribunal. In all other situations, the case should be brought to the defendant's Tribunal.
 
 A magus is required to declare his name and residential Tribunal to any Hermetic magus who asks. If a magus refuses to give his name and Tribunal, a Quaesitor can be asked to investigate their identity. If a principle and witnesses need to travel to another Tribunal the principle must bear the expense. However, a principle can claim back these costs from his counterpart if they win.
 
-### PUBLISHING A CASE
+### Publishing a Case
 
 The prosecuting principle must make reasonable effort to inform the defendant, the Presiding Quaesitor and the Praeco, what charges are to be brought, including a detailed list of the allegations. This should be done no later than three months prior to the Tribunal. Redcaps are normally contracted to deliver these notices. They also witness that they were delivered in time or that reasonable effort was made to deliver them. This is called publishing.
 
-Crimes that occur, or are discovered, within three months of the Tribunal can be published at the Tribunal only if the defendant attends. Such cases are heard last in
-
-### Settlements
-
-Bringing a case to Tribunal is time consuming, often costly and fraught with dangers. In many Tribunals this will be made worse by further elaborate rulings on procedure. A Tribunal's time is precious; unless the case is very serious magi do not wish to be bothered by it. Parties should seek a private settlement if possible and may face great pressure to settle. Senior magi will often step in to initiate a negotiation. If an Archmagus or senior Quaesitor offers to facilitate a settlement, player characters would be wise to accept.
-
-
-
-### Lawful Tyranny
-
-A defendant can threaten to declare Wizard War on the prosecuting principle, demanding they drop the case. This is perfectly legal. Depending on the style of saga, this may or may not be a problem. However, there are ways of checking it.
-
-A prosecuting principle can always transfer a case before publishing it. The new principle should be powerful enough to ignore any threats. In addition, the principle becomes his client's protector. If Wizard War is declared on a client, the principle will threaten the aggressor with Wizard War. If the aggressor cannot be convinced to withdraw the declaration, the client will be offered a hiding place for the war's duration. If the client is killed despite the concealment, the principle is honor bound to kill the aggressor, however long it takes. If the original aggressor chooses to hide, declarations will be made monthly until one of the parties is dead. In cases where such threats are likely, the cost of transferring can be very high.
-
-If no one else will assist and a client has a strong case, a Guernicus advocate will take it. If a Guernicus advocate is threatened or needs to issue a counter declaration, a number of Hoplites normally step in unbidden to help. In many Tribunals, threatening a Guernicus advocate or his client is effective suicide and does not enter the mind of rational magi.
-
-order to give the defense time to prepare and find an advocate if they wish (see below). If the Tribunal is busy these cases are often set back to the following Tribunal. Great pressure is brought to settle such cases out of court.
+Crimes that occur, or are discovered, within three months of the Tribunal can be published at the Tribunal only if the defendant attends. Such cases are heard last in order to give the defense time to prepare and find an advocate if they wish (see below). If the Tribunal is busy these cases are often set back to the following Tribunal. Great pressure is brought to settle such cases out of court.
 
 If a case is properly published and the defendant fails to attend, a Guernicus advocate will act as his defense principle. Although the advocate will do his best, he is obviously at a disadvantage.
 
-### TRANSFERRING A CASE
+> ## Settlements
+> 
+> Bringing a case to Tribunal is time consuming, often costly and fraught with dangers. In many Tribunals this will be made worse by further elaborate rulings on procedure. A Tribunal's time is precious; unless the case is very serious magi do not wish to be bothered by it. Parties should seek a private settlement if possible and may face great pressure to settle. Senior magi will often step in to initiate a negotiation. If an Archmagus or senior Quaesitor offers to facilitate a settlement, player characters would be wise to accept.
+
+> ## Lawful Tyranny
+> 
+> A defendant can threaten to declare Wizard War on the prosecuting principle, demanding they drop the case. This is perfectly legal. Depending on the style of saga, this may or may not be a problem. However, there are ways of checking it.
+> 
+> A prosecuting principle can always transfer a case before publishing it. The new principle should be powerful enough to ignore any threats. In addition, the principle becomes his client's protector. If Wizard War is declared on a client, the principle will threaten the aggressor with Wizard War. If the aggressor cannot be convinced to withdraw the declaration, the client will be offered a hiding place for the war's duration. If the client is killed despite the concealment, the principle is honor bound to kill the aggressor, however long it takes. If the original aggressor chooses to hide, declarations will be made monthly until one of the parties is dead. In cases where such threats are likely, the cost of transferring can be very high.
+> 
+> If no one else will assist and a client has a strong case, a Guernicus advocate will take it. If a Guernicus advocate is threatened or needs to issue a counter declaration, a number of Hoplites normally step in unbidden to help. In many Tribunals, threatening a Guernicus advocate or his client is effective suicide and does not enter the mind of rational magi.
+
+### Transferring a Case
 
 Both the prosecution and defense principle can transfer their case to another, who is then responsible for it. Experienced advocates can make a great deal of difference to the outcome. A successful prosecution can net substantial fines, a third of which go to the prosecution principle. A victim may sweeten this pot with his own resources in order to attract the best candidates. Defense advocates normally set a flat fee for their service, paid in advance.
 
-The most demanding task of a principle is to contact their respective witnesses and gather their testimony. This testimony needs to be checked for accuracy and consis-
-
+The most demanding task of a principle is to contact their respective witnesses and gather their testimony. This testimony needs to be checked for accuracy and consistency. If some error of recollection introduces an inconsistency, a case can be left in disarray. Both the principle and the witness are legally responsible for this testimony.
 
 ### Presenting a Case
 
-### PRIVATE HEARING
+#### Private Hearing
 
 At Tribunal the defense and the prosecution principles must give a fair summary of their case in private before the Presiding Quaesitor. At this point either side may dispute points of fact brought by the other. The Quaesitor may decide to delay the case to the next Tribunal in order to conduct a full investigation. If the truth of the matter can be resolved quickly, the Quaesitor will rule on the disputed facts at the initial hearing.
 
@@ -2020,16 +1808,13 @@ At this initial hearing the Presiding Quaesitor will give his opinion on the mer
 
 Defendants without a strong defense are best advised to accept the offer, as saving the Tribunal's time counts in their favor. The Presiding Quaesitor cannot offer a summary judgment unless both the defense and prosecution principle agree to it. This is true even for low crimes.
 
-#### PUBLIC HEARING
+#### Public Hearing
 
 The majority of cases will not get to this stage. They are either settled either out of court or at the private hearing. The Tribunal should only hear cases that are truly serious or highly contentious.
 
 The case begins with the prosecution, who formally presents the charges and then calls witnesses to give testimony.
 
-Firstly magi are called and each gives testimony. This can include testimony of testimony given by non-attending witnesses. After magi, apprentices are called. In the rare event of supernatural creatures being brought as witnesses, they give their testimony next. Finally any mun-
-
-
-
+Firstly magi are called and each gives testimony. This can include testimony of testimony given by non-attending witnesses. After magi, apprentices are called. In the rare event of supernatural creatures being brought as witnesses, they give their testimony next. Finally any mundane witnesses are called. If there is more than one witness to the same event, they should agree on a single testimony and the most senior presents it.
 
 After the prosecution case is presented, the defendant gives his response, calling on witnesses in the same order.
 
@@ -2051,30 +1836,27 @@ If the same events are subject to a counter-case, that case begins immediately. 
 
 If there is a conviction for a high crime, the prosecution can call for a Wizard's March. The convicted magi can make an appeal for mercy, after which there is a general debate on the proposition. After the Praeco feels there has been sufficient discussion he calls for a vote. A simple majority decides, with a tie defeating the motion.
 
-Assuming that the Tribunal does not demand a March, the Presiding Quaesitor offers a lesser penalty it its place. Before this the convicted magus can make a statement. Displays of contrition are often looked on
+Assuming that the Tribunal does not demand a March, the Presiding Quaesitor offers a lesser penalty it its place. Before this the convicted magus can make a statement. Displays of contrition are often looked on favorably. Others may choose to retain a dignified silence and accept whatever penalty is decided.
 
+> ## Testimony
+> 
+> A magus is obliged to give testimony personally in any case presented at his residential Tribunal. For cases presented at foreign Tribunals, the magus has the option of giving his testimony in writing. This is then read out at Tribunal by the principle. This is referred to as testimony of testimony (see below).
+> 
+> All testimony should be precisely scripted and repeated exactly. Any mistake or contradiction might give the opposition the chance to bring a perjury charge or demand the whole testimony is withdrawn. However, the private hearing should have resolved the majority of these conflicts. If the Presiding Quaesitor believes a principle remained silent at the private hearing in order to bring a perjury charge, he can veto it. If the Presiding Quaesitor judges the error to be immaterial, he can also veto the charge. In either of these cases the testimony can be amended without the principle facing a penalty.
+> 
+> If a charge of perjury is made, a Quaesitorial investigation and a perjury trial will be required. Making false claims of perjury incurs the same degree of punishment as perjury itself.
+> 
+> A Quaesitor can be asked to endorse testimony. If the witness agrees to it, a Quaesitor casts magic to verify its truth; this endorsement normally wins a perjury case. This is not routine and is only done at the principle's request.
+> 
+> No magus can be forced to submit to truth-detection spells. However, only one side needs to be endorsed to win the case. If neither side submits to a Quaesitorial investigation the Tribunal will vote according to their judgment. If both sides submit and both are verified, there is an immediate suspicion of infernal involvement. In this event all related cases are suspended and a full investigation is made immediately after the Tribunal.
+> 
+> Although testimony of testimony might be judged a truthful account of the origin testimony, the original testimony cannot be verified by a Quaesitor at the Tribunal.
+> 
+> If indirect testimony conflicts with other indirect testimony, only Quaesitorial investigation can determine the truth. As the absent witnesses need to be interviewed, this normally delays the case to the next Tribunal. There is great pressure for a private settlement in these circumstances.
 
-A magus is obliged to give testimony personally in any case presented at his residential Tribunal. For cases presented at foreign Tribunals, the magus has the option of giving his testimony in writing. This is then read out at Tribunal by the principle. This is referred to as testimony of testimony (see below).
-
-All testimony should be precisely scripted and repeated exactly. Any mistake or contradiction might give the opposition the chance to bring a perjury charge or demand the whole testimony is withdrawn. However, the private hearing should have resolved the majority of these conflicts. If the Presiding Quaesitor believes a principle remained silent at the private hearing in order to bring a perjury charge, he can veto it. If the Presiding Quaesitor judges the error to be immaterial, he can also veto the charge. In either of these cases the testimony can be amended without the principle facing a penalty.
-
-If a charge of perjury is made, a Quaesitorial investigation and a perjury trial will be required. Making false claims of perjury incurs the same degree of punishment as perjury itself.
-
-A Quaesitor can be asked to endorse testimony. If the witness agrees to it, a Quaesitor casts magic to verify its truth; this endorsement normally wins a perjury case. This is not routine and is only done at the principle's request.
-
-No magus can be forced to submit to truth-detection spells. However, only one side needs to be endorsed to win the case. If neither side submits to a Quaesitorial investigation the Tribunal will vote according to their judgment. If both sides submit and both are verified, there is an immediate suspicion of infernal involvement. In this event all related cases are suspended and a full investigation is made immediately after the Tribunal.
-
-Although testimony of testimony might be judged a truthful account of the origin testimony, the original testimony cannot be verified by a Quaesitor at the Tribunal.
-
-If indirect testimony conflicts with other indirect testimony, only Quaesitorial investigation can determine the truth. As the absent witnesses need to be interviewed, this normally delays the case to the next Tribunal. There is great pressure for a private settlement in these circumstances.
-
-
-
-### Counter-Case Example
-
-Two magi are in dispute about the ownership of a vis source. Both have harvested from the site. Each charges the other with deprivation of magical property. The Praeco decides whose case is heard first. The Tribunal hears all the evidence and acquits the defendant. The other magus then becomes the defendant. The Tribunal has already heard and debated the evidence and so votes. Since they acquitted the first magus, the second magus should be convicted; unless the Tribunal is fickle.
-
-favorably. Others may choose to retain a dignified silence and accept whatever penalty is decided.
+> ## Counter-Case Example
+> 
+> Two magi are in dispute about the ownership of a vis source. Both have harvested from the site. Each charges the other with deprivation of magical property. The Praeco decides whose case is heard first. The Tribunal hears all the evidence and acquits the defendant. The other magus then becomes the defendant. The Tribunal has already heard and debated the evidence and so votes. Since they acquitted the first magus, the second magus should be convicted; unless the Tribunal is fickle.
 
 ## Penalties
 
@@ -2082,20 +1864,17 @@ Hermetic justice seeks to compensate and avenge the victim. The penalty depends 
 
 Hermetic penalties are split into three types: damages, fines and punishments.
 
-### DAMAGES
+### Damages
 
 Damages are paid directly to the victim (or his heirs). This includes any costs incurred in bringing the case. In the case of a Wizard's March, the Presiding Quaesitor will normally grant the victim one quarter of the outcast's estate. If there is more than one victim, the Presiding Quaesitor will split the share amongst them.
 
-### FINES
+### Fines
 
-Fines are paid to compensate the Tribunal and the prosecution for the time and effort spent pursuing the case; one third is given to the prosecutor, two-thirds to the Tribunal coffers. Tribunal coffers are kept by the Praeco and accounted for by the senior Mercere. In the case of a March, the prosecutor receives one fourth of the outcast's estate (if the victim was also the prosecutor he receives one half in total). By Grand Tribunal ruling the
+Fines are paid to compensate the Tribunal and the prosecution for the time and effort spent pursuing the case; one third is given to the prosecutor, two-thirds to the Tribunal coffers. Tribunal coffers are kept by the Praeco and accounted for by the senior Mercere. In the case of a March, the prosecutor receives one fourth of the outcast's estate (if the victim was also the prosecutor he receives one half in total). By Grand Tribunal ruling the Tribunal coffers cannot beneﬁt from calling a March. The remaining half of the estate goes to the inheritor.
 
-
-#### PUNISHMENTS
+#### Punishments
 
 Punishments are purely retributive. They are of course redundant in the case of a March.
-
-remaining half of the estate goes to the inheritor.
 
 ### Determining Penalties
 
@@ -2110,8 +1889,6 @@ Damages, fines or services should normally be paid or completed in full by the n
 Conspiracies to prevent a magus paying fines and damages are not unknown. However, this qualifies as a high crime as it endangers a magus' life.
 
 A magus can appeal to the council of Magvillus if he believes the penalty is impossible to pay. The Magvillus Council carefully reviews the convicted magus's ability to pay and changes the terms to accord with their determination of a maximum penalty. Few penalties are ever appealed to Magvillus.
-
-
 
 ### Wizard's March
 
@@ -2132,29 +1909,27 @@ Some Tribunals have specially constructed wards that the defendant stands within
 Punishments are set in a hierarchy to accord with the seriousness of the conviction. In order of increasing severity:
 
 
-#### SEASONS OF SERVICE
+#### Seasons of Service
 
 These are normally performed for the benefit of Mercere or Guernicus magi in pursuit of their Tribunal duties. Tasks are assigned according to the convicted magus's abilities. If a service requires vis, it is provided. The Presiding Quaesitor normally splits the seasons in the favor of Mercere magi.
 
 Service to Mercere often involves enacting longevity rituals and investing devices. It is up to the senior Mercere to determine the details. In the past some magi have been assigned to work as Redcaps. Service to Guernicus often involves copying Tribunal records. Sometimes a convicted magus is asked to investigate potential breaches of the law himself. Involving a magus in the upholding of Hermetic law is often seen as an excellent opportunity to restore a magus's character.
 
-### INVESTING ITEMS
+### Investing Items
 
 The magus is instructed to invest items with particular effects and deliver them to particular members of House Mercere or Guernicus. The details of the invested effects are negotiated between the convicted magus and the Presiding Quaesitor or senior Mercere.
 
-#### LOSS OF AN APPRENTICE
+#### Loss of an Apprentice
 
 The convicted magus must surrender their apprentice immediately. Theoretically the apprentice can then be claimed by anyone. In practice the prosecuting principle has first claim. If the prosecuting principle does not wish to, the Quaesitor will call for candidates. Ideally the Presiding Quaesitor will place an apprentice with a magus from the same House as their former master (particularly if they have been initiated into a mystery). If multiple suitable candidates step forward, certamen contests decide the matter.
 
 If the apprentice is not already present at Tribunal the new master needs to take possession within the season.
 
-#### BANISHMENT FROM TRIBUNAL
+#### Banishment from Tribunal
 
 Tribunals' geographical boundaries are vague, but the magus should avoid areas generally agreed to belong to a particular Tribunal. If a magus has personal vis sources within these areas, he needs to contract others to harvest them. The magus is required to find another residential Tribunal.
 
-
-
-#### LOSS OF FAMILIAR
+#### Loss of Familiar
 
 To many magi, a familiar is the closest relationship they will ever have. Separation for a familiar is analogous to separation from a wife or child. The emotional impact of this punishment should not be underestimated.
 
@@ -2164,7 +1939,7 @@ Alternatively the process can be achieved in a season of lab activity. To verify
 
 After the cords have been cut, both magus and former familiar find each other's presence too much to bear. A familiar normally flees into the wilderness and avoids all future contact with magi. The former familiar cannot normally be rebound.
 
-#### DEATH OF FAMILIAR
+#### Death of Familiar
 
 The convicted magus's familiar must be killed. The horror of seeing your familiar's execution cannot adequately be expressed in words. Some magi have decided to accept a March rather than submit to this; this is seen as an honorable choice. They would rather take their chances as an outcast than meekly give their familiar up to the butcher's knife.
 
@@ -2176,11 +1951,7 @@ The worst thing a Quaesitor can do is abuse their position. This is one of few o
 
 ### Quaesitor in Good Standing
 
-Each Quaesitor must carry a letter, signed by the Primus of House Guernicus, which declares them to be a
-
-
-
-Quaesitor in good standing (Quaesitor cum auctoritate). This letter must be less than seven years old to be valid. A Quaesitor has no authority without this document and cannot demand cooperation in investigations or preside at Tribunal.
+Each Quaesitor must carry a letter, signed by the Primus of House Guernicus, which declares them to be a Quaesitor in good standing (Quaesitor cum auctoritate). This letter must be less than seven years old to be valid. A Quaesitor has no authority without this document and cannot demand cooperation in investigations or preside at Tribunal.
 
 ### Investigation Duties
 
@@ -2198,16 +1969,7 @@ Magi should also allow their servants to be questioned. Similarly, if servants a
 
 Arcane investigation often involves Intellego magic. However, the Code normally protects a magus from this intrusion. Rather than grant the Quaesitores full immunity or completely forbid a primary method of investigation, the First and Grand Tribunals provided Guernicus and his filii with a set of guidelines for when such methods can be employed. These immunities can also be extended to agents of a Quaesitor.
 
-The scrying prohibition was instituted to protect magi's legitimate magical secrets, not their crimes. Any act performed while committing, or in preparation to commit, a crime is considered outside the protection of
-
-
-### Sanctum Invasions
-
-If they feel it necessary a Quaesitor can enter the sanctum of a magus under investigation. While within the sanctum, the Quaesitor and any of their agents are under forfeit immunity. Theoretically the sanctum owner can attack with impunity. However, as soon as the Quaesitor leaves their immunity is restored. The Quaesitor investigation immunity protects them against charges related to this invasion.
-
-To avoid a confrontation, the Quaesitor or his agent normally enters the sanctum when the owner is distracted elsewhere. Some sanctums, particularly of magi with something to hide, have lethal magic protecting them. However, in the rare case of Quaesitor being killed investigating a sanctum, the investigation is taken over and pursued with every effort.
-
-the Code (see above). Magi are therefore free to use magic to investigate criminal activities.
+The scrying prohibition was instituted to protect magi's legitimate magical secrets, not their crimes. Any act performed while committing, or in preparation to commit, a crime is considered outside the protection of the Code (see above). Magi are therefore free to use magic to investigate criminal activities.
 
 Even if a crime is found, the Quaesitor might be charged with scrying on the innocent activities incidentally discovered while pursuing the inquiry. To protect Quaesitors from this, investigators are granted limited immunity as long as they are engaged in a justified investigation and are reasonable in the scope of their magical inquiry. However, Intellego Mentem magic can never be used on magi or their servants without their permission.
 
@@ -2215,11 +1977,13 @@ Inevitably a Quaesitor will unintentionally gather information on innocent activ
 
 If a magus feels that a Quaesitor has used a minor transgression or baseless allegation to excuse an extensive intrusion into his affairs, he will have to convince the Tribunal of this. The likely success of such a case will vary from Tribunal to Tribunal. Although a case may fail, it will serve to embarrass the individual Quaesitor as well as House Guernicus. In consequence, Quaesitors may choose to hand on any investigation involving a magus they or their covenant is in conflict with.
 
-This limited immunity theoretically extends to any magus in honest investigation of a Hermetic crime. However, other magi do not have the traditional respect for the Quaesitor title backing them up and so should be more cautious. If a serious Hermetic crime is uncovered
+This limited immunity theoretically extends to any magus in honest investigation of a Hermetic crime. However, other magi do not have the traditional respect for the Quaesitor title backing them up and so should be more cautious. If a serious Hermetic crime is uncovered even a non-Quaesitor is fairly safe from prosecution; success is the key.
 
-
-
-even a non-Quaesitor is fairly safe from prosecution; success is the key.
+> ## Sanctum Invasions
+> 
+> If they feel it necessary a Quaesitor can enter the sanctum of a magus under investigation. While within the sanctum, the Quaesitor and any of their agents are under forfeit immunity. Theoretically the sanctum owner can attack with impunity. However, as soon as the Quaesitor leaves their immunity is restored. The Quaesitor investigation immunity protects them against charges related to this invasion.
+> 
+> To avoid a confrontation, the Quaesitor or his agent normally enters the sanctum when the owner is distracted elsewhere. Some sanctums, particularly of magi with something to hide, have lethal magic protecting them. However, in the rare case of Quaesitor being killed investigating a sanctum, the investigation is taken over and pursued with every effort.
 
 ### Compensation
 
@@ -2239,8 +2003,7 @@ Morwena of Ex Miscellanea brought charges against Darius of Guernicus, for abuse
 
 In the most extreme circumstances a Quaesitor may decide to declare a Wizard's March, independent of any Tribunal. This is done when a magus poses a threat to the Order that requires immediate action. A typical example would be a magus discovered to be a diabolist. As magi who cooperate with a Tribunal are so rarely cast out, in practice the majority of Marches are called this way.
 
-The next Tribunal meeting normally ratifies such decisions after the fact. At the Tribunal the Quaesitor will have to justify the action. The evidence presented is expected to be compelling. Were the Tribunal to be
-
+The next Tribunal meeting normally ratifies such decisions after the fact. At the Tribunal the Quaesitor will have to justify the action. The evidence presented is expected to be compelling. Were the Tribunal to be unconvinced, the consequences are likely to be dire. However, no Quaesitor has ever been convicted of calling such a Wizard’s March without due cause. 
 
 By Grand Tribunal ruling, no Quaesitor can materially benefit in any way from calling a Wizard's March. Any property that he might acquire is given to the Tribunal coffers.
 
@@ -2252,17 +2015,13 @@ A Quaesitor may also be asked to arbitrate a dispute, with the seniority of the 
 
 The aim of the exercise is to produce a lasting peace and this is the primary concern. Arbitration ends in a formal agreement drafted and witnessed by the Quaesitor. All three parties keep a copy of this agreement, with the Quaesitor delivering one to the Presiding Quaesitor. Once agreed, failure to comply with this agreement is an offense by Grand Tribunal ruling. Regardless of the merits of the original dispute, the delinquent party will face a heavy penalty at Tribunal.
 
-The Quaesitor is not obligated to provide these services, but it is common practice. The fee charged is
+The Quaesitor is not obligated to provide these services, but it is common practice. The fee charged is entirely at the Quaesitor's discretion. A Quaesitor's reputation will often be made or broken by his conduct in these matters.
 
-### Pardon Me
-
-Unknown parties engineer incidents in order to convince a player character Quaesitor that their enemy is a diabolist. Unless the Quaesitor is cautious, he may declare a Wizard's March in error. As Hoplites start hunting the hapless victim, the Quaesitor may discover the deception, but can he contact the Hoplites in time? If not, what will be the punishment at Tribunal?
-
-The Quaesitor might mitigate his error by exposing the conspirators and prosecuting them. With his reputation in tatters this will be difficult.
-
-
-
-entirely at the Quaesitor's discretion. A Quaesitor's reputation will often be made or broken by his conduct in these matters.
+> ## Pardon Me
+> 
+> Unknown parties engineer incidents in order to convince a player character Quaesitor that their enemy is a diabolist. Unless the Quaesitor is cautious, he may declare a Wizard's March in error. As Hoplites start hunting the hapless victim, the Quaesitor may discover the deception, but can he contact the Hoplites in time? If not, what will be the punishment at Tribunal?
+> 
+> The Quaesitor might mitigate his error by exposing the conspirators and prosecuting them. With his reputation in tatters this will be difficult.
 
 ### Tribunal Duties
 
@@ -2270,7 +2029,7 @@ Quaesitors perform a number of functions at Tribunal. The most important is the 
 
 These roles are discussed in detail below.
 
-### THE PRESIDING QUAESITOR
+#### The Presiding Quaesitor
 
 After the close of each Tribunal meeting, the local Quaesitors meet to decide who will be the Presiding Quaesitor for the following period; the decision is made by vote. Being a Presiding Quaesitor also gives a seat on the outer tier of the Magvillus Council. For ambitious Quaesitors, this can be a path to advancement.
 
@@ -2292,46 +2051,39 @@ The Presiding Quaesitor also sets all punishments for breaches of the law that d
 
 At the Grand Tribunal the Guernicus Primus acts as the Presiding Quaesitor. However, the Guernicus Primus can only exercise his veto if the majority of the Primi agree. In this way the Order is protected from mob rule. The requirement for the concurrence of the Primi ensures that House Guernicus cannot acquire power by corruptly applying the veto.
 
-### ENDORSING TESTIMONY
+### Endorsing Testimony
 
 Evidence in Hermetic law is usually in the form of testimony. If the testifying magus requests it, a Quaesitor will use magic to verify that the testimony is truthful. To give such testimony the witness must dispel his Parma and any other spell or item effect. The Quaesitor then checks for any magical effects that might manipulate the Quaesitor's magic.
 
 For the magus's protection while his Parma is down, this process is normally done in private chambers. In any case, it would be the height of stupidity for a magical attack to be made at Tribunal in the presence of the region's most senior Quaesitors.
 
-Within the Order's history many magi have attempted to deceive a Quaesitor into endorsing false testimony. Various Vim and Mentem effects, directed at themselves or the Quaesitor, have been tried with varying success. When these ruses are discovered, members of House
-
-
-
-### The Veto
-
-Of all the three arms of Order government, the Quaesitores have the least capacity to defend their position independently. As a group the Primi are fairly secure in their authority. Although it varies greatly between Houses, on average a magus will tend to follow his Primus even if he personally disagrees with a policy (to a greater or lesser degree). The authority of local Tribunals is inherently strong as the majority has an interest in its maintenance. The authority of the Quaesitores however, depends on the majority of magi and/or the Primi supporting that authority.
-
-The role of the Quaesitor often involves antagonizing powerful magi. It may well require decisions that antagonizing the majority (of a local Tribunal at least). To maintain their powers therefore, the Quaesitores need to maintain their moral authority. Magi and Primi need to value the services Quaesitors perform. They need to fear an Order without the Quaesitores; they should trust no one better to safeguard the rule of law. Although they might disagree with adherence to tradition, they should respect the person and office of the Quaesitor who follows it.
-
-A veto should only be used in a case of a clear, unambiguous conflict, directly with the Code or a ruling of a higher Tribunal. What constitutes a clear, unambiguous conflict should be clear to all reasonable magi. This is a very limited judgment, requiring an Int + Code of Hermes roll of 6+ to determine. The exact details of this are for individual troupes to determine. However, the section on the Code given above may serve as a standard. An individual ruling might be judged against this by the troupe. If there is not a strong consensus amongst the troupe on the matter, the veto should probably not be used.
-
-Abusing the veto therefore is immediately selfdefeating. In practice the veto should never need to be used. It is there to prevent a casual slide into mob rule; magi should realize the futility of pursuing a clearly illegal position (even if popular) and give up. As the Presiding Quaesitor will have made his opinion known at the private hearing, such a case should not be brought forward. If a controversial case does get a public hearing, the Presiding Quaesitor will make his position very clear before voting begins. Forcing a Presiding Quaesitor to use his veto indicates a Tribunal where Quaesitorial authority has failed. However, the rule of law is backed by the Order at large. Theoretically at least, an outlaw Tribunal could be brought to heel by the rest of the Order.
-
-Any use of a veto will be thoroughly reviewed by the Magvillus Council. If they do not agree with the veto, the Guernicus Primus will revoke it. If there is any suggestion that the Presiding Quaesitor abused his veto, the consequences are likely to be extreme. The council will wish to make a public example of the errant Quaesitor.
-
-Assuming the Magvillus Council supports the veto, it may still be appealed to the Grand Tribunal. If the issue involves a Grand Tribunal ruling, the Grand Tribunal is at perfect liberty overrule the veto; this generates a new Grand Tribunal ruling on the issue.
-
-In the case of a First Tribunal ruling, a traditionalist council might ask their allies to condemn the case in other Tribunals prior to the Grand Tribunal. This would hopefully ensure that popular opinion remains against it. A solid defeat at the Grand Tribunal should serve to embarrass the wayward Tribunal and discourage further challenges. However, if the case has great popular support within the Order, the council will mobilize allies to try to change the majority's opinion, and the Guernicus Primus will lobby the other Primi for their support.
-
-Ultimately, if both the Primi and the populace want to contradict a First Tribunal ruling (or even the Oath itself), the Quaesitores cannot prevent it happening. Should defeat seem likely, the Magvillus Council would need to decide what action would best serve the Order. Maintaining a principled objection might do that. Traditionalists would hope that the Order would come to its senses and reverse the illegal ruling at a later date.
-
-Under a Transitionalist Magvillus Council however, a Guernicus Primus would never use his veto, unless he objected to a ruling on grounds beyond tradition.
-
-Guernicus and allies in House Bonisagus design counter magic to expose the deception. The art in this field is well developed and unless a magus has devoted his life to deceptive magics he would have little chance of success in 1220 AD.
+Within the Order's history many magi have attempted to deceive a Quaesitor into endorsing false testimony. Various Vim and Mentem effects, directed at themselves or the Quaesitor, have been tried with varying success. When these ruses are discovered, members of House Guernicus and allies in House Bonisagus design counter magic to expose the deception. The art in this field is well developed and unless a magus has devoted his life to deceptive magics he would have little chance of success in 1220 AD.
 
 However, as a safeguard the Quaesitor endorsing the testimony must be senior to or at least a peer of the witness. A junior Quaesitor will consider himself unworthy to endorse the testimony of older magi, in which case he will refer the witness to a more senior Quaesitor. Once the Quaesitor is satisfied that the magus is not using magics that might manipulate his own, the Quaesitor will cast a spell like *Ear of Truth*, and then thoroughly discuss the testimony to ensure that there is nothing misleading about it.
-
-
-
 
 In perjury cases, more than one Quaesitor is normally present during testimony, each checking that no magic is being employed to fool the truth telling. Senior magi may be asked to undergo the *Oath of Truth* ritual, which is seen as infallible (see below).
 
 With the aid of infernal powers any magic can be fooled, and therefore this process is not totally certain. In cases with no known infernal connection, this endorsement is seen as ensuring truth. If conflicting endorsed testimony is discovered, there is immediate suspicion of infernal involvement. A senior Quaesitorial investigation will be conducted and both witnesses will be suspect until the matter is resolved.
+
+> ## The Veto
+> 
+> Of all the three arms of Order government, the Quaesitores have the least capacity to defend their position independently. As a group the Primi are fairly secure in their authority. Although it varies greatly between Houses, on average a magus will tend to follow his Primus even if he personally disagrees with a policy (to a greater or lesser degree). The authority of local Tribunals is inherently strong as the majority has an interest in its maintenance. The authority of the Quaesitores however, depends on the majority of magi and/or the Primi supporting that authority.
+> 
+> The role of the Quaesitor often involves antagonizing powerful magi. It may well require decisions that antagonizing the majority (of a local Tribunal at least). To maintain their powers therefore, the Quaesitores need to maintain their moral authority. Magi and Primi need to value the services Quaesitors perform. They need to fear an Order without the Quaesitores; they should trust no one better to safeguard the rule of law. Although they might disagree with adherence to tradition, they should respect the person and office of the Quaesitor who follows it.
+> 
+> A veto should only be used in a case of a clear, unambiguous conflict, directly with the Code or a ruling of a higher Tribunal. What constitutes a clear, unambiguous conflict should be clear to all reasonable magi. This is a very limited judgment, requiring an Int + Code of Hermes roll of 6+ to determine. The exact details of this are for individual troupes to determine. However, the section on the Code given above may serve as a standard. An individual ruling might be judged against this by the troupe. If there is not a strong consensus amongst the troupe on the matter, the veto should probably not be used.
+> 
+> Abusing the veto therefore is immediately selfdefeating. In practice the veto should never need to be used. It is there to prevent a casual slide into mob rule; magi should realize the futility of pursuing a clearly illegal position (even if popular) and give up. As the Presiding Quaesitor will have made his opinion known at the private hearing, such a case should not be brought forward. If a controversial case does get a public hearing, the Presiding Quaesitor will make his position very clear before voting begins. Forcing a Presiding Quaesitor to use his veto indicates a Tribunal where Quaesitorial authority has failed. However, the rule of law is backed by the Order at large. Theoretically at least, an outlaw Tribunal could be brought to heel by the rest of the Order.
+> 
+> Any use of a veto will be thoroughly reviewed by the Magvillus Council. If they do not agree with the veto, the Guernicus Primus will revoke it. If there is any suggestion that the Presiding Quaesitor abused his veto, the consequences are likely to be extreme. The council will wish to make a public example of the errant Quaesitor.
+> 
+> Assuming the Magvillus Council supports the veto, it may still be appealed to the Grand Tribunal. If the issue involves a Grand Tribunal ruling, the Grand Tribunal is at perfect liberty overrule the veto; this generates a new Grand Tribunal ruling on the issue.
+> 
+> In the case of a First Tribunal ruling, a traditionalist council might ask their allies to condemn the case in other Tribunals prior to the Grand Tribunal. This would hopefully ensure that popular opinion remains against it. A solid defeat at the Grand Tribunal should serve to embarrass the wayward Tribunal and discourage further challenges. However, if the case has great popular support within the Order, the council will mobilize allies to try to change the majority's opinion, and the Guernicus Primus will lobby the other Primi for their support.
+> 
+> Ultimately, if both the Primi and the populace want to contradict a First Tribunal ruling (or even the Oath itself), the Quaesitores cannot prevent it happening. Should defeat seem likely, the Magvillus Council would need to decide what action would best serve the Order. Maintaining a principled objection might do that. Traditionalists would hope that the Order would come to its senses and reverse the illegal ruling at a later date.
+> 
+> Under a Transitionalist Magvillus Council however, a Guernicus Primus would never use his veto, unless he objected to a ruling on grounds beyond tradition.
 
 ## Guernicus Magi
 
@@ -2361,13 +2113,11 @@ In sagas where the Quaesitores try to enforce the integrity of Hermetic trials, 
 
 Many of the particular roles given below can be taken by member of other Houses. Non-Guernicus Quaesitors are discussed above, but others can be Hoplites, advocates or magical investigators. Pursuing justice is not an activity Guernicus magi wish to keep to themselves.
 
-
-
-### The Whole of the Law
-
-From both his statements and his policies, it is clear that Guernicus only supported the Order in so far as it allowed magi to live and study in peace. In Guernicus's opinion, if a magus minded his own business, kept to his own property and caused no trouble to others, the Order should leave him be. This principle is strictly applied within House Guernicus. The Primus and council only ever make requests of members, never commands. The idea of the Primus or council commanding a magus is a complete anathema to the principles of the House. If a member does not wish to serve the Order as a Quaesitor, he does not have to.
-
-The title of Quaesitor is a privilege with the House, not a right. If a member does not serve the Hermetic peace or the will of the council, the title will be withdrawn, but no other penalty will befall him. He is free to live and study magic without distraction if he wishes. Only if a member disgraces the House by abusing Quaesitorial privilege will he be expelled.
+> ## The Whole of the Law
+> 
+> From both his statements and his policies, it is clear that Guernicus only supported the Order in so far as it allowed magi to live and study in peace. In Guernicus's opinion, if a magus minded his own business, kept to his own property and caused no trouble to others, the Order should leave him be. This principle is strictly applied within House Guernicus. The Primus and council only ever make requests of members, never commands. The idea of the Primus or council commanding a magus is a complete anathema to the principles of the House. If a member does not wish to serve the Order as a Quaesitor, he does not have to.
+> 
+> The title of Quaesitor is a privilege with the House, not a right. If a member does not serve the Hermetic peace or the will of the council, the title will be withdrawn, but no other penalty will befall him. He is free to live and study magic without distraction if he wishes. Only if a member disgraces the House by abusing Quaesitorial privilege will he be expelled.
 
 ### Being a Quaesitor
 
@@ -2396,12 +2146,7 @@ They also work to resolve disputes out of court, acting for one side but able to
 
 ### Being an Magical Investigation Specialist
 
-Guernicus magi with a particular aptitude are often called in to provide a brief service in support of a main investigation. These services should not disrupt their study. Most have spells that allow them travel magically and devices that enable Quaesitors to call on them as
-
-
-
-
-needed. In particular, a specialist is often in great demand at Tribunal for endorsing testimony.
+Guernicus magi with a particular aptitude are often called in to provide a brief service in support of a main investigation. These services should not disrupt their study. Most have spells that allow them travel magically and devices that enable Quaesitors to call on them as needed. In particular, a specialist is often in great demand at Tribunal for endorsing testimony.
 
 The most experienced specialists conduct research that pushes the boundaries of Hermetic Theory. One of the dreams of these magi is to break the Limit of Time. Rumors that the Quaesitores have a spell that can see into the past often circulate. If the researchers ever succeed, they will not advertise it.
 
@@ -2446,13 +2191,7 @@ Quaesitorial magical investigation often involves high level effects and large a
 
 As a player-character Quaesitor increases in ability, investigations need to become more subtle. As explained above, Hermetic trials are rarely who-done-its. Rather they are about mitigation, justification or lack of it. Attempts to deceive Tribunals will therefore often be aimed at mitigation and justification. A Quaesitor who spots these attempts before trial may save the Tribunal from an injustice.
 
-Senior Quaesitors will also try to resolve protracted conflicts between covenants. The mire of pretty crimes on both sides may threaten to overburden a Tribunal, but if
-
-
-
-
-
-left may lead to serious crimes. Where possible an experienced Quaesitor will try to prevent the situation deteriorating into open conflicts.
+Senior Quaesitors will also try to resolve protracted conflicts between covenants. The mire of pretty crimes on both sides may threaten to overburden a Tribunal, but if left may lead to serious crimes. Where possible an experienced Quaesitor will try to prevent the situation deteriorating into open conflicts.
 
 Just in case it needed to be said, stories involving Hermetic law and Quaesitors should be entertaining, albeit challenging. What form the law takes in a saga should reflect the likes and dislikes of the troupe.
 
@@ -2488,12 +2227,11 @@ Since the beginning of the Order, cunning magi have attempted to use their magic
 
 Senior Quaesitors are normally happy to provide occasional spell training in investigation magic to younger Quaesitors, but their time will be limited. Lab texts are often loaned to young Quaesitors for their own study. These texts are classed among the magical secrets of House Guernicus; they are clearly marked as such and by Grand Tribunal rulings it is a low crime for a non-Quaesitor to read them (see Sanctum Law insert). Even so, Quaesitors in possession of these texts take every care to ensure their security.
 
-
-
-
-As well as protecting sanctums from invasion, additional rulings by the Grand Tribunal have added to sanctum law. Magi can protect their texts from unwelcome eyes by inscribing them with their sanctum mark. This protects the text even outside of a sanctum. A magus who reads from such a marked text is committing a low crime.
-
-By Grand Tribunal ruling a book or scroll-case can also be marked with a House symbol. This marks it as secret within the House. Any other magus who reads it is committing a low crime.
+> ## Sanctum Law
+> 
+> As well as protecting sanctums from invasion, additional rulings by the Grand Tribunal have added to sanctum law. Magi can protect their texts from unwelcome eyes by inscribing them with their sanctum mark. This protects the text even outside of a sanctum. A magus who reads from such a marked text is committing a low crime.
+> 
+> By Grand Tribunal ruling a book or scroll-case can also be marked with a House symbol. This marks it as secret within the House. Any other magus who reads it is committing a low crime.
 
 ### Acute Sense
 
@@ -2501,7 +2239,7 @@ Intensive Quaesitorial training and techniques gives a chance to spot the tell-t
 
 This new mastery ability is only applicable to enhanced sense spells. With this ability an altered, hidden or even a destroyed magical trace, may be sensed. The storyguide should make the following roll on the player's behalf:
 
-#### Perception + Penetration + Stress die
+**Perception + Penetration + Stress die**
 
 The Ease Factor to detect the use of deceptive magic is 6 + the magnitude of the Might of the creature responsible for the effect or 6 + the magnitude of a Hermetic spell.
 
@@ -2513,8 +2251,7 @@ This ability can be taken twice. Taking it a second time allows the magus to add
 
 One investigative tool is to examine active spells and the residual traces of spells (spell traces) to identify the caster. The higher the magnitude of the active spell the easier it is to detect and examine.
 
-Once a spell expires a trace of it remains, these traces also have an associated magnitude, which decays with
-
+Once a spell expires a trace of it remains, these traces also have an associated magnitude, which decays with time. As a general rule, residues of magic decline as follows. As soon as the magic ﬁnishes, the magnitude halves. It then drops by one magnitude for every duration of the spell that passes; Momentary spells decay each round.
 
 After reaching zero magnitude traces associated with non-ritual Momentary, Concentration and Diameter durations decay at a monthly rate, all others decay yearly. The strength of the trace is then measured in negative magnitudes. A spell trace is normally detectable until it reaches a magnitude of –10, at which point it is completely gone.
 
@@ -2522,7 +2259,7 @@ The usual method of investigation involves identifying where the illegal magic m
 
 As well as giving a unique quirk to the spell's operation, the wizard's sigil gives a unique signature to a spell trace. When investigated by an appropriate Intellego Vim spell, this unique mark is revealed. To a Vision spell, the sigil will be expressed as a unique pattern, to a Touch spell the sigil will be expressed as a unique shape, texture and temperature and so on. In order to recognize a previously encountered sigil, the Quaesitor should make a Perception + Awareness roll with a difficulty set by the storyguide. However, the Creo Mentem spell, *By His Works* (see below) can be used to double-check any recollection against a sigil currently present.
 
-#### SHROUD MAGIC
+#### Shroud Magic
 
 Unfortunately, it is a fairly easy to thwart sigil identification by using *Shroud Magic*. If a magic expires under the influence of *Shroud Magic* the resulting trace shows a false sigil. No known Hermetic technique can divine the true sigil in this case.
 
@@ -2530,26 +2267,13 @@ However, a single invention of *Shroud Magic* can only change the sigil into a f
 
 However, a magus can attempt to mimic another magus's sigil with a *Shroud Magic* spell. As the spell is designed the magus establishes an Ease Factor using the following formula:
 
-#### Intelligence + Finesse + Stress die
+**Intelligence + Finesse + Stress die**
 
-The inventor must have carefully studied the sigil he wishes to copy. Working from unaided memory gives a –3 penalty. Using a Creo Mentem effect to aid recollection
-
-
-
-
-### Forceless Casting
-
-When a magus casts a spell that targets a large area, he runs the risk of criminally affecting other magi. In order to reduce this risk, a magus can deliberately ensure the Penetration of a spell never exceeds '0'. In essence the magus casts the spell with no more effort than is required to avoid fatigue and opts not to use his Penetration skill. As most magi have at least a Magic Resistance of '0', he can ensure that his spell will not affect them; providing he does not botch.
-
-However, Redcaps, companions and grogs will still be affected and this might still lead to charges. Forceless casting reduces risk, it does not eliminate it. Magi need to be very careful with any effect that might cause loss or injury to another magus.
-
-Forceless castings requires no particular skill or effort.
-
-applies no penalty. If the inventor has an example of the sigil to hand, this gives a +3 bonus.
+The inventor must have carefully studied the sigil he wishes to copy. Working from unaided memory gives a –3 penalty. Using a Creo Mentem effect to aid recollection applies no penalty. If the inventor has an example of the sigil to hand, this gives a +3 bonus.
 
 This Ease Factor is then embedded within the spell; it is not re-rolled at each casting. Working from memory an observer is unlikely to notice any error in the sigil. However, if *By His Works* is used the Ease Factor is tested against an observer's:
 
-#### Perception + Awareness + Stress die
+**Perception + Awareness + Stress die**
 
 This test is made in addition to any Acute Sense test that may also apply.
 
@@ -2557,17 +2281,27 @@ The use of *Shroud Magic* can be known by the presence of an accompanying Muto V
 
 Other scenes are not discovered in time for spell trace magic. In these cases the investigator needs to use other techniques to get at the truth.
 
+> ## Forceless Casting
+> 
+> When a magus casts a spell that targets a large area, he runs the risk of criminally affecting other magi. In order to reduce this risk, a magus can deliberately ensure the Penetration of a spell never exceeds '0'. In essence the magus casts the spell with no more effort than is required to avoid fatigue and opts not to use his Penetration skill. As most magi have at least a Magic Resistance of '0', he can ensure that his spell will not affect them; providing he does not botch.
+> 
+> However, Redcaps, companions and grogs will still be affected and this might still lead to charges. Forceless casting reduces risk, it does not eliminate it. Magi need to be very careful with any effect that might cause loss or injury to another magus.
+> 
+> Forceless castings requires no particular skill or effort.
+
 ### Spells and Guidelines
 
-**INTELLEGO CORPUS SPELLS**
+#### Intellego Corpus Spells
 
-**THE WHOLE FROM THE PART R:** Touch, **D:** Conc, **T:** Ind, **Level 20**
+##### The Whole from the Part
+
+**R:** Touch, **D:** Conc, **T:** Ind, **Level 20**
 
 This spell needs to be cast on a current Arcane Connection to a human (or human like creature). This spell gives the caster a mental image of the subject's essential nature. Thus the caster sees the subject without clothes, tattoos, scars or other mutilations. The spell does not target the actual subject; it only probes the arcane connection itself. Thus the spell does not need to penetrate the real subject's Magic Resistance.
 
 (Base 10, +1 Touch, +1 Conc)
 
-#### SIGHT OF THE MOLTING MAGUS
+##### Sight of the Molting Magus
 
 **R:** Per, **D:** Conc, **T:** Vision, **Level 25**
 
@@ -2575,9 +2309,9 @@ This spell allows the caster to spot Corpus material (hair, blood, etc.) within 
 
 (Base 4, +1 Conc, +4 Vision)
 
-#### INTELLEGO IMAGINEM SPELLS
+#### Intellego Imaginem Spells
 
-**THE DISCERNING EYE**
+##### The Discerning Eye
 
 **R:** Per, **D:** Sun, **T:** Vision, **Level Gen**
 
@@ -2585,21 +2319,17 @@ An enhanced version of *Discern the Images of Truth and Falsehood*. You can tell
 
 (Base, +2 Sun, +1 Enhanced Effect)
 
-#### CREO MENTEM GUIDELINES
+#### Creo Mentem Guidelines
 
-**Level 4:** Restore a memory of a brief event to a fresh state, as long as a fragment of it remains. The affected mem-
-
-
-
-ory can be no more extensive than a short conversation (two or three rounds).
+**Level 4:** Restore a memory of a brief event to a fresh state, as long as a fragment of it remains. The affected memory can be no more extensive than a short conversation (two or three rounds).
 
 **Level 5:** Restore a memory of an event to a fresh state, as long as a fragment of it remains. The affected memory can be no more extensive than about two minutes.
 
 **Level 10:** Restore a memory of a day's events to a fresh state, as long as a fragment of it remains. Events are remembered as if they had occurred only an hour before.
 
-### CREO MENTEM SPELLS
+#### Creo Mentem Spells
 
-#### BY HIS WORKS
+##### By His Works
 
 **R:** Per, **D:** Conc, **T:** Ind, **Level 5**
 
@@ -2607,7 +2337,7 @@ Refreshes a specific memory within the mind of the caster; as long as some fragm
 
 (Base 4, +1 Conc)
 
-#### THE GOOD WITNESS
+##### The Good Witness
 
 **R:** Touch, **D:** Sun, **T:** Ind, **Level 25**
 
@@ -2615,9 +2345,9 @@ Refreshes a day's memory within the mind of the subject; as long as some fragmen
 
 (Base 10, +1 Touch, +2 Sun)
 
-### INTELLEGO MENTEM SPELLS
+#### Intellego Mentem Spells
 
-#### EAR OF TRUTH
+##### Ear of Truth
 
 **R:** Per, **D:** Conc, **T:** Hearing, **Level 30**
 
@@ -2625,9 +2355,9 @@ The caster can tell if he is hearing the truth or not. If a speaker's Magic Resi
 
 (Base 10, +1 Conc, +3 Hearing)
 
-### REGO MENTEM SPELLS
+#### Rego Mentem Spells
 
-#### TRUST ME
+##### Trust Me
 
 **R:** Eye, **D:** Sun, **T:** Ind, **Level 20**
 
@@ -2637,7 +2367,7 @@ The spell is as powerful as *Aura of Rightful Authority*, but more subtle. The s
 
 (Base 5, +1 Eye, +2 Sun)
 
-#### THE PENITENT'S CONFESSION
+##### The Penitent'S Confession
 
 **R:** Eye, **D:** Conc, **T:** Ind, **Level 30**
 
@@ -2647,22 +2377,17 @@ This effect qualifies as scrying and causes warping, so very few magi will volun
 
 (Base 20, +1 Eye, +1 Conc)
 
-#### AURA OF INCONSEQUENCE
+##### Aura of Inconsequence
 
 **R:** Touch, **D:** Sun, **T:** Spec, **Level 25**
 
 Occasionally a Quaesitor may need to conduct investigations in mundane society. Inspired by the non-Hermetic *Veil all Eyes* ritual (see below), this spell can be used to aid avoiding mundane attention. This spell can be cast on either the magus himself or an ally; this individual is the recipient. At any point during the spell's duration, individuals enter the influence of this spell by looking at the recipient. The spell stops influencing people as soon as they look away. The spell's target is rated at T: Structure. The Penetration of the spell should be noted when cast, as this applies throughout the duration.
 
-This spell simply deflects casual attention away from the recipient. Unless the recipient calls attention to himself or an observer is actively watchful, people will pay him no mind. If a character has some reason to be alert they are allowed a Per + Awareness roll of 12+ to noticed the recipient. The Blatant Gift reduces the Ease Factor to 9+. If the magus takes care to be inconspicuous this Ease Factor may be increased. Quaesitors with effective com-
-
-
-
-
-panions often cast this spell on themselves to avoid compromising mundane investigations with their presence. However, animals still react to the magus as normal.
+This spell simply deflects casual attention away from the recipient. Unless the recipient calls attention to himself or an observer is actively watchful, people will pay him no mind. If a character has some reason to be alert they are allowed a Per + Awareness roll of 12+ to noticed the recipient. The Blatant Gift reduces the Ease Factor to 9+. If the magus takes care to be inconspicuous this Ease Factor may be increased. Quaesitors with effective companions often cast this spell on themselves to avoid compromising mundane investigations with their presence. However, animals still react to the magus as normal.
 
 (Base 3, +1 Touch, +2 Sun, +3 Spec)
 
-### INTELLEGO TERRAM GUIDELINES
+#### Intellego Terram Guidelines
 
 **Level 30:** Commune with a natural rock. Speak with a metal object.
 
@@ -2670,9 +2395,9 @@ panions often cast this spell on themselves to avoid compromising mundane invest
 
 **Level 40:** Commune with a metal object (for example, a knife).
 
-### INTELLEGO TERRAM SPELLS
+#### Intellego Terram Spells
 
-**TELL OF THE FORGED**
+##### Tell of the Forged
 
 **R:** Touch, **D:** Sun, **T:** Ind, **Level 45**
 
@@ -2680,17 +2405,15 @@ As *Stone Tell of the Mind that Sits*, but can be used on even metal objects. Th
 
 (Base 30, +1 Touch, +2 Sun)
 
-**DREAM OF THE MIND THAT SITS**
+##### Dream of the Mind That Sits
 
-**R:** Touch, **D:** Sun, **T:** Ind, **Level 50**
-
-**Requisite:** Creo
+**R:** Touch, **D:** Sun, **T:** Ind, **Level 45**
 
 Allows you to probe the memories of a spirit within a natural stone object. The spell also perfects those memories in the same way as *The Good Witness*. Probing the memories of such a spirit is extremely slow. A typical session lasts between six and twelve hours, during which the caster is oblivious to the outside world. The spell allows the caster to perceive the memories of the spirit. The spirit's senses are limited and slow, but its memory of them is very long. Using this spell the caster can relive events witnessed by the spirit, as it recalls them. Larger stone objects have more powerful spirits and so have better perceptions. Precisely what level of detail an individual spirit can perceive is up to the storyguide.
 
-(Base 30, +1 Touch, +2 Sun, +1 Creo effect)
+(Base 30, +1 Touch, +2 Sun)
 
-**DREAM OF THE ARTIFICE**
+##### Dream of the Artifice
 
 **R:** Touch, **D:** Sun, **T:** Ind, **Level 50**
 
@@ -2698,35 +2421,31 @@ As *Dream of the Mind that Sits*, but can be used on artificial stone objects an
 
 (Base 35, +1 Touch, +2 Sun)
 
-**DREAM OF THE FORGED**
+##### Dream of the Forged
 
-**R:** Touch, **D:** Sun, **T:** Ind, **Level 60,** Ritual
-
-**Requisite:** Creo
+**R:** Touch, **D:** Sun, **T:** Ind, **Level 55,** Ritual
 
 As *Dream of the Mind that Sits*, but can be used on even metal objects. The cooperation of the spirit is not required, but as always the level of detail recalled is up to the storyguide.
 
-(Base 40, +1 Touch, +2 Sun, +1 Creo effect)
+(Base 40, +1 Touch, +2 Sun)
 
-### CREO VIM GUIDELINES
+#### Creo Vim Guidelines
 
 **Gen:** Refreshes all spell traces within the target that are less then the magnitude of the guideline –1, in negative magnitude.
 
-**Level 10:** Detect any active magic and any trace of positive magnitude.
+#### Creo Vim Spells
 
-#### CREO VIM SPELLS
-
-**RESTORE THE FADED THREADS**
+##### Restore the Faded Threads
 
 **R:** Touch, **D:** Dia, **T:** Circle, **Level Gen**
 
-Once a trace has been found or suspected, this spell is used to make it examinable. This spell temporarily restores spell traces to a fresh state (as if they had just expired). The spell will restore spell traces of negative magnitude up to the magnitude of this spell –1. The trace must still be existent to be affected (magnitude –9 or greater). Thus the maximum effective level of this spell is 50.
+Once a trace has been found or suspected, this spell is used to make it examinable. This spell temporarily restores spell traces to a fresh state (as if they had just expired). This spell will restore spell traces of a negative magnitude up to the magnitude of this spell -3. The trace must still be existent to be affected (magnitude –9 or greater). Thus the maximum effective level of this spell is 50.
 
 Versions of this spell also exist for all standard Targets. Diameter duration is normally long enough to conduct Intellego Vim investigations of the spell traces.
 
 (Base, +1 Touch, +1 Dia)
 
-#### INTELLEGO VIM GUIDELINES
+#### Intellego Vim Guidelines
 
 In general, separate spells are needed to analyze effects from each of the four Realms of power. Quaesitors normally learn the spells to detect and analyze magical effects, but the other spells are known. Spells could be invented to detect Infernal traces, but there would be no point.
 
@@ -2734,11 +2453,9 @@ In general, separate spells are needed to analyze effects from each of the four 
 
 +3 magnitudes gives the rough details of the effect and the sigil of the caster. This level also enables the Quaesitor to tell if a Hermetic effect was created by a spell or invested device. Quaesitors with extensive experience of a particular sort of non-Hermetic power can also identify that; the limit is the Quaesitor's ability to interpret the information provided by the spell.
 
+#### Intellego Vim Spells
 
-
-### INTELLEGO VIM SPELLS
-
-#### BITTER TASTE OF BETRAYAL
+##### Bitter Taste of Betrayal
 
 **R:** Per, **D:** Sun, **T:** Taste, **Level 15**
 
@@ -2746,7 +2463,7 @@ If the caster comes under the affect of any active magic he will experience a bi
 
 (Base 5, +2 Sun)
 
-#### IMPRESSION OF THE FADED SIGIL
+##### Impression of the Faded Sigil
 
 **R:** Per, **D:** Mom, **T:** Touch, **Level 30**
 
@@ -2756,7 +2473,7 @@ This spell is commonly mastered and combined with Quaesitorial training gives a 
 
 (Base 10, +1 Touch, +3 Details)
 
-#### ODOR OF LINGERING MAGIC
+##### Odor of Lingering Magic
 
 **R:** Per, **D:** Conc, **T:** Smell, **Level 30**
 
@@ -2764,16 +2481,18 @@ This spell allows the magus to smell active magic or traces of –1 magnitude or
 
 Increasing the magnitude of this basic design allows negative magnitude traces to be seen. The highest nonritual version (Level 50) allows traces of –5 magnitude to be discovered. However, to detect a –9 magnitude trace requires a Level 70 ritual.
 
-(Base 15, +1 Conc, +2 Vision)
+(Base 15, +1 Conc, +2 Smell)
 
-#### SIGHT OF THE SIGIL
+##### Sight of the Sigil
 
 **R:** Per, **D:** Conc, **T:** Vision, **Level 50**
 
-Used by the most experienced Quaesitors, this spell allows the magus to spot active magic or traces of positive magnitude. In the case of Hermetic effects, this spell gives the Technique and Form, the rough details of the effect and the casting sigil of wizard responsible. It can also detect if a Hermetic effect was generated by a spell or invested device. If the effect was non-Hermetic, similar
+Used by the most experienced Quaesitors, this spell allows the magus to spot active magic or traces of positive magnitude. In the case of Hermetic effects, this spell gives the Technique and Form, the rough details of the effect and the casting sigil of wizard responsible. It can also detect if a Hermetic effect was generated by a spell or invested device. If the effect was non-Hermetic, similar information is provided, but a Quaesitor without knowledge of that sort of magic may not be able to interpret it.
+
+(Base 10, +1 Conc, +4 Vision, +3 Details) 
 
 
-### PERDO VIM GUIDELINES
+#### Perdo Vim Guidelines
 
 This combination can be used to make spell traces harder to detect by aging the trace. However, a spell to magically age a trace will leave its own fresh trace; this is generally counterproductive. However, if cast with *Shroud Magic* it can still prove useful. So far, no way has been found of designing a spell that leaves no trace.
 
@@ -2781,13 +2500,13 @@ This combination can be used to make spell traces harder to detect by aging the 
 
 **Gen:** Ages a spell trace to a negative magnitude equal to the guideline used.
 
-**Gen:** Dispel a Hermetic enchantment with a level less than the guideline level used + a stress die (no botch). Spell must be a ritual.
+**Gen:** Dispel a Hermetic enchantment with a level less than the guideline level used + 1 magnitude + a stress die (no botch). The spell must be a Ritual.
 
 **Gen:** Dispel a specific type of enchantment with a level less than twice the guideline level used + a stress die (no botch). To qualify the spell needs to specify a particular Hermetic Form or a specific type of enchantment, such as Talismans, Familiars or Longevity Rituals. More general enchantments do not qualify. Spell must be a ritual.
 
-#### PERDO VIM SPELLS
+#### Perdo Vim Spells
 
-#### CIRCLE OF CLARITY
+##### Circle of Clarity
 
 **R:** Touch, **D:** Mom, **T:** Circle, **Level Gen**
 
@@ -2795,15 +2514,13 @@ This spell will dispel any active Vim effect within the circle whose Casting Tot
 
 (Base, +1 Touch)
 
-#### CUTTING THE CORDS
+##### Cutting the Cords
 
 **R:** Touch, **D:** Mom, **T:** Ind, **Level Gen,** Ritual
 
-Used as a Tribunal punishment, this spell requires the active cooperation of the convicted magus. The cords connecting magus and familiar are cut permanently if double the level of this spell – 5 + a stress die (no botch), exceeds the highest enchantment given the familiar (this may be the Familiar Bond Enchantment). This is an extremely painful and emotionally scarring experience for both parties. After the cords have been cut, both magus and former familiar find each other's presence too much to bear. A familiar normally flees into the wilderness and avoids all future contact with magi. The former familiar cannot normally be rebound.
+Used as a Tribunal punishment, this spell requires the active cooperation of the convicted magus. The cords connecting magus and familiar are cut permanently if double the level of this spell + a stress die (no botch), exceeds the highest enchantment given the familiar (this may be the Familiar Bond Enchantment). This is an extremely painful and emotionally scarring experience for both parties. After the cords have been cut, both magus and former familiar find each other's presence too much to bear. A familiar normally flees into the wilderness and avoids all future contact with magi. The former familiar cannot normally be rebound.
 
 (Base, +1 Touch)
-
-
 
 ## Fenicil's Rituals
 
@@ -2811,11 +2528,11 @@ These rituals are still largely Mercurian or pre-Mercurian in nature. Although a
 
 Each ritual is learnt like a Hermetic spell from a teacher. No lab total is required, but each requires a whole season. Like Hermetic spells, the ritual has an associated Ability that can be developed; this Ability is critical to successful casting. Like Hermetic rituals, mastery Ability can be gained and developed via practice. The magus practices parts of the ritual, becomes familiarized with the details and contemplates the subtleties. This process requires no vis or risk. There are also books on these Abilities; they are kept at Fenicil's library within Magvillus.
 
-It is practically impossible for an individual to cast the more powerful rituals; a large group needs to gather in order to generate the effect. Before starting, the group needs to cast *Wizard's Communion* spells with a combined magnitude equal to the Ease Factor of the ritual.
+It is practically impossible for an individual to cast the more powerful rituals; a large group needs to gather in order to generate the effect. Before starting, the group needs to cast *Wizard's Vigil* spells with a combined magnitude equal to the Ease Factor of the ritual. The Greater Rituals require a Year Duration variant of Wizard's Vigil in order to cover their casting time.
 
 The Casting Total for these rituals is:
 
-#### Sta + [Sum of Ability Scores] + Aura Modifier + Die Roll
+**Sta + [Sum of Ability Scores] + Aura Modifier + Die Roll**
 
 This roll is made by the ritual leader. If the Ease Factor is not met, the effect fails. However, the slow, methodical method of casting is quite safe. Unless stressed or disrupted there are no botch die.
 
@@ -2832,7 +2549,7 @@ As can be imagined these rituals are not cast casually, and in fact some have ne
 
 It should be noted that there is no proof these rituals work at all.
 
-#### CURSE OF THOTH
+##### Curse of Thoth
 
 **PeVi, R:** Arc, **D:** Year, **T:** Spec
 
@@ -2840,7 +2557,7 @@ This spell curses another magical group with misfortune. The final act of castin
 
 **Ease Factor:** 78
 
-#### CURSE OF MARS
+##### Curse of Mars
 
 **ReMe, R:** Arc, **D:** Year, **T:** Spec
 
@@ -2848,29 +2565,25 @@ This spell curses a nation to internal strife. The final act of casting involves
 
 **Ease Factor:** 78
 
-#### CALL FOR JUSTICE
+##### Call for Justice
 
 **ReVi, R:** Arc, **D:** Mom, **T:** Ind
 
 This spell calls on Nemesis herself to deliver justice to a criminal. If the call is unjust Nemesis will punish those who made the call. Nemesis is known best for her hatred of immoderation. She strives to re-establishing order and proportion by punishing excesses of pride and undeserved fortune. She is merciless to unjust men of violence. As this ritual has never been attempted, what exactly would happen is an open question. Given that the other greater rituals target large groups, it is expected to be highly effective.
 
-Nemesis is thought to be an entity of the magic realm. If she physically manifested in Mythic Europe she would equal or exceed the most powerful magical or faerie beings normally present. Even the most powerful Hermetic magus would be in serious peril. However, it is
-
-
-
-### Greater Ritual Example
-
-During the Schism War, thirty senior Guernicus magi were summoned by the inner council to enact the *Curse of Thoth* ritual. All the inner council also joined, making thirty-seven participants. The sum of mastery abilities was 130 (average ability of about 3.5). The Primus's stamina was +2 and the magic aura of Magvillus was +4. The die roll was 3. Thus the Casting Total for the ritual was:
-
-$$2 + 130 + 4 + 3 = 139$$
-
-The ease factor was 78; therefore the Penetration of the effect was 61. The end of the ritual (the sacrifice) was done half a Diameter after sunrise; thus at least some Diedne were caught without Parma. In any case, all but the most senior Vim specialists of House Diedne should have been affected (if the ritual had any effectiveness at all). Thirty-nine pawns of vis were consumed by the ritual, with material costing about thirty-nine pounds of silver.
-
-more likely that she would manipulate the strands of fate to bring ruin to her subject.
+Nemesis is thought to be an entity of the magic realm. If she physically manifested in Mythic Europe she would equal or exceed the most powerful magical or faerie beings normally present. Even the most powerful Hermetic magus would be in serious peril. However, it is more likely that she would manipulate the strands of fate to bring ruin to her subject.
 
 However, if this ritual is enacted, the participants had better be totally sure Nemesis will agree with their judgment.
 
 **Ease Factor:** 78
+
+> ## Greater Ritual Example
+> 
+> During the Schism War, thirty senior Guernicus magi were summoned by the inner council to enact the *Curse of Thoth* ritual. All the inner council also joined, making thirty-seven participants. The sum of mastery abilities was 130 (average ability of about 3.5). The Primus's stamina was +2 and the magic aura of Magvillus was +4. The die roll was 3. Thus the Casting Total for the ritual was:
+> 
+> 2 + 130 + 4 + 3 = 139
+> 
+> The ease factor was 78; therefore the Penetration of the effect was 61. The end of the ritual (the sacrifice) was done half a Diameter after sunrise; thus at least some Diedne were caught without Parma. In any case, all but the most senior Vim specialists of House Diedne should have been affected (if the ritual had any effectiveness at all). Thirty-nine pawns of vis were consumed by the ritual, with material costing about thirty-nine pounds of silver.
 
 ### Lesser Rituals
 
@@ -2878,7 +2591,7 @@ Unlike the greater rituals these see occasional use, although the costs are stil
 
 All these rituals take five minutes for each point of Ease Factor to cast. Those below are only a selection; there may be more at the storyguide's discretion.
 
-#### WISDOM OF ATHENA
+##### Wisdom of Athena
 
 **CrMe, R:** Per, **D:** Sun, **T:** Ind
 
@@ -2886,16 +2599,15 @@ Allows the ritual leader a +5 bonus to all Folk Ken, Intrigue and Awareness test
 
 **Ease Factor:** 12
 
-#### SIGHT OF ALATHEIA
+##### Sight of Alatheia
 
 **InVi, R:** Per, **D:** Sun, **T:** Vision
 
-Gives ritual leader the equivalent of the Second Sight ability with a score of 5 for the duration. If the beneficia-
-
+Gives ritual leader the equivalent of the Second Sight ability with a score of 5 for the duration. If the beneficiary already has the Second Sight ability, they gain a +5 bonus to all Second Sight rolls for the duration. This effect functions exactly like Second Sight, particularly with respect to Magic Resistance.
 
 **Ease Factor:** 12
 
-#### VEIL ALL EYES
+##### Veil All Eyes
 
 **ReMe (An), R:** Touch, **D:** Moon, **T:** Spec
 
@@ -2903,7 +2615,7 @@ Allows the ritual participants to pass unnoticed. A beneficiary will be ignored 
 
 **Ease Factor:** 18
 
-#### THE OATH OF TRUTH
+##### The Oath of Truth
 
 **PeCo, R:** Voice, **D:** Spec, **T:** Ind
 
@@ -2911,7 +2623,7 @@ This ritual can only be cast on a willing subject. At the end of the ritual, the
 
 **Ease Factor:** 18
 
-### THE WILL OF ALATHEIA
+#### The Will of Alatheia
 
 **PeCo, R:** Voice, **D:** Spec, **T:** Ind
 
@@ -2921,54 +2633,41 @@ This ritual is occasional used as a Tribunal punishment. However, it is seen as 
 
 **Ease Factor:** 24
 
-
-### Chapter Three
-
-# House Mercere
+# Chapter Three: House Mercere
 
 *"The entire Order stands on the brink of dissolution, and we are the only force that keeps it from toppling. How quickly the Houses and wizards have fallen into suspicion, competition, and vengefulness! How quickly they would fall upon each other in fear and confusion if we did not keep them together! Fear feeds on ignorance; knowledge starves the unknown. We bring word of what passes and where so that magi can feel safe, and we carry their words with us so that they may bring comfort to others. We are the salvation of the Order."*
 
-> — Aldico, Primus of Mercere, addressing his House during the Schism War
+— Aldico, Primus of Mercere, addressing his House during the Schism War
 
 **Symbol:** A red cap with a yellow circle inscribed with a blue triangle. The cap signifies duty and knowledge, the circle depicts a coin representing wealth and commerce, and the triangle suggests a potsherd from a Roman crossroads, symbolizing communication and travel.
 
 **Motto:** *Ordinem ministramus et sustinemus* ("We serve the Order and keep it alive.")
 
-Mercere is the House of heralds,
+Mercere is the House of heralds, heroes, mercenaries and merchants. It is rife with contradictions: exotic, but traditional; loyal, but self-centered; proud, but humble. It is the largest House, though it has by far the fewest magi, and it is made up of characters that are so individual that they defy generalization, yet are perhaps the most ordinary people in the setting. Merceres are solitary and independent, but true to their masters, and they demonstrate great dedication and determination in pursuit of their duty. They are the backbone of the Order — they hold the loose association of magi together by facilitating communication, encouraging trade, and aiding their sodales in all parts of Mythic Europe.
 
-heroes, mercenaries and merchants. It is rife with contradictions: exotic, but traditional; loyal, but self-centered; proud, but humble. It is the largest House, though it has by far the fewest magi, and it is made up of characters that are so individual that they defy generalization, yet are perhaps the most ordinary people in the setting. Merceres are solitary and independent, but true to their masters, and they demonstrate great dedication and determination in pursuit of their duty. They are the backbone of the Order — they hold the loose association of magi together by facilitating communication, encouraging trade, and aiding their sodales in all parts of Mythic Europe.
+From a player standpoint, there are essentially two kinds of Mercere: **Redcaps**, who do not have The Gift and do not vote at Tribunal, otherwise have many of the same rights and privileges as magi and are usually played as companion characters. They travel from covenant to covenant to form the information and trade network that keeps the Order together. **Mercere magi** are their Gifted counterparts, and tend to focus on making it easier for the rest of their House to fulfill their duties, primarily through crafting invested devices, healing, and other magical support. All told, there are usually about 150 Redcaps in the Order of Hermes, with at least ten living in each Tribunal, compared to about twelve Gifted Merceres in all of Mythic Europe. Mercere magi are more common in the Rhine, Roman, and Provencal Tribunals near their domus magna, and are much more likely to interact regularly with Redcaps than with other magi, since many prefer not to advertise their Gifted status.
 
-From a player standpoint, there are essentially two kinds of Mercere: **Redcaps**, who do not have The Gift and do not vote at Tribunal, otherwise have many of the same rights and privileges as magi and are usually played as companion characters. They travel from covenant to covenant to form the information and trade network that keeps the Order together. **Mercere magi** are their Gifted counterparts, and tend to focus on making it easier for the rest of their House to fulfill their duties, primarily through crafting invested devices, healing, and other magical support. All told, there are usually about 150 Redcaps in the Order of Hermes, with at least ten living in each Tribunal, compared to about twelve Gifted Merceres in all of Mythic Europe. Mercere magi are more common in the Rhine, Roman, and Provencal Tribunals near their domus magna, and are much more likely to interact regularly
+This chapter is broken into three parts to make these differences and similarities between the two kinds of characters more clear. The first section, **Mercere the Founder**, describes the origins, goals and history of the House by following the life of its Founder. The second section, **Redcaps**, outlines the structure of the House and several internal organizations within that structure, to describe the sorts of activities that these characters do in service to the Order. Finally, **Magical Merceres** develops the uniquely magical aspects of the lineage, to give ideas of how a Gifted member of the House might look and act.
 
-> with Redcaps than with other magi, since many prefer not to advertise their Gifted status.
+## Mercere the Founder
 
-> This chapter is broken into three parts to make these differences and similarities between the two kinds of characters more clear. The first section, **Mercere the Founder**, describes the origins, goals and history of the House by following the life of its Founder. The second section, **Redcaps**, outlines the structure of the House and several internal organizations within that structure, to describe
-
-the sorts of activities that these characters do in service to the Order. Finally, **Magical Merceres** develops the uniquely magical aspects of the lineage, to give ideas of how a Gifted member of the House might look and act.
-
-
-Mercere's origins are a mystery. None of his descendants have any idea what part of the world he originally came from, nor do they know for sure where he learned his magic. The stories that remain of him are surely exaggerated by time, by the hero-worship that is common
-
-
-
-Harco is located in Piedmont, in the Roman Tribunal, in a small town of the same name very near the borders of the Provencal and Rhine Tribunals. Mercere chose its location for its convenience, not its magical qualities, and it has almost no magical aura. Instead, it is a center for Hermetic commerce, and there is almost constant intercourse between the various Portals, warehouses and storerooms that make up the focus of the Redcap network. Carts bearing valuable goods from distant lands travel from Hibernia to the Holy Land, Novgorod to Iberia. Vis is catalogued and exchanged before being sent back to the different Tribunals' coffers. Redcaps and records travel to and from the great library at Durenmar in the Rhine. The place is a manor of great wealth and activity, a true crossroads of the Order.
-
-This giant business is shrewdly managed by Prima Insatella. She is a practical woman, nearly eighty, who has been running the covenant successfully for almost forty years. Her father Mihalyi was the last Primus, who replaced Aldico just after the Schism War, and she grew up knowing that she would probably take over for him when he died. She does not have the Gift and is very withdrawn; she tries not to involve herself in the affairs of magi or the politics of the Tribunal, but instead concentrates on seeing that her House and the covenant run as smoothly as possible. She has a large family, and her second-eldest daughter Maria will probably assume her duties when she dies, as she is her mother's chief assistant and knows best what needs to be done to keep their organization successful.
-
-throughout the House, or by the Founder himself: some say he was the descendent of Circe and Odysseus, others of Perseus, Orpheus, or other ancient heroes; some even believe that he was a medieval incarnation of the god Mercury. His followers claim that he had traveled all of Europe before the age of 20.
+Mercere's origins are a mystery. None of his descendants have any idea what part of the world he originally came from, nor do they know for sure where he learned his magic. The stories that remain of him are surely exaggerated by time, by the hero-worship that is common throughout the House, or by the Founder himself: some say he was the descendent of Circe and Odysseus, others of Perseus, Orpheus, or other ancient heroes; some even believe that he was a medieval incarnation of the god Mercury. His followers claim that he had traveled all of Europe before the age of 20.
 
 He is said to have been the first to join Trianoma's cause, and it is whispered within the House that they had an amorous relationship, though others say that she refused his advances. In any case, he swore a solemn oath to her that he and his followers would loyally serve her and her Order, and they traveled together for several years both before and after she took him to meet Bonisagus. He helped her to find several of the other Founders, whom he had met previously or heard stories about, and kept her company for much of her famous journey.
 
+> ## Harco, Domus Magna
+> 
+> Harco is located in Piedmont, in the Roman Tribunal, in a small town of the same name very near the borders of the Provencal and Rhine Tribunals. Mercere chose its location for its convenience, not its magical qualities, and it has almost no magical aura. Instead, it is a center for Hermetic commerce, and there is almost constant intercourse between the various Portals, warehouses and storerooms that make up the focus of the Redcap network. Carts bearing valuable goods from distant lands travel from Hibernia to the Holy Land, Novgorod to Iberia. Vis is catalogued and exchanged before being sent back to the different Tribunals' coffers. Redcaps and records travel to and from the great library at Durenmar in the Rhine. The place is a manor of great wealth and activity, a true crossroads of the Order.
+> 
+> This giant business is shrewdly managed by Prima Insatella. She is a practical woman, nearly eighty, who has been running the covenant successfully for almost forty years. Her father Mihalyi was the last Primus, who replaced Aldico just after the Schism War, and she grew up knowing that she would probably take over for him when he died. She does not have the Gift and is very withdrawn; she tries not to involve herself in the affairs of magi or the politics of the Tribunal, but instead concentrates on seeing that her House and the covenant run as smoothly as possible. She has a large family, and her second-eldest daughter Maria will probably assume her duties when she dies, as she is her mother's chief assistant and knows best what needs to be done to keep their organization successful.
 
-
-
-### Mercere's Portals
-
-Mercere discovered and brought the spell *Hermes' Portal* (ReTe75) to the Order, a spell used by the Cult of Mercury to allow distant Mercurians to gather more easily for their great rituals. In ancient times, building a Portal was a sign of trust, since it required magi to exchange arcane connections, and indicated a special relationship between them. Since the ritual lasted only a year, it was expected that magi would regularly renegotiate their arrangement, and thus Portals became a symbol of a magical alliance. After the Order was formed, Mercere's only magical achievement was to adapt the Portal effect into an invested device (it is assumed that he had help from Bonisagus on this impressive feat) and he built several of these, linking Harco and the other Founders' covenants to Durenmar in this same spirit of cooperation and trust.
-
-Perhaps Mercere did not realize how difficult it would be to duplicate his efforts, but he did not pass on the secret that made designing these devices possible. Few in his age realized what he was doing, for in a practical sense these magical doorways seemed expensive and limited compared to the potential of devices invested with effects like *Leap of Homecoming* (ReCo35). When they later recognized how efficient they were for trade and mass travel, his descendants were able to discover how to make more by examining the Portals he had left behind (see Mercere's Portals in the Appendix, Laboratory), but they could not adapt the effect to other applications. House Mercere would love to make portable items using this magical concept — a "bottomless" pouch that opens into a strongroom, for example, or an ever-full canteen linked to a fresh water well — but thus far no one in the House has been able to connect two places through any item but a Portal, and they jealously guard even this limited knowledge, for they see it as their inheritance: it is all that now remains of their Founder's magic.
-
-As the Order expanded, Mercere's followers established outposts on the edges of the Order — the British Isles, Novgorod, the Holy Land — and connected them to Harco with these Portals. In the interests of joining the Order together they allowed all magi to use them freely, though this policy had unfortunate consequences at the beginning of the Schism War, when a group of unidentified magi snuck through a Portal at Durenmar to Diedne's stronghold in a surprise attack, and the druids' retaliatory strike caused great damage to the covenant. Afterwards, many Houses elected to close their Portals, and others asked that they be moved to more defensible positions outside their covenant walls. In 1220, free access to these Portals is restricted to members of the House and other magi acting in service to the Order, though the guardians may allow others through if they do not seem to pose a threat and pay a toll of one pawn of vis each.
+> ## Mercere's Portals
+> 
+> Mercere discovered and brought the spell *Hermes' Portal* (ReTe75) to the Order, a spell used by the Cult of Mercury to allow distant Mercurians to gather more easily for their great rituals. In ancient times, building a Portal was a sign of trust, since it required magi to exchange arcane connections, and indicated a special relationship between them. Since the ritual lasted only a year, it was expected that magi would regularly renegotiate their arrangement, and thus Portals became a symbol of a magical alliance. After the Order was formed, Mercere's only magical achievement was to adapt the Portal effect into an invested device (it is assumed that he had help from Bonisagus on this impressive feat) and he built several of these, linking Harco and the other Founders' covenants to Durenmar in this same spirit of cooperation and trust.
+> 
+> Perhaps Mercere did not realize how difficult it would be to duplicate his efforts, but he did not pass on the secret that made designing these devices possible. Few in his age realized what he was doing, for in a practical sense these magical doorways seemed expensive and limited compared to the potential of devices invested with effects like *Leap of Homecoming* (ReCo35). When they later recognized how efficient they were for trade and mass travel, his descendants were able to discover how to make more by examining the Portals he had left behind (see Mercere's Portals in the Appendix, Laboratory), but they could not adapt the effect to other applications. House Mercere would love to make portable items using this magical concept — a "bottomless" pouch that opens into a strongroom, for example, or an ever-full canteen linked to a fresh water well — but thus far no one in the House has been able to connect two places through any item but a Portal, and they jealously guard even this limited knowledge, for they see it as their inheritance: it is all that now remains of their Founder's magic.
+> 
+> As the Order expanded, Mercere's followers established outposts on the edges of the Order — the British Isles, Novgorod, the Holy Land — and connected them to Harco with these Portals. In the interests of joining the Order together they allowed all magi to use them freely, though this policy had unfortunate consequences at the beginning of the Schism War, when a group of unidentified magi snuck through a Portal at Durenmar to Diedne's stronghold in a surprise attack, and the druids' retaliatory strike caused great damage to the covenant. Afterwards, many Houses elected to close their Portals, and others asked that they be moved to more defensible positions outside their covenant walls. In 1220, free access to these Portals is restricted to members of the House and other magi acting in service to the Order, though the guardians may allow others through if they do not seem to pose a threat and pay a toll of one pawn of vis each.
 
 In exchange for the Parma Magica, Mercere taught Bonisagus what he knew of Mercurian fertility rituals and shapechanging magic. His Gift was weak, for though it had never had any adverse effect on his interactions with other wizards, Mercere had great difficulty performing magic on his own, and he was so impressed by the difference the Founder's knowledge and advice made that in thanks he promised him the right to any of his future apprentices. Bonisagus graciously accepted this, promising that he would not abuse the privilege, and they became good friends.
 
@@ -2976,21 +2675,17 @@ In the years immediately after the Founding, Mercere established his house in no
 
 Unlike other magi, Mercere did not adopt Gifted children into his lineage, instead bringing those he discovered to Bonisagus. It is said that in those days he considered himself a member of the Great Founder's House in everything but name. He took only two apprentices, both of them his own children, and so his line remained very small while the others quickly grew. Even while teaching his followers, he worked tirelessly to keep the Order together; he spent most of his time traveling and carrying messages, or with Trianoma and Bonisagus at Durenmar.
 
-Mercere's great tragedy occurred at one of these visits. While working with Bonisagus in the lab, Mercere's Gift was destroyed, removing his ability to work any of his magic. Some say this was an accident, brought about by a flaw in the Parma Magica or his weak Gift, while others say Mercere gave it up voluntarily in pursuit of greater magical mysteries. Hermetic records of that time state that Bonisagus tried to restore him, but did not succeed, and that he considered this his greatest failure. He wrote
-
-
-that it was "a sign of the inherent evil of this world, that magic can so easily destroy what only God can create."
+Mercere's great tragedy occurred at one of these visits. While working with Bonisagus in the lab, Mercere's Gift was destroyed, removing his ability to work any of his magic. Some say this was an accident, brought about by a flaw in the Parma Magica or his weak Gift, while others say Mercere gave it up voluntarily in pursuit of greater magical mysteries. Hermetic records of that time state that Bonisagus tried to restore him, but did not succeed, and that he considered this his greatest failure. He wrote that it was "a sign of the inherent evil of this world, that magic can so easily destroy what only God can create."
 
 After this terrible event, Mercere's personality changed dramatically. At first, he seemed desperate to regain his magic, seeking out old stories of mortal men becoming gods, and neglecting his followers to try to mend his failing. When that didn't succeed, he disappeared for more than a decade. He traveled, or remained shut up in his lab at Harco, and many thought he had either died or gone mad. Years later, he calmly emerged and began to adopt mundane followers, all of whom served him for fifteen years like magical apprentices, and to whom he taught everything he could. He stressed to these young men and women that their first duty was to support Trianoma's vision, as he had promised her, in any way that they could. He never acknowledged that they were different in any way, calling all of them "his children," just like his Gifted heirs.
 
 This caused great conflict at Tribunal, for many of the Founders felt it was implicit in the Oath that magi would train their apprentices to work magic, and that by taking unGifted followers Mercere had created a dangerous precedent. Other Houses would gladly bring mundanes into the Order if it were allowed, as servants, companions, or simply as additional votes at Tribunal; and some thought it would cheapen their Hermetic status to consider ordinary men and women their equals. The majority of magi seemed to think that the Code should be altered to require the Gift. Yet Trianoma spoke passionately on Mercere's behalf, for the first time in ages, and out of respect for the Founders it was reluctantly agreed that this would be a special privilege of Mercere's House, and that they would make no ruling preventing it. Mercere humbly promised that his "younger" followers would swear the Oath, and would selflessly serve the Order as he did. He also asked them, before the assembly, to always show special respect to those "with powers more apparent than your own."
 
-Mercere died soon after this. His body was cremated at Harco according to the ancient rites of the Cult of Mercury, and several of the other Founders were present,
+Mercere died soon after this. His body was cremated at Harco according to the ancient rites of the Cult of Mercury, and several of the other Founders were present, including Trianoma. Yet some of those at the ceremony swear that instead of burning away, Mercere was carried through the smoke by the image of man with winged shoes, and many of his followers take this as a sign that Mercere now lives forever among the gods.
 
-### "Redcaps" and "Merceres"
-
-In this text, the term "Redcap" refers to an unGifted member of House Mercere. Gifted members are called "Mercere magi" or "Gifted Merceres," though note that all members of the House are considered magi for the purposes of their Oath and the Code. The general term "Mercere" refers to anyone, Gifted or unGifted, who belongs to the House.
-
+> ## "Redcaps" and "Merceres"
+> 
+> In this text, the term "Redcap" refers to an unGifted member of House Mercere. Gifted members are called "Mercere magi" or "Gifted Merceres," though note that all members of the House are considered magi for the purposes of their Oath and the Code. The general term "Mercere" refers to anyone, Gifted or unGifted, who belongs to the House.
 
 ## Redcaps
 
@@ -3000,23 +2695,19 @@ As magi relied more on Redcaps, so the Redcaps relied more upon magi, and many b
 
 By the time of the Schism War, House Mercere had become so integral to the smooth running of the Order that it was able to influence the outcome of the conflict in very small ways. Some Redcaps learned that by controlling the flow of information — taking a long time to deliver unfavorable news, or conveniently losing some messages while expediting others — they were able to help those whose causes they favored, and hinder those whom they did not wish to succeed. In this way, the Merceres believe that they were able to prevent many atrocities from occurring, and brought about peace much more quickly than it otherwise would have come to pass.
 
-In 1220, House Mercere is probably too disorganized to unite like that again, though groups of them certainly have great influence, and one or two Redcaps working together can disrupt enough communication to be a major hindrance to their enemies. However, Redcaps don't gen-
-
-
-
-### Societies
-
-Within the Order are many smaller groups of magi, each committed to an ideal, a cause, a particular study of magic, or any shared purpose that causes them to band together. Ex Miscellanea, Flambeau, Jerbiton, and Tytalus are considered House societies, but any number of smaller Hermetic societies may be found throughout the Order, which often include magi from many different Houses. Generally, any magus can join a society; they may have requirements for membership, but on the whole societies like having allies in their causes.
-
-The societies described throughout this chapter are fundamentally different, as they are designed primarily for Redcaps. Redcaps form societies in many ways. Some join or found covenants. Others associate primarily with other Redcaps in their Tribunal, overseen by senior Redcaps or magi. Some Redcaps form groups based on common goals or shared attributes such as dressing and acting as lepers, or appreciating nature — and these groups often cross Tribunal boundaries. And some societies are based in family, tracing their lineage back to famous members of the House, or congregating with others of their race or creed.
-
-Below, each Mercere society, or *Societas Merceris*, has a brief description of the group's history and outlook, and any requirements for characters who wish to join. Each is only a suggestion for a group that might be found in your saga; if you don't think a Redcap like that would fit your vision of Mythic Europe, or you don't believe there would be enough Redcaps dedicated to that cause to warrant its inclusion, simply ignore it. You should also feel free to invent societies of your own, and many Redcaps may not wish to belong to a society at all.
-
-erally get involved in politics, and prefer if anything to use their positions to maintain the status quo. Many Redcaps have developed a peculiar independence, though they still serve the Order, and are notoriously indifferent to any personal causes but their own.
+In 1220, House Mercere is probably too disorganized to unite like that again, though groups of them certainly have great influence, and one or two Redcaps working together can disrupt enough communication to be a major hindrance to their enemies. However, Redcaps don't generally get involved in politics, and prefer if anything to use their positions to maintain the status quo. Many Redcaps have developed a peculiar independence, though they still serve the Order, and are notoriously indifferent to any personal causes but their own.
 
 Thus, Redcaps are something of an anomaly in the Order of Hermes. They are not really part of Mercere's lineage, in that not all of them are descended from the Founder. Some of them are, however, so they cannot be said to belong to a completely independent society, either. Redcaps may not have the Gift, but they do have full rights and privileges, and while they do not usually vote at Tribunal out of respect for true magi, they have sigils and could participate in a vote in dire need. In effect, the Redcaps are like Hermetic companions: their role in the Order is to support magi, and help them perform the tasks that The Gift makes difficult.
 
 To fulfill this mission, Redcaps take on many different duties, described below. Most of these duties do not exclusively belong to Redcaps, not in the same way that, say, Quaesitorial duties belong to official Quaesitors. Redcaps just tend to be the ones who do these things that other magi would think beneath them, to justify their membership in a magical Order. Since Redcaps visit almost every covenant, and any covenant might have a resident Redcap, the ideas that follow can also easily be adapted into story hooks for any saga.
+
+> ## Societies
+> 
+> Within the Order are many smaller groups of magi, each committed to an ideal, a cause, a particular study of magic, or any shared purpose that causes them to band together. Ex Miscellanea, Flambeau, Jerbiton, and Tytalus are considered House societies, but any number of smaller Hermetic societies may be found throughout the Order, which often include magi from many different Houses. Generally, any magus can join a society; they may have requirements for membership, but on the whole societies like having allies in their causes.
+> 
+> The societies described throughout this chapter are fundamentally different, as they are designed primarily for Redcaps. Redcaps form societies in many ways. Some join or found covenants. Others associate primarily with other Redcaps in their Tribunal, overseen by senior Redcaps or magi. Some Redcaps form groups based on common goals or shared attributes such as dressing and acting as lepers, or appreciating nature — and these groups often cross Tribunal boundaries. And some societies are based in family, tracing their lineage back to famous members of the House, or congregating with others of their race or creed.
+> 
+> Below, each Mercere society, or *Societas Merceris*, has a brief description of the group's history and outlook, and any requirements for characters who wish to join. Each is only a suggestion for a group that might be found in your saga; if you don't think a Redcap like that would fit your vision of Mythic Europe, or you don't believe there would be enough Redcaps dedicated to that cause to warrant its inclusion, simply ignore it. You should also feel free to invent societies of your own, and many Redcaps may not wish to belong to a society at all.
 
 ### Messengers and Heralds
 
@@ -3028,11 +2719,7 @@ Each Mercer House is run by a senior Redcap who sees to its needs and keeps trac
 
 Some Tribunals have more than one Mercer House, though these might be considered satellites of the central house. A Gifted Mercere might set up a lab in a magical aura far from society, and her covenant might effectively become a Mercer House as Redcaps and other supporting covenfolk join. Or, two Mercer Houses might compete with each other, as in the Rhine Tribunal, with both covenants striving for dominance in the region.
 
-House Mercere's only official obligation to Tribunal is the charge to distribute invitations before the gathering, usually about a year in advance. The Praeco decides
-
-
-
-when and where the meeting will take place, and the Redcaps must do their best to ensure that all magi in the region receive this information with enough time to make arrangements to attend. At the event, the senior Redcap must ceremonially swear to the Praeco and Presiding Quaesitor that this duty was properly carried out before Tribunal can begin.
+House Mercere's only official obligation to Tribunal is the charge to distribute invitations before the gathering, usually about a year in advance. The Praeco decides when and where the meeting will take place, and the Redcaps must do their best to ensure that all magi in the region receive this information with enough time to make arrangements to attend. At the event, the senior Redcap must ceremonially swear to the Praeco and Presiding Quaesitor that this duty was properly carried out before Tribunal can begin.
 
 In the days of the Founders, this task was easy for Mercere; he would simply visit every domus magna, as he usually did at least once every seven years. As the Order grew, magi began to gather together in other places, forming new covenants and striking out on their own, and the Redcaps needed a method of knowing where all these magi could be found. Thus, Mercere's descendants began the tradition of **covenant registration**. If magi wanted to be visited by Redcaps, they needed to make arrangements with the House.
 
@@ -3042,19 +2729,15 @@ To register a covenant, Redcaps ask that a representative visit the nearest Merc
 
 Redcaps keep information about covenants and the magi who live there secret, so that magi who do not want others to know where they are hidden can still receive messages. Redcaps have all the rights of magi, and spying on them with magic is a Hermetic crime, so these secrets are generally safe. Because of their demonstrated discretion, many covenants and independent magi also **register vis sources** with Redcaps. This means that the Redcaps keep a record of the location and annual yield, so that they can swear to prior ownership at Tribunal if a conflict arises. This allows covenants to legally protect their resources without necessarily making them public.
 
-Redcaps generally make their living by traveling and carrying messages to and from registered covenants. Letters addressed to other covenants in a Tribunal might be taken directly to them, if convenient, or back to a
+Redcaps generally make their living by traveling and carrying messages to and from registered covenants. Letters addressed to other covenants in a Tribunal might be taken directly to them, if convenient, or back to a Mercer House for sorting and distribution. Messages for other Tribunals are usually taken to Harco through the Mercere's Portals, where they are collected and eventually delivered to their ultimate destinations in the same way. Most messages can be expected to be received within a year, or within a season for addresses closer to home.
 
+> ## Blacklisting
+> 
+> It is possible for the Redcaps to refuse to recognize a covenant, for while it is their duty to inform magi of Tribunal, it is only their custom to facilitate this with covenant registration. They have no obligation to visit any covenant except their promise to visit every one for which they have records, and this could theoretically be used to keep certain magi from exercising their votes. It would be difficult for a single Redcap to pull off this boycott unless he had a lot of influence, since the others would probably figure out what he was doing, but important messages have been known to go astray when senior members of the House take an extreme dislike to someone. It isn't often that magi or covenants are blacklisted in this manner, but when they are, the House can make things very difficult for them. Granted, many Redcaps are very independent, and some actively rebel against structure and authority, but nearly all of them respect the word that someone is their enemy.
+> 
+> Blacklisting does not happen often; it is the response to years of mistreatment or a particularly heinous act. There is a story in the Hibernian Tribunal that tells how a Flambeau wizard in the tenth century had a grudge against a Redcap for some reason. Perhaps his rancor was justified, but he shocked the House by declaring Wizard's War against his enemy. The Redcap fled to Stonehenge to hide from him, where he would have remained had the magus not tracked him down. On the last night of the hunt the wizard caught his quarry, tied him to a stake, and burned him alive. Content with his victory, he returned to Hibernia, but found that for the rest of his life, none of the Merceres would acknowledge or recognize him. They were polite, respectful and apologetic, but still his records inexplicably disappeared, letters never reached him, and he received no word of Tribunal. When he died, his name was misspelled on his tomb, and his funeral was sparsely attended; no one cried the news of his passing to his House or his sodales.
 
-It is possible for the Redcaps to refuse to recognize a covenant, for while it is their duty to inform magi of Tribunal, it is only their custom to facilitate this with covenant registration. They have no obligation to visit any covenant except their promise to visit every one for which they have records, and this could theoretically be used to keep certain magi from exercising their votes. It would be difficult for a single Redcap to pull off this boycott unless he had a lot of influence, since the others would probably figure out what he was doing, but important messages have been known to go astray when senior members of the House take an extreme dislike to someone. It isn't often that magi or covenants are blacklisted in this manner, but when they are, the House can make things very difficult for them. Granted, many Redcaps are very independent, and some actively rebel against structure and authority, but nearly all of them respect the word that someone is their enemy.
-
-Blacklisting does not happen often; it is the response to years of mistreatment or a particularly heinous act. There is a story in the Hibernian Tribunal that tells how a Flambeau wizard in the tenth century had a grudge against a Redcap for some reason. Perhaps his rancor was justified, but he shocked the House by declaring Wizard's War against his enemy. The Redcap fled to Stonehenge to hide from him, where he would have remained had the magus not tracked him down. On the last night of the hunt the wizard caught his quarry, tied him to a stake, and burned him alive. Content with his victory, he returned to Hibernia, but found that for the rest of his life, none of the Merceres would acknowledge or recognize him. They were polite, respectful and apologetic, but still his records inexplicably disappeared, letters never reached him, and he received no word of Tribunal. When he died, his name was misspelled on his tomb, and his funeral was sparsely attended; no one cried the news of his passing to his House or his sodales.
-
-Mercer House for sorting and distribution. Messages for other Tribunals are usually taken to Harco through the Mercere's Portals, where they are collected and eventually delivered to their ultimate destinations in the same way. Most messages can be expected to be received within a year, or within a season for addresses closer to home.
-
-Redcaps are traditionally paid in silver by the covenants they visit on their rounds. They can expect to receive a total of three shillings (about twelve pennies)
-
-
-from every covenant they visit, which is paid over the course of three days. The first shilling is given to them on the day they arrive, as payment for their journey. The second shilling is given to them when they present their messages, in appreciation of their service. The third shilling is given to them as they leave the covenant, to ensure their goodwill. By visiting about four covenants a season, Redcaps earn a modest wage, approximately a pound of silver each year, which is enough to live on if they do not belong to a covenant.
+Redcaps are traditionally paid in silver by the covenants they visit on their rounds. They can expect to receive a total of three shillings (about twelve pennies) from every covenant they visit, which is paid over the course of three days. The first shilling is given to them on the day they arrive, as payment for their journey. The second shilling is given to them when they present their messages, in appreciation of their service. The third shilling is given to them as they leave the covenant, to ensure their goodwill. By visiting about four covenants a season, Redcaps earn a modest wage, approximately a pound of silver each year, which is enough to live on if they do not belong to a covenant.
 
 If a covenant cannot afford to pay Redcaps and does not otherwise make the visit worth their while, Redcaps may begin to arrive less frequently as word spreads throughout the House. Most covenants eagerly tip the standard amount to encourage Redcaps to visit, and some attempt to curry special favor by making their Redcap's stays very comfortable or giving them special gifts. Vis, especially, is highly prized among messenger Redcaps, and a few pawns every now and then can easily turn them into dedicated allies.
 
@@ -3062,10 +2745,9 @@ There are also political reasons for encouraging Redcaps to remain at a covenant
 
 Even better is to encourage a Redcap to join your covenant, for then his loyalty is to you as well as his House. Most Redcaps prefer this arrangement to living at a Mercer House, as it usually means they don't have to pay their keep and it makes them feel more a part of the Order as a whole. About half of the Redcaps in a given Tribunal usually belong to covenants, and thus do not have to worry as much about how much silver they collect on their rounds. For them, service is a duty and a privilege, not their livelihood.
 
-#### SOCIETAS MERCERIS: FOLLOWERS OF BELIN
+#### Societas Merceris: Followers of Belin
 
 Belin was one of Mercere's most devoted followers, and the last apprentice he ever taught. Her stories have been told so many times throughout the House that she has almost been elevated to a legend herself. It is said that she never shirked her duty, always got her messages through, and constantly put the interests of the Order ahead of her own. Her reputation is so well known that even magi from different Houses might say of a disloyal custos, "he's no Belin."
-
 
 The fact that she was a woman earned her particular admiration, and even grudging respect from her few detractors. In medieval Europe, women do not travel alone, for reasons of safety and propriety, and could expect to be noticed by mundane authorities if they ever did. This made Belin's duties much, much harder, and it is said even Mercere worried that she would not be able to serve the House as well as a man. Yet Belin succeeded, often disguising her appearance through both magical and mundane means, and made her way through human society with awe-inspiring skill and cleverness.
 
@@ -3077,49 +2759,36 @@ Belin only spent about ten years of her life traveling, and afterwards raised ma
 
 ### Merchants and Bankers
 
-House Mercere has always maintained a great interest in commerce and trade. In fact, many Redcaps carry mun-
+House Mercere has always maintained a great interest in commerce and trade. In fact, many Redcaps carry mundane goods in addition to messages for the Order, to supplement their income at Europe's many fairs. However, the most profitable practice the Redcaps have developed in the centuries since the Founding is that of **vis exchange**. Like medieval moneychangers, the Redcaps often carry a variety of different forms of magical currency, which magi find valuable enough to trade for vis that they have no immediate use for.
 
-
-
-
-When keeping records of vis exchanges, "*p*" stands for "pigni," the Latin word for "tokens." However, many magi have come to refer to units of vis as "pawns," as in chess, since the Redcap who popularized this system of exchange often traded literal pawns of vis, tokens shaped into game pieces that indicated their value. According to his terms, ten of these pawns made a "rook," and ten rooks made a "queen." Thus, the abbreviations *r* and *q* are occasionally used to refer to larger quantities of vis, but since p's and q's can be easily confused at a glance, most Redcaps prefer to deal with only one unit of measurement in their accounting.
-
-dane goods in addition to messages for the Order, to supplement their income at Europe's many fairs. However, the most profitable practice the Redcaps have developed in the centuries since the Founding is that of **vis exchange**. Like medieval moneychangers, the Redcaps often carry a variety of different forms of magical currency, which magi find valuable enough to trade for vis that they have no immediate use for.
+> ## Vis Notation
+> 
+> When keeping records of vis exchanges, "*p*" stands for "pigni," the Latin word for "tokens." However, many magi have come to refer to units of vis as "pawns," as in chess, since the Redcap who popularized this system of exchange often traded literal pawns of vis, tokens shaped into game pieces that indicated their value. According to his terms, ten of these pawns made a "rook," and ten rooks made a "queen." Thus, the abbreviations *r* and *q* are occasionally used to refer to larger quantities of vis, but since p's and q's can be easily confused at a glance, most Redcaps prefer to deal with only one unit of measurement in their accounting.
 
 Redcaps follow a simple system of exchange. Generally, they trade one unit of vis for two. To measure these units, they distinguish between vis associated with a Technique (*vis tenta* or *v.t.*, "persistent vis"), and vis associated with a Form (*vis forma* or *v.f.*, "formed vis"). One pawn of *vis tenta* is generally valued the same as two pawns of *vis forma*, since it is less common and more useful. Thus, to make carrying vis worth their while, Redcaps generally adhere to the following exchange rates.
 
 | Covenant  |   | Redcap    | Example                |
 |-----------|---|-----------|------------------------|
-| 1p (v.t.) | = | 1p (v.f.) | 1 Muto for 1 Corpus    |
-| 2p (v.f.) | = | 1p (v.f.) | 2 Aquam for 1 Ignem    |
-| 2p (v.t.) | = | 1p (v.t.) | 2 Intellego for 1 Creo |
-| 4p (v.f.) | = | 1p (v.t.) | 4 Vim for 1 Rego       |
+| *1p (v.t.)* | = | *1p (v.f.)* | 1 Muto for 1 Corpus    |
+| *2p (v.f.)* | = | *1p (v.f.)* | 2 Aquam for 1 Ignem    |
+| *2p (v.t.)* | = | *1p (v.t.)* | 2 Intellego for 1 Creo |
+| *4p (v.f.)* | = | *1p (v.t.)* | 4 Vim for 1 Rego       |
 
 These rates apply to all of Mythic Europe, but may change in a general area based on supply and demand. If a Mercer House needs a particular type of vis, they might encourage Redcaps to trade for it at no additional cost, or even pay more than its common value, trading *vis tenta* for *vis forma*, for example. They may give discounts on large amounts, such as trading four units for five, or conduct straight one-for-one trades if it suits them. However, practically speaking, most magi see this practice as enabling them to spend two pawns of vis to make one, and the convenience of having it brought to them makes it an acceptable exchange.
 
+Redcaps also **borrow** and **lend** vis. Fair practice is to both pay and charge 20% interest annually, and the currency of this interest and the repayment of the principal is determined at the time of the loan. There is some controversy with this practice, as the Church says that charging interest on loans is sinful: the moral crime of usury. Christian moneylenders can sometimes get around this by negotiating payment in a different currency, so that it is not entirely clear what is proﬁt from the loan and what is proﬁt from the exchange. For this reason, Redcaps might loan one form of vis, but require payment in another. 
 
 Not that Redcaps fear charges of usury — most of Europe does not recognize vis as having a monetary value like silver or gold. But dislike of moneylenders and collectors is strong in medieval society, and Merceres do not wish to give magi any cause to hate them. They profit on vis trade, which funds their magic items and longevity potions and so allows them to continue, but banking is not their livelihood, and the House tries to discourage antagonizing their creditors. The goal is to serve the Order, not gouge their sodales.
 
-The Redcaps set quite a humble standard for loans, though magi can borrow vis from each other at whatever terms they like. Characters going into business as vis-
+The Redcaps set quite a humble standard for loans, though magi can borrow vis from each other at whatever terms they like. Characters going into business as vis-lenders would have a hard time competing with the Redcap rates unless they somehow manage to corner the market (say, by gaining control of all the Creo sources in the region). It is unlikely that there would be any legal or spiritual consequences for doing this, except that magi who charge outrageous interest will probably gain poor reputations among their Christian sodales.
 
-### Usurers
-
-Lenders who don't care about accusations of usury might ask closer to 50% interest on common loans, and get away with up to 150% interest when they have a desperate customer. Such characters are extremely unpopular in Mythic Europe, and have many debtors who would be very happy if their creditor were to disappear or die suddenly.
-
-According to precedents set by Roman Law, Jews can lend money at outrageous interest rates to Christians (though not to other Jews) without facing charges of usury. Consequently, Jewish moneylenders are fairly common in parts of Europe where trade is brisk, as their ethnicity allows them to lend at these higher rates. Jewish Redcaps might similarly be willing to lend more vis to magi without collateral, as they can make enough profit on the higher interest to offset the risk of not being paid back.
-
-Players can make a character who is an Usurer (see the Appendix, Virtues and Flaws) to represent this sort of professional focus. Jews should also take the Outsider flaw, while Europeans should take Enemies or some other flaw to represent the consequences of regularly going against the Church. Either sort of character should begin with some experience in the Profession: Accountant Ability.
-
-
-
-
-
-
-
-
-
-
-lenders would have a hard time competing with the Redcap rates unless they somehow manage to corner the market (say, by gaining control of all the Creo sources in the region). It is unlikely that there would be any legal or spiritual consequences for doing this, except that magi who charge outrageous interest will probably gain poor reputations among their Christian sodales.
+> ## Usurers
+> 
+> Lenders who don't care about accusations of usury might ask closer to 50% interest on common loans, and get away with up to 150% interest when they have a desperate customer. Such characters are extremely unpopular in Mythic Europe, and have many debtors who would be very happy if their creditor were to disappear or die suddenly.
+> 
+> According to precedents set by Roman Law, Jews can lend money at outrageous interest rates to Christians (though not to other Jews) without facing charges of usury. Consequently, Jewish moneylenders are fairly common in parts of Europe where trade is brisk, as their ethnicity allows them to lend at these higher rates. Jewish Redcaps might similarly be willing to lend more vis to magi without collateral, as they can make enough profit on the higher interest to offset the risk of not being paid back.
+> 
+> Players can make a character who is an Usurer (see the Appendix, Virtues and Flaws) to represent this sort of professional focus. Jews should also take the Outsider flaw, while Europeans should take Enemies or some other flaw to represent the consequences of regularly going against the Church. Either sort of character should begin with some experience in the Profession: Accountant Ability.
 
 For a typical magus, 10*p* is the maximum amount of a loan. However, as another way to avoid even the semblance of usury, Redcaps often trade vis for the "use" of one of the borrower's vis sources. The legal term for this sort of loan is a **lien**, and it basically means that until the vis is returned, the lender is entitled to the proceeds of the property. The amount of the loan depends upon its annual yield, usually 20% of the principal. So in exchange for the use of a vis source that produces 4*p* a year, the Redcaps would lend up to 20*p*. In this way, magi can negotiate loans of hundreds of pawns, assuming they have sufficient income.
 
@@ -3129,34 +2798,27 @@ Finally, Mercer Houses occasionally **speculate**, funding dangerous expeditions
 
 Redcaps never accept unseen property as collateral. They must witness a demonstration of magical items and watch the collection of vis to verify its value before they agree to the terms of a loan. This is another reason covenants often register their vis sources with House Mercere: should they ever need a loan at short notice, the Redcaps will already have records of where the property is and how much it produces.
 
-In very rare circumstances, Redcaps will exchange or accept payment in silver; but this is usually frowned upon since it is harder for Redcaps to properly vouch for its value, and some Redcaps might be more likely to pocket
+In very rare circumstances, Redcaps will exchange or accept payment in silver; but this is usually frowned upon since it is harder for Redcaps to properly vouch for its value, and some Redcaps might be more likely to pocket the coins than return with them to the treasury. If circumstances warranted, ten pounds of silver might be considered roughly equivalent to a pawn of vis, as an Orderwide starting point for negotiations, though of course this price would fluctuate dramatically depending on the relative availability of vis in the region. Note that Redcaps will never knowingly accept magical or magically-created silver, since it is difficult and even dangerous for them to spend.
 
-### Magical Silver
-
-**A. A. 1347 (A.D. 1208), Stonehenge Tribunal**
-
-*No covenant may put more than two pounds of magically created silver per resident into circulation each year.*
-
-Towards the end of the twelfth century, a number of covenants in the Stonehenge Tribunal were using large amounts of magically created silver. The result was widespread inflation, and the value of silver halved over a few decades. A group of Redcaps brought the issue to Tribunal in 1208, and it was decided that this behavior was interfering with the mundanes, leading them to add the above line to the Peripheral Code. An attempt was made to punish those responsible, but because of the politics of the region the motion was defeated.
-
-The ruling did not cover gold, since gold is not used as currency in England. However, this has brought the issue to the attention of magi throughout Europe, and so most members of the Order practice moderation when using magic to create wealth, to avoid creating a precedent for a Grand Tribunal ruling.
-
-the coins than return with them to the treasury. If circumstances warranted, ten pounds of silver might be considered roughly equivalent to a pawn of vis, as an Orderwide starting point for negotiations, though of course this price would fluctuate dramatically depending on the relative availability of vis in the region. Note that Redcaps will never knowingly accept magical or magically-created silver, since it is difficult and even dangerous for them to spend.
+> ## Magical Silver
+> 
+> **A. A. 1347 (A.D. 1208), Stonehenge Tribunal**
+> 
+> *No covenant may put more than two pounds of magically created silver per resident into circulation each year.*
+> 
+> Towards the end of the twelfth century, a number of covenants in the Stonehenge Tribunal were using large amounts of magically created silver. The result was widespread inflation, and the value of silver halved over a few decades. A group of Redcaps brought the issue to Tribunal in 1208, and it was decided that this behavior was interfering with the mundanes, leading them to add the above line to the Peripheral Code. An attempt was made to punish those responsible, but because of the politics of the region the motion was defeated.
+> 
+> The ruling did not cover gold, since gold is not used as currency in England. However, this has brought the issue to the attention of magi throughout Europe, and so most members of the Order practice moderation when using magic to create wealth, to avoid creating a precedent for a Grand Tribunal ruling.
 
 All of the vis earned from these transactions is taken back to the Mercer House, where it is recorded before it is put back into circulation. Vis-lenders do not get a share of the take; just like other Redcaps, they are paid via the standard commission for showing up at a covenant. However, because vis is a little more dangerous to carry, any time a Redcap delivers an amount into the treasury he is credited with 10% of the total. Most Redcaps carry no more than about 10*p* at a time, which is enough to ensure them a 1*p* profit, but not so much that they cannot cover a loss.
 
-Unscrupulous Redcaps could just hang on to the profits, rather than turning them over to the Mercer House, but they don't really have a use for vis except in their magic items or longevity potions, and for that it needs to be accounted for. All Redcaps have a sort of running vis tab, earning approximately 1*p* each year, and any additional vis they legitimately acquire may be added to their totals. Redcaps can also withdraw their vis if they wish, but they are discouraged from trading it or loaning it out
+Unscrupulous Redcaps could just hang on to the profits, rather than turning them over to the Mercer House, but they don't really have a use for vis except in their magic items or longevity potions, and for that it needs to be accounted for. All Redcaps have a sort of running vis tab, earning approximately 1*p* each year, and any additional vis they legitimately acquire may be added to their totals. Redcaps can also withdraw their vis if they wish, but they are discouraged from trading it or loaning it out as this leads to unnecessary competition within the House.
 
-
-
-
-### Hermetic Charity
-
-The mercantile practices of Redcaps are profitable enough that Mercer Houses occasionally have a surplus of vis. To avoid arousing the envy of their poorer sodales or tempting supernatural powers that punish such wealth, the Redcaps periodically assist deserving magi by leaving gifts of vis during their visits. By tradition, these missions of mercy are conducted at the beginning of winter, when yearly interest payments are paid to their investors, and are usually hidden so that they are not found until after the messenger is gone.
-
-The Redcaps steadfastly refuse to admit that they have anything to do with these gifts, but enough winks and smiles have followed their denials that word of this practice has spread throughout much of the Order, and consequently many covenants believe that Redcaps who visit on the winter solstice are good luck. Young magi tend to be on their best behavior during most of the preceding month, at least when Redcaps are around.
-
-as this leads to unnecessary competition within the House.
+> ## Hermetic Charity
+> 
+> The mercantile practices of Redcaps are profitable enough that Mercer Houses occasionally have a surplus of vis. To avoid arousing the envy of their poorer sodales or tempting supernatural powers that punish such wealth, the Redcaps periodically assist deserving magi by leaving gifts of vis during their visits. By tradition, these missions of mercy are conducted at the beginning of winter, when yearly interest payments are paid to their investors, and are usually hidden so that they are not found until after the messenger is gone.
+> 
+> The Redcaps steadfastly refuse to admit that they have anything to do with these gifts, but enough winks and smiles have followed their denials that word of this practice has spread throughout much of the Order, and consequently many covenants believe that Redcaps who visit on the winter solstice are good luck. Young magi tend to be on their best behavior during most of the preceding month, at least when Redcaps are around.
 
 When Redcaps want new items and longevity rituals, the Mercer Houses contract them from willing magi. A Redcap works with the inventor on the design, who earns a commission of 1*p* for every 10 levels he invests in the device. These contracts are highly sought after, and magi who are good in the lab might try to develop a relationship with their Tribunal's senior Redcaps to get a piece of the action. The Mercer House covers these wages and the rest of the necessary vis for the enchantment (deducting it from the Redcap's account). This typically works out to a cost of about 2*p* per magnitude of the effect, and the House usually extends the courtesy of facilitating this process for any of Mercere's followers with vis to spend.
 
@@ -3168,14 +2830,11 @@ Because Redcaps so often deal in vis and are essentially Hermetic bankers, a Mer
 
 As Tribunals are one of the few places where large groups of magi gather regularly, the mood is often that of a medieval fair, and Redcaps frequently bring a lot of vis to loan and exchange. Other magi bring goods of their own to sell, such as magic devices, arcane materials, and books. Redcaps interested in the mercantile aspects of the House can find good business at Tribunal, and even though they do not usually vote during the proceedings, these opportunities before and after the event are more than enough reason for them to attend.
 
-#### SOCIETAS MERCERIS: THE PAWNBROKERS
+#### Societas Merceris: the Pawnbrokers
 
 The years that followed the Schism War were a new age of Hermetic prosperity, and many Merceres seized upon the commercial opportunities in Ireland and the British Isles. An Italian Redcap named Venafro began seeking out vis in the wild lands left empty by the passing of the Diedne. He had a fondness for the game of chess, which he had learned to play in his birthplace in central Italy, and had fashioned a game piece out of bone and ivory to use as his sigil. When gathering vis using magic items he had commissioned for the purpose, it was his habit to move each unit into one of these pawns, so that he could easily count how much his collection was worth, and he marked each one with a symbol representing its associated Art.
 
-These pawns of vis became immensely popular among magi in all corners of Europe, especially those of
-
-
-House Tremere. Word spread of a dramatic two-day-long certamen fought at the Grand Tribunal, which took the form of a game of chess. One of the contestants made what was regarded as a particularly clever move by all of the spectators, spending eight of Venafro's signature pawns in the process. After this event, it seemed that everyone in the Order wanted their own set.
+These pawns of vis became immensely popular among magi in all corners of Europe, especially those of House Tremere. Word spread of a dramatic two-day-long certamen fought at the Grand Tribunal, which took the form of a game of chess. One of the contestants made what was regarded as a particularly clever move by all of the spectators, spending eight of Venafro's signature pawns in the process. After this event, it seemed that everyone in the Order wanted their own set.
 
 Many other Redcaps and magi joined in to meet the demand, and fashioned vis into chess pieces made from a dizzying variety of materials: hazeltree wood, rock crystal, carved ivory, whale bone, and even walrus tusk. The most famous set, commissioned from Venafro by a very wealthy Tremere magus, had more vis in the bigger pieces: the bishops, knights and towers (or rooks) held 10 pawns' worth, and the kings and queens were each worth 100.
 
@@ -3184,7 +2843,6 @@ Eventually the fad passed, and by 1220 these custom pieces seem out of fashion. 
 There are still Redcaps who engage in the practice of harvesting vis and transferring it into custom shapes, though. They sell these special tokens as art; some of them use coins, others make jewelry, and some have been known to put vis into even more unusual forms, like perfume or tattoos. Why they do this also varies, for some of them wish to use their vis to standardize the currency of the Order, while others see it as beautifying magic in their own small way, and some simply want to make a profit on their craft. In memory of Venafro, they are affectionately referred to as "pawnbrokers" by others in the House.
 
 **Requirements:** None, though they often start out with vis of their own: Pawnbroker Redcaps may trade two levels of their starting magic items for a pawn of vis in their signature shape, and receive one pawn of vis a year from the House in lieu of magic items if they wish. They typically have devices that can measure vis and transfer it into other objects with Rego Vim, and should have at least one Craft Ability. These characters may also take the Hermetic Virtue Personal Vis Source, to represent vis they have discovered in the wild.
-
 
 ### Mercenaries and Guardians
 
@@ -3196,56 +2854,47 @@ When magi build a Mercere's Portal, a custodian is usually assigned to guard the
 
 There are other services that a Redcap might be paid to perform, assuming the price is right. For example, magi occasionally need other resources for their magical activities, such as materials for enchanted items, arcane connections to distant locations, or vis harvested from a dangerous source. Or, he might be contracted to carry an express message across Europe, or travel to someplace that the Redcap network doesn't deliver. Paranoid magi might theoretically employ a custodial Redcap to handle any activity that would normally take them out of the lab — but having them pay the Redcap to accompany them on their dangerous forays makes for a much better story.
 
-As well-traveled members of the Order, Redcaps are often the first to become aware of Hermetic or mundane crimes, as they most often visit the covenants or places
-
-
-
-
-where these events have occurred. Some custodial Redcaps see it as their responsibility to investigate a scene and circumstances thoroughly before the signs have become obscured by time, and to present persuasive evidence (if not convincing proof) of what transpired when bringing it to the attention of a Quaesitor. In this respect they can act as private investigators, assisting Quaesitors with their official duties and helping them prepare their cases.
+As well-traveled members of the Order, Redcaps are often the first to become aware of Hermetic or mundane crimes, as they most often visit the covenants or places where these events have occurred. Some custodial Redcaps see it as their responsibility to investigate a scene and circumstances thoroughly before the signs have become obscured by time, and to present persuasive evidence (if not convincing proof) of what transpired when bringing it to the attention of a Quaesitor. In this respect they can act as private investigators, assisting Quaesitors with their official duties and helping them prepare their cases.
 
 Redcaps can also make excellent spies, as they have access to a lot of secret information and an obvious pretext for just stopping by a covenant. They might be paid to discover where a magus challenged to Wizard's War is hiding, determine the state of a covenant's finances, or simply report on its recent activities. As long as they don't use their magic items, Redcaps cannot be charged with scrying on their sodales, as they cannot use magic to do so. Senior Redcaps do not think much of those who do this, if they happen to find out about it.
 
 Many custodial Redcaps also see it as their role not just to respect but also to **enforce** the decisions of Tribunal — or at least, they see doing so as profitable. This may mean joining the Hoplites and hunting down magi who have been cast out of the Order in exchange for their property, but more often it means collecting vis and magic items when Hermetic justice has ordered their loss, which tends to be seen as a lowly activity unique to custodial Merceres.
 
-Fines assigned as punishment at Tribunal are officially divided between the prosecutor of the case and the treasury. After Tribunal, if a Redcap collects an unpaid fine from the offender and deposits it in the coffers, he is given one-tenth its value from House funds. This makes it a profitable if unpopular duty, since even magi dislike collectors, and they may resent it when a Redcap visits their covenant only to extract payment. It can also be dangerous for the Redcap, since magi who do not agree with the verdict may argue the point with him, or take offense at
-
-### Risky Business
-
-While terribly frowned upon by the Order and the House, brave Redcaps with few scruples sometimes seize damages and fines using subterfuge and stealth. They reason that once a Tribunal has sentenced magi to pay a fine or hand over damages, that property no longer belongs to them. Charges can be brought against magi who fail to pay what they owe by the next Tribunal, but some Redcaps prefer not to wait, and this is often to their advantage. In highly-regulated Tribunals that strictly punish even the lowest of crimes, such cunning practices would probably not succeed, but on the edges of the Order where only obvious breaches of the Code receive official notice, there are many gray areas, as the following excerpts from the Peripheral Code demonstrate.
-
-#### A.A 1290 (A.D. 1151), Transylvanian Tribunal
-
-*Maga Dorisa of Ex Miscellanea charged Constantine of Mercere, a Redcap, with sneaking into her sanctum and taking twelve pawns of Rego vis, thus depriving her of her magical power.* 
-
-*Constantine argued that by contract, Dorisa owed that amount of vis to his sodales, as interest on a loan she had negotiated. He had asked her to settle the debt, and she refused, claiming that she could not pay it. Suspecting that she was lying, he entered her sanctum, avoided her defenses, and retrieved the amount. This he delivered to his sodales "in her better interests."*
-
-*Dorisa countered that there was also more than twelve pawns of Animal vis in her sanctum, and that the Redcap had taken advantage of the situation by seizing the more valuable stash.*
-
-*After deliberation, the presiding Quaesitor determined that Constantine was due twelve pawns and twelve pawns had been paid,* *regardless of the customary value of the two kinds of vis. The Redcap had risked his life by entering her sanctum, but since that was not in itself illegal and no law had been broken, the charges were dismissed.*
-
-#### A.A. 1308 (A.D 1179), Thebes Tribunal
-
-*Bartholomew of Mercere was charged with two counts of depriving the Magus Errantus of Criamon of his magical power. Errantus and other witnesses described a confrontation with the Redcap, where Bartholomew had entered the covenant's council room and wrenched a magical staff from Errantus's hands, ruining a magical ring the magus had been drawing. During the struggle, Bartholomew kicked Errantus hard enough to knock him down, breaking two of the magus's ribs and causing him to be unable to perform magic for the rest of the season. The Redcap then took the staff and fled the scene.*
-
-*Bartholomew reminded the assembly that last Tribunal found that Errantus had stolen the staff from Justina of Criamon, his filia, and had ordered him to return it to her. Though Errantus had many opportunities to discharge this duty, he had not yet done so, and in fact had continued to use the item. Bartholomew maintained that Errantus planned to use it as much as possible before returning it, and that by taking it from him and delivering it to Justina, Bartholomew was merely helping her reclaim her property.*
-
-*The Tribunal acquitted Bartholomew of stealing the device, and Errantus was ordered to pay Justina twelve pawns of vis in damages for his failure to comply with justice. Because Bartholomew had attacked and injured Errantus, he was found guilty of the second charge, and ordered to pay the magus three pawns of vis as recompense for his lost season.*
-
-
-his cheek. Most Redcaps hire an advocate in advance to settle any certamen challenges that may arise from this business.
+Fines assigned as punishment at Tribunal are officially divided between the prosecutor of the case and the treasury. After Tribunal, if a Redcap collects an unpaid fine from the offender and deposits it in the coffers, he is given one-tenth its value from House funds. This makes it a profitable if unpopular duty, since even magi dislike collectors, and they may resent it when a Redcap visits their covenant only to extract payment. It can also be dangerous for the Redcap, since magi who do not agree with the verdict may argue the point with him, or take offense at his cheek. Most Redcaps hire an advocate in advance to settle any certamen challenges that may arise from this business.
 
 When a magus is ordered to pay vis or a magic item as damages, custodial Redcaps may collect it and bring it to the wronged party. As that magus would otherwise have to wait as long as the next Tribunal to receive it, it is customary for him to pay the Redcap a reward for his trouble, typically 10% of its value. If the item is simply to be confiscated, it goes to the Mercere treasury and the Redcap who collects it receives this portion of its value.
 
 Custodial Redcaps also collect payment on loans, gather vis from property on lien, and pay interest to those who have invested in the House. Sometimes, in the course of these activities, they will find that it is necessary to convince magi to make good on their debts. They are not supposed to intimidate or threaten those who cannot pay, but instead try to make other arrangements, at worst bringing charges against them at Tribunal for breach of contract. Nonetheless, some Redcaps do practice less dignified means of collection when resources are scarce. Depending on the degree to which the law is enforced in the Tribunal, custodial Redcaps might get away with convincing magi using magic that causes pain or irritation, blackmail, or seriously injuring or even killing their companions and grogs. Obviously, such brutish Redcaps have very poor reputations among their sodales.
 
-#### SOCIETAS MERCERIS: THE BLOODCAPS
+> ## Risky Business
+> 
+> While terribly frowned upon by the Order and the House, brave Redcaps with few scruples sometimes seize damages and fines using subterfuge and stealth. They reason that once a Tribunal has sentenced magi to pay a fine or hand over damages, that property no longer belongs to them. Charges can be brought against magi who fail to pay what they owe by the next Tribunal, but some Redcaps prefer not to wait, and this is often to their advantage. In highly-regulated Tribunals that strictly punish even the lowest of crimes, such cunning practices would probably not succeed, but on the edges of the Order where only obvious breaches of the Code receive official notice, there are many gray areas, as the following excerpts from the Peripheral Code demonstrate.
+> 
+> **A.A 1290 (A.D. 1151), Transylvanian Tribunal**
+> 
+> *Maga Dorisa of Ex Miscellanea charged Constantine of Mercere, a Redcap, with sneaking into her sanctum and taking twelve pawns of Rego vis, thus depriving her of her magical power.* 
+> 
+> *Constantine argued that by contract, Dorisa owed that amount of vis to his sodales, as interest on a loan she had negotiated. He had asked her to settle the debt, and she refused, claiming that she could not pay it. Suspecting that she was lying, he entered her sanctum, avoided her defenses, and retrieved the amount. This he delivered to his sodales "in her better interests."*
+> 
+> *Dorisa countered that there was also more than twelve pawns of Animal vis in her sanctum, and that the Redcap had taken advantage of the situation by seizing the more valuable stash.*
+> 
+> *After deliberation, the presiding Quaesitor determined that Constantine was due twelve pawns and twelve pawns had been paid,* *regardless of the customary value of the two kinds of vis. The Redcap had risked his life by entering her sanctum, but since that was not in itself illegal and no law had been broken, the charges were dismissed.*
+> 
+> **A.A. 1308 (A.D 1179), Thebes Tribunal**
+> 
+> *Bartholomew of Mercere was charged with two counts of depriving the Magus Errantus of Criamon of his magical power. Errantus and other witnesses described a confrontation with the Redcap, where Bartholomew had entered the covenant's council room and wrenched a magical staff from Errantus's hands, ruining a magical ring the magus had been drawing. During the struggle, Bartholomew kicked Errantus hard enough to knock him down, breaking two of the magus's ribs and causing him to be unable to perform magic for the rest of the season. The Redcap then took the staff and fled the scene.*
+> 
+> *Bartholomew reminded the assembly that last Tribunal found that Errantus had stolen the staff from Justina of Criamon, his filia, and had ordered him to return it to her. Though Errantus had many opportunities to discharge this duty, he had not yet done so, and in fact had continued to use the item. Bartholomew maintained that Errantus planned to use it as much as possible before returning it, and that by taking it from him and delivering it to Justina, Bartholomew was merely helping her reclaim her property.*
+> 
+> *The Tribunal acquitted Bartholomew of stealing the device, and Errantus was ordered to pay Justina twelve pawns of vis in damages for his failure to comply with justice. Because Bartholomew had attacked and injured Errantus, he was found guilty of the second charge, and ordered to pay the magus three pawns of vis as recompense for his lost season.*
+
+#### Societas Merceris: the Bloodcaps
 
 Legend tells that in the vast wilderness between cities, on battlegrounds and sites of massacres, in old Roman forts and ruined peel towers, wicked and violent faeries have lived for centuries. They are drawn to the sites of great slaughter and death, usually on borders where great wars have been fought, such as that region found between England and Scotland. These creatures are described as old, broad-shouldered, and very strong, with long protruding teeth, skinny arms and hands, and great talons like an eagle's claws on each of their fingers.
 
 In the early years of the Order, these faeries were a dangerous threat to Redcaps who traveled in those places, until, it is said, the daughter of one of Mercere's adopted children befriended such a spirit, and married him at midnight in a crumbling church in a frightening parody of the Sacrament. She raised their children as Redcaps, and though many of them now serve the Order, their fearsome appearance and terrible strength still haunt the nightmares and fireside stories of many a borderland peasant.
 
-Whenever they defeat an enemy, be it a challenger in combat or merely an unwary traveler who takes shelter in one of their towers, it is these creatures' dark custom to
-
+Whenever they defeat an enemy, be it a challenger in combat or merely an unwary traveler who takes shelter in one of their towers, it is these creatures' dark custom to dye their caps a brighter shade of red in the blood of their fallen foes, and so members of this lineage are often called “Bloodcaps” by others in the Order. They are very susceptible to the divine realm; it is said that they must ﬂee the sight of the cross or the sound of quoted scripture, for such rites cause their long teeth and nails to fall out one by one.
 
 Most Bloodcaps are only comfortable living alone in haunted ruins, though they may join covenants that allow them the freedom to live far from human intercourse in exchange for their allegiance. Others in whom the faerie blood is not as strong can live as other Redcaps. They make excellent border guards or gatekeepers for Mercere's Portals, and few can match them as intimidating creditors. Because of the legends surrounding them, and the general public's negative associations with these stories, most Redcaps in the British Isles forgo the traditional headgear. Bloodcaps, of course, wear their gory caps with pride.
 
@@ -3257,18 +2906,6 @@ A surprising number of Redcaps serve somewhat reluctantly, working for their liv
 
 Wandering Redcaps might travel all parts of Europe, even going outside its boundaries, and during these trips they occasionally venture into unexplored lands. It is because of their discoveries while on these expeditions that many of them can justify their unusual independence. Primarily, the discovery of unclaimed vis sources funds their aimless ways, which they register with the House and use to purchase magic items. However, there is also an arguably greater value in their trade of news and intelligence.
 
-
-
-### Errant Redcaps
-
-Since Redcaps are officially magi, they have all the rights and privileges of other magi in the Order, including the freedom to do what they wish — there is no law that says they must serve for two seasons of every year. Yet when Redcaps neglect their duties, it angers and upsets true magi, who perceive them as unworthy freeloaders. Merceres fear that if this were to become widespread, it would lead to official restrictions on their activities or even a ruling in the Peripheral Code making the Gift a requirement for membership in the Order. Thus, the House does its best to punish those Redcaps who do not demonstrate the appropriate amount of dedication.
-
-As the House is not particularly well-organized, Redcaps are expected to keep in touch with the senior Redcap in their Tribunal, who can thus ensure that everyone is performing their required duties. Those who do this are rewarded for their service with magic items and longevity potions. Those who do not do this lose the respect of their peers and do not receive these benefits. Some Redcaps accept this tradeoff, preferring to remain apart rather than report to any sort of authority, and are sometimes referred to as Lone Redcaps (see the Appendix, Virtues and Flaws). As long as they do not upset other magi and can be seen to fulfill their obligations, they do not receive sanctions for choosing to keep to themselves and avoiding others in their House.
-
-If a Redcap misses a season or two of his duties he can make it up the following year, but if the time was lost because of other laudable activities of great service to the Order (such as helping to build a covenant, copying books for important magi, or assisting a Quaesitor with an investigation), or because of unavoidable circumstances (grave injury, civil unrest, or impassable roads) it is unlikely that this failure would be counted against him. Attitude and intent are most important in these cases.
-
-When a Redcap blatantly and continually flouts his responsibilities, however, a senior Redcap might mention the problem to the Mercere Primus, who will arrange for a stern warning. The ultimate sanction is to declare the Redcap an orphan ("Orbus"), throwing him out of the House. No one wants this, as no other House is likely to adopt the Redcap, and if Mercere does not accept him back within the year it is effectively a death sentence, since he will be formally cast out of the Order. Usually the threat of this is more than sufficient to steer a wayward Redcap back on track.
-
 Mercer Houses or other covenants will occasionally allow a wandering Redcap to stay and rest for a season, in exchange for sharing worthwhile stories of the outside world with others in the Tribunal. They might be encouraged to write books describing their travels, or to draw maps. Or, they might be allowed to simply relax and enjoy themselves, telling their stories in their cups though many senior Redcaps will find those inclined to be idle more worthwhile tasks than gossiping. Still, a very good story may be worth a short respite from carrying letters, especially if it's information of use to others in the Order.
 
 It is common for retired Redcaps to set up **inns** on well-traveled roads, giving free shelter to members of their House and others in the Order, and making their living by providing a meal and a bed for travelers of Mythic Europe. Merchants, pilgrims, Church representatives, diplomats, returning Crusaders, fairgoers, even mundane messengers — all of them make running a hostelry on a busy route very good business. Other Redcaps set up hospices, funded by charitable donations, where they tend to travelers who are homeless, sick, or injured. These houses can act as subsidiary Mercer Houses, though they are not usually centers of House activity in the Tribunal.
@@ -3277,49 +2914,49 @@ Inns often double as — or are located near — taverns and alehouses, where tr
 
 Some Redcaps practice appropriate **entertainment**, learning performance trades that they can ply at public houses and covenants alike, as a grateful host or audience may pay even better for a show than when they are delivering messages, and even the most reclusive magus might be lured from his lab with the promise of a performance. Occasionally, a group of Redcaps might band together into a troupe of performers and tour Mythic Europe, perhaps overseen by a magus with an interest in the arts. Such shows are said to have a unique magic all of their own, not to be missed, and are royally welcomed at any house they choose to play.
 
-In spite of the alternatives, there are a few Redcaps who seem to do nothing but gamble, drink, and socialize. As a nod to their responsibilities, these wastrels sometimes write poems, compose songs, and generally produce art designed to outlive their brief time on earth. There is nothing necessarily supernatural about their craft — fine art does not absolutely require special virtues — but nevertheless these traveling poets often have an otherworld-
+In spite of the alternatives, there are a few Redcaps who seem to do nothing but gamble, drink, and socialize. As a nod to their responsibilities, these wastrels sometimes write poems, compose songs, and generally produce art designed to outlive their brief time on earth. There is nothing necessarily supernatural about their craft — fine art does not absolutely require special virtues — but nevertheless these traveling poets often have an otherworldly quality about them, perhaps because of their familiarity with magic or their passion for life, and they usually have powerful patrons who financially encourage them in their artistic achievements.
 
+A few of these Redcaps are adopted into the Order for the sole purpose of encouraging their unique talents. They do not carry messages, trade vis, or protect the Order, but instead spend their apprenticeship developing their art to levels of phenomenal virtuosity. " Not all of them pass through House Mercere, but it is less controversial than Houses adopting unGifted followers directly, and it may be possible for Redcaps to join other Houses in the same way.
 
+> ## Errant Redcaps
+> 
+> Since Redcaps are officially magi, they have all the rights and privileges of other magi in the Order, including the freedom to do what they wish — there is no law that says they must serve for two seasons of every year. Yet when Redcaps neglect their duties, it angers and upsets true magi, who perceive them as unworthy freeloaders. Merceres fear that if this were to become widespread, it would lead to official restrictions on their activities or even a ruling in the Peripheral Code making the Gift a requirement for membership in the Order. Thus, the House does its best to punish those Redcaps who do not demonstrate the appropriate amount of dedication.
+> 
+> As the House is not particularly well-organized, Redcaps are expected to keep in touch with the senior Redcap in their Tribunal, who can thus ensure that everyone is performing their required duties. Those who do this are rewarded for their service with magic items and longevity potions. Those who do not do this lose the respect of their peers and do not receive these benefits. Some Redcaps accept this tradeoff, preferring to remain apart rather than report to any sort of authority, and are sometimes referred to as Lone Redcaps (see the Appendix, Virtues and Flaws). As long as they do not upset other magi and can be seen to fulfill their obligations, they do not receive sanctions for choosing to keep to themselves and avoiding others in their House.
+> 
+> If a Redcap misses a season or two of his duties he can make it up the following year, but if the time was lost because of other laudable activities of great service to the Order (such as helping to build a covenant, copying books for important magi, or assisting a Quaesitor with an investigation), or because of unavoidable circumstances (grave injury, civil unrest, or impassable roads) it is unlikely that this failure would be counted against him. Attitude and intent are most important in these cases.
+> 
+> When a Redcap blatantly and continually flouts his responsibilities, however, a senior Redcap might mention the problem to the Mercere Primus, who will arrange for a stern warning. The ultimate sanction is to declare the Redcap an orphan ("Orbus"), throwing him out of the House. No one wants this, as no other House is likely to adopt the Redcap, and if Mercere does not accept him back within the year it is effectively a death sentence, since he will be formally cast out of the Order. Usually the threat of this is more than sufficient to steer a wayward Redcap back on track.
 
-ly quality about them, perhaps because of their familiarity with magic or their passion for life, and they usually have powerful patrons who financially encourage them in their artistic achievements.
-
-A few of these Redcaps are adopted into the Order for the sole purpose of encouraging their unique talents. They do not carry messages, trade vis, or protect the Order, but instead spend their apprenticeship developing their art to levels of phenomenal virtuosity. By arrangement, some of these heralds of the age are invited to join House Jerbiton after swearing the Oath, where they are encouraged to practice their art as "Larta magi." Not all of them pass through House Mercere, but it is less controversial than Houses adopting unGifted followers directly, and it may be possible for Redcaps to join other Houses in the same way.
-
-#### SOCIETAS MERCERIS: THE GOLIARDS
+#### Societas Merceris: the Goliards
 
 Golias was a famous Redcap in the tenth century, a former clerk who joined the House when he lost his post at a monastery in northern France. He didn't have much love for the Order, but he enjoyed wine and women, and wrote lurid poetry and wicked songs about them that were so good that many think he was supernaturally inspired. He also liked to wander, especially in his later years, a vocation that fit perfectly with his job in House Mercere. Fudarus (the domus magna of House Tytalus) was one of his many patrons, and he spent a lot of his free time there, for the magi enjoyed his company and encouraged his ribald talents. In fact, he was a semi-permanent resident when the corruption of House Tytalus came to light, just before the end of the millennium. He was charged with diabolism along with the other magi and cast out of the Order, and all known copies of his works were burned.
 
 His reputation survived, even if he did not, and many years later a small group of artistic magi, Redcaps and their followers revived his name. They called him "Bishop Golias," and considered him a sort of patron saint of their group, the Goliards, or more formally the Ordo Vagarum (OR-doh wag-AH-room, "The Wanderers"). Their philosophy is that the many pleasures of life should be savored and shared, and they communicate this through their song and poetry. They particularly excel at clever parodies of well-known liturgical pieces, changing words to twist their meaning into praise of wine, sex, and gambling. Their heyday is passing, however, for while they produced many great works in the late 1100s and early 1200s, including the famous *Carmina Burana*, by 1220 the Church has begun preaching against them at services and stripping suspected Goliards of church rank.
 
-They still have a small but devoted following within the Order of Hermes in Germany and northern France,
+> ## Medieval Inns
+> 
+> Very few inns in Mythic Europe would fit the common depiction of them in fantasy literature: multiple stories, separate rooms, bath houses, a jolly innkeeper. Most of the time, they are the lowest level of hostelry, a second source of income for a home with an extra bed. Travelers staying with these occasional hosts are expected to bring their own provisions and cook them themselves over the fire, and sleep in the same room as, say, the man and his wife, their teenage daughter, and a one-year-old child.
+> 
+> Even the middling class of inn is not much better. Since the fall of the Roman Empire, baths have become extremely rare, and even chamber pots are scarce. At night, guests make their way outside if they need to relieve themselves, and if they don't get lost in the yard on the way back, they must stumble through the unfamiliar surroundings to try to find their own bed rather than someone else's. Larger hostelries might have several pallets placed right next to each other, and since candles are expensive and dangerous, many travelers have awkward (or happy) encounters when making their way through the crowded darkness.
+> 
+> Grand inns in towns are closer to the stereotype; these houses usually put out a sign with a symbol on it, such as a crown or a wheel, by which they are known to be hostelries and which often suggests what kind of travelers usually stay there. They might have a greater variety of food available for visitors, and even special towels assigned by class, from priests to laymen. Also, many inns are run by foreigners; a German traveler in France appreciates staying with others who speak his language and understand his culture, and so German inns on well-traveled French-German roads do very well.
 
-### Medieval Inns
+They still have a small but devoted following within the Order of Hermes in Germany and northern France, where they continue to preach the Goliardic gospel of enlightened debauchery. Three or four of them are known well for stirring up all sorts of trouble in the cities and schools, and seeking apprentices from the University of Paris and other places where impressionable young students may be found. This would normally be intolerable behavior for Redcaps — and they have been rebuked by the House many times — but their art is genuinely exquisite, and their frank and witty passion has touched the hearts of even the most severe of magi.
 
-Very few inns in Mythic Europe would fit the common depiction of them in fantasy literature: multiple stories, separate rooms, bath houses, a jolly innkeeper. Most of the time, they are the lowest level of hostelry, a second source of income for a home with an extra bed. Travelers staying with these occasional hosts are expected to bring their own provisions and cook them themselves over the fire, and sleep in the same room as, say, the man and his wife, their teenage daughter, and a one-year-old child.
+**Requirements:** To be accepted by the Goliards, characters must take either Clerk or Educated, to represent their academic background, and have a Compulsion to engage in some sort of inspirational vice, usually sex, gambling, or drinking. They tend to be men, but female Goliards are possible. Many of them also have Free Expression or are Inspirational, and might have a Hermetic Patron (see the Appendix, Virtues and Flaws), though these virtues are not essential, for not all Goliards are as accomplished in their artistic endeavors.
 
-Even the middling class of inn is not much better. Since the fall of the Roman Empire, baths have become extremely rare, and even chamber pots are scarce. At night, guests make their way outside if they need to relieve themselves, and if they don't get lost in the yard on the way back, they must stumble through the unfamiliar surroundings to try to find their own bed rather than someone else's. Larger hostelries might have several pallets placed right next to each other, and since candles are expensive and dangerous, many travelers have awkward (or happy) encounters when making their way through the crowded darkness.
-
-Grand inns in towns are closer to the stereotype; these houses usually put out a sign with a symbol on it, such as a crown or a wheel, by which they are known to be hostelries and which often suggests what kind of travelers usually stay there. They might have a greater variety of food available for visitors, and even special towels assigned by class, from priests to laymen. Also, many inns are run by foreigners; a German traveler in France appreciates staying with others who speak his language and understand his culture, and so German inns on well-traveled French-German roads do very well.
-
-where they continue to preach the Goliardic gospel of enlightened debauchery. Three or four of them are known well for stirring up all sorts of trouble in the cities and schools, and seeking apprentices from the University of Paris and other places where impressionable young students may be found. This would normally be intolerable behavior for Redcaps — and they have been rebuked by the House many times — but their art is genuinely exquisite, and their frank and witty passion has touched the hearts of even the most severe of magi.
-
-**Requirements:** To be accepted by the Goliards, characters must take either Clerk or Educated, to represent their academic background, and have a Compulsion to engage in some sort of inspirational vice, usually sex, gambling, or drinking. They tend to be men, but female
-
-
-
-### The Goliard Credo
-
-*I believe — in dice I well believe, That got me often bite and sup, And many a time hath had me drunk, And many a time delivered me From every stitch and every penny. [...]*
-
-*To drink and wench and play at dice Seem to me no such mighty sins... Never man I know descended into Hell for a game. Ask thou something else of me...*
-
-*[...] I believe in wine that's fair to see, And in a barrel of my host More than in the Holy Ghost The tavern is my sweetheart, yea, And Holy Church is not for me. [...]*
-
-*Amen. Priest, I now am through with't. Through with life. Death hath its pain. Too much... Too much... This agony — I'm dying. I to God commend you. I ask it of you — Pray for me.*
-
-— From the Goliards' "Credo au Ribaut"
-
-Goliards are possible. Many of them also have Free Expression or are Inspirational, and might have a Hermetic Patron (see the Appendix, Virtues and Flaws), though these virtues are not essential, for not all Goliards are as accomplished in their artistic endeavors.
+ ## The Goliard Credo
+> 
+> *I believe — in dice I well believe, That got me often bite and sup, And many a time hath had me drunk, And many a time delivered me From every stitch and every penny. [...]*
+> 
+> *To drink and wench and play at dice Seem to me no such mighty sins... Never man I know descended into Hell for a game. Ask thou something else of me...*
+> 
+> *[...] I believe in wine that's fair to see, And in a barrel of my host More than in the Holy Ghost The tavern is my sweetheart, yea, And Holy Church is not for me. [...]*
+> 
+> *Amen. Priest, I now am through with't. Through with life. Death hath its pain. Too much... Too much... This agony — I'm dying. I to God commend you. I ask it of you — Pray for me.*
+> 
+> — From the Goliards' "Credo au Ribaut"
 
 ## Magical Merceres
 
@@ -3333,11 +2970,7 @@ While Mercere magi are not discouraged from voting at Tribunal, they usually abs
 
 In some ways, the House makes Mercere magi feel almost ashamed of their Gift. There is a common taboo against spellcasting in the House; many Merceres believe that magic should be performed behind closed doors, or with invested devices like Redcaps do, and thus Mercere magi often prefer to forgo words and gestures or use small objects that they seem to "activate" when they wish to work magic in front of others. Deleterious Circumstances (in public) and Necessary Condition (casting tools) are appropriate Hermetic Flaws for Mercere magi taught to feel guilty about their magic.
 
-The House has few sexual taboos, however. Because the Gift manifests so unpredictably and apprentices from within the House are preferred, all Merceres are strongly encouraged to have as many children as possible, whether married or not, and thus they have a reputation for
-
-
-
-promiscuity. All Merceres, especially the women, begin having children at young ages, as they are generally expected to have at least one child before they make or commission their longevity rituals. These many children are raised at covenants or in Mercer Houses, and those born with the Gift are treasured while the mundane children who survive the harsh infancy of the Middle Ages are thought to make excellent grogs or might eventually become apprenticed to Redcaps.
+The House has few sexual taboos, however. Because the Gift manifests so unpredictably and apprentices from within the House are preferred, all Merceres are strongly encouraged to have as many children as possible, whether married or not, and thus they have a reputation for promiscuity. All Merceres, especially the women, begin having children at young ages, as they are generally expected to have at least one child before they make or commission their longevity rituals. These many children are raised at covenants or in Mercer Houses, and those born with the Gift are treasured while the mundane children who survive the harsh infancy of the Middle Ages are thought to make excellent grogs or might eventually become apprenticed to Redcaps.
 
 Since Mercere's followers regard their ancestry so highly, they usually know exactly who they are descended from, and tend to practice magic inherited from their masters. Mercere was said to have a natural affinity for Muto, and Creo is highly valued for many reasons (especially healing and making longevity potions), so even Mercere magi who prefer to discover their own magic receive special training in one of those Arts. Thus, starting Mercere magi always take either Puissant Art (Creo) or Puissant Art (Muto) as their free Virtue, unless they are deeply involved with one of the two unique House lineages that follow.
 
@@ -3347,41 +2980,31 @@ Mercere had already taken his first apprentice before the Order formed, and had 
 
 The first follower of Mercere held his ancestors in great awe. Priamitus had little interest in carrying messages, but the old gods fascinated him; as a child he believed his Gift was a blessing and a curse, a sign of heavenly favor and great responsibility, and while traveling with Mercere he came to realize that because of his Gift, when he asked the gods for aid, they listened and responded. As a new magus, he returned to many of these places where legends say the gods had once walked the earth, and he learned much about the ancient rites of worship he practiced. He came to see it as his duty to become a priest of the Cult of Mercury, a new leader of the old order, and returned to Harco to begin this great task.
 
-Other Houses helped him rebuild the Cult, particularly magi of House Flambeau. In fact, it is more accurate to say that he helped them, but because Priamitus learned Mercurian magic from Mercere and taught it to his many
+Other Houses helped him rebuild the Cult, particularly magi of House Flambeau. In fact, it is more accurate to say that he helped them, but because Priamitus learned Mercurian magic from Mercere and taught it to his many followers as a Hermetic lineage, they have special status in the Cult as direct descendants of the priests of old. It is these Mercere magi who describe their Founder as Mercury reborn, and worship him as the greatest manifestation of their Mercurian heritage. Many of them believe that when they die they will ascend through the Magic Realm to join him.
 
-### Cult Practices
+> ### Cult Practices
+> 
+> The Cult of Mercury keeps alive the pagan beliefs of the Romans before the spread of Christianity, where the many great powers of the natural world were worshipped as individual beings, not venerated as aspects of God's creation. Essentially, Mercury Cultists are Mediterranean nature-worshippers, and their ceremonies focus on anthropomorphizing forces like weather, death, love, war and so on. They do not practice human sacrifice, though they do offer animal sacrifices to their gods, and they burn their dead. They also put great store by omens, and practice all forms of divination and ceremonial magic to read and interpret these signs. They avoid the Church and the Dominion, which they see as stifling forces on the practices of pure magic if they consider them at all. Other magi who know about the Cult tend to think its members are backward zealots or dangerous heretics, and though they still honor their Hermetic heritage, they usually prefer to do so from a safe distance.
 
-The Cult of Mercury keeps alive the pagan beliefs of the Romans before the spread of Christianity, where the many great powers of the natural world were worshipped as individual beings, not venerated as aspects of God's creation. Essentially, Mercury Cultists are Mediterranean nature-worshippers, and their ceremonies focus on anthropomorphizing forces like weather, death, love, war and so on. They do not practice human sacrifice, though they do offer animal sacrifices to their gods, and they burn their dead. They also put great store by omens, and practice all forms of divination and ceremonial magic to read and interpret these signs. They avoid the Church and the Dominion, which they see as stifling forces on the practices of pure magic if they consider them at all. Other magi who know about the Cult tend to think its members are backward zealots or dangerous heretics, and though they still honor their Hermetic heritage, they usually prefer to do so from a safe distance.
+About half of all Mercere magi still practice Mercurian magic like their ancestors, and most of their ancient ceremonies were integrated into Magic Theory. The roots of their ancient order can still be seen in spell mastery, for in the earliest days magi knew only a few spells and improved their magic by developing different ways of casting the same spell in different situations. Priamitus learned many of these spell mastery abilities from Mercere, and his followers developed others. They include: Adaptive Casting, Ceremonial Casting, Disguised Casting, Lab Mastery, Learn from Mistakes, and Stalwart Casting. These are described fully in the Appendix (Laboratory, Mastered Spell Special Abilities).
 
-followers as a Hermetic lineage, they have special status in the Cult as direct descendants of the priests of old. It is these Mercere magi who describe their Founder as Mercury reborn, and worship him as the greatest manifestation of their Mercurian heritage. Many of them believe that when they die they will ascend through the Magic Realm to join him.
-
-About half of all Mercere magi still practice Mercurian magic like their ancestors, and most of their ancient ceremonies were integrated into Magic Theory. The roots of their ancient order can still be seen in spell mastery, for in the earliest days magi knew only a few spells and improved their magic by developing different
-
-
-
-
-
-ways of casting the same spell in different situations. Priamitus learned many of these spell mastery abilities from Mercere, and his followers developed others. They include: Adaptive Casting, Ceremonial Casting, Disguised Casting, Lab Mastery, Learn from Mistakes, and Stalwart Casting. These are described fully in the Appendix (Laboratory, Mastered Spell Special Abilities).
-
-### SOCIETAS MERCERIS: THE CULT OF HEROES
+#### Societas Merceris: the Cult of Heroes
 
 The Cult of Mercury includes magi from many different Houses, and is usually found wherever magi practice Mercurian rituals. Within it, or perhaps beside it, there are other smaller groups with similar beliefs and practices, and one of these groups is primarily made up of members of House Mercere. They are known as the Cult of Heroes, and according to them, the great heroes of antiquity still walk the earth. Heracles, Arthur, Beowulf, Gilgamesh they say these legendary figures and others like them were descended from the gods, and the Cult of Heroes believes that they can be born again.
 
-Hero-Cultists seek out exceptional children with supernatural attributes that indicate their divine nature, which they find through stories, investigative magic, or otherworldly visions. They then adopt them into the House as Redcaps. If nurtured and supported by the Order, they believe these potential demigods will grow into the power of their predecessors. Such heroes are very rare; there might be three or four of them in all of Mythic Europe, but their origins are obvious as they are especial-
-
-### Heroes and Magic
-
-The magi of the Cult of Heroes use their magic to improve mere mortals, essentially praying to the gods for blessings on those who worship them. Their greatest ideal, the discovery that they believe would revive the greatness of the ancient world and bring about a new and Heroic Age, is a spell that would create the Gift. While it seems this is not yet possible, they have developed other promising rituals that elevate mundane men and women closer to this ideal. Only the most senior Merceres actually know these spells, but they frequently see use in the Mercurian rituals for which the Cult is famous, and they are often performed as rewards for those who loyally serve the Hero-Cult.
-
-Spells descriptions appear later in this chapter.
-
-*(Characteristic) of the Followers* (CrCo35/CrMe35) *(Characteristic) of the Heroes* (CrCo60/CrMe60) *Mercury's Blessing* (CrVi 25)
-
-ly blessed by nature. They are clearly better than common men and women, and perhaps even superior to magi.
+Hero-Cultists seek out exceptional children with supernatural attributes that indicate their divine nature, which they find through stories, investigative magic, or otherworldly visions. They then adopt them into the House as Redcaps. If nurtured and supported by the Order, they believe these potential demigods will grow into the power of their predecessors. Such heroes are very rare; there might be three or four of them in all of Mythic Europe, but their origins are obvious as they are especially blessed by nature. They are clearly better than common men and women, and perhaps even superior to magi.
 
 **Requirements:** Players who wish to play heroes of the Cult instead of magi must take a special virtue, Blood of Heroes (see the Appendix, Virtues and Flaws), which allows them to take twice as many virtues as flaws during character creation, and also gives them access to other virtues that represent their special connection to the gods. The society also includes normal Redcaps who have an association with the Cult, or who serve one of these heroes. Either type may exchange 10 levels of effects in their starting magic items for a +1 increase to any of their negative Characteristics. Most of them are Pagan (see the Appendix, Virtues and Flaws).
 
 Magi who belong to the Hero-cult should have either Mythic Blood (which allows them to take Heroic Virtues and Flaws) or Mercurian Magic, and should also be Pagan. They may substitute Mastered Spells for Puissant Art as their free virtue, and can choose from the Cult's special mastery abilities in addition to those in ArM5 when assigning this experience.
+
+> ## Heroes and Magic
+> 
+> The magi of the Cult of Heroes use their magic to improve mere mortals, essentially praying to the gods for blessings on those who worship them. Their greatest ideal, the discovery that they believe would revive the greatness of the ancient world and bring about a new and Heroic Age, is a spell that would create the Gift. While it seems this is not yet possible, they have developed other promising rituals that elevate mundane men and women closer to this ideal. Only the most senior Merceres actually know these spells, but they frequently see use in the Mercurian rituals for which the Cult is famous, and they are often performed as rewards for those who loyally serve the Hero-Cult.
+> 
+> Spells descriptions appear later in this chapter.
+> 
+> *(Characteristic) of the Followers* (CrCo35/CrMe35) *(Characteristic) of the Heroes* (CrCo60/CrMe60) *Mercury's Blessing* (CrVi 25)
 
 ### Mutantes
 
@@ -3389,11 +3012,7 @@ Several years after the Order was founded, Mercere took another apprentice, who 
 
 Halfway through his apprenticeship, Mercere lost his Gift and went away suddenly. Like Mercere's first apprentice, the student continued to study on his own and with other magi who took an interest, and he eventually presented himself at Tribunal with the name Hermes Triceres. He had inherited his master's affinity for the new Art of Muto, and demonstrated his abilities by changing himself into three different shapes: a bird, a fish, and a wolf. While the assembled magi agreed he had passed his Gauntlet, they were unwilling to call such a young magus an important name like "Hermes," and instead affectionately named him "Mutant" (MOO-tahnt), meaning "changeling."
 
-Triceres was hurt by this, and felt determined to earn the name he believed he deserved and that his elders denied him. He moved to his master's home at Harco and began working with all the blazing energy that Mercere had put into traveling and charming his sodales, studying and experimenting with Bonisagus's Theory to push what he learned to its limits. He came to specialize in Muto
-
-
-
-Vim, what was later called metamagic, and developed rudimentary versions of spells like Wizard's Reach, which have since been improved by other magi.
+Triceres was hurt by this, and felt determined to earn the name he believed he deserved and that his elders denied him. He moved to his master's home at Harco and began working with all the blazing energy that Mercere had put into traveling and charming his sodales, studying and experimenting with Bonisagus's Theory to push what he learned to its limits. He came to specialize in Muto Vim, what was later called metamagic, and developed rudimentary versions of spells like Wizard's Reach, which have since been improved by other magi.
 
 For most of his life, he had almost no interaction with his father or the rest of the Order. He had sired three children, but none of them could work magic. They also had several children, who were all similarly mundane. When one of his great-grandsons was miraculously born with the Gift, however, Triceres adopted the boy into his magical lineage and taught him everything he could. He had written many books on metamagic, which he gave as his inheritance — copies of these books survive, but few magi think much of them as they are of low quality and the ideas make very little sense to those who do not belong to his lineage.
 
@@ -3405,6 +3024,7 @@ Mutantes call this process "magic-taming." They picture magic as a wild beast or
 
 Thorough grounding in this magical philosophy and their natural affinity with change allows Mutantes to invent spells that have unusual power over magic, altering it in specific ways. Mutantes can use these powers when casting formulaic spells designed to take advantage of them or investing magic items with appropriate effects. They can also write or teach the resulting spells in a way other Mutantes can understand and learn. These changes include:
 
+**Boosting:** By spending a pawn of vis when casting boosted spells or activating a boosted effect in an item, you may increase the Range, Duration, Target, or size of the effect by one magnitude. You can do this multiple times for the same spell. For example, boosting Range from Touch to Sight and Target from Individual to Group would cost you four pawns of vis. You may not reduce any of the parameters of the spell, nor may you exceed the limits of Formulaic magic unless the spell is already a Ritual.Casting success, Fatigue loss, and Penetration are all calculated based on the original level of the spell, but you do add one additional botch die for each pawn of vis used. Mutantes picture this process as "feeding" the magic, using vis to make it grow bigger and stronger.
 
 **Harnessing:** Spells normally last their duration and then end, but harnessed effects are put to work like domesticated animals, and can be released from their service when necessary. They are made to end prematurely simply by the caster concentrating on them; this takes about the same amount of time and concentration as casting a spell, and can be done over any distance. If distracted during this process, the caster may always try again.
 
@@ -3417,7 +3037,7 @@ Mutantes also have three corresponding mastered spell abilities that they can te
 (See the Appendix, Mastered Spell Special Abilities, for details on Boosted Casting, Harnessed Casting, or Tethered Casting.)
 
 
-
+#### Societas Merceris: Milvi Antiquiti
 
 In ancient days, as Diodorus Siculus wrote in his *Bibliotheca Historica*, there were Egyptian shapechangers who served as hereditary priests and also kept records of their magical practices. The roots of these primitive spells were later incorporated into Mercurian rituals and ultimately became part of Hermetic magic. Many of the Mutantes believe that these wizard-priests are the source of their magical blood, and that they are descended from them by way of Mercere the Founder.
 
@@ -3425,18 +3045,27 @@ Other legends unearthed by the Mutantes suggest that these early ancestors of He
 
 Thus, the Milvi Antiquiti, or "kites of old," consists of Mutantes and their companions who seek to preserve and distribute knowledge throughout the Order. They do this in two ways: they make copies of ancient books, and they lend these books to other magi. Because many of their books are in high demand, and because they assume the borrowers will make copies, the Milvi charge a small amount of vis for this service, usually 1p a season or 3p a year. Magi are generally willing to pay this for access to books that they wouldn't see otherwise, and starting covenants can generally get more value from a good book than studying from the vis it costs to borrow it.
 
-### Milvini Spells
-
-The Milvi Antiquiti have developed many spells that make use of their Mutantes heritage and magictaming skills. They generally keep these to themselves, though characters who earn their respect and who have some ability with Mutantum Magic might convince the Milvi to loan them a lab text, or commission a magical item from them, thus making these effects available to magi outside the society.
-
-Spells descriptions appear later in this chapter.
-
-*Twinning the Tome* (CrAn50) *The Transformed Folio* (MuAn35) *Hunter's Lethal Arrow* (PeAn40) *Shape of the Ancient Kite* (MuCo40) *The Tireless Flight* (ReCo20) *Sense the True Path* (InTe15)
-
-
 To carry books from covenant to covenant, the Milvi cast a spell that transforms the bearer and all of his possessions into a bird, traditionally the small hawk of the society, who can then fly unburdened to his destination. The Milvi still carry messages and fulfill other common Redcap duties, but this practice makes it easy for them to also carry valuable and heavy items. They usually keep a list of books that are available from their libraries, and sometimes bring along desirable tomes that they think might tempt magi to borrow them.
 
 **Requirements:** Milvini magi should take Mutantum Magic for their free virtue. Their Redcap followers usually learn Latin, Profession: Scribe and Magic Theory, so that they can write and copy books, and usually have a Milvinus magus for a Hermetic Patron (see Virtues and Flaws). Most have a magic item that casts a version of *Shape of the Ancient Kite* (MuCo40), usually in their feathered caps.
+
+> ## Milvini Spells
+> 
+> The Milvi Antiquiti have developed many spells that make use of their Mutantes heritage and magictaming skills. They generally keep these to themselves, though characters who earn their respect and who have some ability with Mutantum Magic might convince the Milvi to loan them a lab text, or commission a magical item from them, thus making these effects available to magi outside the society.
+> 
+> Spells descriptions appear later in this chapter.
+> 
+> *Twinning the Tome* (CrAn50)
+> 
+> *The Transformed Folio* (MuAn35)
+> 
+> *Hunter's Lethal Arrow* (PeAn40)
+> 
+> *Shape of the Ancient Kite* (MuCo40)
+> 
+> *The Tireless Flight* (ReCo20)
+> 
+> *Sense the True Path* (InTe15)
 
 ### Other Specialties
 
@@ -3447,8 +3076,6 @@ All Mercere's followers tend towards independence with a hint of wanderlust, and
 **Champions.** Redcaps occasionally find themselves at odds with other members of the Order, and the proper method for resolving their differences is through the use of certamen, which Redcaps cannot do. Instead of conceding, some Redcaps seek out a champion to take their part, and so specialized Merceres who aid their sodales by defending their causes in the dueling ring are highly respected.
 
 **Healers.** Since the Schism War, Mercere has been a House devoted to peace, and a few of its magi embrace their duty to the Order by giving succor to their sodales. They craft magic items that help heal the sick and mend the wounded, and practice spells like *Chirurgeon's Healing Touch* (CrCo20) and *Purification of the Festering Wounds* (CrCo20). Many Mercurian magi develop in this direction, as the Rituals cost them much less vis to cast.
-
-
 
 **Rogues.** How easy it would be for Mercere magi to pretend to be Redcaps, visiting other covenants at will and gathering information about them for their own purposes! They can change and even improve their appearances, make sad people happy, alter the spots on dice, and even transform rocks into gold. As long as they are careful to observe Hermetic Law with regard to their sodales, they can have a grand time at the expense of others.
 
@@ -3466,62 +3093,71 @@ Any time magi earn a level in a spell mastery ability, they may choose from thes
 
 Characters who take Mastered Spells during character creation and who have access to these abilities during apprenticeship may spend their mastery points on them if they wish.
 
-#### ADAPTIVE CASTING
+#### Adaptive Casting
 
 (Cult of Mercury)
 
-This special ability may only be taken for General spells. You may use your mastery score and all the special
+You may use your mastery score and all the special abilities associated with it whenever you cast a similar spell. If you have two or more mastery Abilities that apply to a single spell (because you have mastered two or more spells that are similar to the spell you are casting) you may only use the score of one Ability, and the special abilities taken for that mastery Ability. For example, if you have mastered Demon's Eternal Oblivion 30 with a score of 3, and the abilities Adaptive, Fast Casting, and Penetration, and Demon's Eternal Oblivion 25 with a score of 4 and the abilities Adaptive, Quiet Casting twice, and Still Casting, you are must use the score of 3 if you want to use the Penetration ability, and the score of 4 if you want to use the Still Casting ability, and you cannot use the Penetration ability with the score of 4.
 
+> ## Mercere Special Abilities
+> 
+> ### Mercurian Magi
+> 
+> Adaptive Casting
+> 
+> Ceremonial Casting
+> 
+> Disguised Casting
+> 
+> Lab Mastery Learn From Mistakes
+> 
+> Stalwart Casting
+> 
+> #### MUTANTES
+> 
+> Boosted Casting
+> 
+> Harnessed Casting
+> 
+> Tethered Casting
 
-### MERCURIAN MAGI
-
-Adaptive Casting Ceremonial Casting Disguised Casting Lab Mastery Learn From Mistakes Stalwart Casting
-
-#### MUTANTES
-
-Boosted Casting Harnessed Casting Tethered Casting
-
-abilities associated with this spell whenever you cast the same spell at a different level.
-
-#### BOOSTED CASTING
+#### Boosted Casting
 
 (Mutantes)
 
-When casting this spell, you may use vis to increase the Range, Duration, or Target by one magnitude for each pawn spent. You may not boost the Duration to Year or the Target to Boundary unless the spell is already a Ritual.
+When casting this spell, you may use vis to increase the Range, Duration, Target, or size by one magnitude for each pawn spent. You may increase more than one aspect of the same spell. You may not reduce any of the parameters, nor exceed the limits of Formulaic magic unless the spell is already a Ritual. Casting success, Fatigue loss, and Penetration are all calculated based on the original level of the spell, but you do add one additional botch die for each pawn of vis used.
 
-#### CEREMONIAL CASTING
+#### Ceremonial Casting
 
 (Cult of Mercury)
 
 You may use ceremonial methods when casting this spell, increasing the casting time and adding your Artes Liberales and Philosophiae to your total. This cannot be taken for Ritual spells, which always require ceremonial casting.
 
-#### DISGUISED CASTING
+#### Disguised Casting
 
 (Cult of Mercury)
 
 When casting this spell, you may suppress or alter your sigil, to hide your identity or make the spell appear to have been cast by someone else. Since this actually changes your sigil, it is impossible for others to recognize you from it, though magi might be able to recognize that a fake sigil is not genuine. When you mimic the sigil of another magus, you may add your Spell Mastery score to the roll that determines how difficult it is to recognize.
 
-#### HARNESSED CASTING
+#### Harnessed Casting
 
 (Mutantes)
 
-
-
 You may end the effects of this spell at will, simply by concentrating on it. For timing and concentration purposes, treat this as if you were casting the spell. If you are distracted and fail your Concentration roll, you may try again in another round.
 
-#### LAB MASTERY
+#### Lab Mastery
 
 (Cult of Mercury)
 
 You understand the theory of this spell so perfectly that you may add your spell mastery score to your Lab Total when designing effects that are similar to it (see Similar Spells, **Ars Magica** 5th Edition page 101). This is in addition to the standard similar spell bonus.
 
-#### LEARN FROM MISTAKES
+#### Learn from Mistakes
 
 (Cult of Mercury)
 
 The first time in a session that you botch a roll for this spell or fail it by exactly one point, you gain five experience points towards mastery of this spell. The roll must come up naturally in the course of the story.
 
-#### STALWART CASTING
+#### Stalwart Casting
 
 (Cult of Mercury)
 
@@ -3537,12 +3173,7 @@ You may give control of this spell to another person, who is subsequently treate
 
 This activity is generally restricted to Mercere magi. This is because they must spend a season studying an existing Mercere's Portal or the lab notes of someone who has already built one to learn the method of constructing them, and the House prefers to limit access to this information, keeping it exclusively inside House Mercere.
 
-Once the secret method is learned, the magus must design two archways as invested devices, each with an instilled effect of Rego Terram, level 65 (base level 35, +4
-
-
-
-
-Arc; +10 for Unlimited uses). They can be built by different magi in different locations, but both sides of the paired set must include an arcane connection to the other. Portals built after the Schism War always include special passwords, and many of them have linked triggers that only permit a member of House Mercere to activate them.
+Once the secret method is learned, the magus must design two archways as invested devices, each with an instilled effect of Rego Terram, level 65 (base level 35, +4 Arc; +10 for Unlimited uses). They can be built by different magi in different locations, but both sides of the paired set must include an arcane connection to the other. Portals built after the Schism War always include special passwords, and many of them have linked triggers that only permit a member of House Mercere to activate them.
 
 After the two devices are enchanted in the lab, they are moved into place and a magical connecting ceremony similar to *Hermes' Portal* (ReTe75) is performed simultaneously in each location. This ceremony is learned as part of the procedure, and does not require a roll, but until it is completed the devices do not function. Once the two Portals have been connected, they cannot be moved without permanently destroying the effect.
 
@@ -3557,7 +3188,6 @@ Mutantum Magic is a special form of metamagic found primarily in House Mercere. 
 **Boosting:** The Mutantes can spend vis while casting a boosted spell or activating a boosted item to increase the Range, Duration, or Target by one magnitude for each pawn. For example, a spell with Sun duration could be made to last a year by spending two pawns of vis. This vis is spent before the die roll, and increases the number of dice if a potential botch is rolled. Mutantes picture this process as "feeding" the magic, using vis to make it grow bigger and stronger. It is not possible to boost Duration to Year or Target to Boundary unless the spell is a Ritual.
 
 **Harnessing:** Spells normally last their duration and then end, but harnessed effects are put to work like domesticated animals, and can be released from their service when necessary. They are made to end prematurely simply by the caster concentrating on them; this takes about the same amount of time and concentration as casting a spell, and can be done over any distance. If distracted during this process, the caster may always try again.
-
 
 ## Spells
 
@@ -3577,34 +3207,30 @@ Note that the Mutantum Magic Virtue allows a character to learn, cast and invent
 
 These spells are primarily used by the Milvi Antiquiti (see their society description in House Mercere, Mutantes).
 
-#### CREO ANIMAL MUTANTUM SPELLS
+#### Creo Animal Mutantum Spells
 
-**TWINNING THE TOME**
+##### Twinning the Tome
 
 **R:** Touch, **D:** Mom, **T:** Group, **Level 50,** Ritual **Requisites:** Intellego, Terram
 
-This spell creates a nearly perfect copy of the binding and every page of a book you are touching, including illumination, creases, and damages. It requires an Intellego
-
-
-
-
-requisite to determine the shape and size of the pages, and a Terram requisite to create the ink. While an effective method of quickly copying the contents of a book, the vis cost is generally considered prohibitive; Milvi instead use it to recover valuable books that have been stolen or lost, or to copy ancient works that are too fragile to move. Thus, this version of the spell also allows for vis boosting, so that you can accommodate an arcane connection to the book without requiring you to learn another spell.
+This spell creates a nearly perfect copy of the binding and every page of a book you are touching, including illumination, creases, and damages. It requires an Intellego requisite to determine the shape and size of the pages, and a Terram requisite to create the ink. While an effective method of quickly copying the contents of a book, the vis cost is generally considered prohibitive; Milvi instead use it to recover valuable books that have been stolen or lost, or to copy ancient works that are too fragile to move. Thus, this version of the spell also allows for vis boosting, so that you can accommodate an arcane connection to the book without requiring you to learn another spell.
 
 (Base 5, +1 Touch, +2 Group, +5 intricacy, +1 requisites; Boosted)
 
-#### MUTO ANIMAL MUTANTUM SPELLS
+#### Muto Animal Mutantum Spells
 
-#### THE TRANSFORMED FOLIO
+##### The Transformed Folio
 
-**R:** Touch, **D:** Year, **T:** Group, **Level 35,** Ritual
+**R:** Touch, **D:** Year, **T:** Group, **Level 45,** Ritual
 
-This changes all the pages of a book into those of a different book for the duration of the spell. You must touch both books when casting the spell, and may end the spell at any time by concentrating. If the original book is damaged or altered, the contents of the duplicate will change to match it. Milvi occasionally use this spell to lend the same book to several different magi, or to communicate with each other on a long journey. The spell allows for vis boosting, allowing you to copy a book using an arcane connection from wherever you happen to be, and is harnessed so that the book can be quickly returned to normal when the reader is finished with it, or for reasons of secrecy.
+This changes all the pages of a book into those of a different book for the duration of the spell. You must touch both books when casting the spell, and because the spell is harnessed, you may end it at any time by concentrating. If the original book is damaged or altered, the contents of the duplicate will change to match it. Milvi occasionally use this spell to lend the same book to several different magi, or to communicate with each other over a long journey by linking a central book to a Redcap's travel journal. The spell also allows for vis boosting, so that you may copy a book using an Arcane Connection from wherever you happen to be.
+(Base 1, +1 Touch, +4 Year, +2 Group, +5 intricacy; Boosted, Harnessed)
 
-(Base 1, +1 Touch, +4 Year, +5 intricacy; Boosted, Harnessed)
+The Tireless Flight (p. 102): Change the calculation information as follows: (Base 10, +1 Touch, +1 Conc; Boosted, Harnessed, Tethered) 
 
-### PERDO ANIMAL MUTANTUM SPELLS
+#### Perdo Animal Mutantum Spells
 
-#### HUNTER'S LETHAL ARROW
+##### Hunter'S Lethal Arrow
 
 **R:** Touch, **D:** Diam, **T:** Ind, **Level 40**
 
@@ -3612,9 +3238,9 @@ This spell causes an animal to suffer a fatal wound, just as if it had been pier
 
 (Base 30, +1 Touch, +1 Diam; Tethered)
 
-#### MUTO CORPUS MUTANTUM SPELLS
+#### Muto Corpus Mutantum Spells
 
-#### SHAPE OF THE ANCIENT KITE
+##### Shape of the Ancient Kite
 
 **R:** Touch, **D:** Moon, **T:** Ind, **Level 40**
 
@@ -3624,9 +3250,9 @@ You transform the target into a hawk, kite, or other small raptor, and any books
 
 (Base 20, +1 Touch, +3 Moon; Harnessed, Tethered)
 
-#### REGO CORPUS MUTANTUM SPELLS
+#### Rego Corpus Mutantum Spells
 
-#### THE TIRELESS FLIGHT
+##### The Tireless Flight
 
 **R:** Touch, **D:** Conc, **T:** Ind, **Level 20**
 
@@ -3636,15 +3262,13 @@ The spell is tethered so that the target can control the effect, allowing her to
 
 (Base 10, +1 Touch, +3 Moon; Boosted, Harnessed, Tethered)
 
-#### INTELLEGO TERRAM MUTANTUM SPELLS
+#### Intellego Terram Mutantum Spells
 
-#### SENSE THE TRUE PATH
+##### Sense the True Path
 
 **R:** Arc, **D:** Conc, **T:** Ind, **Level 15**
 
 You can sense the direction of any location to which you have an Arcane Connection. You feel an instinctive pull towards its relative position to you while you concentrate, though you must make simple Perception rolls of 6+ to stay on track when traveling on foot through woods or brush, and if your destination moves, the Ease Factor of this roll increases depending on its speed.
-
-
 
 The spell is tethered, so that it may be controlled by another, and boosted so that it may be made to last longer if necessary.
 
@@ -3654,15 +3278,17 @@ The spell is tethered, so that it may be controlled by another, and boosted so t
 
 These spells are associated with the Cult of Heroes, and are rarely found outside of that society.
 
-### CREO CORPUS SPELLS
+#### Creo Corpus Spells
 
-#### (PHYSICAL CHARACTERISTIC) OF THE FOLLOWERS R: Touch, D: Mom, T: Ind, Level 35, Ritual
+##### (Physical Characteristic) of the Followers
+
+R: Touch, D: Mom, T: Ind, Level 35, Ritual
 
 There are four variations of this lesser version of *(Physical Characteristic) of the Heroes* (CrCo60), which permanently increase a physical Characteristic (Strength, Stamina, Dexterity or Quickness) by one, but to no more than 0. During these minor rituals, followers of the Cult of Heroes are purified and anointed with oil, and have their innate weaknesses magically removed, making them truer to their ideal forms, to prepare them for the other, greater rituals.
 
 (Base 30, +1 Touch)
 
-#### (PHYSICAL CHARACTERISTIC) OF THE HEROES
+##### (Physical Characteristic) of the Heroes
 
 **R:** Touch, **D:** Mom, **T:** Ind, **Level 60,** Ritual
 
@@ -3670,14 +3296,17 @@ Each of the four variations of this ritual permanently increases one of the subj
 
 (Base 55, +1 Touch)
 
-#### CREO MENTEM SPELLS
+#### Creo Mentem Spells
 
-#### (MENTAL CHARACTERISTIC) OF THE FOLLOWERS R: Touch, D: Mom, T: Ind, Level 35, Ritual
+##### (Mental Characteristic) of the Followers
+
+R: Touch, D: Mom, T: Ind, Level 35, Ritual
 
 There are four variations of this lesser version of *(Mental Characteristic) of the Heroes* (CrMe60), which permanently increase a mental Characteristic (Intelligence, Perception, Presence or Communication) by one, but to no more than 0. During these minor rituals, followers of the Cult of Heroes are purified and anointed with oil, and have their innate weaknesses magically removed, making them truer to their ideal forms, to prepare them for the other, greater rituals.
 
+(Base 30, +1 Touch)
 
-### (MENTAL CHARACTERISTIC) OF THE HEROES (CRME60)
+##### (Mental Characteristic) of the Heroes (CrMe)
 
 **R:** Touch, **D:** Mom, **T:** Ind, **Level 60,** Ritual
 
@@ -3685,9 +3314,9 @@ Each of the four variations of this ritual permanently increases one of the subj
 
 (Base 55, +1 Touch)
 
-### CREO VIM SPELLS
+#### Creo Vim Spells
 
-#### MERCURY'S BLESSING
+##### Mercury'S Blessing
 
 **R:** Touch, **D:** Year, **T:** Ind, **Level 25,** Ritual
 
@@ -3699,21 +3328,11 @@ This ritual imbues the target with a kind of supernatural aura, similar to Might
 
 These new Virtues and Flaws are most often found in characters belonging to House Mercere, but most are not exclusive to that House.
 
-#### BLOOD OF HEROES
+#### Blood of Heroes
 
 You are descended from a great hero of legend or a powerfully supernatural being. You do not have The Gift, and taking this Virtue means that you are a Mythic Companion.
 
 You should have some idea of the character's heritage, linking your background to the story of some legendary ancient or medieval hero. You need not be descended from that figure, but you should give some thought as to how it has been reborn or made manifest in your character, and consider what you will be expected to accomplish because of it. This will help describe your personality and your heroic powers, though the specifics may remain a mystery to the character if you wish.
-
-
-
-### Mythic Companions
-
-Characters with Blood of Heroes are Mythic Companions, a new character type. These characters are closer in power to Hermetic magi than other companions, and can never have The Gift. More types of Mythic Companion will be introduced in future supplements.
-
-### Heroic Characters in a Saga
-
-Heroic unGifted characters are very rare within House Mercere, even though the Cult of Heroes specifically seeks them out. In the wider world, they are incredibly rare. If possible, you should try to avoid having more than one Heroic unGifted player character in a saga, and if multiple players really want them you should come up with a good reason why there are so many in one place. There are not enough of them in the world for it to be mere coincidence.
 
 You may take Heroic Virtues and Flaws, and each point of Flaws that you take during character creation balances two points of Virtues instead of one. You also receive one free Minor Virtue that describes your supernatural heritage. You must take the Heroic Personality Flaw (described below), and you must normally belong to House Mercere. For most hero characters, this means taking Redcap, and that leaves you with nine more points of Flaws for as many as eighteen points of Virtues. As a member of House Mercere, you are considered a full member of the Order of Hermes and are treated with special respect by your House. Other magi may think less of you, just as they might not think much of Redcaps, but you have much more chance of getting away with voting at Tribunal than a normal unGifted Redcap. Nevertheless, you are normally expected to abstain, out of respect for those with The Gift.
 
@@ -3721,73 +3340,103 @@ This sort of character is very rare, and much more powerful than other unGifted 
 
 Like The Gift, Blood of Heroes is a free Virtue. It is not possible to have both Blood of Heroes and The Gift; magi can gain access to Heroic Virtues and Flaws by taking Mythic Blood. Also like The Gift, Blood of Heroes is not available to grogs; this Virtue makes a character too important to be a grog.
 
-### HEROIC
+> ## Mythic Companions
+> 
+> Characters with Blood of Heroes are Mythic Companions, a new character type. These characters are closer in power to Hermetic magi than other companions, and can never have The Gift. More types of Mythic Companion will be introduced in future supplements.
+> 
+> ### Heroic Characters in a Saga
+> 
+> Heroic unGifted characters are very rare within House Mercere, even though the Cult of Heroes specifically seeks them out. In the wider world, they are incredibly rare. If possible, you should try to avoid having more than one Heroic unGifted player character in a saga, and if multiple players really want them you should come up with a good reason why there are so many in one place. There are not enough of them in the world for it to be mere coincidence.
+
+#### Heroic
 
 Only "Heroic" characters can take Heroic Virtues and Flaws. These are characters with the Blood of Heroes virtue or the Legacy flaw, or magi with Mythic Blood. Other story circumstances such as Latent Magic Ability might warrant taking them, at the storyguide's discretion.
 
 ### Virtues
 
-#### BOOSTED MAGIC
+#### Boosted Magic
 
 *Minor, Hermetic*
 
-By spending a pawn of vis when casting formulaic spells you may "boost" the Range, Duration, or Target of the effect by one magnitude. You can do this multiple times for the same spell. For example, boosting Range from Touch to Sight and Target from Individual to Group would cost you four pawns of vis. This has no effect on spontaneous or Ritual spells, though you can still use vis to boost your Penetration as normal. Note that while magi with Mutantum Magic (see below) can invent spells that allow this, they cannot boost spells that were not designed to do so without taking this Virtue.
+By spending a pawn of vis when casting Formulaic spells you may “boost” the Range, Duration, Target, or size of the effect by one magnitude. You can do this multiple times for the same spell. For example, boosting Range from Touch to Sight and Target from Individual to Group would cost you four pawns of vis. You may not reduce any of the parameters of the spell, nor may you exceed the limits of Formulaic magic. Casting success, Fatigue loss, and Penetration are all calculated based on the original level of the spell, but you do add one additional botch die for each pawn of vis used. This has no effect on Spontaneous or Ritual spells, though you can still use vis to boost your Penetration as normal. Note that while magi with Mutantum Magic (below) can invent spells that allow this, they cannot boost spells that were not designed to do so without taking this Virtue.
 
-### CHARMED LIFE
+#### Charmed Life
 
 *Major, Heroic*
 
 Fortune smiles upon you, often protecting you from the random consequences of adventure. You have the Luck virtue, and whenever you roll a 0 on a stress die in dangerous or deadly circumstances, you may spend a Confidence point to reroll it rather than checking for a botch. This should be applied in chaotic circumstances, not calculated efforts, since luck must play a factor to make use of this virtue — for example, charging into a rain of arrows or diving off a sheer cliff are appropriate actions, but not forging a letter or following a set of tracks.
 
-#### FAERIE BLOOD
+##### Faerie Blood
 
 *Minor, General*
 
-*Bloodcap:* You are descended from a frightening spirit of cruel, dark winter, and receive a +1 bonus to your Strength, though this does not increase your score beyond +3. Your teeth and nails tend to be much longer than normal and you look older than you actually are. You also tend to be very susceptible to the Divine, and should
+*Bloodcap:* You are descended from a frightening spirit of cruel, dark winter, and receive a +1 bonus to your Strength, though this does not increase your score beyond +3. Your teeth and nails tend to be much longer than normal and you look older than you actually are. You also tend to be very susceptible to the Divine, and should take a Flaw to represent that fact. This faerie lineage is rare in humans, and probably found only in characters of House Mercere.
 
+> ## Virtues
+> 
+> Blood of Heroes
+> 
+> ### Hermetic, Major
+> 
+> Tamed Magic
+> 
+> ### Heroic, Major
+> 
+> Charmed Life
+> 
+> Invisible to Magic
+> 
+> Mythic Mimicry
+> 
+> Vis Sensitivity
+> 
+> ### Hermetic, Minor
+> 
+> Boosted Magic
+> 
+> Harnessed Magic
+> 
+> Mutantum Magic
+> 
+> Tethered Magic
+> 
+> ### Heroic, Minor
+> 
+> Gift of Tongues
+> 
+> Great Bearer
+> 
+> Heroes' Birthright
+> 
+> Messenger's
+> 
+> Memory Mythic (Characteristic)
+> 
+> Sure Traveler
+> 
+> ### Status, Minor
+> 
+> Lone Redcap
+> 
+> ### General, Minor
+> 
+> Faerie Blood (Bloodcap)
+> 
+> Magic Items
 
-
-
-Blood of Heroes
-
-**HERMETIC, MAJOR**
-
-Tamed Magic
-
-**HEROIC, MAJOR**
-
-Charmed Life Invisible to Magic Mythic Mimicry Vis Sensitivity
-
-**HERMETIC, MINOR**
-
-Boosted Magic Harnessed Magic Mutantum Magic Tethered Magic
-
-**HEROIC, MINOR**
-
-Gift of Tongues Great Bearer Heroes' Birthright Messenger's Memory Mythic (Characteristic) Sure Traveler
-
-**STATUS, MINOR**
-
-Lone Redcap
-
-**GENERAL, MINOR**
-
-Faerie Blood (Bloodcap) Magic Items
-
-take a Flaw to represent that fact. This faerie lineage is rare in humans, and probably found only in characters of House Mercere.
-
+#### Gift of the Tongues
 
 *Minor, Heroic*
 
 You can understand and speak any language as long as you are communicating directly with someone else who is fluent in that language. Others who hear your words and who understand that language can understand what you are saying. You cannot carry on a conversation in multiple languages, but you can act as a translator for two or more people who do not have this virtue.
 
-### GREAT BEARER
+### Great Bearer
 
 *Minor, Heroic*
 
 You can carry twice as much on your back before you become weighted down, as long as you have time to arrange yourself and your equipment properly. Divide your Burden by two before calculating your Encumbrance. You can also travel twice as far before you become fatigued by a journey.
 
-#### HARNESSED MAGIC
+#### Harnessed Magic
 
 *Minor, Hermetic*
 
@@ -3795,18 +3444,13 @@ You have great control over your spells. You are able to cancel any of your spel
 
 The drawback is that when you die, all of your spells and magic items sputter out.
 
-#### HEROES' BIRTHRIGHT
+#### Heroes ' Birthright
 
 *Minor, Heroic*
 
-You have a special magical power which you can invoke and cancel at will, or which is always active. It should be designed as a Hermetic effect, no greater than Level 15, which works like the Mythic Blood virtue in **Ars Magica** 5th Edition (page 47) with regards to words and gestures. There should be something about your background that explains why you have been blessed in this way, beyond simply having Blood of Heroes — perhaps it is a reward for your heroic actions, or you have been given the power to help you complete an important task. This
+You have a special magical power which you can invoke and cancel at will, or which is always active. It should be designed as a Hermetic effect, no greater than Level 15, which works like the Mythic Blood virtue in **Ars Magica** 5th Edition (page 47) with regards to words and gestures. There should be something about your background that explains why you have been blessed in this way, beyond simply having Blood of Heroes — perhaps it is a reward for your heroic actions, or you have been given the power to help you complete an important task. This virtue can be taken more than once to indicate a more powerful birthright, and is compatible with Mythic Blood, though none of your accumulated powers can have effects greater than Level 30.
 
-
-
-
-virtue can be taken more than once to indicate a more powerful birthright, and is compatible with Mythic Blood, though none of your accumulated powers can have effects greater than Level 30.
-
-#### INVISIBLE TO MAGIC
+#### Invisible to Magic
 
 *Major, Heroic*
 
@@ -3814,35 +3458,33 @@ By concentrating, you can cause yourself to become temporarily invisible to magi
 
 You must make a Stamina + Concentration roll for each spell every round during which you would be affected, against an Ease Factor of 3 + (3 x the magnitude of the spell). For example, avoiding *The Wound That Weeps* (PeCo15) would require a total of at least 12, while *Weight of a Thousand Hells* (CrMe25) would need 18 or more. If you have magic resistance, first check that the spell can "see" you, and then resolve Penetration as normal. Attempting to perform other actions while invisible to magic requires additional Concentration rolls, but you do not need to know where spells are coming from to make yourself invisible to them.
 
-#### LONE REDCAP
+#### Lone Redcap
 
 *Minor, Status*
 
 You are a Redcap who does not maintain ties to a Mercer House, and thus do not receive magic items and longevity potions. You still begin with 300 experience points for your fifteen years spent as an apprentice, and receive the benefits of the Well-Traveled virtue, but you are estranged from the other Redcaps in your area, and have a poor reputation at level 2 within your House.
 
-You must still devote two seasons each year carrying messages and performing other services for the Order, for if you do not there is the possibility you will be declared Orbus and thrown out of your House. This work pays enough for you to live on if you do not belong to a covenant, unless you take the Poor flaw and must work a third season as well. If you take the Wealthy virtue, you can maintain your position with only a single season of effort each year.
+You must still devote two seasons each year carrying messages and performing other services for the Order, for if you do not there is the possibility you will be declared Orbus and thrown out of your House. This work pays enough for you to live on if you do not belong to a covenant, unless you take the Poor flaw and must work a third season as well. If you take the Wealthy virtue, you can maintain your position with only a single season of effort each year. This social status is compatible with any other mundane Social Status Virtue that would reasonably allow you to do your job as a Redcap, such as Merchant or Mendicant Friar.
 
-### MAGIC ITEMS
+#### Magic Items
 
 *Minor, General*
 
 You begin with 25 more starting levels of magic items than you would otherwise, and the rate at which your items are improved is increased by one level per year. This is probably because of your exceptional devotion to the House, or because you have inherited a number of items from other Redcaps. You must be a Redcap to take this virtue, and you may take it more than once, though no single effect in any of your items can be greater than Level 30.
 
-#### MESSENGER'S MEMORY
+#### Messenger'S Memory
 
 *Minor, Heroic*
 
 You can remember, word for word, any short messages you have heard or read in the last year. You must concentrate when you first read or hear the message, but afterwards you can recite or copy it exactly, and you can even recall personalized details like inflection and handwriting, though you may not be able to perfectly reproduce these nuances. While you might recall excerpts of longer works, like an hour-long speech or a book, it is impossible for you to memorize more than a few choice passages.
 
-
-
-
+#### Mutantum Magic
 
 *Minor, Hermetic*
 
 You are descended from the Mutantum lineage, and can thus invent formulaic spells and magic items that take advantage of Boosting, Harnessing and Tethering (see Mutantum Magic, under Magic, above). You may also take the Tamed Magic virtue, and half of your starting spells may be "tamed" versions of common spells. Most characters with Mutantum Magic belong to House Mercere and consider themselves Mutantes, and all of them must be descended by blood from the Founder or one of his ancestors.
 
-### MYTHIC (CHARACTERISTIC)
+### Mythic (Characteristic)
 
 *Minor, Heroic*
 
@@ -3850,85 +3492,98 @@ Because of your great innate potential, you may take a specialty for one of your
 
 Here are some specialty suggestions for each Characteristic.
 
-*Intelligence:* brilliant ideas, quick thinker, great knowledge *Perception:* notices details, big picture, attuned to change *Strength:* killing blows, athletic prowess, brute strength *Stamina:* tireless will, iron constitution, Bacchus's endurance
+*Intelligence:* brilliant ideas, quick thinker, great knowledge
+
+*Perception:* notices details, big picture, attuned to change *
+
+*Strength:* killing blows, athletic prowess, brute strength
+
+*Stamina:* tireless will, iron constitution, Bacchus's endurance
 
 *Presence:* alluring eyes, commanding presence, terrifying visage
 
 *Communication:* prolific author, stirring speaker, strong leader
 
-*Dexterity:* nimble fingers, legendary aim, relentless attacker *Quickness:* lightning-fast defense, sudden strikes, short-distance runner
+*Dexterity:* nimble fingers, legendary aim, relentless attacker
 
-#### MYTHIC MIMICRY
+*Quickness:* lightning-fast defense, sudden strikes, short-distance runner
+
+#### Mythic Mimicry
 
 *Major, Heroic*
 
-This Virtues grants all the abilities of *Messenger's Memory* (see above), but in addition you are so accomplished at memorizing and reciting messages that you can recall accounts of any length, and perfectly recreate the voice or handwriting of the author, so much that it is indistinguishable from the original. Once you have heard or read something from a person, you can easily mimic their voice or writing style, creating perfect imitations if you are so inclined. With a season of effort you can even
+This Virtues grants all the abilities of *Messenger's Memory* (see above), but in addition you are so accomplished at memorizing and reciting messages that you can recall accounts of any length, and perfectly recreate the voice or handwriting of the author, so much that it is indistinguishable from the original. Once you have heard or read something from a person, you can easily mimic their voice or writing style, creating perfect imitations if you are so inclined. With a season of effort you can even memorize an entire book, and reproduce it in another season afterwards, though you must have been able to comprehend the contents to do this accurately.
 
-
-#### SURE TRAVELER
+#### Sure Traveler
 
 *Minor, Heroic*
 
 As long as you have traveled the route before, you never become lost on a journey, and you may add +3 to any Survival rolls based on finding your way through unfamiliar terrain. You are never adversely affected by weather, bad roads, or other negative travel conditions; you can muddle through no matter what, making nearly the same time as you would in ideal circumstances. If you are leading other travelers you can speed the journey for all of you by encouraging them to match your pace. This does not apply when you do not control of the means of travel (riding in a cart, traveling by ship); then you are at the mercy of your driver.
 
-prehend the contents to do this accurately.
-
-#### TAMED MAGIC
+#### Tamed Magic
 
 *Major, Hermetic*
 
 You have the equivalent of both Harnessed Magic and Tethered Magic, but do not suffer the inherent flaws of those Virtues. That is, you can also use the principles of Mutantum Magic to change any of your spontaneous or formulaic spells or effects of magic items that you activate, but your spells and effects are not arcane connections to you and do not sputter out when you die. This virtue may only be taken by characters who also begin with Mutantum Magic (see above).
 
-#### TETHERED MAGIC
+#### Tethered Magic
 
 *Minor, Hermetic*
 
 You can pass control of your non-Ritual spells to others, just as if they were the caster, "tethering" the magic to them for the spell's duration. You may also tether a spell to an object, which can then transfer the spell to an appropriate target when it comes into range. This can even be done whenever you activate an effect in a magic item. However, a side effect of this sort of magic is that all of your spells and the effects of any magic items you activate are arcane connections to you.
 
-#### VIS SENSITIVITY
+#### Vis Sensitivity
 
 *Major, Heroic*
 
-
-
-
-**STORY, MAJOR**
-
-Pagan
-
-**HERMETIC, MINOR**
-
-Bound Magic Fettered Magic Illegitimate Lineage
-
-**HEROIC, MINOR**
-
-Heroic Personality Tragic (Characteristic)
-
-**STORY, MINOR**
-
-Hermetic Patron Legacy
-
-**STATUS, MINOR**
-
-Usurer
-
 You are unusually sensitive to raw vis, and can tell whether or not an object contains any simply by touching it. You can also determine how many pawns it is worth by weighing it in your hand, and learn what Art it is associated with by examining it closely. In this way you can recognize magic items, active rituals, familiars, and other objects that require vis to prepare, though you cannot identify them or determine any specific details about them. You may also begin with the Magic Sensitivity virtue at no cost. Magic Sensitivity is not compulsory, if you do not want the penalty to Magic Resistance.
+
+> ## Flaws
+> 
+> **STORY, MAJOR**
+> 
+> Pagan
+> 
+> **HERMETIC, MINOR**
+> 
+> Bound Magic
+> 
+> Fettered Magic
+> 
+> Illegitimate Lineage
+> 
+> **HEROIC, MINOR**
+> 
+> Heroic Personality
+> 
+> Tragic (Characteristic)
+> 
+> **STORY, MINOR**
+> 
+> Hermetic Patron
+> 
+> Legacy
+> 
+> **STATUS, MINOR**
+> 
+> Usurer
+
 
 ### Flaws
 
-### BOUND MAGIC
+#### Bound Magic
 
 Minor, Hermetic
 
 When you die, all of your spells end abruptly and any magic items that you created cease to function. This suggests that you could have a natural aptitude for Mutantum Magic, or you might take it with Tamed Magic to represent an imperfect understanding of your talent. You cannot take this with Harnessed Magic (**Ars Magica** 5th Edition, page 43), as it already includes this effect.
 
-#### FETTERED MAGIC
+#### Fettered Magic
 
 *Minor, Hermetic*
 
 All of your spells and the effects of any magic items you activate are arcane connections to you. This suggests that you may have a natural aptitude for Mutantum Magic, or you might take it with Tamed Magic to represent an imperfect understanding of your talent. You cannot take this with Tethered Magic, as it already includes this effect.
 
-### HERMETIC PATRON
+#### Hermetic Patron
 
 *Minor, Story*
 
@@ -3938,36 +3593,31 @@ You are watched over by an older magus or a more established Redcap, who conside
 
 You may take this Flaw with a large group of magi as your patrons, though the more numerous your benefactors, the more you will be expected to do for them.
 
-### HEROIC PERSONALITY
+#### Heroic Personality
 
 *Minor, Heroic*
 
-You may take Personality traits of up to +5 or –5, and have a Confidence score of two. You also begin with five Confidence points instead of three. As part of your being a hero, however, you may occasionally do things without knowing why, as you receive guidance or direction from some kind of higher power. Your feelings are so strong that you may lose control of yourself and act on instinct, without thinking about the consequences, allowing the storyguide to bring you into a story or cause you to
+You may take Personality traits of up to +5 or –5, and have a Confidence score of two. You also begin with five Confidence points instead of three. As part of your being a hero, however, you may occasionally do things without knowing why, as you receive guidance or direction from some kind of higher power. Your feelings are so strong that you may lose control of yourself and act on instinct, without thinking about the consequences, allowing the storyguide to bring you into a story or cause you to respond to a situation in a certain way, based on these heroic traits. Thus, you should choose Personality traits that reflect your heroic behavior, to give the storyguide ideas for passions that motivate your character. **Note:** If you take this Flaw, the storyguide *can* occasionally tell you what your character does. If you are not happy with this potential loss of control, do not play a character with heroic blood.
 
-
-
-respond to a situation in a certain way, based on these heroic traits. Thus, you should choose Personality traits that reflect your heroic behavior, to give the storyguide ideas for passions that motivate your character. **Note:** If you take this Flaw, the storyguide *can* occasionally tell you what your character does. If you are not happy with this potential loss of control, do not play a character with heroic blood.
-
-#### ILLEGITIMATE LINEAGE
+#### Illegitimate Lineage
 
 *Minor, Hermetic*
 
 You were raised in House Mercere, but are not descended by blood from Mercere or one of his heirs, and so are not considered a "true Mercere." Because of this, Redcaps do not follow or admire you as they do other magi, and Gifted Merceres think of you as inferior to them. You have a poor reputation (Illegitimate) within the House at level 2, and you receive no special benefits for belonging to House Mercere, such as interest-free loans, magic item contracts, or vis exchanges at no charge. Your parens probably has a poor reputation as well. Only through exemplary service to the Order and taking legitimate apprentices born to Redcaps or other magi descended from the Founder will you be forgiven for your heritage.
 
-#### LEGACY
+#### Legacy
 
 *Minor, Story*
 
 You are descended from a legendary magus or Redcap of old, or have such potential that it is assumed you will rise to similar greatness. Because of this, you are accorded great respect by magi of your House who care about such things, the equivalent of Hermetic Prestige. You may also take Heroic Virtues and Flaws if they are appropriate to your lineage. However, you are also expected to live up to your reputation by performing great deeds, and you are given much more difficult tasks than your peers. As a Redcap, you will not simply be asked to carry messages, for your assigned duties will involve greater danger and much more effort.
 
-#### PAGAN
+#### Pagan
 
 *Major, Story*
 
-You do not follow the teachings of the Church, and have never been baptized. This tends to upset those in authority in Mythic Europe and frighten common people
+You do not follow the teachings of the Church, and have never been baptized. This tends to upset those in authority in Mythic Europe and frighten common people who learn of it. You do not observe Christian holidays, and you try to avoid churchmen and the Dominion. You cannot pretend to go along with society, however, because you believe that it would displease your gods and incur their wrath — you might suffer grave supernatural consequences if you take Communion or appear to worship gods other than your own. You may begin with Magic Lore or Faerie Lore, depending on the speciﬁcs of your faith. (This is not a Flaw in areas of Mythic Europe with substantial pagan populations, but by 1220 the only such areas are in parts of the Novgorod Tribunal.) 
 
-
-#### TRAGIC (CHARACTERISTIC)
+#### Tragic (Characteristic)
 
 *Minor, Heroic*
 
@@ -3985,16 +3635,13 @@ You must take a specialty for one of your negative Characteristics, similar to a
 
 *Dexterity:* easily unbalanced, all thumbs, bad aim *Quickness:* often surprised, lumbering run, easy target
 
-#### USURER
+#### Usurer
 
 *Minor, Status*
 
 You often lend silver or other valuables to people at interest rates that many consider abusive. You get away with this somehow, possibly because you belong to a group that can avoid moral judgment for these actions, because you operate outside of the law, or perhaps because you lend a type of currency not accepted by the mundane population. You receive the equivalent of approximately ten pounds of silver each year from interest payments, though you may occasionally need to chase down debtors, and you have a poor reputation (Usurer) at level 4 within your community and the local region.
 
-
-### Chapter Four
-
-# House Tremere
+### Chapter Four: House Tremere
 
 *Words fail.*
 
@@ -4002,75 +3649,65 @@ You often lend silver or other valuables to people at interest rates that many c
 
 *You will not love or fear me as you loved or feared him, but in this place, beyond mortal dissimulation, I tell you this: we are all he has left for any of us.*
 
-> — The Eulogy for Tremere, spoken by Primus Albanus, beyond the Gate to Hades
+— The Eulogy for Tremere, spoken by Primus Albanus, beyond the Gate to Hades
 
-and that they are soldiers, which is less strident that the Founder intended.
+**Symbol:** Mars incised with a square
 
-The square in the center of the symbol represents a flagstone. This is reminds the House of the importance of Roman roads in the spread of the Empire. The roads provided communication, transport, and ordnance to armies, and members of House Tremere understand each of these aspects of logistics far better than most mundanes. The House sees war as inevitable and sets aside resources for that conflict. Tremere magi draw on this reserve to fund peacetime projects.
-
-**Symbol:** Mars incised with a square **Motto:** *Voluntas vincit omnia.* (The Will conquers all.)
+**Motto:** *Voluntas vincit omnia.* (The Will conquers all.)
 
 Members of House Tremere assume that the world is chaotic and dangerous. They strive to control events and prepare for inevitable, future battles. They cultivate influence and acquire resources to respond to emerging crises. They settle internal arguments with non-fatal duels. Tremere magi are pragmatic, dutiful and courageous.
 
-
-#### WOLVES
-
-Tremere thinking, art and literature praise the ethos of the wolf pack. Wolves are gentle with each other and savage to their enemies. They serve their families, particularly the dominant pair, and aid in the raising of their lair mates' cubs. The Dacians, from the word *daoi* meaning "wolves", ruled Transylvania before the Romans came, and went to war behind wolf-headed dragon ban-
-
 ### Symbols
 
-#### MARS INCISED WITH A SQUARE
+#### Mars Incised with a Square
 
-Members of House Tremere accept the inevitability of war, but no longer hunger for it. Tremere conceived of his House as an army, but his military adventures failed, and then the House suffered terribly during the Schism War. Modern Tremere accept the use of force where necessary, but prize cunning more than their ancestors. Many see the House's mark as a reminder that war is inevitable
+Members of House Tremere accept the inevitability of war, but no longer hunger for it. Tremere conceived of his House as an army, but his military adventures failed, and then the House suffered terribly during the Schism War. Modern Tremere accept the use of force where necessary, but prize cunning more than their ancestors. Many see the House's mark as a reminder that war is inevitable and that they are soldiers, which is less strident that the Founder intended.
 
-### Key Facts
+The square in the center of the symbol represents a flagstone. This is reminds the House of the importance of Roman roads in the spread of the Empire. The roads provided communication, transport, and ordnance to armies, and members of House Tremere understand each of these aspects of logistics far better than most mundanes. The House sees war as inevitable and sets aside resources for that conflict. Tremere magi draw on this reserve to fund peacetime projects.
 
-**Population:** 92 magi (41 in Transylvania)
+#### Wolves
 
-**Domus Magna:** Coeris, in the Transylvanian Tribunal.
-
-**Prima:** Poena
-
-**Favored Tribunals:** Transylvania, where the House
-
-utterly dominates politics.
-
-### Famous Figures
-
-**Tremere,** Founder, developer of certamen. **Cercistum,** Primus at the beginning of the Schism War, killed in battle.
-
-
-
-### Cult Stories
-
-The necromantic cult did not leave the cities to flee the Dominion. Most made lairs in the subterranean spaces of their cities, particularly in places like Naples, which surmounts an enormous cave complex. Occasionally, a Hermetic magus will discover that there was a necromantic presence in a city and mount an expedition to find their cult center.
-
-This is often profitable. The necromancers were not afraid to steal from graves. The defenses of their sites were designed before the invention of the Parma Magica. The Dominion has often invaded the site as the city above expanded, further reducing the effectiveness of the defenses. A few necromantic sites have been claimed by spring covenants. On a few occasions, however, the locations have been revealed to diabolists by their infernal masters.
-
-ners. Tremere's familiar was a white wolf, of a pack sacred to Hermes. Familiars lead the packs about Coeris and many of the other House covenants.
+Tremere thinking, art and literature praise the ethos of the wolf pack. Wolves are gentle with each other and savage to their enemies. They serve their families, particularly the dominant pair, and aid in the raising of their lair mates' cubs. The Dacians, from the word *daoi* meaning "wolves", ruled Transylvania before the Romans came, and went to war behind wolf-headed dragon banners. Tremere's familiar was a white wolf, of a pack sacred to Hermes. Familiars lead the packs about Coeris and many of the other House covenants.
 
 Odd rumors circulate concerning the House's link to wolves. Some say that Tremere magi know the ritual of Mount Lycaeon, which turns men into wolves for nine years, and use it upon rebellious Housemates to adjust their attitude. Some claim that werewolves serve the House, others that the House's servants are equipped with items that change their shapes. Many believe the white wolves of the forest are Tremere spies and saboteurs.
 
-### BUTTERFLY AND TWO-PRONGED FORK
+> ## Key Facts
+> 
+> **Population:** 92 magi (41 in Transylvania)
+> 
+> **Domus Magna:** Coeris, in the Transylvanian Tribunal.
+> 
+> **Prima:** Poena
+> 
+> **Favored Tribunals:** Transylvania, where the House
+> 
+> utterly dominates politics.
+> 
+> ### Famous Figures
+> 
+> **Tremere,** Founder, developer of certamen. **Cercistum,** Primus at the beginning of the Schism War, killed in battle.
+
+> ## Cult Stories
+> 
+> The necromantic cult did not leave the cities to flee the Dominion. Most made lairs in the subterranean spaces of their cities, particularly in places like Naples, which surmounts an enormous cave complex. Occasionally, a Hermetic magus will discover that there was a necromantic presence in a city and mount an expedition to find their cult center.
+> 
+> This is often profitable. The necromancers were not afraid to steal from graves. The defenses of their sites were designed before the invention of the Parma Magica. The Dominion has often invaded the site as the city above expanded, further reducing the effectiveness of the defenses. A few necromantic sites have been claimed by spring covenants. On a few occasions, however, the locations have been revealed to diabolists by their infernal masters.
+
+### Butterfly and Two - Pronged Fork
 
 These two, ancestral symbols are sometimes seen on items significant to the House. The Aita priesthood from which the House descends had the butterfly as its mark. During its period as servants of Pluto, the God of the Underworld and hidden wealth, its symbol was a twopronged pitchfork. Items with these marks are rarely used publicly.
 
 Many Romanians believe that moths, particularly the death's head moth, are shapes of the *moro*. *Moro* are a type of vampire created when parents murder their unbaptized children through exposure in the wilderness. Exposure still happens at times, particularly to Gifted children. Members of the House like to adopt these foundlings, as apprentices or servants, since they tend to be loyal to their saviors.
 
-The pitchfork motif has one noticeable effect on Tremere magi. Many see two as a balanced, sufficient number. They prefer to work in pairs, train two appren-
+The pitchfork motif has one noticeable effect on Tremere magi. Many see two as a balanced, sufficient number. They prefer to work in pairs, train two apprentices, make two copies of letters and so on. This attitude explains why certamen duelists may disallow the first Art that their rival offers, but not the second. Tremere magi call a magus's preferred certamen arts his "tines".
 
-
-
-
-tices, make two copies of letters and so on. This attitude explains why certamen duelists may disallow the first Art that their rival offers, but not the second. Tremere magi call a magus's preferred certamen arts his "tines".
-
-### UNIFORM ROBES
+### Uniform Robes
 
 The formal robes of Tremere magi are dyed with the residue left after vis is extracted from the Waters of Forgetfulness. The Waters are harvested in the funeral cavern at the heart of Coeris, the domus magna of House Tremere. To members of the House, their uniform appearance at Tribunal is a sign of kinship and solidarity. The dye also reminds Tremere magi that the House will care for them until they, too, rest in the cavern.
 
 The dye is self-mordanting, and changes color with time. It is initially blue-black, but deepens in shade as it ages. After about twenty years, the garment is a deep, true black. It fades to charcoal gray after a further thirty. The House dyes spare cloth each year, so that a magus requiring a new robe may request one of suitably venerable hue.
 
-#### MOTTO
+#### Motto
 
 The House motto, — "The Will conquers all" — is rarely used. The Sundering demonstrated that it isn't true and quoting Tremere offends other magi pointlessly. He said several things that they resent, and the Quaesitorial motto opposes House Tremere's. Many Tremere magi favor classical aphorisms, particularly from Xenophon. A quote from King Lycurgus of Sparta serves a moral touchstone: "Obedience is of the highest benefit."
 
@@ -4096,26 +3733,21 @@ There are several, contradictory, epiphany stories explaining Tremere's decision
 
 Tremere's empire building was unsuccessful. A group of magi in the Empire pledged to support each other, accepted Jerbiton's nominal suzerainty, and retook much of the territory Tremere had gained. Forced into a settlement with the Theban League, Tremere sought other ways of achieving power.
 
-Tremere attempted to subvert the Order's legal tradition. He aided Bonisagus in the creation of certamen, and
-
-
-
-### The House View of Tremere in 1220
-
-Members of House Tremere do not venerate the Founder. They respect Tremere, but they are distant enough from him that they can analyze the flaws in his strategies. Many see him as a tragic figure, who reached for more than he could grasp. Although he was rightly doomed for his hubris, they have a sly affection for a person so willing to dare so much. This view is popular outside his House, also.
-
-Many magi assume that were House Tremere ever to discover who ruined their plan for dominating the Order, it would rouse them to war. This isn't accurate, although individual Tremere magi would trouble the descendants of the Sunderers. The spell involved was probably a Perdo Mentem ritual that worked inside Coeris. Many Tremere magi assume that it was a particularly devious blow by Albanus, Tremere's successor. If it was not he, then the House wishes to be sure that it could prevent the same happening again.
-
-then propagated it with the assistance of Trianoma and Jerbiton. He became a master duelist, able, in this limited sphere, to face Flambeau or Tytalus without the need of supporters. In 817 Tremere was able to have the Grand Tribunal accept certamen as "decisive in all disputes", which gave Tremere advantages in pivotal matters.
+Tremere attempted to subvert the Order's legal tradition. He aided Bonisagus in the creation of certamen, and then propagated it with the assistance of Trianoma and Jerbiton. He became a master duelist, able, in this limited sphere, to face Flambeau or Tytalus without the need of supporters. In 817 Tremere was able to have the Grand Tribunal accept certamen as "decisive in all disputes", which gave Tremere advantages in pivotal matters.
 
 In a strategy stretching over decades, Tremere took control of vast sections of the Order. He manufactured disputes, and then settled them with certamen. Some magi respected him as the final Founder. Others were convinced that they needed a strong leader, by Tremere's fear mongering. His House bound others through economic convenience and political aid. In the final stages of his plan, Tremere used naked force to subdue key enemies, and cowed others with threats. Tremere intended to have himself declared overlord of the Order at a special Grand Tribunal in 850.
 
 A group of magi ruined his plans in 848. They broke the minds of Tremere's lieutenants, leaving him vulnerable to the many mages he had browbeaten into submission. The Primus of Guernicus arranged a truce between Tremere and his enemies. In exchange for his promise to cease his attempt to dominate the Order, Tremere's lieutenants were restored. To ensure Tremere kept his promise, the Primus of Guernicus removed his memory of who was responsible or where he had met them. Tremere agreed to have his memories monitored, to ensure he would find no way to recollect his foes.
 
+It is not true to say that he died of disappointment, because Tremere lived until 862, but he was broken by his defeat, and turned the control of his House over to his advisers. Following the Sundering, few trusted the magi of Tremere, and they become insular, retreating to their places of strength.
 
+> ## The House View of Tremere in 1220
+> 
+> Members of House Tremere do not venerate the Founder. They respect Tremere, but they are distant enough from him that they can analyze the flaws in his strategies. Many see him as a tragic figure, who reached for more than he could grasp. Although he was rightly doomed for his hubris, they have a sly affection for a person so willing to dare so much. This view is popular outside his House, also.
+> 
+> Many magi assume that were House Tremere ever to discover who ruined their plan for dominating the Order, it would rouse them to war. This isn't accurate, although individual Tremere magi would trouble the descendants of the Sunderers. The spell involved was probably a Perdo Mentem ritual that worked inside Coeris. Many Tremere magi assume that it was a particularly devious blow by Albanus, Tremere's successor. If it was not he, then the House wishes to be sure that it could prevent the same happening again.
+ 
 ### The House After Tremere
-
-places of strength.
 
 In the eyes of many other magi, House Tremere regained its honor on the battlefield.
 
@@ -4123,21 +3755,6 @@ After a century, the leaders that had faced the Founder had passed away, and alt
 
 It is popular, in parts of the Order, to suggest that perhaps House Diedne did not deserve extermination.
 
-### Why Did They Care?
-
-When rumors began to circulate that the members of House Diedne were practicing human sacrifice, most magi were unconvinced or disgusted, but only House Tremere felt driven to annihilate the druids. The Tremere say that this was a simple matter of principle, and many magi accept that explanation, but there was a deeper reason for their loathing of the Diedne wicker men. House Tremere's ancestors worshipped Aita, then Pluto, then Mercury. They served each god of the dead with devotion for centuries. Their tradition became secular because each god, in turn, abandoned them.
-
-Members of the House will never again love anything so much that they will die for it, except each other. On a level beneath thinking, they remember that they have been three times betrayed. Many Tremere do not trust anything that desires human worship. This colors their view of the religions of others, although there are many Tremere magi who follow the Christian religion, whose God, in an unusual inversion, let humans kill Him.
-
-Tremere magi know that ghosts are less than people. They are just reflections, usually tied to the world by duty or grief or love. Tremere magi understand, with absolute clarity, what happens to a person when they are murdered to please a god.
-
-They don't think that gods are worth it.
-
-
-
-### Amber Eyes
-
-The Tremere returned sight to over a thousand blinded Bulgars with a single ritual, since this was the least expensive method. The new eyes the Bulgars grew were colored amber, the sigil of the maga who cast the ritual. Many of the covenfolk in Transylvania have inherited this eye color, which deepens with Warping. Children with these eyes are often named for the blind bard Thamyris, and are more likely to be homosexual than other characters.
 
 Perhaps, some say, the druids were not the evil figures depicted in stories of the time, which the Tremere magi may have spread anyway. The Schism War, they point out, allowed House Tremere to hold its head high again, so perhaps it was responsible for the general breakdown of Hermetic culture that preceded its intervention. Tremere magi do not believe this to be true.
 
@@ -4147,37 +3764,47 @@ At the end of the Schism, mundane warfare threatened the House's interests. In 1
 
 For around 60 years after the Schism, House Tremere became introspective again. Its leaders continued to interact politically with other magi, but its resources were spent in a reconstruction effort that was, with hindsight, excessive. The leaders of House Tremere knew that the Schism had devastated and impoverished the House, and could not be certain a further challenge did not await them. Many of the House's military magic items date from this time, built to replace items exhausted or destroyed in the Schism War. By 1071, House Tremere's leaders felt that their preparations against the absent leaders of House Diedne and easily corrupted Byzantines had become embarrassingly fulsome. Large numbers of Tremere magi begin to join multi-House covenants in the 1070s, in part to make the House appear less threatening to other magi.
 
+> ## Why Did They Care?
+> 
+> When rumors began to circulate that the members of House Diedne were practicing human sacrifice, most magi were unconvinced or disgusted, but only House Tremere felt driven to annihilate the druids. The Tremere say that this was a simple matter of principle, and many magi accept that explanation, but there was a deeper reason for their loathing of the Diedne wicker men. House Tremere's ancestors worshipped Aita, then Pluto, then Mercury. They served each god of the dead with devotion for centuries. Their tradition became secular because each god, in turn, abandoned them.
+> 
+> Members of the House will never again love anything so much that they will die for it, except each other. On a level beneath thinking, they remember that they have been three times betrayed. Many Tremere do not trust anything that desires human worship. This colors their view of the religions of others, although there are many Tremere magi who follow the Christian religion, whose God, in an unusual inversion, let humans kill Him.
+> 
+> Tremere magi know that ghosts are less than people. They are just reflections, usually tied to the world by duty or grief or love. Tremere magi understand, with absolute clarity, what happens to a person when they are murdered to please a god.
+> 
+> They don't think that gods are worth it.
+
+> ## Amber Eyes
+> 
+> The Tremere returned sight to over a thousand blinded Bulgars with a single ritual, since this was the least expensive method. The new eyes the Bulgars grew were colored amber, the sigil of the maga who cast the ritual. Many of the covenfolk in Transylvania have inherited this eye color, which deepens with Warping. Children with these eyes are often named for the blind bard Thamyris, and are more likely to be homosexual than other characters.
+
+
+
 ### Mortal affairs
 
 The Tremere have never formally decided to foment trouble among the nobility of their Tribunal but, on a purely local basis, they have tended to prevent power aggregating. This lack of powerful nobles has helped fuel an endless cycle of invasion and civil war. During the Twelfth Century, the Byzantine Empire invaded Hungary and Bulgaria, the two principal kingdoms in the Tribunal, over twenty times. Before 1185, patchy civil war was incessant.
 
 In 1185 a pair of brothers, minor lords from near Tirnova, rebelled against the Empire and forced a truce that removed the area north of the Bulgarian mountains from Imperial control. The elder brother, called Asen, began raiding Thrace and Macedonia, forcing Emperor Isaac Angelus to send his forces north. The Bulgarians crushed the Byzantine army, sending shocks through the Empire's government.
 
-The Bulgarian rebellion persisted under a series of kings leading to Ivan Asen II, the current Tsar of Bulgaria. Ivan II claims the title "Emperor of the Bulgars and Greeks" and is a skilled enemy of the Latins who currently occupy Constantinople. He wishes to take the capital from them, to serve as the center of his Bulgar-Greek Empire. The main factor protecting Constantinople from
+The Bulgarian rebellion persisted under a series of kings leading to Ivan Asen II, the current Tsar of Bulgaria. Ivan II claims the title "Emperor of the Bulgars and Greeks" and is a skilled enemy of the Latins who currently occupy Constantinople. He wishes to take the capital from them, to serve as the center of his Bulgar-Greek Empire. The main factor protecting Constantinople from his armies, in the decade following 1220, is that it is the weakest of the four players in the game of empire on the Balkan Peninsula. Ivan is more worried about either Epirus or Nicea than the Latins.
 
-### Peace Initiatives
+> ## Coeris
+> 
+> Coeris, the Domus Magnus of Tremere, is a pleasant place. Tremere originally designated it as a site where damaged warriors could take the waters of forgetfulness and be healed of their psychological injuries.
+> 
+> According to the House's history, Coeris surmounts the Gate of Eurydice, the abyss through which Orpheus departed into the underworld. Some Tremere magi claim that they could visit Hades if they wished, but the use of the Gate of Eurydice causes Warping, so they choose not to. The House as a whole has little practical interest in the Gate of Eurydice, because most Tremere magi many believe it to be a regio that shows visions from the quester's own thoughts and dreams, leading to selfabsorption and detachment from reality.
+> 
+> The Gate of Eurydice is the focus of the House's funereal practices. Tremere's coffin was carried through the Gate of Eurydice, and the ashes of his descendants are poured into it. The walls of the cavern that surround it have ten thousand niches. There is a space for the sigil of every Tremere magus, ordered by Gauntlet date. The Primus, for ceremonial reasons, sometimes removes the Founder's.
+> 
+> Coeris is the ultimate strong point for the House. It is not considered a place of final retreat: the House assumes that by the time Coeris becomes the final bastion of the Order, all hope is likely lost. Coeris is the storehouse where the magi of Tremere keep much of their vast treasury to be expended in future conflicts. It is also their mustering point of preference in times of Europe-wide conflict. That the Primus has immediate call on the House's reserve is not lost on fractious senior Tremere.
+> 
+> Large Tremere House covenants are found in the Tribunals of Transylvania, Iberia, Rome, Stonehenge, and Thebes. Small House covenants are found in five of the other Tribunals. The House covenants serve as storage depots, research facilities and fortified rallying points. Experienced magi, each usually accompanied by a young assistant, live in many of the multiple-house covenants.
+> 
+> Single Tremere magi are sometimes found in covenants at the borders the House's sphere of influence. These magi receive special attention from their superiors, since their position is exposed. They are also likely to be from Transylvania, and unaccustomed to the selfindulgent, short-sighted and tiresome ways of young magi from other traditions. Members of the House hope that these young wizards will develop into experienced magi with assistants of their own, over time.
 
-The previous Primus of Tremere gently supported the Asen rebellion, a policy the current Prima adheres to. This support was not formal alliance. The Primus simply directed that Tremere magi should assist local disputes to non-violent resolution. The Primus believed that stable monarchies would prevent brigandage, invasion, and the diabolism that accompanies widespread suffering. In Hungary, conflicts between the king, Andrew II, and his nobles are also gradually being resolved. The servants of Tremere magi have cordial dealings with many Hungarian nobles, so a constitutional system may develop. The daughter of Andrew II married John II in 1218, partially due to Tremere influence.
-
-
-
-Coeris, the Domus Magnus of Tremere, is a pleasant place. Tremere originally designated it as a site where damaged warriors could take the waters of forgetfulness and be healed of their psychological injuries.
-
-According to the House's history, Coeris surmounts the Gate of Eurydice, the abyss through which Orpheus departed into the underworld. Some Tremere magi claim that they could visit Hades if they wished, but the use of the Gate of Eurydice causes Warping, so they choose not to. The House as a whole has little practical interest in the Gate of Eurydice, because most Tremere magi many believe it to be a regio that shows visions from the quester's own thoughts and dreams, leading to selfabsorption and detachment from reality.
-
-The Gate of Eurydice is the focus of the House's funereal practices. Tremere's coffin was carried through the Gate of Eurydice, and the ashes of his descendants are poured into it. The walls of the cavern that surround it have ten thousand niches. There is a space for the sigil of every Tremere magus, ordered by Gauntlet date. The Primus, for ceremonial reasons, sometimes removes the Founder's.
-
-Coeris is the ultimate strong point for the House. It is not considered a place of final retreat: the House assumes that by the time Coeris becomes the final bastion of the Order, all hope is likely lost. Coeris is the storehouse where the magi of Tremere keep much of their vast treasury to be expended in future conflicts. It is also their mustering point of preference in times of Europe-wide conflict. That the Primus has immediate call on the House's reserve is not lost on fractious senior Tremere.
-
-Large Tremere House covenants are found in the Tribunals of Transylvania, Iberia, Rome, Stonehenge, and Thebes. Small House covenants are found in five of the other Tribunals. The House covenants serve as storage depots, research facilities and fortified rallying points. Experienced magi, each usually accompanied by a young assistant, live in many of the multiple-house covenants.
-
-Single Tremere magi are sometimes found in covenants at the borders the House's sphere of influence. These magi receive special attention from their superiors, since their position is exposed. They are also likely to be from Transylvania, and unaccustomed to the selfindulgent, short-sighted and tiresome ways of young magi from other traditions. Members of the House hope that these young wizards will develop into experienced magi with assistants of their own, over time.
-
-
-
-
-
-his armies, in the decade following 1220, is that it is the weakest of the four players in the game of empire on the Balkan Peninsula. Ivan is more worried about either Epirus or Nicea than the Latins.
+> ## Peace Initiatives
+> 
+> The previous Primus of Tremere gently supported the Asen rebellion, a policy the current Prima adheres to. This support was not formal alliance. The Primus simply directed that Tremere magi should assist local disputes to non-violent resolution. The Primus believed that stable monarchies would prevent brigandage, invasion, and the diabolism that accompanies widespread suffering. In Hungary, conflicts between the king, Andrew II, and his nobles are also gradually being resolved. The servants of Tremere magi have cordial dealings with many Hungarian nobles, so a constitutional system may develop. The daughter of Andrew II married John II in 1218, partially due to Tremere influence.
 
 ## The House in 1220
 
@@ -4207,19 +3834,15 @@ The Magi of Tremere support the Order because, with a handful of gross exception
 
 ### Extent
 
-House Tremere dominates the Transylvania Tribunal absolutely. No Tremere proposal has failed to pass in over two hundred years. In 1220, 41 Tremere magi live in Transylvania, and 51 live in the other Tribunals, an outward-looking political posture. Another 20 magi and redcaps live in Transylvania as guests of the House. These are
+House Tremere dominates the Transylvania Tribunal absolutely. No Tremere proposal has failed to pass in over two hundred years. In 1220, 41 Tremere magi live in Transylvania, and 51 live in the other Tribunals, an outward-looking political posture. Another 20 magi and redcaps live in Transylvania as guests of the House. These are usually specialists, paid to create items and perform research.
 
-
-
-usually specialists, paid to create items and perform research.
-
-The Transylvanian Tribunal is larger than House Tremere can effectively administer. It contains only five covenants, and stretches from the Adriatic to the Black Sea, including all of Hungary and Croatia, with all of Bulgaria north of the Rodopi Mountains. The House has deliberately kept the Tribunal's population far lower than necessary, to allow its members to collect sufficient vis to pay its specialists, fund its projects, and lay aside logistical reserves necessary for war
+The Transylvanian Tribunal is larger than House Tremere can effectively administer. It contains only five covenants, and stretches from the Adriatic to the Black Sea, including all of Hungary and Croatia, with all of Bulgaria north of the Rodopi Mountains. The House has deliberately kept the Tribunal's population far lower than necessary, to allow its members to collect sufficient vis to pay its specialists, fund its projects, and lay aside logistical reserves necessary for war.
 
 Young magi trained in the other Tribunals usually spend at least a few years in Transylvania before resuming duties in other Tribunals. This maintains the cultural cohesiveness of the House. Young magi acting without immediate support, for example those few who join forming Spring covenants just after their Gauntlet, were usually trained in Transylvania.
 
 ### Political Priorities
 
-### BLOCK VOTING
+#### Block Voting
 
 Tremere magi vote in blocks at Tribunal meetings. This allows their leaders to negotiate with other politically powerful magi from a position of strength. It also allows them to coordinate their position in criminal trials. The free proxy of votes to the House's Tribune, their speaker at Tribunal, sidesteps the rulings that prevent magi buying and selling votes on criminal matters.
 
@@ -4229,32 +3852,27 @@ The main tactics that Tremere magi use to reform the Peripheral Code are:
 - Requesting that rulings be reviewed, when circumstances have changed. The Tremere, for example, question the assumption, found in older rulings, that the property of all magi in a covenant is held communally by the covenant. They question what a legitimate dispute, settled by certamen, is.
 - Defining terms in a favorable way. An example occurred when the House argued that giving sanctuary to a faerie prince involved in a civil war, even if it did lead to his rivals to attacking another covenant, was interference, certainly, but not molestation.
 
-### TRANSITIONALISM
+#### Transitionalism
 
 House Tremere advocates changes to the Code that would permit Tribunals to compel magi to assist the Order. Contributions to research covenants, embassies to foreign magical groups and expeditions to distant lands are currently voluntary. Miserly covenants often refuse to assist, knowing that House Bonisagus will share any useful information with them. House Tremere favors a common purse to pay for these things. They also believe that the Order should be able to compel material assistance from every covenant during war.
 
-#### SECULARIZATION OF PUBLIC LIFE
+#### Secularization of Public Life
 
 With the possible exception of the Divine, the Tremere believe that gods are swindlers who deserve no role in the deliberations of magi. This is not a major point in the Order during the Thirteenth Century. Many Tremere magi refuse to swear oaths to Hermes, which offends some of their sodales.
 
-### BORDER AWARENESS
+### Border Awareness
 
 House Tremere is interested in the abilities of the mystical groups beyond the Order's influence. These groups could be a source of useful ideas, or might threaten the Order, so assessing their abilities is prudent. House Tremere currently focuses on the abilities of Islamic wizards.
 
-#### STORING UP MATERIEL
+#### Storing Up Materiel
 
-Tremere magi constantly seek to strengthen and enrich the House. The House claims many vis sites and sources of mundane wealth, and spares a portion of all
+Tremere magi constantly seek to strengthen and enrich the House. The House claims many vis sites and sources of mundane wealth, and spares a portion of all that it collects, against future strife. Tremere magi avoid wasting the House's resources, which makes their lives less luxurious than those of their sodales. Tremere magi use the treasures of the House, during peacetime, to fund projects that bring in greater wealth, or that make minor conflicts less likely.
 
-### Hospitality
+> ## Hospitality
+> 
+> Hospitality is the gift of somewhere safe to rest, goods required for a journey to continue, and defense against those wishing to attack the guest. The Tremere support the right of wizards to engage in War, but a Tremere magus hunted by a superior foe does not consider it dishonorable to hide in the sanctum of a senior Tremere magus. To do so is an admission that the younger magus is not an equal of their patron, but this is less embarrassing for Tremere magi than those of other Houses.
 
-Hospitality is the gift of somewhere safe to rest, goods required for a journey to continue, and defense against those wishing to attack the guest. The Tremere support the right of wizards to engage in War, but a Tremere magus hunted by a superior foe does not consider it dishonorable to hide in the sanctum of a senior Tremere magus. To do so is an admission that the younger magus is not an equal of their patron, but this is less embarrassing for Tremere magi than those of other Houses.
-
-
-
-
-that it collects, against future strife. Tremere magi avoid wasting the House's resources, which makes their lives less luxurious than those of their sodales. Tremere magi use the treasures of the House, during peacetime, to fund projects that bring in greater wealth, or that make minor conflicts less likely.
-
-#### CONTACTS WITH OUTSIDERS
+#### Contacts with Outsiders
 
 House Tremere interacts frequently with the groups protected from harm by the Code. The Tremere would prefer an open détente with the faeries, church and nobility of Europe, explaining the Order's aims, their prohibitions against molestation, and the services which magi are permitted to provide in exchange for land or other favors.
 
@@ -4282,8 +3900,6 @@ A key duty of Tremere magi is to answer the call to arms. In times of crisis, Ho
 
 Other duties include:
 
-
-
 - negotiating with the landholders and churchmen in the immediate area.
 - collecting vis from a site frequented by minor, hostile faeries or magical creatures.
 - finding and claiming a suitable Gifted child as an apprentice for a superior.
@@ -4308,7 +3924,7 @@ Assume a young magus may have one form of aid at a time and that it takes a comp
 
 The House cannot provide every item on this list at demand. Its ships and horses, for example, provide logistical support in times of crisis, so they center their peacetime activities on the House covenants that act as mustering points. Distant Tremere magi may find it difficult to access them. The House's supply of magic items is not limitless and new items are not created for young magi. Senior members of the House have preferential call on its logistical reserves.
 
-### THE ROLE OF SKILLED MAGI
+#### The Role of Skilled Magi
 
 A magus who has served the House well for a period of years, and come to the attention of the experienced magi, is trusted with tasks of greater importance and risk. These magi are respected members of their covenants and have significant influence, in their surrounding area, with lesser noblemen and the leaders of small church establishments. They spend more time in the service of the House than the youngest magi, but their masters try to balance the demand that they serve the House now with their need to serve it better in future.
 
@@ -4333,30 +3949,13 @@ Forms of support often given to magi of this level include:
 - the use of a debt owed to the House by a significant nobleman, or an abbot.
 - the hire of a small group of mercenaries.
 
-A magus at this level of skill can have two types of support from the list above. Each of the types of support above may be traded for three types of support in the previous list. Senior magi often choose to give skilled magi
+A magus at this level of skill can have two types of support from the list above. Each of the types of support above may be traded for three types of support in the previous list. Senior magi often choose to give skilled magi more support than this, particularly the assistance of young magi.
 
-
-
-
-more support than this, particularly the assistance of young magi.
-
-#### THE ROLE OF EXPERIENCED MAGI
+#### The Role of Experienced Magi
 
 An experienced magus is one trusted to act, with little supervision, in the interests of the House. If he lives outside the House covenants, he is likely to be the House's representative in a broad geographical area. He deals with problems as they emerge, and although he works within the House's strategy, he enjoys great freedom concerning his methods of completing tasks. An experienced magus is one who has come into his power, and is expected to lead members of the House less powerful than he.
 
-Some experienced magi are skilled in dealing with a particular threat, dark faeries for example. The House uses
-
-### Material Aid in Your Saga
-
-Storyguides and players should negotiate the degree of aid provided to Tremere characters.
-
-The system of aid is the Tremere alternative to the fantastic powers granted to other Houses, like Merinita and Criamon. It is practical, and powerful, but too slow to be useful in emergencies. In sagas where stories favor another House, the troupe may decide that Tremere characters receive greater aid. Similarly, in campaigns that focus on mundane and magical intrigue, the Tremere magus might receive less aid. High fantasy sagas may justify more aid, historically realistic sagas may require less.
-
-The system of aid also compensates Tremere magi for the seasons of study they lose in the service of their House. Tremere magi have access to excellent books, and loans of vis, so that they fall only slightly behind their age-mates. If the demands of the House are making a player character far weaker than his sodales, then the troupe should increase the level of aid. Similarly, characters developing far more rapidly than others in the group owe time to the House.
-
-Troupes should justify changes in the level of aid. A more parsimonious or generous magus replaces an exarch. The character's pet project may fall into, or from, favor, due to changes in the threat perceptions of the senior magi of the House. Major projects may strip the House of particular resources, or the conclusion of long-running projects creates a sudden surplus. As a campaign evolves, the interests of players and their characters change. The degree of aid should wane, and wax, in sympathy with the saga's themes.
-
-them as problem-solvers, rather than as part of the geographical web of command. These magi often travel extensively, enjoying hospitality from Tremere covenants.
+Some experienced magi are skilled in dealing with a particular threat, dark faeries for example. The House uses them as problem-solvers, rather than as part of the geographical web of command. These magi often travel extensively, enjoying hospitality from Tremere covenants.
 
 The duties of experienced Tremere magi include:
 
@@ -4383,15 +3982,21 @@ Resources available to experienced magi include:
 - the use of a warship, or a small force of grogs familiar with Hermetic magic.
 - the use of a debt owed to the House by a minor king or bishop.
 
-An experienced magus may select three forms of support from the list above. Each of these slots may be traded for either three choices on the skilled magus list, or nine choices on the young magi list. The Exarch will often give further assistance if the magus has been set a difficult
-
-
-
-task. This can include the assistance of magi specialized in dealing with particular sorts of problems.
+An experienced magus may select three forms of support from the list above. Each of these slots may be traded for either three choices on the skilled magus list, or nine choices on the young magi list. The Exarch will often give further assistance if the magus has been set a difficult task. This can include the assistance of magi specialized in dealing with particular sorts of problems.
 
 A magus of this level does not need to pay back the money or vis he spends, but does need to show a consistent pattern of success that justifies his expenditures. A magus who uses a slot to acquire a gift from the House can regain the slot by returning items of equal worth, or by waiting until his superiors deem him to have served off the gift.
 
-### THE ROLE OF THE EXARCHS
+> ## Material Aid in Your Saga
+> 
+> Storyguides and players should negotiate the degree of aid provided to Tremere characters.
+> 
+> The system of aid is the Tremere alternative to the fantastic powers granted to other Houses, like Merinita and Criamon. It is practical, and powerful, but too slow to be useful in emergencies. In sagas where stories favor another House, the troupe may decide that Tremere characters receive greater aid. Similarly, in campaigns that focus on mundane and magical intrigue, the Tremere magus might receive less aid. High fantasy sagas may justify more aid, historically realistic sagas may require less.
+> 
+> The system of aid also compensates Tremere magi for the seasons of study they lose in the service of their House. Tremere magi have access to excellent books, and loans of vis, so that they fall only slightly behind their age-mates. If the demands of the House are making a player character far weaker than his sodales, then the troupe should increase the level of aid. Similarly, characters developing far more rapidly than others in the group owe time to the House.
+> 
+> Troupes should justify changes in the level of aid. A more parsimonious or generous magus replaces an exarch. The character's pet project may fall into, or from, favor, due to changes in the threat perceptions of the senior magi of the House. Major projects may strip the House of particular resources, or the conclusion of long-running projects creates a sudden surplus. As a campaign evolves, the interests of players and their characters change. The degree of aid should wane, and wax, in sympathy with the saga's themes.
+
+#### The Role of the Exarchs
 
 The exarchs are senior Tremere placed in command of the House's operations in one or more Tribunals. There are currently six exarchs. One supervises each of the Rhine and Roman Tribunals. Another oversees the Theban and Levant tribunals, although in time the Levant may become a unique exarchate, as its exarch has granted the tribune broad powers beyond his role as advocate. Provencal and Iberia share an exarch. The exarchate based in Stonehenge Tribunal controls the three British Tribunals and Normandy. Transylvania, Novgorod and the Greater Alps comprise the final exarchate. This exarch's role includes traveling as a spokeswoman for the Prima, since her exarchate includes tribunals where the House is either ubiquitously powerful or all but absent.
 
@@ -4411,13 +4016,7 @@ The duties of an exarch may include:
 
 Resources available to exarchs include:
 
-• the gift of vast quantities of silver or 12 pawns of vis,
-
-
-During the violent portions of the House's history, it was usual for Tremere magi to serve in small, mobile squads. Each member had a set of skills that complemented those of the other members of the group. These military units, called *vexillations*, still exist within the House, but in 1220 the term is used for any group of magi who have been given a single task. The leader of an important vexillation is often given a pennant enchanted with useful effects. Most vexillation pennants were designed for military use, and assist communication and travel.
-
-Senior Tremere magi call vexillations for important tasks together from across the breadth of Europe. The order to "assemble beneath the flag" is keenly anticipated by Tremere magi. It gives them an opportunity to collaborate with their peers within the House. Members are usually ordered to bring allies or equipment that their superior feels will prove useful, so magi of other Houses often assist Tremere vexillations.
-
+- the gift of vast quantities of silver or 12 pawns of vis,
 - the loan of a masterpiece concerning an Art, or a magical item of extraordinary power. Items are often created to order for magi of this level of responsibility.
 - the secret services of groups of highly-skilled individuals, including soldiers trained to hunt magi, and friendly troupes of faeries.
 - the assistance of experienced Tremere magi.
@@ -4428,52 +4027,53 @@ An exarch may choose three items from this list, each tradable for three picks o
 
 The battle banner of each exarch is an enchanted, wolfish dragonhead, carried on a pole. Attached to it is a long cone of fabric, which catches the wind as a tail, but is not enchanted. Various heads have differing powers: at least two spit flame. A banner bearer, who often has a pole as a talisman, attends each exarch.
 
+> ## Vexilations
+> 
+> During the violent portions of the House's history, it was usual for Tremere magi to serve in small, mobile squads. Each member had a set of skills that complemented those of the other members of the group. These military units, called *vexillations*, still exist within the House, but in 1220 the term is used for any group of magi who have been given a single task. The leader of an important vexillation is often given a pennant enchanted with useful effects. Most vexillation pennants were designed for military use, and assist communication and travel.
+> 
+> Senior Tremere magi call vexillations for important tasks together from across the breadth of Europe. The order to "assemble beneath the flag" is keenly anticipated by Tremere magi. It gives them an opportunity to collaborate with their peers within the House. Members are usually ordered to bring allies or equipment that their superior feels will prove useful, so magi of other Houses often assist Tremere vexillations.
+> 
+> Some vexillations never disband, because they have tasks that they cannot finish. These vexillations encourage young Tremere magi to become worthy inheritors of the task. There are many continuing vexillations, and many invite members from outside the House.
+> 
+> ### Abyssal Bearer Vexillation
+> 
+> *Task: To ensure no Tremere magus is left unburied. Beyond the emotional appeal of doing the correct thing for deceased relatives, the House does not want ghosts of its magi to fall into enemy hands.*
+> 
+> Members of this vexillation have the ultimate responsibility for ensuring the safety of Tremere magi. This vexillation contains four members, each the descendant, eldest student by eldest student, of a magus who carried Tremere's coffin into the Gate of Euridyce. They have many other demands on their time, and some lack detective skill, so they seek the assistance of other Tremere magi when they suspect trouble.
+> 
+> Leader: Since the First Primus, Albanus, was one of Tremere's coffin-bearers and was his oldest student, the leader of this vexillation is the descendant, eldest by eldest, from the Founder. She is a young maga in a spring covenant, who finds her responsibilities arduous.
+> 
+> ### Burning Acorn Vexillation
+> 
+> *Task: To discover the whereabouts of the leaders of House Diedne. Arguably, this is the least successful of the continuing vexillations, but they don't let that worry them.*
+> 
+> Members of this vexillation are the House's explorers. They are equipped to survive expeditions into unknown territory and confront hostile magic there. They often collaborate with the Houses Mercere and Merinita. Members of this vexillation would be surprised if they were ever to discover any sign of the Diedne, but are finding so many other interesting things while they attempt it that the House would prefer they continued trying.
+> 
+> This vexillation has developed a breed of partiallyfae horse that does not react badly to Gifted riders, and can see in the dark. This line does not breed quite true, and the stallions have a vicious temper. These are a rare exception to the House's disapproval of mounts.
+> 
+> This vexillation is currently governed by Umno, the previous Primus of the House, which grants it prestige.
+> 
+> ### Cold Iron Vexillation
+> 
+> *Task: To settle disputes with faeries to the advantage of the House.*
+> 
+> Each member of this vexillation has faerie blood, is a competent soldier, and a skilled diplomat. It maintains a small force of auxiliaries, trained to fight faeries.
+> 
+> This vexillation is always led by a masked figure called the Epicurean. Presumably the mask has changed wearers over time, but in Arcadia, the Epicurean is, in a very real sense, a continuing entity.
+> 
+> ### Broken Mirrors Vexillation
+> 
+> *Task: To investigate suspicion of diabolism, treason against the House, or cowardice in battle.*
+> 
+> The Broken Mirror Vexillation was founded by Albanus, the First Primus, to ensure that the House did not fracture after Tremere's retirement. Its members are ruthless, unflinchingly violent, and impeccably polite.
+> 
+> Leadership: This vexillation is usually controlled by whichever member of House Tremere has been accepted as a Quaesitor.
 
-
-
-Some vexillations never disband, because they have tasks that they cannot finish. These vexillations encourage young Tremere magi to become worthy inheritors of the task. There are many continuing vexillations, and many invite members from outside the House.
-
-#### ABYSSAL BEARER VEXILLATION
-
-*Task: To ensure no Tremere magus is left unburied. Beyond the emotional appeal of doing the correct thing for deceased relatives, the House does not want ghosts of its magi to fall into enemy hands.*
-
-Members of this vexillation have the ultimate responsibility for ensuring the safety of Tremere magi. This vexillation contains four members, each the descendant, eldest student by eldest student, of a magus who carried Tremere's coffin into the Gate of Euridyce. They have many other demands on their time, and some lack detective skill, so they seek the assistance of other Tremere magi when they suspect trouble.
-
-Leader: Since the First Primus, Albanus, was one of Tremere's coffin-bearers and was his oldest student, the leader of this vexillation is the descendant, eldest by eldest, from the Founder. She is a young maga in a spring covenant, who finds her responsibilities arduous.
-
-#### BURNING ACORN VEXILLATION
-
-*Task: To discover the whereabouts of the leaders of House Diedne. Arguably, this is the least successful of the continuing vexillations, but they don't let that worry them.*
-
-Members of this vexillation are the House's explorers. They are equipped to survive expeditions into unknown territory and confront hostile magic there. They often collaborate with the Houses Mercere and Merinita. Members of this vexillation would be surprised if they were ever to discover any sign of the Diedne, but are finding so many other interesting things while they attempt it that the House would prefer they continued trying.
-
-This vexillation has developed a breed of partiallyfae horse that does not react badly to Gifted riders, and can see in the dark. This line does not breed quite true, and the stallions have a vicious temper. These are a rare exception to the House's disapproval of mounts.
-
-This vexillation is currently governed by Umno, the previous Primus of the House, which grants it prestige.
-
-### COLD IRON VEXILLATION
-
-*Task: To settle disputes with faeries to the advantage of the House.*
-
-Each member of this vexillation has faerie blood, is a competent soldier, and a skilled diplomat. It maintains a small force of auxiliaries, trained to fight faeries.
-
-This vexillation is always led by a masked figure called the Epicurean. Presumably the mask has changed wearers over time, but in Arcadia, the Epicurean is, in a very real sense, a continuing entity.
-
-#### BROKEN MIRRORS VEXILLATION
-
-*Task: To investigate suspicion of diabolism, treason against the House, or cowardice in battle.*
-
-The Broken Mirror Vexillation was founded by Albanus, the First Primus, to ensure that the House did not fracture after Tremere's retirement. Its members are ruthless, unflinchingly violent, and impeccably polite.
-
-Leadership: This vexillation is usually controlled by whichever member of House Tremere has been accepted as a Quaesitor.
-
-#### THE ROLE OF THE PRIMUS AND LEGATUS
+#### The Role of the Primus and Legatus
 
 The Primus rules the House from Coeris, a covenant in the Transylvanian Alps. The current Prima, Poena, has governed the House since her predecessor retired at the Deccenial held two years ago. Poena has channeled resources into a series of research projects, some of which require purpose-built facilities. Staff for these new covenants are drawn from across the House, but new Tremere magi, or those who rise suddenly in status, are likely to be ordered to assist a research covenant. Poena particularly favors research that reduces the battlefield advantages of the Islamic wizards of the Levant.
 
 The most important magus in the House, aside from the Primus, is the Legatus. The Legatus is the field-leader of the House in war, selected by the Primus. It has become popular, since the death of Primus Cercistum during the Schism, for the Primus to avoid the battlefield, to maintain command. It is usual for the Legatus to live in Coeris, but use magical transport to reach a forward base of operations if required. The Legatus is the Primus's heir. Were Coeris destroyed by a surprise attack, leadership of the House would fall to the Exarch of Rome.
-
-
 
 ## Promotion by Force
 
@@ -4506,40 +4106,31 @@ The exarch or tribune selects which matters are trivial at each tribunal. A matt
 
 ### Claiming the Tribunal's Dragon Banner, to Move to the Role of Exarch by Force
 
-The role of exarch is economic and executive, so disruptions to the exarchate distress the plans of the House. At the exarch's ascension, his senior colleagues meet. They debate who might be suitable to act as exarch if the post becomes vacant, agreeing to a pool of candidates who then duel for the role of heir. The exarch ensures that the heir is familiar with their plan for the exarchate. The
+The role of exarch is economic and executive, so disruptions to the exarchate distress the plans of the House. At the exarch's ascension, his senior colleagues meet. They debate who might be suitable to act as exarch if the post becomes vacant, agreeing to a pool of candidates who then duel for the role of heir. The exarch ensures that the heir is familiar with their plan for the exarchate. The heir serves as exarch until the primus replaces him. The heir also accepts challenges at Decennials.
 
-
-
-
-### Addled Secutor
-
-The Archmagus Valerius is the current Secutor. Three months ago, an incident in a faerie forest damaged his mind. He is intermittently lucid, and has sought the aid of the player characters. His rival, Theodoros of Tytalus, has become aware of his injury. Theodoros has boasted that he intends to challenge Valerius to certamen, then claim he has the right to challenge the Prima.
-
-Most Tremere would refuse to accept the challenge as valid, but were Prima Poena to refuse certamen, she would look pathetic. Valerius worries that foolish elements of the House might accept an outsider's legitimacy in exchange for greater autonomy. Ambitious magi, sensing weakness in the Prima, would challenge her exarchs and disrupt the House's projects. Valerius's worries may be unfounded but he, and perhaps the Prima, would like to ensure that Theodoros never has the opportunity to challenge.
-
-Valerius is unable to provide the characters with much assistance in planning his defense. He is only lucid for a few moments at a time, between lengthy stretches of amused-looking catatonia. The characters could try to transport him to Coeris, or another covenant whose members are loyal to the Prima, but Theodoros may have found a way to locate his foe. They might hide Valerius in their covenant and travel to Coeris for an arcane connection, to allow them instant travel. They might, alternatively, negotiate with the terrible faerie powers that drove Valerius insane, either to repair his mind, or to do the same to his enemy.
-
-heir serves as exarch until the primus replaces him. The heir also accepts challenges at Decennials.
+> ## Addled Secutor
+> 
+> The Archmagus Valerius is the current Secutor. Three months ago, an incident in a faerie forest damaged his mind. He is intermittently lucid, and has sought the aid of the player characters. His rival, Theodoros of Tytalus, has become aware of his injury. Theodoros has boasted that he intends to challenge Valerius to certamen, then claim he has the right to challenge the Prima.
+> 
+> Most Tremere would refuse to accept the challenge as valid, but were Prima Poena to refuse certamen, she would look pathetic. Valerius worries that foolish elements of the House might accept an outsider's legitimacy in exchange for greater autonomy. Ambitious magi, sensing weakness in the Prima, would challenge her exarchs and disrupt the House's projects. Valerius's worries may be unfounded but he, and perhaps the Prima, would like to ensure that Theodoros never has the opportunity to challenge.
+> 
+> Valerius is unable to provide the characters with much assistance in planning his defense. He is only lucid for a few moments at a time, between lengthy stretches of amused-looking catatonia. The characters could try to transport him to Coeris, or another covenant whose members are loyal to the Prima, but Theodoros may have found a way to locate his foe. They might hide Valerius in their covenant and travel to Coeris for an arcane connection, to allow them instant travel. They might, alternatively, negotiate with the terrible faerie powers that drove Valerius insane, either to repair his mind, or to do the same to his enemy.
 
 Any Tremere magus may challenge the exarch to certamen over their policies for the House, or for their office. The exarch may accept personally, or ask an ally to meet the challenge. A magus may only challenge the exarch for his role once, and must not do so while the House faces rivals, at Tribunal for example.
 
 To challenge an exarch is not within the normal course of ambition for a Tremere magus. At times of such serious division, the House minimizes the opportunities presented to potential enemies. Any change in leadership is swift and decisive — a defeated exarch may not challenge to regain the role. The old exarch is required to give assistance to the new exarch.
 
-The Primus appoints and dismisses each exarch, so it challenges the primus's authority for a magus to remove an appointee. Sometimes the Primus simply selects the deposed exarch again and punishes the usurper. Primi have also, historically, accepted the new exarch, sent a third party to the tribunal as mediator or candidate, collapsed the disputed exarchate into a neighboring exarchate and, on one occasion, declared the challenger an Orbus and mustered the House to war against him. Even
+The Primus appoints and dismisses each exarch, so it challenges the primus's authority for a magus to remove an appointee. Sometimes the Primus simply selects the deposed exarch again and punishes the usurper. Primi have also, historically, accepted the new exarch, sent a third party to the tribunal as mediator or candidate, collapsed the disputed exarchate into a neighboring exarchate and, on one occasion, declared the challenger an Orbus and mustered the House to war against him. Even if the challenge is successful, and the Primus accepts them, the new exarch is ceremonially punished, to demonstrate that the authority of the Primus remains intact.
 
-### Dissent
-
-The House has never engaged in civil war but, at times, sections of the House have acted independently. This is not due to a failure of authority: it is always clear who is the Primus. Usually, dissent is due to a lack of charisma or coercion on the part of the Primus, and centers about an exarch.
-
-In a time of dissent, most members of the House pretend that the structure is still functioning normally. An exarch may ignore the requirements of the Primus, but she will still pretend to be following them closely, because her authority is itself a function of the role of the Primus. The House tries to heal these rifts through several mechanisms: challenge for the role of Primus, retirement of the Primus, appointment of a new exarch, voluntary relinquishment of the role of exarch, private negotiation resulting in a determined degree of independent authority for the exarch, and, in the most dire of situations, casting out the exarch and civil war. This final sanction has never been used, but members of the House are certain it would be, were no compromise possible.
-
-Both sides of the dissent will test experienced player characters, which is itself a powerful motivation to seek compromise. The vis, money and other support that usually flows from the Primus to experienced magi is lost to dissenters, and the manpower and items which dissenters usually provide are lost to the assenters. The Tremere magi are not reckless when they argue and in the face of enemies, for example hostile proposals at Tribunal, they set aside their differences temporarily.
-
-A young player character living in a time of dissent may not, initially, notice that there is a fracture within the House. They have limited access to the House's resources in Transylvania — which has always stayed loyal to the Primus in times of trouble because of his location and access to powerful tools of retribution and so may not notice that they are unable to draw on the assistance of part of the House. If they travel to an area outside their exarch's influence, they still receive hospitality, but it is less generous than usual, unless they are overtly supportive of the same leader as their host.
-
-
-
-if the challenge is successful, and the Primus accepts them, the new exarch is ceremonially punished, to demonstrate that the authority of the Primus remains intact.
+> ## Dissent
+> 
+> The House has never engaged in civil war but, at times, sections of the House have acted independently. This is not due to a failure of authority: it is always clear who is the Primus. Usually, dissent is due to a lack of charisma or coercion on the part of the Primus, and centers about an exarch.
+> 
+> In a time of dissent, most members of the House pretend that the structure is still functioning normally. An exarch may ignore the requirements of the Primus, but she will still pretend to be following them closely, because her authority is itself a function of the role of the Primus. The House tries to heal these rifts through several mechanisms: challenge for the role of Primus, retirement of the Primus, appointment of a new exarch, voluntary relinquishment of the role of exarch, private negotiation resulting in a determined degree of independent authority for the exarch, and, in the most dire of situations, casting out the exarch and civil war. This final sanction has never been used, but members of the House are certain it would be, were no compromise possible.
+> 
+> Both sides of the dissent will test experienced player characters, which is itself a powerful motivation to seek compromise. The vis, money and other support that usually flows from the Primus to experienced magi is lost to dissenters, and the manpower and items which dissenters usually provide are lost to the assenters. The Tremere magi are not reckless when they argue and in the face of enemies, for example hostile proposals at Tribunal, they set aside their differences temporarily.
+> 
+> A young player character living in a time of dissent may not, initially, notice that there is a fracture within the House. They have limited access to the House's resources in Transylvania — which has always stayed loyal to the Primus in times of trouble because of his location and access to powerful tools of retribution and so may not notice that they are unable to draw on the assistance of part of the House. If they travel to an area outside their exarch's influence, they still receive hospitality, but it is less generous than usual, unless they are overtly supportive of the same leader as their host.
 
 ### Claiming the Sigil of Tremere, to Move to the Pole of Primus by Force
 
@@ -4557,214 +4148,211 @@ Tremere magi are trained to be useful to the House. Virtually every magus is com
 
 Magi of Tremere usually desire to be excellent duelists, which means they specialize in four arts. This is because the other party in a duel can veto their rival's first choice of form or technique. Tremere was skilled in Rego, particularly with Mentem, and his descendants commonly select these two Arts. Rego Mentem spells lack direct offensive power, so many Tremere magi choose secondary arts that aid magical violence. In the current House, Muto is slightly more popular than the other techniques, and Terram, Animal, Corpus and Imaginem are all popular forms.
 
-### THE ART OF REGO
+#### The Art of Rego
 
 Rego specialists have to work with materials that are already present at casting, so they may lack the offensive power of Perdo or Creo specialists. Some develop a broad knowledge of the Forms and use spontaneous spells in precise, creative ways. Other Tremere magi carry objects that are affected by aggressive formulaic spells. Others develop their understanding of the forms of Terram or Herbam, on the basis that wood and stone are ubiquitous.
 
 In Wizard's War members of House Tremere gain two advantages from their preference for the art of Rego. Their warding spells are excellent, which allows them to create secure spaces to recuperate, store supplies, and muster forces. Many can use Leap of Homecoming and, in moments of desperation, the far riskier Seven League Stride. This allows members of the House to retreat or deploy with extraordinary speed, while maintaining the cohesion of their combat units. Each of these advantages permits the Tremere magi to remain soldiers, fighting together under doctrine, instead of a force of scattered warriors.
 
-#### THE ART OF MENTEM
+#### The Art of Mentem
 
 Tremere magi are skilled at exploiting necromancy to acquire information about their enemies. They question the dead, but also use them as spies and scouts. In limited circumstances, ghosts are effective magical infantry.
 
 Some Tremere magi are skilled at controlling dreams. Many people in Mythic Europe credit dreams with the power of prophecy, and so subtle changes to the dreams of significant mundanes can have disproportionate political outcomes. The real skill involved in this style of manipulation is surreptitiously acquiring an arcane connection to the victim, so that the spells can be used from an untraceable distance.
 
-
-
-
-### Ghostly Armies
-
-Millions of pagans have died traumatically in Europe, and a skilled necromancer can summon many of them at the sites of their deaths. During the Schism, for example, a small group of necromancers lured a covenant of Diedne magi into battle at Kalkriese. The druids did not realize this was the site of one of the preliminary skirmishes in the Varius Disaster, which killed 60,000 Roman legionaries. Their ghosts demoralized and scattered the druids, who were then defeated in detail.
-
-During the Schism, Primus Cercistum made many claims about his ability to call up ghost armies. He claimed to be able to call up the casualties of Hannibal's three victories against the Romans in Italy (150,000 dead) and the victims of the storm that destroyed the Roman invasion fleet off Cape Pachynus in 255 BC (100,000 soldiers and over 250 ghostly ships). These claims were never tested, but were not novel, because Guorna the Fetid claimed to be able to rouse the spirits of those who died when Belisarius's troops sacked Naples. The House continues to encourage young magi to find such useful sites.
-
-Young magi are also encouraged to find remains, which summon ghosts away from their burial sites. The senior necromancer in the House, for example, carries a torc crafted from the teeth of a Scythian chieftain and his warriors, which allows him to summon thirty-four ghostly horsemen, away from the site of their internment. Kore, the fifth and only necromantic Prima, created the torc and for years afterward had young magi looking for an enormous bronze vessel made from the census arrowheads of the Scythian army. She hoped to bring an entire nation of dead to the battlefield. Kore was the first Primus replaced by force, on the grounds of insanity. Some necromancers search for the skull of Guorna the Fetid, hoping to learn the techniques of the archnecromantrix. Others fear she would find a way to claim the body of her pupil.
-
-### Varieties of Ghost
-
-Tremere magi have noted that there are many types of ghost. The commonest, those linked to the magical realm, are tied to the world either by unfinished business, or by a burden of sin. Many ghosts in Transylvania can construct permanent, solid forms. These are indistinguishable from the dark faeries of Western Europe. Why certain ways of dying create faeries, while others create ghosts, is not clear to Tremere magi. They are interested in sponsoring research into the question. Tremere magi are forbidden to summon the ghosts of the damned, because it breaches the Code. Many Tremere consider saints to be particularly powerful ghosts, but summoning saints does not work.
-
-### LEGIONARY
-
-This ghost is typical of the fallen legionaries summoned in Western Europe. Many vanish after their first victory in combat, but a small portion feel they have a duty to defend Rome, and undertake moonlit pilgrimages to the Eternal City, dissolving into the Dominion at their quest's end.
-
-**Magical Might:** 10 (Mentem)
-
-**Characteristics:** Int 0, Per 0, Pre 0, Com 0, Str +2, Sta
-
-+2, Dex +2, Qik +1
-
-**Size:** 0
-
-**Age:** Appears to be between 16 and 35
-
-**Decrepitude:** n/a **Virtues and Flaws:** n/a **Personality Traits:** Loyal +3
-
-**Reputations:** n/a
-
-**Combat:**
-
-*Sword (gladius) and rectangular shield (scutum):* Init. +2, Attack
-
-+11, Defense +12, Damage +7.
-
-*Dagger (pugio):* Init.1, Attack +9, Defense +6, Damage +5 *Javelin (pilum):* Init +1, Attack +9, Defense +10, Damage +7
-
-**Soak:** Varies by historical period to suit armor: Chain 6, Plate 9, Scale 8, including Stamina bonus. Immune to physical weapons.
-
-**Fatigue:** Tireless
-
-**Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20)
-
-**Abilities:** [Area] Lore 3 (ancient fortifications), Athletics 3 (marching), Awareness 3 (in combat), Bargain 2 (for supplies), Brawl 4 (dagger), Carouse 3 (drinking), Charm 2 (opposite sex), Latin 5 (military jargon), Legion Lore 2 (pay and conditions), Profession (Soldier) 4 (fortifications), Single Weapon 5 (short sword), Survival 1 (foraging), Thrown weapon 4 (javelin)
-
-**Powers:**
-
-*Strike:* 0 points, Terram: The centurion can affect the world through a single possession. For most, this is a gladius: a Roman sword.
-
-**Equipment:** Arms and equipment of a Roman soldier
-
-**Encumbrance:** 0 (0)
-
-
-
-
-**Appearance:** Varies: usually a fit young man clad in ancient armor, but occasionally, a skeletal or decaying corpse clad in rusted armor and tattered clothing.
-
-#### CATAPHRACT
-
-Cataphracts are the mounted warriors of the Eastern Empire. They are found in the West in a handful of places, left behind after Justinian's imperial adventure in the Sixth Century. Cataphracts found in the West are particularly useful to the House. Their unfinished business is often the rebuilding of the Empire: a task that the Tremere do not oppose. The House recruits ghostly cataphracts where it can, and directs the remainder over the border into the Theban Tribunal, where they harass the Latin invaders. The statistics here are for a young cataphract, with basic training but little combat experience.
-
-**Magic Might:** 15 (Mentem)
-
-**Characteristics:** Int 0, Per +1, Pre 0, Com 0, Str +1, Sta
-
-+1, Dex +2, Qik +2
-
-**Size:** 0
-
-**Age:** Appears 20 **Decrepitude:** n/a
-
-**Virtues and Flaws:** Improved characteristics **Personality Traits:** Loyal +3, Proud +2
-
-**Reputations**: n/a
-
-**Combat:**
-
-*Cavalry sword (spatha) and shield (mounted):* Init +4, Atk +18, Def +17, Dam +7
-
-*Cavalry sword (spatha) and shield (on foot):* Init +4, Atk +12, Def +11, Dam +7
-
-*Lance (mounted):* Init +4, Atk +17, Def +8, Dam +6\* *Bow (mounted):* Init +1, Atk +14, Def +11, Dam +7 *Bow (on foot):* Init +1, Atk +11, Def +8, Dam +7
-
-*Dagger:* Init +2, Atk +7, Def +5, Dam: +4
-
-\* Cataphracts charge slowly in tight formation, because they lack stirrups.
-
-**Soak:** usually +10 for chainmail or +8 for scale. Rare examples of plate (+12) are known known.
-
-**Fatigue:** Tireless
-
-**Wound Penalties**: –1 (1-7), –3 (8-11), –5 (12-14), Incapacitated (16-19)
-
-**Abilities:** Animal Handling 2 (horses), [Area] Lore 3 (posting), Athletics 2 (hiking), Awareness 3 (battle), Bow 5 (short bow), Brawl 1 (dagger), Chirurgy 1 (arrow wounds), Etiquette (archaic Byzantine) 3, Hunt 2 (varies by posting), Intrigue 1 (Byzantine court), Leadership 4 (soldiers), Roman Army Lore 2
-
-
-**Equipment:** Full chain mail, cavalry sword, mediumsized shield, bow, lance.
-
-**Encumbrance:** 0 (0)
-
-**Vis:** 2 pawns Mentem, engagement ring or keepsake. **Appearance:** An impressive warrior, obscured by his armor. Sometimes the armor contains an ethereal skeleton. Sometimes it is empty.
-
-#### WILI
-
-These dark faeries are the ghosts of maidens who died on their wedding day. They are often found in graveyards, singly or in groups, where they attempt to convince young men to kiss them. A pack of wili can drain the life breath from a young man in a few minutes. The House uses wili as assassins. Most wili want to be reunited with their betrothed, but this is usually impossible. Destroying their lover dispels some. Most can be exorcised.
-
-**Faerie Might:** 15 (Mentem)
-
-**Characteristics:** Int 0, Per +1, Pre +3, Com +1, Str +1,
-
-Sta 0, Dex 0, Qik 0
-
-**Size:** 0
-
-**Age:** Appears 16 **Decrepitude:** n/a **Virtues and Flaws:** n/a **Personality Traits:** Lonely +5 **Reputations:** Murderous +1
-
-**Combat:** n/a: Wili cannot attack physically. **Soak:** 0, immune to physical weapons.
-
-**Fatigue:** Tireless
-
-**Wound Penalties**: –1 (1-7), –3 (8-11), –5 (12-14),
-
-Incapacitated (16-19) **Abilities:** Vary by station in life
-
-**Powers:**
-
-*Float*, 0 points, Mentem: Wili can float through the air at walking pace.
-
-*Incorporeal,* 0 points, Mentem: This ghost is incorporeal when she wishes to be, and solid when she desires to be.
-
-*Eyes you can forget everything in*, 5 points, Init. +5, Mentem: If the wili makes eye contact with a young man, she can cloud his mind so that he forgets any warning he has been been given about the wili. He can protect himself with an Intelligence roll of 9+, which reminds him not to make eye contact with the girl at the cemetery.
-
-
-
-
-*Kiss:* 5 points, Corpus: If the wili kisses a willing victim, or one made compliant by her mesmerizing eyes, she permanently steals a fatigue level from the character, and gains back all of her Might points. Each wili can only feed on a victim once per day, but a pack of wili can kill a man in a single round of kisses.
-
-When a man kisses a wili, his mind becomes clouded. He knows the wili is a ghost who is killing him with her kisses, but he cannot bring himself to avoid their next rendezvous. Unless the man makes an Intelligence roll of 9+, he does everything in his power to meet the wili again. Friends can break this charm with the assistance of a priest, after which the man regains a fatigue level after each night of rest. Some wili kill with the second kiss, others drain another fatigue level.
-
-**Equipment:** Wears the beautiful dress she was buried in. Probably carries a locket, cross, hair ribbon or other keepsake from her betrothed.
-
-**Encumbrance:** 0 (0)
-
-**Vis:** 2 pawns Mentem, engagement ring or keepsake. **Appearance:** A beautiful, if sad, girl in a flowing white dress, mourning at a fresh grave site.
-
-#### MORO
-
-Moro are vampires created when parents murder their children by exposure. They can take the shape of butterflies, and drink blood, but the loss is negligible. They can drain life itself, a power to which children are particularly vulnerable. Most moro want revenge on their parents, which the Tremere think it only just to give them.
-
-**Faerie Might:** 20 (Animal)
-
-**Characteristics:** Int +1, Per 0, Pre –2, Com 0, Str –1,
-
-Sta –1, Dex 0, Qik 0
-
-**Size:** –2 (infant form), –4 (insect form)
-
-**Age:** Appears as an infant
-
-**Decrepitude:** n/a
-
-**Virtues and Flaws:** n/a
-
-**Personality Traits:** Vengeful +5
-
-**Reputations:** Vampire +5
-
-**Combat:** n/a, Moro attack only by stealth. **Soak:** 0, immune to normal weapons.
-
-**Fatigue:** Tireless
-
-**Wound Penalties**: –1 (1-5), –3 (6-9), –5 (10-12),
-
-Incapacitated (14-17)
-
-
-
-
-*Shapechange*, 0 points, Animal: Moro can swap between forms, human and death's head moth, at will.
-
-*Create storm,* 10 points, Auram: This ghost creates powerful storms that damage crops, to take revenge on those who left it to starve.
-
-*Bite:* 0 points, Corpus: If the moro bites a sleeping victim, in butterfly form, it steals a fatigue level from the character for the next week, and gains back all of its Might points. Each moro can only feed on a victim once per day, but a single feeding will murder an infant. A week of feeding will kill an adult, since they die if fed from once they have lost all of their fatigue levels. Priests and folk magicians can defend people from moros, after which the victim regains a fatigue level after each night of rest.
-
-**Equipment:** None. **Encumbrance:** 0 (0) **Vis:** 3 pawns Perdo, body.
-
-**Appearance:** A tiny, blue, emaciated, shivering child,
-
-or a death's head moth.
-
-### ANIMALS
+> ## Ghostly Armies
+> 
+> Millions of pagans have died traumatically in Europe, and a skilled necromancer can summon many of them at the sites of their deaths. During the Schism, for example, a small group of necromancers lured a covenant of Diedne magi into battle at Kalkriese. The druids did not realize this was the site of one of the preliminary skirmishes in the Varius Disaster, which killed 60,000 Roman legionaries. Their ghosts demoralized and scattered the druids, who were then defeated in detail.
+> 
+> During the Schism, Primus Cercistum made many claims about his ability to call up ghost armies. He claimed to be able to call up the casualties of Hannibal's three victories against the Romans in Italy (150,000 dead) and the victims of the storm that destroyed the Roman invasion fleet off Cape Pachynus in 255 BC (100,000 soldiers and over 250 ghostly ships). These claims were never tested, but were not novel, because Guorna the Fetid claimed to be able to rouse the spirits of those who died when Belisarius's troops sacked Naples. The House continues to encourage young magi to find such useful sites.
+> 
+> Young magi are also encouraged to find remains, which summon ghosts away from their burial sites. The senior necromancer in the House, for example, carries a torc crafted from the teeth of a Scythian chieftain and his warriors, which allows him to summon thirty-four ghostly horsemen, away from the site of their internment. Kore, the fifth and only necromantic Prima, created the torc and for years afterward had young magi looking for an enormous bronze vessel made from the census arrowheads of the Scythian army. She hoped to bring an entire nation of dead to the battlefield. Kore was the first Primus replaced by force, on the grounds of insanity. Some necromancers search for the skull of Guorna the Fetid, hoping to learn the techniques of the archnecromantrix. Others fear she would find a way to claim the body of her pupil.
+> 
+> ### Varieties of Ghost
+> 
+> Tremere magi have noted that there are many types of ghost. The commonest, those linked to the magical realm, are tied to the world either by unfinished business, or by a burden of sin. Many ghosts in Transylvania can construct permanent, solid forms. These are indistinguishable from the dark faeries of Western Europe. Why certain ways of dying create faeries, while others create ghosts, is not clear to Tremere magi. They are interested in sponsoring research into the question. Tremere magi are forbidden to summon the ghosts of the damned, because it breaches the Code. Many Tremere consider saints to be particularly powerful ghosts, but summoning saints does not work.
+> 
+> #### Legionary
+> 
+> This ghost is typical of the fallen legionaries summoned in Western Europe. Many vanish after their first victory in combat, but a small portion feel they have a duty to defend Rome, and undertake moonlit pilgrimages to the Eternal City, dissolving into the Dominion at their quest's end.
+> 
+> **Magical Might:** 10 (Mentem)
+> 
+> **Characteristics:** Int 0, Per 0, Pre 0, Com 0, Str +2, Sta+2, Dex +2, Qik +1
+> 
+> **Size:** 0
+> 
+> **Age:** Appears to be between 16 and 35
+> 
+> **Decrepitude:** n/a
+> 
+> **Virtues and Flaws:** n/a
+> 
+> **Personality Traits:** Loyal +3
+> 
+> **Reputations:** n/a
+> 
+> **Combat:**
+> 
+> *Sword (gladius) and rectangular shield (scutum):* Init. +2, Attack +11, Defense +12, Damage +7.
+> 
+> *Dagger (pugio):* Init.1, Attack +9, Defense +6, Damage +5 *Javelin (pilum):* Init +1, Attack +9, Defense +10, Damage +7
+> 
+> **Soak:** Varies by historical period to suit armor: Chain 6, Plate 9, Scale 8, including Stamina bonus. Immune to physical weapons.
+> 
+> **Fatigue:** Tireless
+> 
+> **Wound Penalties**: –1 (1-5), –3 (6-10), –5 (11-15), Incapacitated (16-20)
+> 
+> **Abilities:** \[Area\] Lore 3 (ancient fortifications), Athletics 3 (marching), Awareness 3 (in combat), Bargain 2 (for supplies), Brawl 4 (dagger), Carouse 3 (drinking), Charm 2 (opposite sex), Latin 5 (military jargon), Legion Lore 2 (pay and conditions), Profession (Soldier) 4 (fortifications), Single Weapon 5 (short sword), Survival 1 (foraging), Thrown weapon 4 (javelin)
+> 
+> **Powers:**
+> 
+> *Strike:* 0 points, Terram: The centurion can affect the world through a single possession. For most, this is a gladius: a Roman sword.
+> 
+> **Equipment:** Arms and equipment of a Roman soldier
+> 
+> **Encumbrance:** 0 (0)
+> 
+> **Appearance:** Varies: usually a fit young man clad in ancient armor, but occasionally, a skeletal or decaying corpse clad in rusted armor and tattered clothing.
+> 
+> #### Cataphract
+> 
+> Cataphracts are the mounted warriors of the Eastern Empire. They are found in the West in a handful of places, left behind after Justinian's imperial adventure in the Sixth Century. Cataphracts found in the West are particularly useful to the House. Their unfinished business is often the rebuilding of the Empire: a task that the Tremere do not oppose. The House recruits ghostly cataphracts where it can, and directs the remainder over the border into the Theban Tribunal, where they harass the Latin invaders. The statistics here are for a young cataphract, with basic training but little combat experience.
+> 
+> **Magic Might:** 15 (Mentem)
+> 
+> **Characteristics:** Int 0, Per +1, Pre 0, Com 0, Str +1, Sta+1, Dex +2, Qik +2
+> 
+> **Size:** 0
+> 
+> **Age:** Appears 20
+> 
+> **Decrepitude:** n/a
+> 
+> **Virtues and Flaws:** Improved characteristics
+> 
+> **Personality Traits:** Loyal +3, Proud +2
+> 
+> **Reputations**: n/a
+> 
+> **Combat:**
+> 
+> *Cavalry sword (spatha) and shield (mounted):* Init +4, Atk +15, Def +14, Dam +7
+> 
+> *Cavalry sword (spatha) and shield (on foot):* Init +4, Atk +12, Def +11, Dam +7
+> 
+> *Lance (mounted):* Init +4, Atk +17, Def +8, Dam +6\* *Bow (mounted):* Init +1, Atk +14, Def +11, Dam +7 *Bow (on foot):* Init +1, Atk +11, Def +8, Dam +7
+> 
+> *Dagger:* Init +2, Atk +7, Def +5, Dam: +4
+> 
+> \* Cataphracts charge slowly in tight formation, because they lack stirrups.
+> 
+> **Soak:** usually +10 for chainmail or +8 for scale. Rare examples of plate (+12) are known known.
+> 
+> **Fatigue:** Tireless
+> 
+> **Wound Penalties**: –1 (1–5), –3 (6–10), –5 (11–15), Incapacitated (16–20) 
+> 
+> **Abilities:** Animal Handling 2 (horses), \[Area\] Lore 3 (posting), Athletics 2 (hiking), Awareness 3 (battle), Bow 5 (short bow), Brawl 1 (dagger), Chirurgy 1 (arrow wounds), Etiquette (archaic Byzantine) 3, Hunt 2 (varies by posting), Intrigue 1 (Byzantine court), Leadership 4 (soldiers), Roman Army Lore 2 (duties of ofﬁcers), Greek 5 (giving orders), Ride 5 (in combat), Single Weapon 5 (spatha), Survival 1 (deserts),
+> 
+> **Equipment:** Full chain mail, cavalry sword, mediumsized shield, bow, lance.
+> 
+> **Encumbrance:** 0 (0)
+> 
+> **Vis:** 2 pawns Mentem, engagement ring or keepsake. **Appearance:** An impressive warrior, obscured by his armor. Sometimes the armor contains an ethereal skeleton. Sometimes it is empty.
+> 
+> #### Wili
+> 
+> These dark faeries are the ghosts of maidens who died on their wedding day. They are often found in graveyards, singly or in groups, where they attempt to convince young men to kiss them. A pack of wili can drain the life breath from a young man in a few minutes. The House uses wili as assassins. Most wili want to be reunited with their betrothed, but this is usually impossible. Destroying their lover dispels some. Most can be exorcised.
+> 
+> **Faerie Might:** 15 (Mentem)
+> 
+> **Characteristics:** Int 0, Per +1, Pre +3, Com +1, Str +1,
+> 
+> Sta 0, Dex 0, Qik 0
+> 
+> **Size:** 0
+> 
+> **Age:** Appears 16
+> 
+> **Decrepitude:** n/a
+> 
+> **Virtues and Flaws:** n/a
+> 
+> **Personality Traits:** Lonely +5
+> 
+> **Reputations:** Murderous +1
+> 
+> **Combat:** n/a: Wili cannot attack physically. **Soak:** 0, immune to physical weapons.
+> 
+> **Fatigue:** Tireless
+> 
+> **Wound Penalties**: –1 (1–5), –3 (6–10), –5 (11–15), Incapacitated (16–20) 
+>
+> **Abilities:** Vary by station in life
+> 
+> **Powers:**
+> 
+> *Float*, 0 points, Mentem: Wili can float through the air at walking pace.
+> 
+> *Incorporeal,* 0 points, Mentem: This ghost is incorporeal when she wishes to be, and solid when she desires to be.
+> 
+> *Eyes you can forget everything in*, 5 points, Init. +5, Mentem: If the wili makes eye contact with a young man, she can cloud his mind so that he forgets any warning he has been been given about the wili. He can protect himself with an Intelligence roll of 9+, which reminds him not to make eye contact with the girl at the cemetery.
+> 
+> *Kiss:* 5 points, Corpus: If the wili kisses a willing victim, or one made compliant by her mesmerizing eyes, she permanently steals a fatigue level from the character, and gains back all of her Might points. Each wili can only feed on a victim once per day, but a pack of wili can kill a man in a single round of kisses.
+> 
+> When a man kisses a wili, his mind becomes clouded. He knows the wili is a ghost who is killing him with her kisses, but he cannot bring himself to avoid their next rendezvous. Unless the man makes an Intelligence roll of 9+, he does everything in his power to meet the wili again. Friends can break this charm with the assistance of a priest, after which the man regains a fatigue level after each night of rest. Some wili kill with the second kiss, others drain another fatigue level.
+> 
+> **Equipment:** Wears the beautiful dress she was buried in. Probably carries a locket, cross, hair ribbon or other keepsake from her betrothed.
+> 
+> **Encumbrance:** 0 (0)
+> 
+> **Vis:** 2 pawns Mentem, engagement ring or keepsake. **Appearance:** A beautiful, if sad, girl in a flowing white dress, mourning at a fresh grave site.
+> 
+> #### Moro
+> 
+> Moro are vampires created when parents murder their children by exposure. They can take the shape of butterflies, and drink blood, but the loss is negligible. They can drain life itself, a power to which children are particularly vulnerable. Most moro want revenge on their parents, which the Tremere think it only just to give them.
+> 
+> **Faerie Might:** 20 (Animal)
+> 
+> **Characteristics:** Int +1, Per 0, Pre –2, Com 0, Str –1,
+> 
+> Sta –1, Dex 0, Qik 0
+> 
+> **Size:** –2 (infant form), –4 (insect form)
+> 
+> **Age:** Appears as an infant
+> 
+> **Decrepitude:** n/a
+> 
+> **Virtues and Flaws:** n/a
+> 
+> **Personality Traits:** Vengeful +5
+> 
+> **Reputations:** Vampire +5
+> 
+> **Combat:** n/a, Moro attack only by stealth.
+
+**Soak:** 0, immune to normal weapons.
+> 
+> **Fatigue:** Tireless
+> 
+> **Wound Penalties**: Infant Form: –1 (1–3), –3 (4–6), –5 (7–9), Incapacitated (10–12);
+>
+> **Wound Penalties**: Insect Form: –1 (1), –3 (2), –5, (3), Incapacitated (4),
+> 
+> *Shapechange*, 0 points, Animal: Moro can swap between forms, human and death's head moth, at will.
+> 
+> *Create storm,* 10 points, Auram: This ghost creates powerful storms that damage crops, to take revenge on those who left it to starve.
+> 
+> *Bite:* 0 points, Corpus: If the moro bites a sleeping victim, in butterfly form, it steals a fatigue level from the character for the next week, and gains back all of its Might points. Each moro can only feed on a victim once per day, but a single feeding will murder an infant. A week of feeding will kill an adult, since they die if fed from once they have lost all of their fatigue levels. Priests and folk magicians can defend people from moros, after which the victim regains a fatigue level after each night of rest.
+> 
+> **Equipment:** None. **Encumbrance:** 0 (0) **Vis:** 3 pawns Perdo, body.
+> 
+> **Appearance:** A tiny, blue, emaciated, shivering child, or a death's head moth.
+
+#### Animals
 
 The Founder Tremere was interested in Animal magic because he was unable to precisely control animals with his political skills, or the muscles of his followers. Tremere magi use mundane animals to extend their senses, carry supplies, collect arcane connections and perform sabotage. The House's Doctrine prefers small, swift carnivores. The House used raptors and wolves extensively during the Schism, and prefers dogs and rats in cities.
 
@@ -4772,127 +4360,115 @@ The House collects and tames magical animals. There are several varieties of ani
 
 House Tremere lacks a detailed doctrine for magical mounts. It's not possible to grant a mount Magic Resistance, except by extending the Parma over it. This means either the mount is undefended, or the magus's own protection is halved. Neither of these options is pleasant. Riders of magical beasts are effective against mundane forces, so they have some history in the House, but for the most part they are considered glamorous and wrongheaded. The discovery of a large group of biddable animals with a Might of 30 or more could see this doctrine revised.
 
-
-Tremere magi often trap and study the magical animals they encounter, adding them to the House's resources. If a covenant has a population of interesting animals, perhaps as a vis source, a young Tremere magus may be sent to determine their usefulness. If they prove valuable, the magus will want to procure live samples for his superiors. The House might also secure breeding pairs, to start new colonies of the animals at a House Covenant.
-
-### COMMON WHITE WOLVES
-
-There are several types of magical wolf that serve the House in its packs but this type, descended from Tremere's familiar, are the most common.
-
-**Magic Might:** 10 (Animal)
-
-**Characteristics:** Int +1, Per +3, Pre +1, Com +1, Str
-
-+2, Sta +2, Dex +2, Qik +2
-
-**Size:** 1 **Age:** n/a
-
-**Decrepitude:** n/a
-
-**Virtues and Flaws:** The Visions Virtue occurs occa-
-
-sionally among these wolves.
-
-**Personality Traits:** Loyal +2, Amused by Humans +1
-
-**Reputations:** None
-
-**Combat:**
-
-*Bite:* Init +12, Attack +10, Defense +14, Damage +9
-
-**Soak:** +7
-
-**Fatigue:** 0,–1/–1,–3/–3,–5,Unconscious
-
-**Wound Penalties**: –1 (1-6), –3 (7-10), –5 (11-13),
-
-Incapacitated (15-18)
-
-**Abilities:** [Area] Lore 6 (Pack land), Brawl 3 (bite), Folk Ken (Tremere magi) 3, Hunt 6 (in a pack), Latin\* 3 (Hermetic terms). Stealth (forests) 3, Swim (lakes) 1, Survival 6 (forests)
-
-\* Cannot speak Latin without magical assistance, but some packs are trained to understand it by familiars which can.
-
-**Powers:**
-
-*Theft of Voice,* 1 point, Init +10, Mentem: The wolf can steal the voice of any human with whom it makes eye contact. The effect usually lasts until the next sunrise, although some individual wolves have variant powers, so that the effect ceases when
-
-
-
-crossing a stream, or entering a church, or by firelight.
-
-*Eyes like Lanterns,* 5 points, Init +5, Mentem: The wolf can paralyze a victim with terror. This requires the wolf to make eye contact, and the victim to fail a Brave check with an ease factor of 9+. A victim who makes eye contact with several wolves may need to make several checks. The victim may make a new check each round if attacked, with an ease factor of 6+, so wolves tend to form a circle about a mesmerized victim and all pounce at the same time. Slapping or shaking the victim also allows a check, against an ease factor of 6+.
-
-**Equipment:** None. **Encumbrance:** 0 (0) **Vis:** 1 pawn Animal, tail
-
-**Appearance:** Large wolf, white to gray in color, that
-
-looks amused.
-
-White wolves are far larger than normal wolves, and are extremely intelligent. Over the centuries, their human allies have assisted the wolves to modify their pack lands. These reserves about the Tremere House covenants are more confusing than natural forest, and often contain game runs, pits, and enchanted items that the wolves can activate.
-
-### SHADOW OWLS AND FIRE HAWKS
-
-Shadow Owls and Fire Hawks are small raptors, sharing many mechanical attributes.
-
-**Magic Might:** 10 (Animal)
-
-**Characteristics:** Cun –2, Per +5, Pre n/a, Com n/a, Str
-
-–2, Sta 0, Dex +2, Qik +3
-
-**Size:** –3 **Age:** n/a
-
-**Decrepitude:** n/a **Virtues and Flaws:** Nil
-
-**Personality Traits:** Fierce +5, Patient +2
-
-**Reputations:** None
-
-**Combat:** Talons: Init +7, Attack +6, Defense –1,
-
-Damage +4
-
-**Soak:** 0
-
-**Fatigue:** 0, –3, Unconscious
-
-**Wound Penalties**: –1 (1-2), –3 (3-6), –5 (7-9),
-
-Incapacitated (10-15)
-
-**Abilities:** n/a
-
-**Shadow owl powers:**
-
-*Dapple,* 1 point, Imaginem: Shadow owls can alter the appearance of their plumage, so that they blend more readily with their surroundings. If stationary, the owl is hidden by a minor illusion of sight. During flight, any roll to detect an owl using this power suffers a –3 penalty.
-
-*Straight chase,* 1 point, Animal: After this power is activated, a shadow owl can fly through solid objects, for the next few minutes, as if it was a ghost. Shadow owls cannot strike through objects, like armor, because they need to be solid to harm their target. Owls pursue game through forests using this power. The House uses these owls to collect arcane connections, as they can carry game, or small items, in ghostly form.
-
-#### Fire kite powers:
-
-*Kindle,* 1 point, +5 Init. Ignem: Fire kites can ignite flammable objects by touch. They light small brushfires to flush, and sometimes cook, insects. They usually grasp a stick or clump of grass, ignite it, and then drop it while swooping over a target area. A kite using the Kindle power that strikes a foe does +9 damage (including the talon damage given above). The House uses these animals as saboteurs.
-
-**Equipment:** None. **Encumbrance:** 0 (0)
-
-**Vis:** 1 pawn Imaginem, feathers or 1 pawn Ignem, both claws.
-
-The House has found uses for a variety of small raptors. Shadow owls are useful for collecting arcane connections. Fire kites are used as saboteurs.
-
-The most popular large raptor in House Tremere is the griffin vulture, found along the Adriatic coast. These creatures, which follow griffins and feed on their scraps, can see tremendous distances and are magically sensitive. Their cooperative hunting pattern, searching for dead lambs by scouring the countryside in a comb formation, makes them perfect intelligence gatherers.
-
-#### ETHEREAL FISHERMAN SPIDERS
-
-Ethereal fishermen are social spiders: arachnids that work communally to construct traps. They consume the spirits of their victims, which are generally insects. To breed the ethereal fishermen need to take on additional mass, and then distribute their eggs. They do this by trapping persistent spirits, preferably human ghosts.
-
-The webs constructed by ethereal fishermen are individually small, but they work as a swarm to construct large, elaborate structures that capture ghosts of Might 20 or less. Use the *Weaver's Trap of Webs* spell as a guideline to determine if the ghost can escape. The spiders
-
-
-prefer, when breeding, to lay webs across roads, to catch wandering spirits. The tiny spiders swarm anything that falls into their web, cocooning it. They feed from the ghost, draining its Might pool repeatedly until they are bloated enough to breed. The spiders then lay eggs, which are in spectral form, into the ghost. The ghost is then released to flee to its usual haunt, taking the spider eggs with it. The hatching spiders usually destroy the ghost.
-
-The webs of ethereal fishermen do not catch humans. Contact with the web does no damage, although it causes a cold, spine-tingling sensation. To Second Sight, the web is a deep blue, almost black, but the spiders are luminous and milky. They form beautiful constellations in their three-dimensional traps. Some Tremere keep them simply for their attractiveness, others for the coolness of their webs, which is pleasant in the Mediterranean summer.
-
-Tremere magi are fascinated by the way that these spiders skirt the barrier between the material and ethereal states. They use controlled swarms of spiders to imprison ghosts. Tremere magi farm these spiders for their beautiful silk, from which they make formal robes. Their small, farmed colony is fed with pure Mentem vis. The silk becomes shimmering and translucent when dyed. Some Tremere believe there is a complete ethereal ecosystem, which magi glimpse only tangentially.
+> ## Animals: Magic Items that can be Trained
+> 
+> Tremere magi often trap and study the magical animals they encounter, adding them to the House's resources. If a covenant has a population of interesting animals, perhaps as a vis source, a young Tremere magus may be sent to determine their usefulness. If they prove valuable, the magus will want to procure live samples for his superiors. The House might also secure breeding pairs, to start new colonies of the animals at a House Covenant.
+> 
+> ### Common White Wolves
+> 
+> There are several types of magical wolf that serve the House in its packs but this type, descended from Tremere's familiar, are the most common.
+> 
+> **Magic Might:** 10 (Animal)
+> 
+> **Characteristics:** Int +1, Per +3, Pre +1, Com +1, Str+2, Sta +2, Dex +2, Qik +2
+> 
+> **Size:** 1 **Age:** n/a
+> 
+> **Decrepitude:** n/a
+> 
+> **Virtues and Flaws:** The Visions Virtue occurs occasionally among these wolves.
+> 
+> **Personality Traits:** Loyal +2, Amused by Humans +1
+> 
+> **Reputations:** None
+> 
+> **Combat:**
+> 
+> *Bite:* Init +12, Attack +10, Defense +14, Damage +9
+> 
+> **Soak:** +7
+> 
+> **Fatigue:** 0,–1/–1,–3/–3,–5,Unconscious
+> 
+> **Wound Penalties**: –1 (1–6), –3 (7–12), –5 (13–18), Incapacitated (19–24) 
+> 
+> **Abilities:** \[Area\] Lore 6 (Pack land), Brawl 3 (bite), Folk Ken (Tremere magi) 3, Hunt 6 (in a pack), Latin\* 3 (Hermetic terms). Stealth (forests) 3, Swim (lakes) 1, Survival 6 (forests)
+> 
+> \* Cannot speak Latin without magical assistance, but some packs are trained to understand it by familiars which can.
+> 
+> **Powers:**
+> 
+> *Theft of Voice,* 1 point, Init +10, Mentem: The wolf can steal the voice of any human with whom it makes eye contact. The effect usually lasts until the next sunrise, although some individual wolves have variant powers, so that the effect ceases when crossing a stream, or entering a church, or by firelight.
+> 
+> *Eyes like Lanterns,* 5 points, Init +5, Mentem: The wolf can paralyze a victim with terror. This requires the wolf to make eye contact, and the victim to fail a Brave check with an ease factor of 9+. A victim who makes eye contact with several wolves may need to make several checks. The victim may make a new check each round if attacked, with an ease factor of 6+, so wolves tend to form a circle about a mesmerized victim and all pounce at the same time. Slapping or shaking the victim also allows a check, against an ease factor of 6+.
+> 
+> **Equipment:** None.
+> 
+> **Encumbrance:** 0 (0)
+> 
+> **Vis:** 1 pawn Animal, tail
+> 
+> **Appearance:** Large wolf, white to gray in color, that looks amused.
+> 
+> White wolves are far larger than normal wolves, and are extremely intelligent. Over the centuries, their human allies have assisted the wolves to modify their pack lands. These reserves about the Tremere House covenants are more confusing than natural forest, and often contain game runs, pits, and enchanted items that the wolves can activate.
+> 
+> ### Shadow Owls and Fire Hawks
+> 
+> Shadow Owls and Fire Hawks are small raptors, sharing many mechanical attributes.
+> 
+> **Magic Might:** 10 (Animal)
+> 
+> **Characteristics:** Cun –2, Per +5, Pre n/a, Com n/a, Str -2, Sta 0, Dex +2, Qik +3
+> 
+> **Size:** –3
+> 
+> **Age:** n/a
+> 
+> **Decrepitude:** n/a
+> 
+> **Virtues and Flaws:** Nil
+> 
+> **Personality Traits:** Fierce +5, Patient +2
+> 
+> **Reputations:** None
+> 
+> **Combat:** Talons: Init +7, Attack +6, Defense –1, Damage +4
+> 
+> **Soak:** 0
+> 
+> **Fatigue:** 0, –3, Unconscious
+> 
+> **Wound Penalties**: –1 (1–2), –3 (3–4), –5 (5–6), Incapacitated (7–8)
+> 
+> **Abilities:** n/a
+> 
+> **Shadow owl powers:**
+> 
+> *Dapple,* 1 point, Imaginem: Shadow owls can alter the appearance of their plumage, so that they blend more readily with their surroundings. If stationary, the owl is hidden by a minor illusion of sight. During flight, any roll to detect an owl using this power suffers a –3 penalty.
+> 
+> *Straight chase,* 1 point, Animal: After this power is activated, a shadow owl can fly through solid objects, for the next few minutes, as if it was a ghost. Shadow owls cannot strike through objects, like armor, because they need to be solid to harm their target. Owls pursue game through forests using this power. The House uses these owls to collect arcane connections, as they can carry game, or small items, in ghostly form.
+> 
+> #### Fire kite powers:
+> 
+> *Kindle,* 1 point, +5 Init. Ignem: Fire hawks can ignite flammable objects by touch. They light small brushfires to flush, and sometimes cook, insects. They usually grasp a stick or clump of grass, ignite it, and then drop it while swooping over a target area. A kite using the Kindle power that strikes a foe does +9 damage (including the talon damage given above). The House uses these animals as saboteurs.
+> 
+> **Equipment:** None. **Encumbrance:** 0 (0)
+> 
+> **Vis:** 1 pawn Imaginem, feathers or 1 pawn Ignem, both claws.
+> 
+> The House has found uses for a variety of small raptors. Shadow owls are useful for collecting arcane connections. Fire hawks are used as saboteurs.
+> 
+> The most popular large raptor in House Tremere is the griffin vulture, found along the Adriatic coast. These creatures, which follow griffins and feed on their scraps, can see tremendous distances and are magically sensitive. Their cooperative hunting pattern, searching for dead lambs by scouring the countryside in a comb formation, makes them perfect intelligence gatherers.
+> 
+> #### Ethereal Fisherman Spiders
+> 
+> Ethereal fishermen are social spiders: arachnids that work communally to construct traps. They consume the spirits of their victims, which are generally insects. To breed the ethereal fishermen need to take on additional mass, and then distribute their eggs. They do this by trapping persistent spirits, preferably human ghosts.
+> 
+> The webs constructed by ethereal fishermen are individually small, but they work as a swarm to construct large, elaborate structures that capture ghosts of Might 20 or less. Use the *Weaver's Trap of Webs* spell as a guideline to determine if the ghost can escape. The spiders prefer, when breeding, to lay webs across roads, to catch wandering spirits. The tiny spiders swarm anything that falls into their web, cocooning it. They feed from the ghost, draining its Might pool repeatedly until they are bloated enough to breed. The spiders then lay eggs, which are in spectral form, into the ghost. The ghost is then released to flee to its usual haunt, taking the spider eggs with it. The hatching spiders usually destroy the ghost.
+> 
+> The webs of ethereal fishermen do not catch humans. Contact with the web does no damage, although it causes a cold, spine-tingling sensation. To Second Sight, the web is a deep blue, almost black, but the spiders are luminous and milky. They form beautiful constellations in their three-dimensional traps. Some Tremere keep them simply for their attractiveness, others for the coolness of their webs, which is pleasant in the Mediterranean summer.
+> 
+> Tremere magi are fascinated by the way that these spiders skirt the barrier between the material and ethereal states. They use controlled swarms of spiders to imprison ghosts. Tremere magi farm these spiders for their beautiful silk, from which they make formal robes. Their small, farmed colony is fed with pure Mentem vis. The silk becomes shimmering and translucent when dyed. Some Tremere believe there is a complete ethereal ecosystem, which magi glimpse only tangentially.
 
 ### Virtues and Flaws
 
@@ -4901,16 +4477,14 @@ Some other virtues have a particular resonance with the history of the House:
 - All Tremere magi have a Minor Magical Focus in Certamen. This makes them excellent duelists, but means that they cannot, age for age, match the power of other magi with similar interests. Like their Founder, they work around this problem with diplomacy, preparation and supporters.
 - Most of the House's practitioners of Mercurian magic died in the Tempest, the decisive battle of the Schism War. Four hundred years on, their descendants still exist, but the virtue is not required for membership of the House.
 - The Heir, Mentor and Close Family Ties virtues can be used to modify a Tremere magus's relationship with his tribune or conciliarius, with the Storyguide's approval.
-- Entrancement, Skilled Parens, Piercing Gaze, Self Confident, Second Sight, Social Contacts, Cautious
-
-
+- Entrancement, Skilled Parens, Piercing Gaze, Self Confident, Second Sight, Social Contacts, Cautious Sorcerer and Temporal Inﬂuence are common, as are afﬁnities in Guile, Bargain and Finesse.
 - The Shapeshifter and Skinchanger virtues may explain some of the stories about the wolves of Coeris. Tremere Shapeshifters also often take the form of owls.
 - Dark Secret (Diedne Magic) is not appropriate for Tremere characters. Tremere is the House most likely to react violently to the re-emergence of a druidical lineage of magi.
 - Berserk magi cannot fight to doctrine and so are ineffective soldiers.
 
 The attitude of the House toward most characters with Flaws is based on the magus's capacity to serve as a soldier in times of crisis. Few Tremere magi would accept an apprentice with any of the following flaws: Hedge Wizard, Faerie Upbringing, Noncombatant, Softhearted, and Reclusive. A Weak Parens would not train a child, although a master might become Infamous during or after an apprenticeship. Apprentices with physical disabilities, or who are Tainted with Evil, would not be selected for training, but those who developed these flaws after they were accepted might not be sold to other Houses. Magic Addiction, Painful Magic, Fury and many physical disabilities prevent a magus from serving effectively, and most Tremere magi would see them as humiliating.
 
-A second group of flaws make a magus suboptimal on the battlefield, but can be hidden by sufferers. They are likely a cause of embarrassment, particularly if they seem to indicate a lack of self-control. These flaws include Rigid Magic, Short-ranged Magic, Unstructured Caster, Careless Sorcerer, Slow Magic, Unpredictable Magic, Warped Magic, Weak Magic, Weird Magic, Weakness, Afflicted Tongue, Motion Sickness, No Sense of Direction, Obese, Palsied Hands, Poor Eyesight, Poor Hearing.
+A second group of flaws make a magus suboptimal on the battlefield, but can be hidden by sufferers. They are likely a cause of embarrassment, particularly if they seem to indicate a lack of self-control. These flaws include Rigid Magic, Short-ranged Magic, Unstructured Caster, Careless Sorcerer, Slow Caster, Unpredictable Magic, Warped Magic, Weak Magic, Weird Magic, Weakness, Afflicted Tongue, Motion Sickness, No Sense of Direction, Obese, Palsied Hands, Poor Eyesight, Poor Hearing.
 
 The Clumsy Magic flaw would cripple a Tremere magus in sagas that use the dueling rules provided later in this chapter.
 
@@ -4918,18 +4492,13 @@ The Favors flaw creates an obligation in addition to that caused by membership o
 
 ### Abilities
 
-Members of House Tremere value Abilities that allow them to serve in times of crisis, and acquire power during peace. Many Tremere are masters of Intrigue and Bargain skillfully. Magical combat skills, like Penetration, Concentration, Parma Magica and Finesse are valued. Younger magi are expected to be able to fend for themselves on the Wizard's March, and so they develop some skill in Survival, Swim, Athletics (hiking) and Profession
-
-
-
-
-(soldier). Most cannot Hunt well, since the Tremere doctrine discourages foraging. A Tremere who is being groomed as a specialist in an area concentrates on skills that will aid in his missions. Leadership is useful in older magi and those who lead mortal forces.
+Members of House Tremere value Abilities that allow them to serve in times of crisis, and acquire power during peace. Many Tremere are masters of Intrigue and Bargain skillfully. Magical combat skills, like Penetration, Concentration, Parma Magica and Finesse are valued. Younger magi are expected to be able to fend for themselves on the Wizard's March, and so they develop some skill in Survival, Swim, Athletics (hiking) and Profession (soldier). Most cannot Hunt well, since the Tremere doctrine discourages foraging. A Tremere who is being groomed as a specialist in an area concentrates on skills that will aid in his missions. Leadership is useful in older magi and those who lead mortal forces.
 
 ### Magical Items Popular in the House
 
 Tremere magi expect to carry their own gear, so they prefer small magical items, crafted out of expensive materials. Many members of the House believe that Tremere invented the wand as a more manageable version of the staff. Tremere magi like rings, for their portability and because they can be comfortably worn while sleeping. Pouches that allow a magus to carry a campaign's worth of food on his belt and flasks that draw water from nearby clouds are popular. Sacks that reduce the bulkiness of bedding and camping gear are valuable.
 
-### MATERIALS
+#### Materials
 
 Minor magical items from the Transylvanian covenants are often amber, rhodocrosite or opal. Major magic items are comprised of the full range of materials found in other Hermetic manufactures, but lesser items favor these cheaper alternatives. Amber and rhodocrosite are semiprecious gems for enchantment cost calculation; opal is precious.
 
@@ -4947,87 +4516,81 @@ Younger magi are often the most convenient members of the House to assign to pro
 
 There are many roles, common in other Houses, that Tremere magi rarely perform. Tremere magi cannot have magical focuses other than certamen, so they hire magi from other Houses to provide specialized services. Major spell research is sponsored with the aid of Magi from House Bonisagus. The House contracts Verditus magi to construct many of its magic items, providing them with lodgings in the Covenant of Lycaneon, which maintains the House's amber supplies.
 
-#### ARCHITECTS
+#### Architects
 
 Initially the House's combat engineers, these Terram specialists now have a primarily economic role. The House's architects supervise House Tremere's fortifications, tunnels and mines. They also, surreptitiously, maintain roads and bridges in Transylvania, and are the source of several bridges said to have been built overnight by the Devil.
 
-#### ARTIFICERS
+#### Artificers
 
 Artificers manufacture the ritual objects of the House, both magical and mundane. If a new dragon banner is required, it is fitting a Tremere magus make it. Artificers make the reliquaries of other Tremere magi. If the table around which the Council meets needs repair, an artificer performs it. Artificers also dye the cloaks, and often craft the sigils, of Tremere magi. Artificers create the magic items that the House does not want discussed with outsiders.
 
 Artificers do not have techniques that are novel: they are less skilled than Verditus magi of the same age. They do, however, bring the Tremere mindset to problems. They see the need for devices in the same way other Tremere do, and hired Verditus magi often realize their concepts for new devices.
 
-
-
-#### ASSESSOR
+#### Assessor
 
 Assessors have a variety of urban roles: diplomat, merchant or spy. The cadre of Assessors maintains a series of identities that a member can wear using suitable illusions. All have the Gentle Gift. Assessors are, in part, the source of the folktale in Transylvania about vampires who work as merchants, traveling between cities, returning after years under the pretense that they are their own sons.
 
-### DISPUTANTS
+### Disputants
 
 Disputants specialize in Certamen. They are less common than magi of other Houses expect. The House trains a few, who act as its representatives in vital matters, but prefers that most of its magi focus on other tasks. Disputants, as a group, also have an unfortunate reputation for egomania.
 
 Some disputants claim that with sufficient mastery of certamen, they learn to mimic the magical focus of the Founder Tremere. They believe Tremere, hounded through his apprenticeship by his parens and brother, was skilled at defensive fast-casting when assailed with magic.
 
-#### MASTER OF AUXILIARIES
+#### Master of Auxiliaries
 
 A handful of Tremere magi train to lead mundane soldiers, whom the House calls auxiliaries. Magi in this role master small, incapacitating spells which they multicast. When masses of mundanes are intermingled, single strike spells make little difference and killing your own troops is with area-effect spells is gauche, if sometimes necessary. Over the course of a battle, small multicasts allow aimed fire at masses of troops. Spells that create and then control animals are fashionable in this role, as the animals persist after they strike, and are intelligent enough to seek fresh targets.
 
-### NAUARCHOS
+### Nauarchos
 
 House Tremere maintains a fleet of ships, which is particularly active in the Adriatic and Black Seas. The fleet is a method of transporting materiel in times of crisis, so most of its ships are cargo vessels. The fleet engages in commerce during peace. The fleet's warships guard the cargo vessels, and dissuade piracy. They aren't dependable platforms for magical combat.
 
-Tremere naval officers have spells that control or create weather, allow communication at a distance, and suppress fire. A handful of Tremere magi have engaged in
+Tremere naval officers have spells that control or create weather, allow communication at a distance, and suppress fire. A handful of Tremere magi have engaged in small fleet actions or arranged shore bombardments, and doctrine on the use of ships may emerge if the House's influence in the Eastern Mediterranean improves.
 
+> ## Saga Seeds: Weapons Research
+> 
+> House Tremere's leaders are aware that they may soon have a far stronger position on the Greek Peninsula. This implies the fleet will cease to concentrate on the Black and Adriatic Seas, which may attract the hostility of naval powers. The House would like to prepare for this possibility by developing a doctrine of naval warfare. This would move ships beyond their cargo-carrying role, so that they became offensive platforms. Player characters review ship types, develop naval strategies, and design magic items for the new doctrine. A small covenant is established, well away from the Theban Tribunal, to test the naval doctrine, evolving into a fleet maintenance base. The new doctrine is to be tested against the pirates of Rhodes, so other characters are sent there, to reconnoiter. If a suitable site can be secured, a second base is likely to develop there.
+> 
+> A complication of the expansion of House Tremere's interests beyond Cyprus is that their sphere of operations will overlap the territory of a group of Arabic wizards who have been able to defeat small Hermetic forces. Their success, in part, is due to their control of spirits that can fly, and carry wizards. This gives this group of Arabic wizards rapid reaction forces that the Order cannot match, and allows them limited air superiority. The House may respond by developing an avian force.
+> 
+> Magi seek mounts for the new force. Companions, who are easier to replace if ripped to pieces by genies, become the preferred riders. Magi develop offensive capabilities for the mounts, or invent a system that allows magical weapons to be recovered from the fallen and given to replacements.
 
-House Tremere's leaders are aware that they may soon have a far stronger position on the Greek Peninsula. This implies the fleet will cease to concentrate on the Black and Adriatic Seas, which may attract the hostility of naval powers. The House would like to prepare for this possibility by developing a doctrine of naval warfare. This would move ships beyond their cargo-carrying role, so that they became offensive platforms. Player characters review ship types, develop naval strategies, and design magic items for the new doctrine. A small covenant is established, well away from the Theban Tribunal, to test the naval doctrine, evolving into a fleet maintenance base. The new doctrine is to be tested against the pirates of Rhodes, so other characters are sent there, to reconnoiter. If a suitable site can be secured, a second base is likely to develop there.
+#### Physicians
 
-A complication of the expansion of House Tremere's interests beyond Cyprus is that their sphere of operations will overlap the territory of a group of Arabic wizards who have been able to defeat small Hermetic forces. Their success, in part, is due to their control of spirits that can fly, and carry wizards. This gives this group of Arabic wizards rapid reaction forces that the Order cannot match, and allows them limited air superiority. The House may respond by developing an avian force.
-
-Magi seek mounts for the new force. Companions, who are easier to replace if ripped to pieces by genies, become the preferred riders. Magi develop offensive capabilities for the mounts, or invent a system that allows magical weapons to be recovered from the fallen and given to replacements.
-
-small fleet actions or arranged shore bombardments, and doctrine on the use of ships may emerge if the House's influence in the Eastern Mediterranean improves.
-
-### PHYSICIANS
-
-Members of this branch of the House are skilled healers and crafters of longevity potions. They specialize in medical spells that do not require vis but are still superior to mundane medicine; examples include anesthesia, bone setting and arrow extraction. Tremere magi trust the skill and loyalty of their physicians but, since they are usually corporeal necromancers, find their sigils, reputations and experiments disturbing. These unsettling figures assess
-
-
-potential Tremere apprentices before their mystical potential is tested.
+Members of this branch of the House are skilled healers and crafters of longevity potions. They specialize in medical spells that do not require vis but are still superior to mundane medicine; examples include anesthesia, bone setting and arrow extraction. Tremere magi trust the skill and loyalty of their physicians but, since they are usually corporeal necromancers, find their sigils, reputations and experiments disturbing. These unsettling figures assess potential Tremere apprentices before their mystical potential is tested.
 
 Most Tremere magi feel that corporeal necromancers suffer unusually poor luck, and wonder if the work of Guorna is cursed. They are more likely to slip into diabolism than other members of the House, and are watched carefully by their superiors and the Quaesitores.
 
-### SCOUTS
+#### Scouts
 
 These magi, descended from the Schism scouts, are trained to move through potentially hostile territory, collect information, and return home. They are used, during peace, to assess situations where only fragmentary information is available. For example, if the House was seeking a missing redcap they would, initially, send a scout. Scouts are also the house's explorers. Some scouts track and capture magical animals.
 
-### SIGNALERS
+#### Signalers
 
 These magi are descended from a small corps of tricksters who, during the Schism, fed false information to House Diedne's human supporters, created bogus targets, hid Tremere scouts, and confused enemy signals. In the modern house, the signalers are the magicians who speed communication, although most dabble in the tricks of their illusionist ancestors. Of all branches of the House, Signalers seem to be most cheerful.
 
-### Certamen reputations
-
-A character encountering another duelist may roll on the following table to determine information about their potential foe:
-
-#### die + Reputation
-
-- 3 Scandalous breaches of etiquette
-- 6 School
-- 9 Favored arts
-- 12 Favored victory spells
-- 15 Famous victories
-
-#### Modifiers:
-
-Members of the same school +1
-
-From the same Tribunal +1
-
-From the same house, other than Tremere or Tytalus +1
-
-Both members of House Tytalus +2
-
-Both members of House Tremere +3
+> ## Certamen reputations
+> 
+> A character encountering another duelist may roll on the following table to determine information about their potential foe:
+> 
+> ### die + Reputation
+> 
+> - 3 Scandalous breaches of etiquette
+> - 6 School
+> - 9 Favored arts
+> - 12 Favored victory spells
+> - 15 Famous victories
+> 
+> ### Modifiers:
+> 
+> Members of the same school +1
+> 
+> From the same Tribunal +1
+> 
+> From the same house, other than Tremere or Tytalus +1
+> 
+> Both members of House Tytalus +2
+> 
+> Both members of House Tremere +3
 
 ## Dueling
 
@@ -5043,11 +4606,7 @@ Tremere magi often participate in certamen without wishing to settle an issue. A
 
 A famous duelist from the tenth century, named Agrippina, used to send white roses with her challenges. She found ways to shower her defeated enemies with rose petals using her final spell, across a surprising variety of art combinations. Many serious duelists for love emulate her. Her nickname, "Nemesis", from the goddess that enforces humility, has entered the duelist vernacular.
 
-Even a skilled duelist may develop a poor reputation if they use their abilities in an uncouth way. It is important that a magus knows when to challenge to certamen,
-
-
-
-and if the challenge should be for love. Victory by first blow or surrender is usual, because Tremere magi consider it vulgar to force your rival to beat you unconscious. Other significant factors include the selection of venue, the wording of the challenge, and the acceptance or rejection of arts, the choice of final spell, the way a loser faces the spell, the words exchanged after the duel concludes and the actions of the defeated magus which demonstrate their acquiescence to the outcome. A magus must be powerful to attract respect, but one who demonstrates exquisite self-control is admired.
+Even a skilled duelist may develop a poor reputation if they use their abilities in an uncouth way. It is important that a magus knows when to challenge to certamen, and if the challenge should be for love. Victory by first blow or surrender is usual, because Tremere magi consider it vulgar to force your rival to beat you unconscious. Other significant factors include the selection of venue, the wording of the challenge, and the acceptance or rejection of arts, the choice of final spell, the way a loser faces the spell, the words exchanged after the duel concludes and the actions of the defeated magus which demonstrate their acquiescence to the outcome. A magus must be powerful to attract respect, but one who demonstrates exquisite self-control is admired.
 
 ### Styles of Certamen
 
@@ -5057,78 +4616,68 @@ At the start of each certamen, each combatant chooses if they are going to duel 
 
 Magi are raised in their masters' schools. Magi not trained in certamen during apprenticeship become a member of a school by studying with a skilled member of the school for a season. Most schools are vague groups of magi who duel in a similar way, but some schools, at the troupe's discretion, have political hierarchies.
 
-### GLADIATOR
+#### Gladiator
 
-The School of the Swordsman is the style of the Founder Tremere, reflected in the basic rules. It is a balanced, simple style, for which many teachers are available. Rumors persist that there are a series of secret techniques for this school, allowing dedicated Followers to can spend vis to greater effect than other magi. The Tremere treat these rumors as an attack on their integrity — if other magi lost faith in the certamen system, it would disadvantage the House. The shared illusions of the
+The School of the Swordsman is the style of the Founder Tremere, reflected in the basic rules. It is a balanced, simple style, for which many teachers are available. Rumors persist that there are a series of secret techniques for this school, allowing dedicated Followers to can spend vis to greater effect than other magi. The Tremere treat these rumors as an attack on their integrity — if other magi lost faith in the certamen system, it would disadvantage the House. The shared illusions of the School of the Swordsman tend to be humaniform and are heavily influenced by the sigil of the magus.
 
-
-
-
-School of the Swordsman tend to be humaniform and are heavily influenced by the sigil of the magus.
-
-#### ANDABATUS
+#### Andabatus
 
 Followers of Blind Fighting school use savage, chaotic attacks to finish duels quickly, while accepting strikes to themselves. The andabatus adds a bonus to his Attack Total of up to twice his Finesse score, but also accepts an equal penalty to his Defense Total. Fighting in the style of the andabata allows a magus to accept a bonus to their Attack Total up to their Finesse score, but the penalty is twice the bonus. The shared illusion of the certamen churns and loses focus when an andabatus fights, because their technique is instinctual, imprecise and assumes the opponent will strike them.
 
-#### BESTIARIUS
+#### Bestiarius
 
 Employed only by members of House Bjornaer, the techniques of the School of Beasts allows them to use their Heartbeast score instead of their Finesse score during duels in the Muto form, or involving their own bodies. In Muto Corpus or Muto Animal duels, they can add twice their Heartbeast score to their Resistance Total. Bjornaers who dabble in the Bestiarus technique add their Heartbeast score to their Resistance.
 
-#### BONE-BITING
+#### Bone - Biting
 
-This technique is based on the magical practices of certain Irish bards, and was brought to the Order by magi of House Diedne. It allows a magus to injure himself to resist fatigue, or increase the strength of his next attack. The dedicated followers of this technique died in the Schism. Those fighting in this style cause themselves a Body level of damage, and either ignore the loss of the next two fatigue levels, or add ten points to their next Attack Total. Traditionally the magus bites through the tip of the left thumb, to the bone.
+This technique is based on the magical practices of certain Irish bards, and was brought to the Order by magi of House Diedne. It allows a magus to injure himself to resist fatigue, or increase the strength of his next attack. The dedicated followers of this technique died in the Schism. Those fighting in this style cause themselves a Light Wound, and either ignore the loss of the next two fatigue levels, or add ten points to their next Attack Total. Traditionally the magus bites through the tip of the left thumb, to the bone.
 
 In 1220, the few magi who practice this technique bite their tongues instead. Accidental tongue biting occasionally occurs during certamen, so this does not look like an overtly druidical practice. It is very difficult for these magi to surreptitiously do more than one Body level of damage to themselves, because it is reflected in the shared illusion, with elements of blood and fire.
 
-### CHARON
+#### Charon
 
 A trick, rather than a school, named for the Ferryman on the River Styx, a magus fighting in the style of Charon may cast two spells on an opponent at the end of certamen. They do this by casting a spell silently and without gestures during an earlier round of the certamen (Intelligence + Concentration of 15+), then maintaining it until the round they believe will be the final one, declared before the Attack Roll (Intelligence + Concentration of 12+ each round). If they are correct, this spell travels along the arcane connection provided by the certamen duel, along with whatever spell they cast in the round after the certamen is complete. Using this trick is likely a breach of the Peripheral Code, but it has only appeared recently, and so no Tribunal has considered it. Rumors suggest that there is a School of Charon whose members can cast many spells on those they defeat in certamen.
 
-#### ESSEDARIUS
+#### Essedarius
 
 The Charioteer techniques are flashy and intimidating. They subdue foes psychologically. After a successful attack, the essedarius may choose to do no damage and instead create the impression of a powerful and dreadful attack that failed, but by the barest chance. The intention is to frighten the foe into surrender, which may occur if they fail a Brave check of 3 + 2 per Fatigue level the essedarius has declined to take during this certamen. Magi fighting in this style can force a similar Brave check, but the target is 3 + 2 per fatigue level forgone in this round of combat.
 
-#### GLADIATRIX
+#### Gladiatrix
 
 The School of the Swordswoman uses a chessboard as a setting for the duel. The phantoms rise from the squares of the board and slaughter each other. The pieces do not always correspond to those of either mundane or Tremere chess. The matches are spectacular to watch, and give insights into the mental iconography of each player.
 
-Certamen is fought across a chessboard if both duelists accept this in advance, or if the follower of the School of the Gladiatrix voluntarily does no damage after an otherwise successful attack, suing this opportunity to create a phantasmal chessboard. On a successful attack, a follower of the School can choose to do no damage and instead strike out at an enemy piece that represents a concept, idea or value of the opponent. If the opponent does not make an Intelligence roll of 9+, any Gladiatrix viewing the game can surmise their emotional reactions to the
-
-
-
-
-Tremere magi play many non-magical variants of chess. Games at family meetings are popular, and some of the letters that redcaps carry between Tremere magi contains chess moves. The three most popular variants are "old", "prima" and "expedition" chess.
-
-Old chess is the game played by the mundanes in some parts of Europe. It's a slow form, based on the careful building of forces, because the bishops can move only three squares, and the vizier only one, on the diagonal. The king may move up to three spaces in any direction on the first move.
-
-Prima chess has a queen instead of a vizier. The queen can move any number of spaces on the diagonals, rows or columns. Bishops may move an unlimited number of squares on the diagonal. There may only be one queen per side at any time. If the queen is lost, the game is lost.
-
-Expedition chess centers about the magus, his shield-grog, companions and grogs, who have the misfortune to encounter faeries that duplicate the party. The magus may kill distant pieces without moving. If he is lost, the game is lost.
-
-Many Tremere magi consider playing chess a form of intimacy. Some refuse to play with members of the opposite sex, because they consider it an erotic familiarity.
-
-
+Certamen is fought across a chessboard if both duelists accept this in advance, or if the follower of the School of the Gladiatrix voluntarily does no damage after an otherwise successful attack, suing this opportunity to create a phantasmal chessboard. On a successful attack, a follower of the School can choose to do no damage and instead strike out at an enemy piece that represents a concept, idea or value of the opponent. If the opponent does not make an Intelligence roll of 9+, any Gladiatrix viewing the game can surmise their emotional reactions to the concept, idea or value that was threatened. Skilled Gladiatrixes can develop a deep understanding of their rivals using this technique.
 
 Those fighting in the style of the Gladiatrix can create the visual effect of battle on the chessboard, and can summon phantasmal boards, but cannot read their opponent's opinions. Any magus trained in the School of the Sword can fight in the style of the gladiatrix without further training. This is probably because Tremere was a Master of the Games.
 
 Some members of this school believe that they can develop a complicated form of team certamen, in which a magus plays each piece. They have yet to demonstrate this technique at Decennial. It is possible to play chess with Folk Dancers as pieces. The Dance of the White and Red Kings, where two sides fight for the heart of a princess, translates easily to the ritual, with the average score of the dancers on side acting as if it were a Vis bonus during each round.
 
-### HOPLOMACHUS
+> ## Chess
+> 
+> Tremere magi play many non-magical variants of chess. Games at family meetings are popular, and some of the letters that redcaps carry between Tremere magi contains chess moves. The three most popular variants are "old", "prima" and "expedition" chess.
+> 
+> Old chess is the game played by the mundanes in some parts of Europe. It's a slow form, based on the careful building of forces, because the bishops can move only three squares, and the vizier only one, on the diagonal. The king may move up to three spaces in any direction on the first move.
+> 
+> Prima chess has a queen instead of a vizier. The queen can move any number of spaces on the diagonals, rows or columns. Bishops may move an unlimited number of squares on the diagonal. There may only be one queen per side at any time. If the queen is lost, the game is lost.
+> 
+> Expedition chess centers about the magus, his shield-grog, companions and grogs, who have the misfortune to encounter faeries that duplicate the party. The magus may kill distant pieces without moving. If he is lost, the game is lost.
+> 
+> Many Tremere magi consider playing chess a form of intimacy. Some refuse to play with members of the opposite sex, because they consider it an erotic familiarity.
+> 
+
+#### Hoplomachus
 
 This style, named for warriors armored in impersonation of the Greek hoplites, sacrifices many advantages for increased defensiveness. A hoplomachus cannot win initiative contests except against another hoplomachus. Each round the hoplomachus reduces their Attack Total by up to their Finesse score, then increases their Defense Total by up to twice that penalty. In a round where the hoplomachus declines to attack at all, their Defense total gains a bonus of three times their Finesse score. Other magi fighting in the style of the hoplomachus, may decline to attack during a round, and gain a bonus to their Defense Total equal to twice their Finesse score. The half of the shared illusion controlled by the hoplomachus tends be slow, but annoyingly persistent, and resistant to damage.
 
-#### LAQUERIUS
+#### Laquerius
 
 Magi of the School of the Noose gradually bind the ritual working of their opponent, making it inert and ineffective. In any round the laquerius can take a Defense Total penalty equal to or less than their Finesse score. If they land a blow that round, they may choose to inflict no damage and instead reduce their opponent's Defense total for the rest of the duel by the Defense Penalty. This penalty is visible in the shared illusion as a tether marked by the sigil of the laquerius. Magi fighting in the style of the laquetores inflict Defense penalties in the same way, but the penalty lasts only a single round.
 
-
-
-
-#### PROVOCATOR
+#### Provocator
 
 Members of the School of Challengers sacrifice fleetness for protection. A provocator may accept a penalty on their Initiative Total that is equal or less than their Finesse score, but in all future rounds their Resistance Total attracts a bonus equal to the penalty. Many provocators develop strong Parma Magicae and do not attempt to win Initiative contests. Others may only fight effectively in the style of the provocator if they have initiative in the duel. They lose the initiative in the following round, but their Resistance Total rises by their Finesse score. In the round that follows, they regain the initiative. The shared illusions contributed by provocators tend to be annoying — but that may reflect the personalities of the members of this school, which is a little more social and organized than the others. They delight in dodging blows by a whisker and flippant duel conversation.
 
-### PUMILIUS
+#### Pumilius
 
 Use of the techniques of the School of the (Amusing) Dwarfs is considered offensive by some Tremere magi. This style has been active for over two centuries, however, and many Tremere magi believe that, in some more dignified way, its core movement is acceptable in polite society. The provocatores find it humorous, for example.
 
@@ -5138,11 +4687,11 @@ The Pumilius declines to do damage after a successful attack, and instead projec
 
 The retiarius attempts to strike swiftly, and evade damage. Dedicated practitioners of the School of the Fisherman may add a bonus of equal to or less than their Finesse score to their Initiative roll. They must subtract twice that number of points from their Attack Advantage in the next three rounds. A reitarius who does not have the initiative can claim it by landing a blow and declining to do damage. A magus fighting in the style of the retiarii may force a fresh initiative roll by landing a blow and declining to do damage. The illusory presences of retarii are swift, flickering things that dance away from blows, and return with feathery attacks that wear the opponent down over several rounds.
 
-#### SAGGITARIUS
+#### Saggitarius
 
 Many Tremere magi do not accept the saggitarius technique as legitimate. It probably lacks dedicated followers. A Merinita magus who desired to humiliate a rival from House Tremere introduced it to the Order. When using the saggitarius technique, the magus may add up to triple their Finesse to their Attack Total, subtracting the same amount from their Defense total. Regardless of the outcome of their rolls, they can never do more than one Fatigue level of damage. It creates a tiny attack based on the duelist's sigil that is extremely effective for winning duels to the first blow — but very little else. Many Tremere magi refuse to use the Technique of the Archer, and challenge its legitimacy in legal contexts.
 
-#### SCISSOR
+#### Scissor
 
 The School of Carvers uses cripplingly deep attacks. The scissor may choose not to attack in a round, then, in the following round, they attack as normal, but if successful they use the following damage formula:
 
@@ -5150,61 +4699,57 @@ The School of Carvers uses cripplingly deep attacks. The scissor may choose not 
 
 A magus fighting in the style of the scissores skips an attack, and then if their next attack is successful, they use the formula above, dividing instead by 4.
 
-### VELITUS
+#### Velitus
 
-The Style of the Spear is based on wearing down an enemy's magical resistance during the early rounds of the combat. A velitus who lands a blow and declines to do damage reduces their foe's Resistance total by one half of the velitus's Finesse score, rounded down. A velitus can damage a foe's ritual working so badly that it acts as a channel for hostile magic — their Resistance Total can become negative. A magus fighting in the velitus style may decline to do damage and instead reduce their opponent's resistance by Finesse divided by 3, rounded down, to a minimum Resistance of zero. The effect of a success-
-
-
-
-ful spear attack on the shared illusion varies with the sigil of the duelist and the context of the illusion, but sometimes looks like a long cylinder skewering the champion of the other duelist.
+The Style of the Spear is based on wearing down an enemy's magical resistance during the early rounds of the combat. A velitus who lands a blow and declines to do damage reduces their foe's Resistance total by one half of the velitus's Finesse score, rounded down. A velitus can damage a foe's ritual working so badly that it acts as a channel for hostile magic — their Resistance Total can become negative. A magus fighting in the velitus style may decline to do damage and instead reduce their opponent's resistance by Finesse divided by 3, rounded down, to a minimum Resistance of zero. The effect of a successful spear attack on the shared illusion varies with the sigil of the duelist and the context of the illusion, but sometimes looks like a long cylinder skewering the champion of the other duelist.
 
 ## New Spells
 
-### CREO ANIMAL SPELLS
+#### Creo Animal Spells
 
-**VENOMOUS VELITES**
+##### Venomous Velites
 
-**R:** Sight, **D:** Sun, **T:** Group, **Level 40**
+**R:** Sight, **D:** Sun, **T:** Group, **Level 45**
 
 **Requisite:** Rego
 
 Creates a swarm of a hundred poisonous scorpions. The Rego requisite allows the magus to command them to attack specific targets. If used in combination with spells like "To Mark With Umbrage", the magus can command his scorpions to kill anyone on the battlefield not bearing his sigil. It is important for magi with weak Parmae Magicae to ensure they bear the mark.
 
-(Base 5, +3 Sight, +2 Sun, +1 Group, +1 extra effect from requisite.)
+(Base 5, +3 Sight, +2 Sun, +2 Group, +1 extra effect from requisite.)
 
-#### INTELLEGO ANIMAL SPELLS
+#### Intellego Animal Spells
 
-**TO SEE AS OTHERS SEE**
+##### To See as Others See
 
-**R:** Arcane, **D:** Sun, **T:** Ind, **Level 45**
+**R:** Arcane, **D:** Sun, **T:** Ind, **Level 40**
 
 **Requisite:** Rego
 
 This spell allows a magus to read the thoughts of an animal, and give it directions. This allows the magus to indirectly sense the animal's location, using it as a spy. The magus's perceptions are filtered through the mind of the animal, so they focus on those stimuli that the animal finds most vivid. Dogs find smell vivid, so the magus's perceptions, when using a dog, will focus on odiferous substances. A magus reading the mind of a magpie finds that they fixate on reflective surfaces.
 
-(Base 5, +4 Arcane Connection, +2 Sun, +1 Group, +1 extra effect from requisite.)
+(Base 5, +4 Arcane Connection, +2 Sun, +1 extra effect from requisite.)
 
-#### REGO ANIMAL
+#### Rego Animal
 
-**THE UNFAITHFUL FAVOR**
+##### The Unfaithful Favor
 
-**R:** Arc, **D:** Sun **T:** Ind, **Level 20**
-
-### Shape and Material Bonus Table Additions
-
-**Amber:** +3 Controlling movement, +2 Corpus. **Human Skull:** +4 destroy human body, +5 destroy human mind, +5 destroy or control ghosts, +10 destroy of control ghost of particular skull.
-
-**Lead:** +4 wards, +3 summoning and binding ghosts **Mirror:** +6 display images, +3 summon or bind ghosts **Opal:** +4 travel, +6 eyes, +2 images, +2 invisibility **Rhodocrosite:** +3 forgetfulness, +2 memories, +3
-
-binding wounds
+**R:** Touch, **D:** Sun **T:** Ind, **Level 45**
 
 This spell commands a silk handkerchief to strangle an enemy for whom the magus has an arcane connection. The handkerchief appears near the victim and swiftly wraps itself about their throat. They take damage according to the rules in **Ars Magica** until death or the destruction of the handkerchief. Conscious victims can often avoid the handkerchief, so this spell is usually cast at night. After the victim dies, the handkerchief hides itself in their bedding, or up their sleeve.
 
-(Base 1, +4 Arcane, +2 Sun, +1 Commands in addition to transport)
+(Base 25, +1 Touch, +2 Sun, +1 commands in addition to transport)
 
-### REGO AQUAM SPELLS
+> ### Shape and Material Bonus Table Additions
+> 
+> **Amber:** +3 Controlling movement, +3 Corpus.
+>
+>**Human Skull:** +4 destroy human body, +5 destroy human mind, +5 destroy or control ghosts, +10 destroy of control ghost of particular skull.
+> 
+> **Lead:** +4 wards, +3 summoning and binding ghosts **Mirror:** +6 display images, +3 summon or bind ghosts **Opal:** +4 travel, +6 eyes, +2 images, +2 invisibility **Rhodocrosite:** +3 forgetfulness, +2 memories, +3 binding wounds
 
-**EXACTLY TO SCALE**
+#### Rego Aquam Spells
+
+##### Exactly to Scale
 
 **R:** Touch, **D:** Mom, **T:** Ind, **Level 10**
 
@@ -5216,28 +4761,23 @@ The magus requires an Intelligence + Finesse roll of 9+ for the diagram to be le
 
 (Base 3, +1 Touch, +2 for highly unnatural control)
 
-#### CREO IMAGINEM SPELLS
+#### Creo Imaginem Spells
 
-**TO MARK WITH UMBRAGE**
+##### To Mark with Umbrage
 
-**R:** Sight, **D:** Sun, **T:** Group, **Level 40**
+**R:** Sight, **D:** Sun, **T:** Group, **Level 30**
 
-This spell marks every member in a force mundanes, so that, in the confusion of battle, they can tell friend
-
-
-
-
-from foe. The mark is a large visual representation of the sigil of the magus. The spell's creator had a shadowy sigil, so the grogs she marked appeared dark and featureless, giving the spell its name. The spell can be cast on any group of people, and can project any sort of visual mark, so Tremere magi also use it for processions and sport.
+This spell marks every member in a force mundanes, so that, in the confusion of battle, they can tell friend from foe. The mark is a large visual representation of the sigil of the magus. The spell's creator had a shadowy sigil, so the grogs she marked appeared dark and featureless, giving the spell its name. The spell can be cast on any group of people, and can project any sort of visual mark, so Tremere magi also use it for processions and sport.
 
 Any Awareness roll concerning the location of forces has a +3 bonus while this spell is in effect. Examples include selecting areas of the battlefield to target with destructive spells, selecting victims for missile fire, finding groups to rally to when separated from the army in the swirl of battle.
 
 This version of the spell is able to mark up to a thousand individuals, in groups within the magus's Sight. Some younger magi prefer a version of the spell suited for smaller units of grogs. This version is level 25, is effective to Voice range, and can only affect a group of about ten. Others don't bother because grogs from House covenants usually have a covenant symbol (called a badge) or color on their clothes.
 
-(Base 1, Range +4, Duration +2, Group +3, Size+2)
+(Base 1, +3 Sight, +2 Sun, +2 Group, +2 Size)
 
-#### MUTO MENTEM SPELLS
+#### Muto Mentem Spells
 
-**FALSE PROPHECY**
+##### False Prophecy
 
 **R:** Arcane, **D:** Moon, **T:** Ind, **Level 30**
 
@@ -5245,7 +4785,7 @@ This spell alters the victim's memories of their dreams, so that they recall a p
 
 (Base 3, +4 Arcane, +3 Moon)
 
-**SWORDS OF SILVER AND MOONLIGHT**
+##### Swords of Silver and Moonlight
 
 **R:** Eye, **D:** Sun, **T:** Ind, **Level 40**
 
@@ -5255,7 +4795,7 @@ This spell makes the metal accouterments of a ghost solid. Many ghosts are able 
 
 (Base 25, +1 Eye, +2 Sun)
 
-**SPECTRAL QUINREME**
+##### Spectral Quinreme
 
 **R:** Eye, **D:** Moon, **T:** Structure, **Level 50**
 
@@ -5265,7 +4805,7 @@ A ghostly ship is not the spirit of a ship, it's a prop projected by the psyche 
 
 (Base 15, +1 Eye, +3 Moon, +3 Structure)
 
-**ARMING THE LEGION OF THE DEAD**
+##### Arming the Legion of the Dead
 
 **R:** Touch, **D:** Moon **T:** Group, **Level 70,** Ritual **Requisites:** Terram
 
@@ -5273,17 +4813,17 @@ This spell makes the metal accouterments for an army of ghosts, up to 10,000 str
 
 (Base 25, +1 Touch, +3 Moon, +2 Group, +3 size)
 
-### REGO MENTEM SPELLS
+#### Rego Mentem Spells
 
-**VOICES FROM HOLLOW SPACES**
+##### Voices from Hollow Spaces
 
-**R:** Voice, **D**: Ring, **T:** Ind, **Level 35**
+**R:** Voice, **D**: Ring, **T:** Ind, **Level 25**
 
 This spell binds ghosts to objects or places. Traditional sites include mirrors, skulls and graves. It does not compel trapped ghosts to serve willingly, but members of House Tremere threaten or bribe their ghosts into compliance.
 
-(Base 15, +2 Voice, +2 Ring)
+(Base 5, +2 Voice, +2 Ring)
 
-**THE FACE IN THE MIRROR**
+##### The Face in the Mirror
 
 **R:** Eye, **D:** Moon, **T:** Ind, **Level 40**
 
@@ -5291,14 +4831,11 @@ This spell forces a ghost to possess a magus, but allows the magus to maintain c
 
 This spell does not summon a ghost. Its designer assumed that he would have the ghost he wished to use stored in a mirror. Tremere magi are supplied with ghosts by Leadworkers, or call them up.
 
-This spell allows the magus to give the ghost complex, unbreakable instructions, but Assessors find it best to convince their ghosts to assist. This is not difficult, because most ghosts are tied to the Earth by a piece of unfinished business that they cannot accomplish. The
-
-
-
+This spell allows the magus to give the ghost complex, unbreakable instructions, but Assessors find it best to convince their ghosts to assist. This is not difficult, because most ghosts are tied to the Earth by a piece of unfinished business that they cannot accomplish. The Tremere can usually bargain for the ghost’s assistance, in exchange for the resolution of its problem.
 
 (Base effect: 20, +1 Eye, +3 Moon)
 
-#### CALL THE FALLEN EAGLES FROM THE MIST
+##### Call the Fallen Eagles from the Mist
 
 **R:** Touch, **D:** Moon, **T:** Group, **Level 65,** Ritual
 
@@ -5306,9 +4843,9 @@ A spell used on ancient battlefields to call up the pagan dead. This spell grant
 
 (Base 15, +1 Touch, +3 Moon, +2 Group, +3 size: up to 10,000 ghosts, + 1 summon and control)
 
-### CREO TERRAM SPELLS
+#### Creo Terram Spells
 
-#### A SIMPLE METHOD FOR RAPID VALLATION
+##### A Simple Method for Rapid Vallation
 
 **R:** Voice, **D:** Sun, **T:** Ind, **Level 35**
 
@@ -5318,9 +4855,9 @@ This spell makes a wall of granite up to 500 paces wide, 5 paces high, and 1 pac
 
 (Base 3, +2 Voice, +2 Sun, +4 size)
 
-#### INTELLEGO TERRAM SPELLS
+#### Intellego Terram Spells
 
-#### LOVE'S UNFAITHFUL WITNESS
+##### Love's Unfaithful Witness
 
 **R:** Touch, **D:** Conc, **T:** Ind, **Level** 35
 
@@ -5328,19 +4865,21 @@ This spell is used to question jewelry about its wearer's activities. The sympat
 
 (Base 25, +1 Touch, +1 Conc)
 
-### MUTO TERRAM SPELLS
+#### Muto Terram Spells
 
-#### A WINDOW OF SINGULAR DIRECTION
+##### A Window of Singular Direction
 
-**R:** Touch, **D:** Ring, **T:** Ind, **Level 10**
+**R:** Touch, **D:** Ring, **T:** Part, **Level 15**
 
 This spell, created by the Architects of Tremere, makes a circle of wall transparent, from one side only. It was developed in the early years of the Order, to allow magi protected by temporary fortifications to target their foes.
 
-(Base 3, +1 Touch, +2 Ring)
+(Base 3, +1 Touch, +2 Ring, +1 Part)
+
+Increase the Base to 4, and the spell level to 20, creates a version that can affect stone walls, which fits the descriptive text better. 
 
 ### New Virtues
 
-### DHAMPIR
+#### Dhampir
 
 *Major, Supernatural*
 
@@ -5352,12 +4891,11 @@ Dhampirs have the following advantages:
 
 - Dhampirs start making aging rolls at the age of fifty, and get –3 to all rolls to resist the effects of aging, cumulative with any other bonuses.
 - Dhampirs have the Virtue Second Sight (see **Ars Magica** 5th Edition, page 48), and can see normally in darkness or semi-darkness. Their eyes look mostly normal, but are an unusual and vivid color.
-
-
-• Dhampirs may learn Faerie Lore during character generation, and gain a +1 bonus on all Faerie lore rolls.
+- Dhampirs may learn Faerie Lore during character generation, and gain a +1 bonus on all Faerie lore rolls.
 
 Dhampirs may have The Gift, but House Tremere forbids the training of dhampirs as Hermetic magi. It did happen once, long ago, and might happen again (Dark Secret Flaw). This is a supernatural ability, and you cannot lose it when being trained as a magus (see **Ars Magica** 5th Edition, page 107). If your master cannot preserve the ability, you cannot be trained. A character who becomes a vampire is given to the Storyguide. Vampires cannot use Hermetic magic, but have a wide variety of powers. Hedge wizard dhampirs are permitted as servants.
 
+#### Folk Dancer
 
 *Minor, Supernatural*
 
@@ -5367,7 +4905,7 @@ A troupe of a dozen or more folk dancers, who all make Dexterity + Carouse rolls
 
 If creating a folk dancer, negotiate three dances with the rest of the Troupe.
 
-### SAMOVILY BLOOD
+### Samovily Blood
 
 *Minor, Supernatural*
 
@@ -5375,12 +4913,7 @@ Bulgarians use the term "Samovily" for several different types of mystical maide
 
 Some samovily are maidens of the woodland, who ride deer, are archers, and can milk the moon like a cow. They love music, and kidnap shepherds to force them to play their pipes. These maidens bathe at dusk and can be forced into servitude by those who steal their clothing. They make poor mothers and flee when they find their clothes.
 
-Other samovily are spirits of the waters, or winged spirits the air. Some are spirits of the waters in Spring and Summer, but spirits of the Air in Autumn and Winter. Spirits of the air are sometimes young women doing penance for frivolous lives. Others are ghosts of women
-
-
-
-
-who died on their wedding day. This last type is able to suck the breath out of young men (see Wili, above).
+Other samovily are spirits of the waters, or winged spirits the air. Some are spirits of the waters in Spring and Summer, but spirits of the Air in Autumn and Winter. Spirits of the air are sometimes young women doing penance for frivolous lives. Others are ghosts of women who died on their wedding day. This last type is able to suck the breath out of young men (see Wili, above).
 
 Characters with samovily blood gain the usual bonuses for Faerie Blood, and one bonus from the list below:
 
@@ -5390,7 +4923,7 @@ Characters with samovily blood gain the usual bonuses for Faerie Blood, and one 
 - +1 on all Presence rolls for characters that find young, blonde women attractive.
 - +2 on all activities undertaken underwater.
 
-### MYTHIC BLOOD (ZMEY)
+#### Mythic Blood (Zmey)
 
 *Major, Hermetic*
 
@@ -5404,15 +4937,15 @@ A human who eats the heart of a zmey gains many of its powers, including superna
 
 Descent from a zmey grants a Minor Magical Focus with Storms, and the Minor Personality Flaw tends to be one of Lecherous, Meddler, or Proud. The granted power may be invisibility (as *Veil of Invisibility* (ArM5 page 146), but with Personal Range and no Penetration, castable without words or gestures), the ability to fly on the wind (as *Wings of the Soaring Wind* (ArM5 page 126), requires words and gestures), or the ability to turn into a dog or bear (like *Shape of the Woodland Prowler* (ArM5 page 131), but with Personal Range, and requiring only a gesture).
 
-### LEADWORKER
+#### Leadworker
 
 *Minor, Hermetic*
 
 Leadworking is a skill descended from the style of necromancy practiced by the Aita cult. The name refers to the ability to craft *katadesmoi*. A katadesmos is a tablet that is used to curse and control the individual whose name is written upon it. Occasionally figurines, *kolossoi* are created instead. Curse tablets are most easily crafted from lead, but modern Tremere also use the non-reflective sides of mirrors.
 
-Much of the original power of the tradition has been lost in the move to Hermetic magic, but two useful powers remain to the leadworkers. They may create arcane connections to the restless dead, and to those animals and spirits able to recognize their own names. They may also make *kolossoi* that contain fixed arcane connections, taken from the bodies of their victims, without spending vis or study time. Success in both activities is automatic.
+Much of the original power of the tradition has been lost in the move to Hermetic magic, but two useful powers remain to the leadworkers. They may also create a fixed Arcane Connection to someone by incorporating an Arcane Connection taken from the body of the victim into a kolossos, without spending vis or study time. They may also make *kolossoi* that contain fixed arcane connections, taken from the bodies of their victims, without spending vis or study time. Success in both activities is automatic.
 
-#### Penetration bonus table additions:
+**Penetration bonus table additions:**
 
 Katadesmos tablet, inscribed with the name of a victim (+2)
 
@@ -5420,7 +4953,7 @@ A Kolossos is a representation, like any other (+2)
 
 A Kolossos constructed with a sympathetic connection from the body of the victim imbedded in it (+3)
 
-#### HARENARIUS
+#### Harenarius
 
 *Minor, Hermetic*
 
@@ -5428,16 +4961,13 @@ A "Person of the Sand" is one of the very few magi able to master two Certamen S
 
 A Harenarius may choose to fight as a member of one of his schools at the commencement of certamen, or may choose to fight as a generalist, as other magi do. Harenarii begin with a Reputation 2, as a master duelist, with Tremere magi. They are more likely to be sought out by Magi seeking Certamen instructors than other Tremere magi. Harenarii pioneer the majority of new Certamen schools and tricks.
 
-#### NYKTOPHYLAX
+#### Nyktophylax
 
 *Minor, Hermetic*
 
 Nyktophylaxes, "night guards," are magi whose magic of Sun duration fails at noon and midnight, rather than dawn and dusk. Their name comes from their role as sentries during the Schism War.
 
-
-### Appendix
-
-# Timeline
+# Appendix: Timeline
 
 This list compiles the dates important to the four True Lineages. All dates are AD and conform to the mundane measuring of history rather than the Hermetic.
 
@@ -5459,9 +4989,7 @@ This list compiles the dates important to the four True Lineages. All dates are 
 - 773 The second meeting of the First Tribunal. The Grand Tribunal and regional Tribunals are constituted. That winter, Mercere loses his Gift.
 - 799 The first meeting of the Grand Tribunal. Many magi in the thirteenth century confuse the meetings of the early Grand Tribunals with the meetings of the First Tribunal, the original Founders, erroneously counting this as the third Grand Tribunal.
 - 812 Bonisagus is forced to March his own filius, Jovius. Bonisagus never takes another apprentice.
-- 817 The second meeting of the Grand Tribunal of the Hermetic Order. Certamen is accepted as decisive in
-
-- all disputes. Mercere and Trianoma persuade the other magi of the Order to bring Redcaps into the Order.
+- 817 The second meeting of the Grand Tribunal of the Hermetic Order. Certamen is accepted as decisive in all disputes. Mercere and Trianoma persuade the other magi of the Order to bring Redcaps into the Order.
 - 818 Mercere dies.
 - 832 The third meeting of the Grand Tribunal of the Order of Hermes. The 33 year schedule of Grand Tribunals is set. Trianoma attends the Grand Tribunal and later dies in her sleep. Fenicil becomes Primus of House Guernicus.
 - 836 Bonisagus is last seen alive at the regional Thebes Tribunal gathering, recruiting magi for an expedition.
@@ -5472,7 +5000,7 @@ This list compiles the dates important to the four True Lineages. All dates are 
 - 937 Duresca scrolls discovered.
 - 961 Golias of House Mercere cast out of the Order.
 - 1003 1017 The Schism War.
-- 1010 The inner council of Magvillus summons thirty Guernicus magi to the domus magna to perform the "Curse of Thoth" ritual.
+- 1011 The inner council of Magvillus summons thirty Guernicus magi to the domus magna to perform the "Curse of Thoth" ritual.
 - 1014 A Bulgarian army is blinded by a Constantinopolitan general. House Tremere recruits some of the blind people, offering them their sight for their lifelong obedience.
 - 1071 Tremere magi begin to join multi-House covenants again.
 - 1141 Insatella becomes Prima of House Mercere.
@@ -5481,4 +5009,3 @@ This list compiles the dates important to the four True Lineages. All dates are 
 - 1204 Sack of Constantinople.
 - 1213 Murion selected as Prima of House Bonisagus.
 - 1218 Most recent Tremere Decenial. Primus Umno retires to lead the Burning Acorns Vexillation. Poena becomes Prima. Begins a series of research covenants. Bilera elected as Guernicus Prima.
-


### PR DESCRIPTION
First-pass clean-up and normalization achieved for Houses of Hermes: True Lineages.

Rebuilt the TOC, cleaned headings, restored tables, repaired broken paragraphs and merged fragments, and fixed various OCR / formatting issues throughout.

Official errata were integrated where they could be confidently located in this source/version; a small number could not be matched with certainty and were left unapplied.